### PR TITLE
Move initialization of extrusionAmountAtPreviousRetraction.

### DIFF
--- a/gcodeExport.h
+++ b/gcodeExport.h
@@ -32,7 +32,6 @@ public:
         extrusionPerMM = 0;
         retractionAmount = 4.5;
         minimalExtrusionBeforeRetraction = 0.0;
-        extrusionAmountAtPreviousRetraction = -10000;
         extruderSwitchRetraction = 14.5;
         extruderNr = 0;
         currentFanSpeed = -1;
@@ -92,6 +91,7 @@ public:
         this->retractionSpeed = retractionSpeed;
         this->extruderSwitchRetraction = double(extruderSwitchRetraction) / 1000.0;
         this->minimalExtrusionBeforeRetraction = double(minimalExtrusionBeforeRetraction) / 1000.0;
+        this->extrusionAmountAtPreviousRetraction = -10000;
     }
     
     void setZ(int z)


### PR DESCRIPTION
With extrusionAmountAtPreviousRetraction initialized only in the constructor of the GCodeExport class, only the first object is printed with retraction. Moving this to setRetractionSettings() ensures initialization before processing each file.

Test-Case:

(tested with the Ultimaker GCode flavor as it makes the retraction easier to see in the output)

retract-test.scad:

```
lh = 0.2;

cube([50, 50, 2 * lh]);
cube([10, 10, 4 * lh]);
translate([40, 40, 0]) cube([10, 10, 4 * lh]);
```

Makefile:

```
OPENSCAD='/Applications/\#RepRap/OpenSCAD.app/Contents/MacOS/OpenSCAD'
CURAENGINE='/Users/tp/Developer/CuraEngine/CuraEngine'

all : retract-test.gcode

.PHONY: clean
clean :
    $(RM) -f *.gcode *.stl

%.stl : %.scad
    $(OPENSCAD) -o $@ $^

%.gcode : %.stl
    $(CURAENGINE) -v -o $@ -s gcodeFlavor=1 -s multiVolumeOverlap=200 -m 1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0 -s posx=300000 -s posy=80000 $^ -m 1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0 -s posx=100000 -s posy=80000 $^
```
