### PR TITLE
added setting for bottom layer flow

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -313,7 +313,7 @@ void processFile(const char* input_filename, ConfigSettings& config, GCodeExport
         }
         gcodeLayer.forceMinimalLayerTime(config.minimalLayerTime, config.minimalFeedrate);
         if (layerNr == 0)
-            gcode.setExtrusion(config.initialLayerThickness, config.filamentDiameter, config.filamentFlow);
+            gcode.setExtrusion(config.initialLayerThickness, config.filamentDiameter, config.initialFilamentFlow);
         else
             gcode.setExtrusion(config.layerThickness, config.filamentDiameter, config.filamentFlow);
         if (int(layerNr) >= config.fanOnLayerNr)
@@ -385,6 +385,7 @@ int main(int argc, char **argv)
 
     config.filamentDiameter = 2890;
     config.filamentFlow = 100;
+    config.initialFilamentFlow = 100;
     config.initialLayerThickness = 300;
     config.layerThickness = 100;
     config.extrusionWidth = 400;

--- a/settings.cpp
+++ b/settings.cpp
@@ -10,6 +10,7 @@ ConfigSettings::ConfigSettings()
 {
     SETTING(layerThickness);
     SETTING(initialLayerThickness);
+    SETTING(initialFilamentFlow);
     SETTING(filamentDiameter);
     SETTING(filamentFlow);
     SETTING(extrusionWidth);

--- a/settings.h
+++ b/settings.h
@@ -47,6 +47,7 @@ public:
     int initialLayerThickness;
     int filamentDiameter;
     int filamentFlow;
+    int initialFilamentFlow;
     int extrusionWidth;
     int insetCount;
     int downSkinCount;


### PR DESCRIPTION
Hi,

I added a setting to adjust the filament flow for the bottom layer as there was too much material at the beginning. This resulted in bubbles on the printed surface.

This pull request is according to request https://github.com/daid/Cura/issues/563

Best regards
