### PR TITLE
Speed up scanbeam traversal

### DIFF
--- a/clipper/clipper.hpp
+++ b/clipper/clipper.hpp
@@ -35,6 +35,8 @@
 #define clipper_hpp
 
 #include <vector>
+#include <set>
+#include <functional>
 #include <stdexcept>
 #include <cstring>
 #include <cstdlib>
@@ -130,11 +132,6 @@ struct LocalMinima {
   LocalMinima  *next;
 };
 
-struct Scanbeam {
-  long64    Y;
-  Scanbeam *next;
-};
-
 struct OutPt; //forward declaration
 
 struct OutRec {
@@ -224,7 +221,7 @@ private:
   JoinList          m_Joins;
   HorzJoinList      m_HorizJoins;
   ClipType          m_ClipType;
-  Scanbeam         *m_Scanbeam;
+  std::set<long64, std::greater<long64> > m_Scanbeam;
   TEdge           *m_ActiveEdges;
   TEdge           *m_SortedEdges;
   IntersectNode    *m_IntersectNodes;
@@ -304,5 +301,3 @@ class clipperException : public std::exception
 } //ClipperLib namespace
 
 #endif //clipper_hpp
-
-


### PR DESCRIPTION
Scanbeam was a list of unique long kept sorted at each insertion.
Keeping it sorted is a O(n2) process.
This use a set instead where the process is O(nlog(n)).

On a huge model, I saw 10% speedup with this modification.
