### PR TITLE
Renamed LONG_LONG_MAX to LLONG_MAX

### DIFF
--- a/slicer.h
+++ b/slicer.h
@@ -191,7 +191,7 @@ public:
                 unsigned int bestA = -1;
                 unsigned int bestB = -1;
                 gapCloserResult bestResult;
-                bestResult.len = LONG_LONG_MAX;
+                bestResult.len = LLONG_MAX;
                 bestResult.polygonIdx = -1;
                 bestResult.pointIdxA = -1;
                 bestResult.pointIdxB = -1;
@@ -224,7 +224,7 @@ public:
                     }
                 }
                 
-                if (bestResult.len < LONG_LONG_MAX)
+                if (bestResult.len < LLONG_MAX)
                 {
                     if (bestA == bestB)
                     {


### PR DESCRIPTION
LONG_LONG_\* are obsolete so this just replaces references to those with LLONG_*
