### PR TITLE
Use _FILE_OFFSET_BITS to select which file system interface to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #g++ main.cpp modelFile/modelFile.cpp clipper/clipper.cpp -I. -o CuraEngine
 
 CXX ?= g++
-CFLAGS += -I. -c -Wall -Wextra -O3 -fomit-frame-pointer
+CFLAGS += -I. -c -Wall -Wextra -O3 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64
 # also include debug symbols
 #CFLAGS+=-ggdb
 LDFLAGS +=

--- a/gcodeExport.h
+++ b/gcodeExport.h
@@ -62,20 +62,20 @@ public:
     
     void replaceTagInStart(const char* tag, const char* replaceValue)
     {
-        off64_t oldPos = ftello64(f);
+        off_t oldPos = ftello(f);
         
         char buffer[1024];
-        fseeko64(f, 0, SEEK_SET);
+        fseeko(f, 0, SEEK_SET);
         fread(buffer, 1024, 1, f);
         
         char* c = strstr(buffer, tag);
         memset(c, ' ', strlen(tag));
         if (c) memcpy(c, replaceValue, strlen(replaceValue));
         
-        fseeko64(f, 0, SEEK_SET);
+        fseeko(f, 0, SEEK_SET);
         fwrite(buffer, 1024, 1, f);
         
-        fseeko64(f, oldPos, SEEK_SET);
+        fseeko(f, oldPos, SEEK_SET);
     }
     
     void setExtruderOffset(int id, Point p)


### PR DESCRIPTION
This allows using the regular file system functions and determining the interface to use when compiling.
