### PR TITLE
First travel movement towards initial position is not slowed down

### DIFF
--- a/gcodeExport.cpp
+++ b/gcodeExport.cpp
@@ -473,7 +473,8 @@ void GCodePlanner::writeGCode(bool liftHeadIfNeeded, int layerThickness)
         if (path->config->lineWidth != 0)// Only apply the extrudeSpeedFactor to extrusion moves
             speed = speed * extrudeSpeedFactor / 100;
         else
-            speed = speed * travelSpeedFactor / 100;
+            if (n>0)
+                speed = speed * travelSpeedFactor / 100;
         
         if (path->points.size() == 1 && path->config != &travelConfig && shorterThen(gcode.getPositionXY() - path->points[0], path->config->lineWidth * 2))
         {


### PR DESCRIPTION
Travel speed at layer 0 is slowed down by a factor, as with the extrude speed. Initially, the extruder may need to travel a relatively large distance before it starts printing and because of the slowing down, its possible to have oozing, no matter how much you retracted before the move.

This commit, prevents slowing down the very first travel movement, i.e. the movement just before printing.
