### PR TITLE
Omit additional infill when infill is set to zero.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -212,7 +212,6 @@ void processFile(const char* input_filename, ConfigSettings& config, GCodeExport
         gcode.setZ(z);
         if (layerNr == 0)
             gcodeLayer.addPolygonsByOptimizer(storage.skirt, &skirtConfig);
-        
         for(unsigned int volumeCnt = 0; volumeCnt < storage.volumes.size(); volumeCnt++)
         {
             if (volumeCnt > 0)
@@ -548,6 +547,7 @@ int main(int argc, char **argv)
     if (gcode.isValid())
     {
         gcode.addFanCommand(0);
+        gcode.addRetraction();
         gcode.setZ(maxObjectHeight + 5000);
         gcode.addMove(gcode.getPositionXY(), config.moveSpeed, 0);
         gcode.addCode(config.endCode);


### PR DESCRIPTION
Omit the additional infill when infill is disabled. Allows to print multi-walled objects where the interior is important (like big vases and cups, but using a standard nozzle).
