### PR TITLE
a memory leak occurs when use "support type" option

### DIFF
--- a/sliceDataStorage.h
+++ b/sliceDataStorage.h
@@ -55,6 +55,8 @@ public:
     int32_t gridScale;
     int32_t gridWidth, gridHeight;
     vector<SupportPoint>* grid;
+   	SupportStorage(){grid = NULL;}
+	  ~SupportStorage(){if(grid) delete [] grid;}
 };
 /******************/
 


### PR DESCRIPTION
due to following reasons

void generateSupportGrid(SupportStorage& storage, OptimizedModel\* om, int supportAngle, bool supportEverywhere, int supportXYDistance, int supportZDistance)
{
    storage.generated = false;
    if (supportAngle < 0)
        return;
    storage.generated = true;

```
storage.gridOffset.X = om->vMin.x;
...
storage.grid = new vector<SupportPoint>[storage.gridWidth * storage.gridHeight];
...
```
