### PR TITLE
Add perimeter inset setting to the Advanced settings.

### DIFF
--- a/fffProcessor.h
+++ b/fffProcessor.h
@@ -221,7 +221,7 @@ private:
                 if (config.spiralizeMode && int(layerNr) < config.downSkinCount && layerNr % 2 == 1)//Add extra insets every 2 layers when spiralizing, this makes bottoms of cups watertight.
                     insetCount += 5;
                 SliceLayer* layer = &storage.volumes[volumeIdx].layers[layerNr];
-                generateInsets(layer, config.extrusionWidth, insetCount);
+                generateInsets(layer, config.extrusionWidth, insetCount, config.perimInset);
 
                 for(unsigned int partNr=0; partNr<layer->parts.size(); partNr++)
                 {
@@ -565,7 +565,7 @@ private:
             for(unsigned int n=0; n<layer->parts.size(); n++)
                 supportGenerator.polygons = supportGenerator.polygons.difference(layer->parts[n].outline.offset(config.supportXYDistance));
         }
-        //Contract and expand the suppory polygons so small sections are removed and the final polygon is smoothed a bit.
+        //Contract and expand the support polygons so small sections are removed and the final polygon is smoothed a bit.
         supportGenerator.polygons = supportGenerator.polygons.offset(-config.extrusionWidth * 3);
         supportGenerator.polygons = supportGenerator.polygons.offset(config.extrusionWidth * 3);
         sendPolygonsToGui("support", layerNr, z, supportGenerator.polygons);

--- a/inset.cpp
+++ b/inset.cpp
@@ -2,7 +2,7 @@
 #include "inset.h"
 #include "polygonOptimizer.h"
 
-void generateInsets(SliceLayerPart* part, int offset, int insetCount)
+void generateInsets(SliceLayerPart* part, int offset, int insetCount, int perimInset)
 {
     part->combBoundery = part->outline.offset(-offset);
     if (insetCount == 0)
@@ -14,7 +14,7 @@ void generateInsets(SliceLayerPart* part, int offset, int insetCount)
     for(int i=0; i<insetCount; i++)
     {
         part->insets.push_back(Polygons());
-        part->insets[i] = part->outline.offset(-offset * i - offset/2);
+        part->insets[i] = part->outline.offset(-offset * i - offset/2 - perimInset);
         optimizePolygons(part->insets[i]);
         if (part->insets[i].size() < 1)
         {
@@ -24,11 +24,11 @@ void generateInsets(SliceLayerPart* part, int offset, int insetCount)
     }
 }
 
-void generateInsets(SliceLayer* layer, int offset, int insetCount)
+void generateInsets(SliceLayer* layer, int offset, int insetCount, int perimInset)
 {
     for(unsigned int partNr = 0; partNr < layer->parts.size(); partNr++)
     {
-        generateInsets(&layer->parts[partNr], offset, insetCount);
+        generateInsets(&layer->parts[partNr], offset, insetCount, perimInset);
     }
     
     //Remove the parts which did not generate an inset. As these parts are too small to print,

--- a/inset.h
+++ b/inset.h
@@ -4,8 +4,8 @@
 
 #include "sliceDataStorage.h"
 
-void generateInsets(SliceLayerPart* part, int offset, int insetCount);
+void generateInsets(SliceLayerPart* part, int offset, int insetCount, int perimInset);
 
-void generateInsets(SliceLayer* layer, int offset, int insetCount);
+void generateInsets(SliceLayer* layer, int offset, int insetCount, int perimInset);
 
 #endif//INSET_H

--- a/settings.cpp
+++ b/settings.cpp
@@ -27,6 +27,7 @@ ConfigSettings::ConfigSettings()
     SETTING(skirtDistance, 6000);
     SETTING(skirtLineCount, 1);
     SETTING(skirtMinLength, 0);
+    SETTING(perimInset, 0);
 
     SETTING(initialSpeedupLayers, 4);
     SETTING(initialLayerSpeed, 20);

--- a/settings.h
+++ b/settings.h
@@ -88,6 +88,7 @@ public:
     int skirtDistance;
     int skirtLineCount;
     int skirtMinLength;
+    int perimInset;
 
     //Retraction settings
     int retractionAmount;


### PR DESCRIPTION
Added the inset setting as suggested by the discussion in this thread: http://forums.reprap.org/read.php?263,273929

The associated updates to Cura are in another pull request (pull/780).

This allows the flow rate to set so that 100% filled objects are perfectly filled whilst having an independent setting to adjust for the minor oversizing of objects because of the way the plastic is laid down (as discussed in the forum thread).