### PR TITLE
Shifting raft surface only for first layer

### DIFF
--- a/fffProcessor.h
+++ b/fffProcessor.h
@@ -423,7 +423,10 @@ private:
 
             GCodePlanner gcodeLayer(gcode, config.moveSpeed, config.retractionMinimalDistance);
             int32_t z = config.initialLayerThickness + layerNr * config.layerThickness;
-            z += config.raftAirGap + config.raftBaseThickness + config.raftInterfaceThickness + config.raftSurfaceLayers*config.raftSurfaceThickness;
+            z += config.raftBaseThickness + config.raftInterfaceThickness + config.raftSurfaceLayers*config.raftSurfaceThickness;
+            if (layerNr == 0) {
+                z += config.raftAirGap;
+            }
             gcode.setZ(z);
 
             bool printSupportFirst = (storage.support.generated && config.supportExtruder > 0 && config.supportExtruder == gcodeLayer.getExtruder());


### PR DESCRIPTION
Shifting only the same layer off the raft surface is more efficient and makes the first layer cleaner

I update my recommended config for raft surface:

```
raftBaseThickness = 300
raftBaseLinewidth = 1000
raftLineSpacing = 3000
raftBaseSpeed = 8

raftInterfaceThickness = 270
raftInterfaceLinewidth = 400
raftInterfaceLineSpacing = 1000

raftSurfaceThickness = 270
raftSurfaceLinewidth = 300
raftSurfaceLineSpacing = 275
raftSurfaceLayers = 2
raftAirGap = 230

skirtDistance = 4000
skirtLineCount = 1
```

Seems to works good 
