### PR TITLE
Adding anchor line

### DIFF
--- a/settings.cpp
+++ b/settings.cpp
@@ -93,6 +93,13 @@ ConfigSettings::ConfigSettings()
     SETTING(extruderOffset[2].Y, 0);
     SETTING(extruderOffset[3].X, 0);
     SETTING(extruderOffset[3].Y, 0);
+    
+    SETTING(anchorThickness, 400);
+    SETTING(anchorLinewidth, 400);
+    SETTING(anchorSpeed, 8);
+    SETTING(anchorY, 10000);
+    SETTING(anchorFromX, 50000);
+    SETTING(anchorToX, 150000);
 
     startCode =
         "M109 S210     ;Heatup to 210C\n"

--- a/settings.h
+++ b/settings.h
@@ -158,6 +158,14 @@ public:
     int raftSurfaceLayers;
     int raftAirGap;
 
+    // Anchor settings
+    int anchorThickness;
+    int anchorLinewidth;
+    int anchorSpeed;
+    int anchorY;
+    int anchorFromX;
+    int anchorToX;
+
     FMatrix3x3 matrix;
     IntPoint objectPosition;
     int objectSink;


### PR DESCRIPTION
This adds the possibility of drawing an anchor line at the begining of the print on the X axis

It introduces following parameters:
* `anchorThickness` and `anchorLinewidth`, the size of the anchor line
* `anchorSpeed`, the speed of the anchor line
* `anchorY`, the Y position of the anchor line
* `anchorFromX` and `anchorToX`, the X interval on which the line have to be

It can be disabled with anchorThickness=0