### PR TITLE
Introducing raftFanSpeed and raftSurfaceSpeed

### DIFF
--- a/fffProcessor.h
+++ b/fffProcessor.h
@@ -354,7 +354,7 @@ private:
             GCodePathConfig raftBaseConfig((config.raftBaseSpeed <= 0) ? config.initialLayerSpeed : config.raftBaseSpeed, config.raftBaseLinewidth, "SUPPORT");
             GCodePathConfig raftMiddleConfig(config.printSpeed, config.raftInterfaceLinewidth, "SUPPORT");
             GCodePathConfig raftInterfaceConfig(config.printSpeed, config.raftInterfaceLinewidth, "SUPPORT");
-            GCodePathConfig raftSurfaceConfig(config.printSpeed, config.raftSurfaceLinewidth, "SUPPORT");
+            GCodePathConfig raftSurfaceConfig((config.raftSurfaceSpeed > 0) ? config.raftSurfaceSpeed : config.printSpeed, config.raftSurfaceLinewidth, "SUPPORT");
             
             {
                 gcode.writeComment("LAYER:-2");
@@ -372,6 +372,10 @@ private:
                 gcodeLayer.addPolygonsByOptimizer(raftLines, &raftBaseConfig);
 
                 gcodeLayer.writeGCode(false, config.raftBaseThickness);
+            }
+
+            if (config.raftFanSpeed) {
+                gcode.writeFanCommand(config.raftFanSpeed);
             }
             
             {

--- a/settings.cpp
+++ b/settings.cpp
@@ -70,11 +70,12 @@ ConfigSettings::ConfigSettings()
     SETTING(raftInterfaceLineSpacing, 250);
     SETTING(raftAirGap, 0);
     SETTING(raftBaseSpeed, 0);
-
+    SETTING(raftFanSpeed, 0);
     SETTING(raftSurfaceThickness, 0);
     SETTING(raftSurfaceLinewidth, 0);
     SETTING(raftSurfaceLineSpacing, 0);
     SETTING(raftSurfaceLayers, 0);
+    SETTING(raftSurfaceSpeed, 0);
 
     SETTING(minimalLayerTime, 5);
     SETTING(minimalFeedrate, 10);

--- a/settings.h
+++ b/settings.h
@@ -151,11 +151,12 @@ public:
     int raftInterfaceThickness;
     int raftInterfaceLinewidth;
     int raftInterfaceLineSpacing;
-
+    int raftFanSpeed;
     int raftSurfaceThickness;
     int raftSurfaceLinewidth;
     int raftSurfaceLineSpacing;
     int raftSurfaceLayers;
+    int raftSurfaceSpeed;
     int raftAirGap;
 
     FMatrix3x3 matrix;


### PR DESCRIPTION
This introduces two new parameters:
- `raftFanSpeed`, the speed of the fan during printing of the raft
- `raftSurfaceSpeed`, the speed of the raft printing (if 0, will default to the print speed)
