### PR TITLE
Change the angle on which raft interface layer's infill generated.  

### DIFF
--- a/fffProcessor.h
+++ b/fffProcessor.h
@@ -387,7 +387,7 @@ private:
                 gcode.setExtrusion(config.raftInterfaceThickness, config.filamentDiameter, config.filamentFlow);
 
                 Polygons raftLines;
-                generateLineInfill(storage.raftOutline, raftLines, config.raftInterfaceLinewidth, config.raftInterfaceLineSpacing, config.infillOverlap, 45);
+                generateLineInfill(storage.raftOutline, raftLines, config.raftInterfaceLinewidth, config.raftInterfaceLineSpacing, config.infillOverlap, config.raftSurfaceLayers > 0 ? 45 : 90);
                 gcodeLayer.addPolygonsByOptimizer(raftLines, &raftInterfaceConfig);
 
                 gcodeLayer.writeGCode(false, config.raftInterfaceThickness);


### PR DESCRIPTION
In case of no surface layers in raft (which is default by now) - generate interface layer infill on 90 degree angle instead of 45 (to prevent situation when the last level of raft and the first level of model have same infill  angle direction). 
