### PR TITLE
Up skin generation error when the raft support is used.

### DIFF
--- a/fffProcessor.h
+++ b/fffProcessor.h
@@ -214,6 +214,7 @@ private:
         //dumpLayerparts(storage, "c:/models/output.html");
 
         const unsigned int totalLayers = storage.volumes[0].layers.size();
+        const unsigned int raftLayers = (config.raftBaseThickness > 0 && config.raftInterfaceThickness > 0) ? 2 + config.raftSurfaceLayers : 0;
         for(unsigned int layerNr=0; layerNr<totalLayers; layerNr++)
         {
             for(unsigned int volumeIdx=0; volumeIdx<storage.volumes.size(); volumeIdx++)
@@ -273,7 +274,7 @@ private:
                     int extrusionWidth = config.extrusionWidth;
                     if (layerNr == 0)
                         extrusionWidth = config.layer0extrusionWidth;
-                    generateSkins(layerNr, storage.volumes[volumeIdx], extrusionWidth, config.downSkinCount, config.upSkinCount, config.infillOverlap);
+                    generateSkins(layerNr, storage.volumes[volumeIdx], extrusionWidth, config.downSkinCount, config.upSkinCount, config.infillOverlap, raftLayers);
                     generateSparse(layerNr, storage.volumes[volumeIdx], extrusionWidth, config.downSkinCount, config.upSkinCount);
 
                     SliceLayer* layer = &storage.volumes[volumeIdx].layers[layerNr];

--- a/skin.cpp
+++ b/skin.cpp
@@ -1,7 +1,7 @@
 /** Copyright (C) 2013 David Braam - Released under terms of the AGPLv3 License */
 #include "skin.h"
 
-void generateSkins(int layerNr, SliceVolumeStorage& storage, int extrusionWidth, int downSkinCount, int upSkinCount, int infillOverlap)
+void generateSkins(int layerNr, SliceVolumeStorage& storage, int extrusionWidth, int downSkinCount, int upSkinCount, int infillOverlap, int raftLayers)
 {
     SliceLayer* layer = &storage.layers[layerNr];
 
@@ -28,7 +28,7 @@ void generateSkins(int layerNr, SliceVolumeStorage& storage, int extrusionWidth,
                     downskin = downskin.difference(layer2->parts[partNr2].insets[layer2->parts[partNr2].insets.size() - 1]);
             }
         }
-        if (int(layerNr + upSkinCount) < (int)storage.layers.size())
+        if (int(layerNr + upSkinCount) < (int)storage.layers.size()-raftLayers)
         {
             SliceLayer* layer2 = &storage.layers[layerNr + upSkinCount];
             for(unsigned int partNr2=0; partNr2<layer2->parts.size(); partNr2++)

--- a/skin.h
+++ b/skin.h
@@ -4,7 +4,7 @@
 
 #include "sliceDataStorage.h"
 
-void generateSkins(int layerNr, SliceVolumeStorage& storage, int extrusionWidth, int downSkinCount, int upSkinCount, int infillOverlap);
+void generateSkins(int layerNr, SliceVolumeStorage& storage, int extrusionWidth, int downSkinCount, int upSkinCount, int infillOverlap, int raftLayers);
 void generateSparse(int layerNr, SliceVolumeStorage& storage, int extrusionWidth, int downSkinCount, int upSkinCount);
 
 #endif//SKIN_H


### PR DESCRIPTION
When the raft used, up skin is generated thinner than configurated by settings.
In my case, with layer height 0.25 and bottom/top thickness = 0.5, without raft - generated 3 bottom and top skin layers. But when I set raft support - only one up skin layer generated.

So I've made this fix, which resolve this issue.

P.S. This pull request contain one line changed in my previous pull request. It's line 390 in fffProcessor.h file. I don't know how to take it out of this pull request.
