### PR TITLE
C++11 range-based for loops and minor cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_DIR = build
 SRC_DIR = src
 LIBS_DIR = libs
 
-BUILD_TYPE = RELEASE
+BUILD_TYPE = WEB
 
 VERSION ?= DEV
 CXX ?= g++
@@ -22,18 +22,23 @@ ifeq ($(BUILD_TYPE),RELEASE)
 	CFLAGS+= -O3 -fomit-frame-pointer
 endif
 
-LDFLAGS += -Lbuild/ -lclipper
-
 SOURCES_RAW = bridge.cpp comb.cpp gcodeExport.cpp infill.cpp inset.cpp layerPart.cpp main.cpp optimizedModel.cpp pathOrderOptimizer.cpp polygonOptimizer.cpp raft.cpp settings.cpp skin.cpp skirt.cpp slicer.cpp support.cpp timeEstimate.cpp
 SOURCES_RAW += modelFile/modelFile.cpp utils/gettime.cpp utils/logoutput.cpp utils/socket.cpp
+
+ifeq ($(BUILD_TYPE), WEB)
+	SOURCES_RAW += ../$(LIBS_DIR)/clipper/clipper.cpp
+	EXECUTABLE = $(BUILD_DIR)/CuraEngine.html
+else
+	LDFLAGS +=
+	EXECUTABLE = $(BUILD_DIR)/CuraEngine
+endif
+
 SOURCES = $(addprefix $(SRC_DIR)/,$(SOURCES_RAW))
 
 OBJECTS_RAW = $(SOURCES_RAW:.cpp=.o)
 OBJECTS = $(addprefix $(BUILD_DIR)/,$(OBJECTS_RAW))
 
 DIRS = $(sort $(dir $(OBJECTS)))
-
-EXECUTABLE = $(BUILD_DIR)/CuraEngine
 
 ifeq ($(OS),Windows_NT)
 	#For windows make it large address aware, which allows the process to use more then 2GB of memory.

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SOURCES_RAW = bridge.cpp comb.cpp gcodeExport.cpp infill.cpp inset.cpp layerPart
 SOURCES_RAW += modelFile/modelFile.cpp utils/gettime.cpp utils/logoutput.cpp utils/socket.cpp
 
 ifeq ($(BUILD_TYPE), WEB)
-	CXX = emcc
+	CXX = $(EMSCRIPTEN)/emcc
 	SOURCES_RAW += ../$(LIBS_DIR)/clipper/clipper.cpp
 	EXECUTABLE = $(BUILD_DIR)/CuraEngine.html
 else
@@ -65,7 +65,15 @@ else
 	endif
 endif
 
-all: $(DIRS) $(SOURCES) $(EXECUTABLE)
+all: check-env $(DIRS) $(SOURCES) $(EXECUTABLE)
+
+check-env:
+ifndef EMSCRIPTEN
+	ifeq ($(BUILD_TYPE, WEB)
+		$(error EMSCRIPTEN is not set)
+	endif
+endif
+
 
 $(BUILD_DIR)/libclipper.a: $(LIBS_DIR)/clipper/clipper.cpp
 	$(CXX) $(CFLAGS) -o $(BUILD_DIR)/libclipper.a $(LIBS_DIR)/clipper/clipper.cpp

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ else ifeq ($(BUILD_TYPE),PROFILE)
 	CFLAGS+= -pg
 else ifeq ($(BUILD_TYPE),RELEASE)
 	CFLAGS+= -O3 -fomit-frame-pointer
+else ifeq ($(BUILD_TYPE),WEB)
+	CFLAGS+= -s ALLOW_MEMORY_GROWTH=1
 endif
 
 SOURCES_RAW = bridge.cpp comb.cpp gcodeExport.cpp infill.cpp inset.cpp layerPart.cpp main.cpp optimizedModel.cpp pathOrderOptimizer.cpp polygonOptimizer.cpp raft.cpp settings.cpp skin.cpp skirt.cpp slicer.cpp support.cpp timeEstimate.cpp

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,13 @@ LIBS_DIR = libs
 BUILD_TYPE = WEB
 
 VERSION ?= DEV
-CXX ?= g++
 CFLAGS += -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"$(VERSION)\" -isystem libs
 
 ifeq ($(BUILD_TYPE),DEBUG)
 	CFLAGS+=-ggdb -Og -g
-endif
-ifeq ($(BUILD_TYPE),PROFILE)
+else ifeq ($(BUILD_TYPE),PROFILE)
 	CFLAGS+= -pg
-endif
-ifeq ($(BUILD_TYPE),RELEASE)
+else ifeq ($(BUILD_TYPE),RELEASE)
 	CFLAGS+= -O3 -fomit-frame-pointer
 endif
 
@@ -26,10 +23,12 @@ SOURCES_RAW = bridge.cpp comb.cpp gcodeExport.cpp infill.cpp inset.cpp layerPart
 SOURCES_RAW += modelFile/modelFile.cpp utils/gettime.cpp utils/logoutput.cpp utils/socket.cpp
 
 ifeq ($(BUILD_TYPE), WEB)
+	CXX = emcc
 	SOURCES_RAW += ../$(LIBS_DIR)/clipper/clipper.cpp
 	EXECUTABLE = $(BUILD_DIR)/CuraEngine.html
 else
-	LDFLAGS +=
+	CXX = g++
+	LDFLAGS += -Lbuild/ -lclipper
 	EXECUTABLE = $(BUILD_DIR)/CuraEngine
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LIBS_DIR = libs
 
 BUILD_TYPE = WEB
 
-VERSION ?= DEV
+VERSION ?= DEV_$(BUILD_TYPE)
 CFLAGS += -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"$(VERSION)\" -isystem libs
 
 ifeq ($(BUILD_TYPE),DEBUG)
@@ -18,7 +18,10 @@ else ifeq ($(BUILD_TYPE),PROFILE)
 else ifeq ($(BUILD_TYPE),RELEASE)
 	CFLAGS+= -O3 -fomit-frame-pointer
 else ifeq ($(BUILD_TYPE),WEB)
-	CFLAGS+= -s ALLOW_MEMORY_GROWTH=1
+	CFLAGS+= -O3 --llvm-lto 3 -s NO_EXIT_RUNTIME=1 --memory-init-file 0 -s INVOKE_RUN=0 -s FORCE_ALIGNED_MEMORY=1 -s AGGRESSIVE_VARIABLE_ELIMINATION=1
+	#-s ALLOW_MEMORY_GROWTH=1
+	#TODO: Enable memory init file
+	#TODO: ENable closure compiler
 endif
 
 SOURCES_RAW = bridge.cpp comb.cpp gcodeExport.cpp infill.cpp inset.cpp layerPart.cpp main.cpp optimizedModel.cpp pathOrderOptimizer.cpp polygonOptimizer.cpp raft.cpp settings.cpp skin.cpp skirt.cpp slicer.cpp support.cpp timeEstimate.cpp
@@ -28,6 +31,7 @@ ifeq ($(BUILD_TYPE), WEB)
 	CXX = $(EMSCRIPTEN)/emcc
 	SOURCES_RAW += ../$(LIBS_DIR)/clipper/clipper.cpp
 	EXECUTABLE = $(BUILD_DIR)/CuraEngine.html
+	LDFLAGS += -O3 --llvm-lto 3 --memory-init-file 0
 else
 	CXX = g++
 	LDFLAGS += -Lbuild/ -lclipper


### PR DESCRIPTION
This pull request adds C++11 for loops instead of indexed loops.
Also there are some minor changes, to utilize the algorithm standard header, rather than duplicate code functions.
Lastly, fffprocessor and multivolume has been split into CPP/H files.
