### PR TITLE
fix compilation on Linux

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -60,7 +60,7 @@ void GCodeExport::replaceTagInStart(const char* tag, const char* replaceValue)
     fseek(f, 0, SEEK_SET);
     fwrite(buffer, 1024, 1, f);
     
-    fseek(f, oldPos, SEEK_SET);
+    fsetpos(f, &oldPos);
 }
 
 void GCodeExport::setExtruderOffset(int id, Point p)


### PR DESCRIPTION
src/gcodeExport.cpp:63:23: error: cannot convert ‘fpos_t {aka _G_fpos_t}’ to ‘long int’ for argument ‘2’ to ‘int fseek(FILE*, long int, int)’
     fseek(f, oldPos, SEEK_SET);
