### PR TITLE
Adds support for multi extrusion print based on color flag in the STL

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -17,6 +17,7 @@ class fffProcessor
 private:
     int maxObjectHeight;
     int fileNr;
+    bool coloredStlSupport = false;
     GCodeExport gcode;
     ConfigSettings& config;
     TimeKeeper timeKeeper;
@@ -85,6 +86,11 @@ public:
         return true;
     }
 
+    void enableColoredStlSupport()
+    {
+      this->coloredStlSupport = true;
+    }
+
     void finalize()
     {
         if (!gcode.isOpened())
@@ -146,7 +152,7 @@ private:
                     model->volumes.push_back(SimpleVolume());
                 else {
                     cura::log("Loading %s from disk...\n", files[i].c_str());
-                    SimpleModel *test = loadModelFromFile(model,files[i].c_str(), config.matrix);
+                    SimpleModel *test = loadModelFromFile(model,files[i].c_str(), config.matrix, this->coloredStlSupport);
                     if(test == nullptr) { // error while reading occurred
                         cura::logError("Failed to load model: %s\n", files[i].c_str());
                         return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,6 +152,10 @@ int main(int argc, char **argv)
                         &config.matrix.m[1][0], &config.matrix.m[1][1], &config.matrix.m[1][2],
                         &config.matrix.m[2][0], &config.matrix.m[2][1], &config.matrix.m[2][2]);
                     break;
+                case 'e':
+                  cura::log("Support for multiple extruders using the color flag in STL file has been enabled\n");
+                    processor.enableColoredStlSupport();
+                    break;
                 default:
                     cura::logError("Unknown option: %c\n", *str);
                     break;

--- a/src/modelFile/modelFile.h
+++ b/src/modelFile/modelFile.h
@@ -113,6 +113,6 @@ public:
     }
 };
 
-SimpleModel* loadModelFromFile(SimpleModel*m,const char* filename, FMatrix3x3& matrix);
+SimpleModel* loadModelFromFile(SimpleModel*m,const char* filename, FMatrix3x3& matrix, bool colorSupport);
 
 #endif//MODELFILE_H


### PR DESCRIPTION
- this feature must be enabled by the '-e' flag
- supports only binary STL files
- what this does, is that it groups all faces with same color into same
  SimpleVolume. Model then has as many volumes, as there were distinct
  colors for the faces, so it requires you to color your model correctly.
  The effect of grouping the faces is that at the end multiple extruders
  will be used.
- the volumes get sorted by the (numerical) value of the color (so color
  1 will be printed with extruder 1 and volume with color 2 with
  extruder 2 no matter what was the order of faces discovered in the STL file
