### PR TITLE
Fixed abs() -> fabs() typo that blocked build on FreeBSD.

### DIFF
--- a/src/timeEstimate.cpp
+++ b/src/timeEstimate.cpp
@@ -116,7 +116,7 @@ void TimeEstimateCalculator::plan(Position newPos, double feedrate)
     for(unsigned int n=0; n<NUM_AXIS; n++)
     {
         current_feedrate[n] = block.delta[n] * feedrate / block.distance;
-        current_abs_feedrate[n] = abs(current_feedrate[n]);
+        current_abs_feedrate[n] = fabs(current_feedrate[n]);
         if (current_abs_feedrate[n] > max_feedrate[n])
             feedrate_factor = std::min(feedrate_factor, max_feedrate[n] / current_abs_feedrate[n]);
     }


### PR DESCRIPTION
BUILD SYSTEM:
% uname -a
FreeBSD hexagon 10.0-RELEASE-p2 FreeBSD 10.0-RELEASE-p2 #0: Tue Apr 29 17:06:01 UTC 2014     root@amd64-builder.daemonology.net:/usr/obj/usr/src/sys/GENERIC  amd64

BUILD LOG BEFORE FIX:
% gmake CXX="c++"
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/bridge.cpp -o build/bridge.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/comb.cpp -o build/comb.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/gcodeExport.cpp -o build/gcodeExport.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/infill.cpp -o build/infill.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/inset.cpp -o build/inset.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/layerPart.cpp -o build/layerPart.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/main.cpp -o build/main.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/optimizedModel.cpp -o build/optimizedModel.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/pathOrderOptimizer.cpp -o build/pathOrderOptimizer.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/polygonOptimizer.cpp -o build/polygonOptimizer.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/raft.cpp -o build/raft.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/settings.cpp -o build/settings.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/skin.cpp -o build/skin.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/skirt.cpp -o build/skirt.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/slicer.cpp -o build/slicer.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/support.cpp -o build/support.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/timeEstimate.cpp -o build/timeEstimate.o
src/timeEstimate.cpp:119:35: error: use of undeclared identifier 'abs'; did you mean 'fabs'?
        current_abs_feedrate[n] = abs(current_feedrate[n]);
                                  ^~~
                                  fabs
/usr/include/math.h:259:8: note: 'fabs' declared here
double  fabs(double) __pure2;
        ^
1 error generated.
gmake: **\* [build/timeEstimate.o] Error 1

BUILD LOG AFTER FIX:
% gmake CXX="c++"
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/bridge.cpp -o build/bridge.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/comb.cpp -o build/comb.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/gcodeExport.cpp -o build/gcodeExport.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/infill.cpp -o build/infill.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/inset.cpp -o build/inset.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/layerPart.cpp -o build/layerPart.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/main.cpp -o build/main.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/optimizedModel.cpp -o build/optimizedModel.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/pathOrderOptimizer.cpp -o build/pathOrderOptimizer.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/polygonOptimizer.cpp -o build/polygonOptimizer.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/raft.cpp -o build/raft.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/settings.cpp -o build/settings.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/skin.cpp -o build/skin.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/skirt.cpp -o build/skirt.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/slicer.cpp -o build/slicer.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/support.cpp -o build/support.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/timeEstimate.cpp -o build/timeEstimate.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/modelFile/modelFile.cpp -o build/modelFile/modelFile.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/utils/gettime.cpp -o build/utils/gettime.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/utils/logoutput.cpp -o build/utils/logoutput.o
c++ -c -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -std=c++11 -DVERSION=\"DEV\" -isystem libs -O3 -fomit-frame-pointer src/utils/socket.cpp -o build/utils/socket.o
c++ build/bridge.o build/comb.o build/gcodeExport.o build/infill.o build/inset.o build/layerPart.o build/main.o build/optimizedModel.o build/pathOrderOptimizer.o build/polygonOptimizer.o build/raft.o build/settings.o build/skin.o build/skirt.o build/slicer.o build/support.o build/timeEstimate.o build/modelFile/modelFile.o build/utils/gettime.o build/utils/logoutput.o build/utils/socket.o -o build/CuraEngine -Lbuild/ -lclipper
