### PR TITLE
Increase adhesion of support structure with raft by filling the air gap

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -461,9 +461,12 @@ private:
                 if (layerNr == 0)
                 {
 					// Increase adhesion of support structure with raft by filling the air gap
+					GCodePlanner gcodeLayerAirGap(gcode, config.moveSpeed, config.retractionMinimalDistance);
 					gcode.setExtrusion(config.raftAirGapLayer0, config.filamentDiameter, config.filamentFlow);
 					gcode.setZ(z);
-					addSupportToGCode(storage, gcodeLayer, layerNr);
+					addSupportToGCode(storage, gcodeLayerAirGap, layerNr);
+					gcodeLayer.writeGCode(false, config.initialLayerThickness);
+					gcode.setExtrusion(config.initialLayerThickness, config.filamentDiameter, config.filamentFlow);
                     z += config.raftAirGapLayer0;
                 } else {
                     z += config.raftAirGap;

--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -460,6 +460,10 @@ private:
             {
                 if (layerNr == 0)
                 {
+					// Increase adhesion of support structure with raft by filling the air gap
+					gcode.setExtrusion(config.raftAirGapLayer0, config.filamentDiameter, config.filamentFlow);
+					gcode.setZ(z);
+					addSupportToGCode(storage, gcodeLayer, layerNr);
                     z += config.raftAirGapLayer0;
                 } else {
                     z += config.raftAirGap;

--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -460,14 +460,14 @@ private:
             {
                 if (layerNr == 0)
                 {
-					z += config.raftAirGapLayer0;
-					// Increase adhesion of support structure with raft by filling the air gap
-					GCodePlanner gcodeLayerAirGap(gcode, config.moveSpeed, config.retractionMinimalDistance);
-					gcode.setExtrusion(config.raftAirGapLayer0, config.filamentDiameter, config.filamentFlow);
-					gcode.setZ(z - config.initialLayerThickness);
-					addSupportToGCode(storage, gcodeLayerAirGap, layerNr);
-					gcodeLayerAirGap.writeGCode(false, config.raftAirGapLayer0);
-					gcode.setExtrusion(config.initialLayerThickness, config.filamentDiameter, config.filamentFlow);
+                    z += config.raftAirGapLayer0;
+                    // Increase adhesion of support structure with raft by filling the air gap
+                    GCodePlanner gcodeLayerAirGap(gcode, config.moveSpeed, config.retractionMinimalDistance);
+                    gcode.setExtrusion(config.raftAirGapLayer0, config.filamentDiameter, config.filamentFlow);
+                    gcode.setZ(z - config.initialLayerThickness);
+                    addSupportToGCode(storage, gcodeLayerAirGap, layerNr);
+                    gcodeLayerAirGap.writeGCode(false, config.raftAirGapLayer0);
+                    gcode.setExtrusion(config.initialLayerThickness, config.filamentDiameter, config.filamentFlow);
                 } else {
                     z += config.raftAirGap;
                 }

--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -460,14 +460,14 @@ private:
             {
                 if (layerNr == 0)
                 {
+					z += config.raftAirGapLayer0;
 					// Increase adhesion of support structure with raft by filling the air gap
 					GCodePlanner gcodeLayerAirGap(gcode, config.moveSpeed, config.retractionMinimalDistance);
 					gcode.setExtrusion(config.raftAirGapLayer0, config.filamentDiameter, config.filamentFlow);
-					gcode.setZ(z);
+					gcode.setZ(z - config.initialLayerThickness);
 					addSupportToGCode(storage, gcodeLayerAirGap, layerNr);
-					gcodeLayerAirGap.writeGCode(false, config.initialLayerThickness);
+					gcodeLayerAirGap.writeGCode(false, config.raftAirGapLayer0);
 					gcode.setExtrusion(config.initialLayerThickness, config.filamentDiameter, config.filamentFlow);
-                    z += config.raftAirGapLayer0;
                 } else {
                     z += config.raftAirGap;
                 }

--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -465,7 +465,7 @@ private:
 					gcode.setExtrusion(config.raftAirGapLayer0, config.filamentDiameter, config.filamentFlow);
 					gcode.setZ(z);
 					addSupportToGCode(storage, gcodeLayerAirGap, layerNr);
-					gcodeLayer.writeGCode(false, config.initialLayerThickness);
+					gcodeLayerAirGap.writeGCode(false, config.initialLayerThickness);
 					gcode.setExtrusion(config.initialLayerThickness, config.filamentDiameter, config.filamentFlow);
                     z += config.raftAirGapLayer0;
                 } else {


### PR DESCRIPTION
The base of support structure does not adhere properly to the raft because of the air gap.
This patch leaves air gap for the model, but fills for the support structure.
