### PR TITLE
Handling correctly both the Ascii models and Binary models.

### DIFF
--- a/src/modelFile/modelFile.cpp
+++ b/src/modelFile/modelFile.cpp
@@ -133,13 +133,15 @@ SimpleModel* loadModelSTL(SimpleModel *m,const char* filename, FMatrix3x3& matri
         SimpleModel* asciiModel = loadModelSTL_ascii(m, filename, matrix);
         if (!asciiModel)
             return nullptr;
-        else
-            return asciiModel;
+
+        // This logic is used to handle the case where the file starts with
+        // "solid" but is a binary file.
         if (m->volumes[m->volumes.size()-1].faces.size() < 1)
         {
             m->volumes.erase(m->volumes.end() - 1);
             return loadModelSTL_binary(m, filename, matrix);
         }
+        return asciiModel;
     }
     return loadModelSTL_binary(m, filename, matrix);
 }


### PR DESCRIPTION
Now returns the asciiModel, previously there was no possibility for the ascii SimpleModel\* to be returned but only the Binary model.

In other words, the previous code would return a model that would be parsed using the binary parser even for the Ascii files which obviously would not give satisfying results.

For reference, the extra logic after the if(!asciiModel) was the result of a previous commit that would handle the case where the model starts with solid but is actually a binary file (I think openScad produces those files).
