### PR TITLE
Print blobs reduction

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -96,8 +96,8 @@ private:
     void preSetup()
     {
         skirtConfig.setData(config.printSpeed, config.extrusionWidth, "SKIRT");
-        inset0Config.setData(config.inset0Speed, config.extrusionWidth, "WALL-OUTER");
-        insetXConfig.setData(config.insetXSpeed, config.extrusionWidth, "WALL-INNER");
+        inset0Config.setData(config.inset0Speed, config.extrusionWidth, config.pointsClipDistance, "WALL-OUTER");
+        insetXConfig.setData(config.insetXSpeed, config.extrusionWidth, config.pointsClipDistance, "WALL-INNER");
         fillConfig.setData(config.infillSpeed, config.extrusionWidth, "FILL");
         supportConfig.setData(config.printSpeed, config.extrusionWidth, "SUPPORT");
 

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -681,6 +681,11 @@ void GCodePlanner::writeGCode(bool liftHeadIfNeeded, int layerThickness)
         			 */
         			currentDistance = vSize((path->points[p] - path->points[p-1]));
 
+        			/**
+        			 * If distance exceeds clip distance:
+        			 * - Stores last point to do a fast move after the clip
+        			 * - Sets the new last path point
+        			 */
         			if(currentDistance > targetDistance)
         			{
         				Point temp;
@@ -698,11 +703,13 @@ void GCodePlanner::writeGCode(bool liftHeadIfNeeded, int layerThickness)
         			}
         			else if(currentDistance == targetDistance)
         			{
+        				//Pops up last point because it is at the limit distance
         				path->points.pop_back();
         				break;
         			}
         			else
         			{
+        				//Pops last point and reduces distance remaining to target
         				targetDistance = targetDistance - currentDistance;
         				path->points.pop_back();
         			}
@@ -715,6 +722,11 @@ void GCodePlanner::writeGCode(bool liftHeadIfNeeded, int layerThickness)
         		gcode.writeMove(path->points[i], speed, path->config->lineWidth);
         	}
 
+        	/**
+        	 * If it is to clip, then do:
+        	 * - a retraction in INNER WALLS
+        	 * - a fast move in OUTER WALLS
+        	 */
         	if(clip == true)
         	{
         		if(strcmp(path->config->name,"WALL-INNER") == 0)

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -666,23 +666,79 @@ void GCodePlanner::writeGCode(bool liftHeadIfNeeded, int layerThickness)
                 gcode.writeMove(path->points[i], speed, path->config->lineWidth);
             }
         }else{
-            for(unsigned int i=0; i<path->points.size(); i++)
-            {
-                gcode.writeMove(path->points[i], speed, path->config->lineWidth);
-            }
+        	Point lastPoint;
+        	bool clip = false;
+
+        	if(strcmp(path->config->name,"WALL-OUTER") == 0 || strcmp(path->config->name,"WALL-INNER") == 0)
+        	{
+        		double currentDistance = 0.0;
+        		double targetDistance = path->config->clip;
+
+        		for(unsigned int p=path->points.size()-1; p>0; p--)
+        		{
+        			/**
+        			 * Calculate distance between 2 points
+        			 */
+        			currentDistance = vSize((path->points[p] - path->points[p-1]));
+
+        			if(currentDistance > targetDistance)
+        			{
+        				Point temp;
+        				Point dir = (path->points[p] - path->points[p-1])/ currentDistance;
+
+        				temp = path->points[p-1] + dir*(currentDistance-targetDistance);
+
+        				lastPoint.X = path->points[p].X;
+        				lastPoint.Y = path->points[p].Y;
+
+        				path->points[p].X = temp.X;
+        				path->points[p].Y = temp.Y;
+        				clip = true;
+        				break;
+        			}
+        			else if(currentDistance == targetDistance)
+        			{
+        				path->points.pop_back();
+        				break;
+        			}
+        			else
+        			{
+        				targetDistance = targetDistance - currentDistance;
+        				path->points.pop_back();
+        			}
+        		}
+
+        	}
+
+        	for(unsigned int i=0; i<path->points.size(); i++)
+        	{
+        		gcode.writeMove(path->points[i], speed, path->config->lineWidth);
+        	}
+
+        	if(clip == true)
+        	{
+        		if(strcmp(path->config->name,"WALL-INNER") == 0)
+        		{
+        			gcode.writeRetraction();
+        		}
+        		if(strcmp(path->config->name,"WALL-OUTER") == 0 )
+        		{
+        			gcode.writeMove(lastPoint, speed, 0);
+        		}
+        	}
+        }
+
+        gcode.updateTotalPrintTime();
+        if (liftHeadIfNeeded && extraTime > 0.0)
+        {
+        	gcode.writeComment("Small layer, adding delay of %f", extraTime);
+        	gcode.writeRetraction(true);
+        	gcode.setZ(gcode.getPositionZ() + MM2INT(3.0));
+        	gcode.writeMove(gcode.getPositionXY(), travelConfig.speed, 0);
+        	gcode.writeMove(gcode.getPositionXY() - Point(-MM2INT(20.0), 0), travelConfig.speed, 0);
+        	gcode.writeDelay(extraTime);
         }
     }
-    
-    gcode.updateTotalPrintTime();
-    if (liftHeadIfNeeded && extraTime > 0.0)
-    {
-        gcode.writeComment("Small layer, adding delay of %f", extraTime);
-        gcode.writeRetraction(true);
-        gcode.setZ(gcode.getPositionZ() + MM2INT(3.0));
-        gcode.writeMove(gcode.getPositionXY(), travelConfig.speed, 0);
-        gcode.writeMove(gcode.getPositionXY() - Point(-MM2INT(20.0), 0), travelConfig.speed, 0);
-        gcode.writeDelay(extraTime);
-    }
-}
+ }
 
 }//namespace cura

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -120,6 +120,11 @@ public:
         this->name = name;
     }
 
+    /**
+     * New method to support clip distance value.
+     * - Clip value comes from SETTINGS
+     * - This method is called by inset0Config and insetXConfig
+     */
     void setData(int speed, int lineWidth, int clip, const char* name)
     {
         this->speed = speed;

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -108,15 +108,24 @@ public:
     int lineWidth;
     const char* name;
     bool spiralize;
+    int clip;
     
-    GCodePathConfig() : speed(0), lineWidth(0), name(nullptr), spiralize(false) {}
-    GCodePathConfig(int speed, int lineWidth, const char* name) : speed(speed), lineWidth(lineWidth), name(name), spiralize(false) {}
+    GCodePathConfig() : speed(0), lineWidth(0), name(nullptr), spiralize(false), clip(0) {}
+    GCodePathConfig(int speed, int lineWidth, const char* name) : speed(speed), lineWidth(lineWidth), name(name), spiralize(false), clip(0) {}
     
     void setData(int speed, int lineWidth, const char* name)
     {
         this->speed = speed;
         this->lineWidth = lineWidth;
         this->name = name;
+    }
+
+    void setData(int speed, int lineWidth, int clip, const char* name)
+    {
+        this->speed = speed;
+        this->lineWidth = lineWidth;
+        this->name = name;
+        this->clip = clip;
     }
 };
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -31,8 +31,6 @@ ConfigSettings::ConfigSettings()
     SETTING(skirtLineCount, 1);
     SETTING(skirtMinLength, 0);
     SETTING(pointsClipDistance, 0);
-    SETTING(polygonL1Resolution, 0);
-    SETTING(polygonL2Resolution, 0);
 
     SETTING(initialSpeedupLayers, 4);
     SETTING(initialLayerSpeed, 20);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -30,6 +30,9 @@ ConfigSettings::ConfigSettings()
     SETTING(skirtDistance, 6000);
     SETTING(skirtLineCount, 1);
     SETTING(skirtMinLength, 0);
+    SETTING(pointsClipDistance, 0);
+    SETTING(polygonL1Resolution, 0);
+    SETTING(polygonL2Resolution, 0);
 
     SETTING(initialSpeedupLayers, 4);
     SETTING(initialLayerSpeed, 20);

--- a/src/settings.h
+++ b/src/settings.h
@@ -128,6 +128,9 @@ public:
     int skirtDistance;
     int skirtLineCount;
     int skirtMinLength;
+    int pointsClipDistance;
+    int polygonL1Resolution;
+    int polygonL2Resolution;
 
     //Retraction settings
     int retractionAmount;

--- a/src/settings.h
+++ b/src/settings.h
@@ -129,8 +129,6 @@ public:
     int skirtLineCount;
     int skirtMinLength;
     int pointsClipDistance;
-    int polygonL1Resolution;
-    int polygonL2Resolution;
 
     //Retraction settings
     int retractionAmount;


### PR DESCRIPTION
Printing with latest versions was causing blobs during prints:
![before](https://cloud.githubusercontent.com/assets/5079803/3508842/2400d574-0691-11e4-9239-f1d82ddcb17c.png)

To reduce them it was inserted a clipping algorithm in the writeGCode method to clip points for a limit distance (new SETTING). Depending if it is a INNER or OUTER wall a retraction or a fast move is done.
After results show improvements:

![after](https://cloud.githubusercontent.com/assets/5079803/3508871/955c6562-0691-11e4-951e-04b15d93b2ef.png)

Algorithm behavior:

Planner (previous)

![cura_3](https://cloud.githubusercontent.com/assets/5079803/3508899/28a89dfe-0692-11e4-9b5f-865e83f6e68a.png)
![cura_4](https://cloud.githubusercontent.com/assets/5079803/3508900/2bdb3c20-0692-11e4-87d6-3d5afaf5b83a.png)

Planner (after)

![cura_13_5](https://cloud.githubusercontent.com/assets/5079803/3508906/46c3b274-0692-11e4-900a-0a3a6c88ff95.png)

Clipping with retractions (after)

![cura_13_3](https://cloud.githubusercontent.com/assets/5079803/3508927/acf8db82-0692-11e4-8e63-d8a9b4157dd4.png)

![cura_13_4](https://cloud.githubusercontent.com/assets/5079803/3508929/afe1e816-0692-11e4-8e4f-5986f0602ccf.png)

Summary:
- New setting - pointsClipDistance  (settings.cpp)
- New GCode path configuration data constructor -  void setData(int speed, int lineWidth, int clip, const char\* name)   (gcodeExport.h)
- New GCode export algorithm when clipping and spiralize is off (gcodeExport.cpp)
- GCodePathConfig (inset0Config and insetXConfig) using setData constructor to support clip  (fffProcessor.h)
- New GCode moves for Inner and Outer walls with clip, if not spiralize.
