### PR TITLE
Fix PolygonRef::inside

### DIFF
--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -134,28 +134,10 @@ public:
         return ret;
     }
     
-    //Check if we are inside the polygon. We do this by tracing from the point towards the negative X direction,
-    //  every line we cross increments the crossings counter. If we have an even number of crossings then we are not inside the polygon.
+    //Check if we are inside the polygon.
     bool inside(Point p)
     {
-        if (polygon->size() < 1)
-            return false;
-        
-        int crossings = 0;
-        Point p0 = (*polygon)[polygon->size()-1];
-        for(unsigned int n=0; n<polygon->size(); n++)
-        {
-            Point p1 = (*polygon)[n];
-            
-            if ((p0.Y >= p.Y && p1.Y < p.Y) || (p1.Y > p.Y && p0.Y <= p.Y))
-            {
-                int64_t x = p0.X + (p1.X - p0.X) * (p.Y - p0.Y) / (p1.Y - p0.Y);
-                if (x >= p.X)
-                    crossings ++;
-            }
-            p0 = p1;
-        }
-        return (crossings % 2) == 1;
+        return PointInPolygon(p,*polygon) != 0;
     }
 
     friend class Polygons;


### PR DESCRIPTION
The function PolygonRef::inside fails when the tested point is at the same Y value than an edge of the polygon, like in the following example.

![inside_fix](https://cloud.githubusercontent.com/assets/6553898/3634591/8abacf2a-0f3a-11e4-8560-742c0fdecc49.png)


The red point is considered in the yellow triangle, this is obviously wrong.
It is possible to test the issue with the following test case:
<pre>
void inside_testcase()
{
    Point p;
    p.X = 0;
    p.Y = 1;
    Polygon poly;
    {
        Point pt;
        pt.X = 1;
        pt.Y = 0;
        poly.add(pt);
    }
    {
        Point pt;
        pt.X = 2;
        pt.Y = 1;
        poly.add(pt);
    }
    {
        Point pt;
        pt.X = 3;
        pt.Y = 0;
        poly.add(pt);
    }
    if (poly.inside(p))
        printf("Point in triangle (this is wrong!)\n");
    else
        printf("Point out of triangle\n");
}
</pre>
My fix consists in using the function <i>PointInPolygon</i> provided by Clipper.