### PR TITLE
No -flto compiler option in debug mode under Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,12 @@ else
 	UNAME := $(shell uname)
 	ifeq ($(UNAME), Linux)
 		OPEN_HTML=firefox
-		CFLAGS += -flto
-		LDFLAGS += --static -flto
+		ifeq ($(BUILD_TYPE),DEBUG)
+			LDFLAGS += --static
+		else
+			CFLAGS += -flto
+			LDFLAGS += --static -flto
+		endif
 	endif
 	ifeq ($(UNAME), Darwin)
 		OPEN_HTML=open


### PR DESCRIPTION
Under Linux (at least OpenSuse 13.1 64 bits) the <i>-flto</i> compiler option combined with the debug mode <i>-g</i> generates a binary the debugger gdb is unable to work with.
I'm using gcc 4.8.1 and gdb 7.7
The <i>-flto</i> option is an optimization, and all optimizations should be turned off in debug mode
