### PR TITLE
update Makefile to include static linking for gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifeq ($(OS),Windows_NT)
 	#For windows make it large address aware, which allows the process to use more then 2GB of memory.
 	EXECUTABLE := $(EXECUTABLE).exe
 	CFLAGS += -march=pentium4 -flto
-	LDFLAGS += -Wl,--large-address-aware -lm -lwsock32 -flto
+	LDFLAGS += -Wl,--large-address-aware -lm -lwsock32 -flto -static-libgcc -static-libstdc++
 	MKDIR_PREFIX = mkdir -p
 else
 	MKDIR_PREFIX = mkdir -p


### PR DESCRIPTION
This fixes a problem I was having where the package.sh script in Cura would not make a functional CuraEngine.exe on a fresh copy of Windows.