### PR TITLE
Add a bulge correction factor to the outer contour to make outer dimensions accurate

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -249,10 +249,21 @@ private:
                 if (config.spiralizeMode && static_cast<int>(layerNr) < config.downSkinCount && layerNr % 2 == 1)//Add extra insets every 2 layers when spiralizing, this makes bottoms of cups watertight.
                     insetCount += 5;
                 SliceLayer* layer = &storage.volumes[volumeIdx].layers[layerNr];
-                int extrusionWidth = config.extrusionWidth;
-                if (layerNr == 0)
-                    extrusionWidth = config.layer0extrusionWidth;
-                generateInsets(layer, extrusionWidth, insetCount);
+                int extrusionWidth = layerNr == 0 ? config.layer0extrusionWidth  : config.extrusionWidth;
+                int layerThickness = layerNr == 0 ? config.initialLayerThickness : config.layerThickness;
+
+                // The outer layer bulges outwards a bit. Apply a correction to make outer dimensions accurate.
+                // Assume circular bulges with radius layerThickness/2 and a rectangular section of width x,
+                // the total area of the laid filament profile = radius^2 * PI + x * layerThickness,
+                // the assumed (ideal) filament profile has an area of layerThickness * extrusionWidth,
+                // equating the two areas give x = extrusionWidth - layerThickness * PI / 4
+                // the total width is (layerThickness + x) instead of the ideal layerWidth.
+                int realExtrusionWidth = layerThickness + extrusionWidth - layerThickness * (M_PI / 4);
+
+                // Apply a correction
+                int bulgeOffset = (realExtrusionWidth - extrusionWidth) / 2;
+
+                generateInsets(layer, extrusionWidth, bulgeOffset, insetCount);
 
                 for(unsigned int partNr=0; partNr<layer->parts.size(); partNr++)
                 {

--- a/src/inset.cpp
+++ b/src/inset.cpp
@@ -4,9 +4,9 @@
 
 namespace cura {
 
-void generateInsets(SliceLayerPart* part, int offset, int insetCount)
+void generateInsets(SliceLayerPart* part, int offset, int bulgeOffset, int insetCount)
 {
-    part->combBoundery = part->outline.offset(-offset);
+    part->combBoundery = part->outline.offset(-offset-bulgeOffset);
     if (insetCount == 0)
     {
         part->insets.push_back(part->outline);
@@ -16,7 +16,7 @@ void generateInsets(SliceLayerPart* part, int offset, int insetCount)
     for(int i=0; i<insetCount; i++)
     {
         part->insets.push_back(Polygons());
-        part->insets[i] = part->outline.offset(-offset * i - offset/2);
+        part->insets[i] = part->outline.offset(-offset * i - offset/2 - bulgeOffset);
         optimizePolygons(part->insets[i]);
         if (part->insets[i].size() < 1)
         {
@@ -26,11 +26,11 @@ void generateInsets(SliceLayerPart* part, int offset, int insetCount)
     }
 }
 
-void generateInsets(SliceLayer* layer, int offset, int insetCount)
+void generateInsets(SliceLayer* layer, int offset, int bulgeOffset, int insetCount)
 {
     for(unsigned int partNr = 0; partNr < layer->parts.size(); partNr++)
     {
-        generateInsets(&layer->parts[partNr], offset, insetCount);
+        generateInsets(&layer->parts[partNr], offset, bulgeOffset, insetCount);
     }
     
     //Remove the parts which did not generate an inset. As these parts are too small to print,

--- a/src/inset.h
+++ b/src/inset.h
@@ -6,9 +6,9 @@
 
 namespace cura {
 
-void generateInsets(SliceLayerPart* part, int offset, int insetCount);
+void generateInsets(SliceLayerPart* part, int offset, int bulgeOffset, int insetCount);
 
-void generateInsets(SliceLayer* layer, int offset, int insetCount);
+void generateInsets(SliceLayer* layer, int offset, int bulgeOffset, int insetCount);
 
 }//namespace cura
 


### PR DESCRIPTION
Yet another dimension correction patch. This one doesn't address filament stretching for rounded contours, but merely adjusts for the bulging of the outer surface of the outer perimeter. Assuming a circular bulge profile, the correction factor is easy to calculate and no parameter is needed.

Here is an example of how, with this patch, a 10x10 mm square peg (with rounded corners) fits tightly into a 10x10 mm square hole with quite good dimensional accuracy:

![h_id](https://cloud.githubusercontent.com/assets/3725313/3875737/ffc3dfd8-2154-11e4-8612-d4560e9d9162.jpeg)
![h_od](https://cloud.githubusercontent.com/assets/3725313/3875741/ffd49594-2154-11e4-9f61-395b4cd4f748.jpeg)
![p_od](https://cloud.githubusercontent.com/assets/3725313/3875740/ffc6b334-2154-11e4-9fbb-b761a44889f3.jpeg)
![fit2](https://cloud.githubusercontent.com/assets/3725313/3875738/ffc44b6c-2154-11e4-9bcd-32104285f371.jpeg)
![fit1](https://cloud.githubusercontent.com/assets/3725313/3875739/ffc5d388-2154-11e4-90ff-1edb46ab560a.jpeg)
