### PR TITLE
"*.STL" files might be STL files too

### DIFF
--- a/src/modelFile/modelFile.cpp
+++ b/src/modelFile/modelFile.cpp
@@ -149,7 +149,7 @@ SimpleModel* loadModelSTL(SimpleModel *m,const char* filename, FMatrix3x3& matri
 SimpleModel* loadModelFromFile(SimpleModel *m,const char* filename, FMatrix3x3& matrix)
 {
     const char* ext = strrchr(filename, '.');
-    if (ext && strcmp(ext, ".stl") == 0)
+    if (ext && stringcasecompare(ext, ".stl") == 0)
     {
         return loadModelSTL(m,filename, matrix);
     }


### PR DESCRIPTION
Makes STL file detection based on extension work case insensitive. Without
that patch, files named like "FILE.STL" or "file.StL" or ... couldn't be
sliced. CuraEngine quit attempts to do so with "Could not load file"
instead.
