### PR TITLE
Add Travis CI config to build & test CuraEngine on each commit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+language: c
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -qq gcc-4.9 g++-4.9
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 90
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
+  - gcc --version
+  - g++ --version
+
+script: "make && make test"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 CuraEngine
 ==========
+
+[![Travis Build Status](https://travis-ci.org/Ultimaker/CuraEngine.svg)](https://travis-ci.org/Ultimaker/CuraEngine)
+
 The CuraEngine is a C++ console application for 3D printing GCode generation. It has been made as a better and faster alternative to the old Skeinforge engine.
 
 The CuraEngine is pure C++ and uses Clipper from http://www.angusj.com/delphi/clipper.php


### PR DESCRIPTION
This CL adds a [Travis CI](https://travis-ci.org/) config to allow automatic builds on every commit and send an email, if the build is failed. It also adds a build status banner, like below:

[![Build Status](https://travis-ci.org/krasin/CuraEngine.svg)](https://travis-ci.org/krasin/CuraEngine)

The only difference is that the banner above points to my fork, and the banner proposed by this CL points to the not-yet-existing profile for Ultimaker.

This CL also opens a door for running automated tests on each commit.

To enable Travis CI on github.com/Ultimaker/CuraEngine, the following quick setup is needed:

1. Go to https://travis-ci.org/ and click "Sign in with GitHub" button in the upper right corner.
2. Grant the requested permissions (it will not ask for code access, just commit hooks/list emails/access project activity)
3. Go to https://travis-ci.org/profile and enable builds on Ultimaker/CuraEngine repository
4. Merge this CL and enjoy the reduced risk to break the build and not to get noticed.

Please, let me know, if this CL needs more clarification. I would be happy to address any concerns.
