### PR TITLE
Reset start position for new layers

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -471,6 +471,7 @@ private:
                 }
             }
             gcode.setZ(z);
+            gcode.resetStartPosition();
 
             bool printSupportFirst = (storage.support.generated && config.supportExtruder > 0 && config.supportExtruder == gcodeLayer.getExtruder());
             if (printSupportFirst)
@@ -579,7 +580,7 @@ private:
         }
 
 
-        PathOrderOptimizer partOrderOptimizer(gcode.getPositionXY());
+        PathOrderOptimizer partOrderOptimizer(gcode.getStartPositionXY());
         for(unsigned int partNr=0; partNr<layer->parts.size(); partNr++)
         {
             partOrderOptimizer.addPolygon(layer->parts[partNr].insets[0][0]);

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -11,7 +11,7 @@
 namespace cura {
 
 GCodeExport::GCodeExport()
-: currentPosition(0,0,0)
+: currentPosition(0,0,0), startPosition(INT32_MIN,INT32_MIN,0)
 {
     extrusionAmount = 0;
     extrusionPerMM = 0;
@@ -127,6 +127,17 @@ void GCodeExport::setZ(int z)
 Point GCodeExport::getPositionXY()
 {
     return Point(currentPosition.x, currentPosition.y);
+}
+
+void GCodeExport::resetStartPosition()
+{
+    startPosition.x = INT32_MIN;
+    startPosition.y = INT32_MIN;
+}
+
+Point GCodeExport::getStartPositionXY()
+{
+    return Point(startPosition.x, startPosition.y);
 }
 
 int GCodeExport::getPositionZ()
@@ -284,6 +295,7 @@ void GCodeExport::writeMove(Point p, int speed, int lineWidth)
     }
     
     currentPosition = Point3(p.X, p.Y, zPos);
+    startPosition = currentPosition;
     estimateCalculator.plan(TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), extrusionAmount), speed);
 }
 

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -27,6 +27,7 @@ private:
     double minimalExtrusionBeforeRetraction;
     double extrusionAmountAtPreviousRetraction;
     Point3 currentPosition;
+    Point3 startPosition;
     Point extruderOffset[MAX_EXTRUDERS];
     char extruderCharacter[MAX_EXTRUDERS];
     int currentSpeed, retractionSpeed;
@@ -67,6 +68,10 @@ public:
     
     Point getPositionXY();
     
+    void resetStartPosition();
+
+    Point getStartPositionXY();
+
     int getPositionZ();
 
     int getExtruderNr();


### PR DESCRIPTION
Reset the start position of the path optimizer for each new layer
so that it doesn't double up on the layers, causing problems for
cooling.
See also: http://umforum.ultimaker.com/index.php?/topic/8650-doubling-up-on-layers-bad-for-cooling/
