### PR TITLE
Fix wrong pull-request #134

### DIFF
--- a/src/optimizedModel.h
+++ b/src/optimizedModel.h
@@ -62,6 +62,7 @@ public:
         vMax = model->max();
 
         Point3 vOffset((vMin.x + vMax.x) / 2, (vMin.y + vMax.y) / 2, vMin.z);
+        vOffset -= center;
         if(ConfigSettings::config->autoCenter != 1)
         {
             vOffset.x = 0;
@@ -69,7 +70,6 @@ public:
             if(ConfigSettings::config->autoCenter == 2)
                 vOffset.z = 0;
         }
-        vOffset -= center;
         for(unsigned int i=0; i<volumes.size(); i++)
             for(unsigned int n=0; n<volumes[i].points.size(); n++)
                 volumes[i].points[n].p -= vOffset;


### PR DESCRIPTION
After updating to newer CuraEngine I got error reports that position was not honored as it should. Reason was Pull-Request #134 which rendered the disabling centering useless. This patch undoes the line position change that caused it.