### PR TITLE
New option: Add chamfer to bottom of models

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -254,7 +254,11 @@ private:
                 int extrusionWidth = config.extrusionWidth;
                 if (layerNr == 0)
                     extrusionWidth = config.layer0extrusionWidth;
-                generateInsets(layer, extrusionWidth, insetCount);
+
+                // add a chamfer to the bottom of the object to correct for bulging due to first layer squish
+                int shrink = std::max(0, config.bottomChamfer - layer->sliceZ);
+
+                generateInsets(layer, extrusionWidth, insetCount, shrink);
 
                 for(unsigned int partNr=0; partNr<layer->parts.size(); partNr++)
                 {

--- a/src/inset.cpp
+++ b/src/inset.cpp
@@ -4,7 +4,7 @@
 
 namespace cura {
 
-void generateInsets(SliceLayerPart* part, int offset, int insetCount)
+void generateInsets(SliceLayerPart* part, int offset, int insetCount, int shrink)
 {
     part->combBoundery = part->outline.offset(-offset);
     if (insetCount == 0)
@@ -16,7 +16,7 @@ void generateInsets(SliceLayerPart* part, int offset, int insetCount)
     for(int i=0; i<insetCount; i++)
     {
         part->insets.push_back(Polygons());
-        part->insets[i] = part->outline.offset(-offset * i - offset/2);
+        part->insets[i] = part->outline.offset(-offset * i - offset/2 - shrink);
         optimizePolygons(part->insets[i]);
         if (part->insets[i].size() < 1)
         {
@@ -26,11 +26,11 @@ void generateInsets(SliceLayerPart* part, int offset, int insetCount)
     }
 }
 
-void generateInsets(SliceLayer* layer, int offset, int insetCount)
+void generateInsets(SliceLayer* layer, int offset, int insetCount, int shrink)
 {
     for(unsigned int partNr = 0; partNr < layer->parts.size(); partNr++)
     {
-        generateInsets(&layer->parts[partNr], offset, insetCount);
+        generateInsets(&layer->parts[partNr], offset, insetCount, shrink);
     }
     
     //Remove the parts which did not generate an inset. As these parts are too small to print,

--- a/src/inset.h
+++ b/src/inset.h
@@ -6,9 +6,9 @@
 
 namespace cura {
 
-void generateInsets(SliceLayerPart* part, int offset, int insetCount);
+void generateInsets(SliceLayerPart* part, int offset, int insetCount, int shrink = 0);
 
-void generateInsets(SliceLayer* layer, int offset, int insetCount);
+void generateInsets(SliceLayer* layer, int offset, int insetCount, int shrink = 0);
 
 }//namespace cura
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -30,6 +30,7 @@ ConfigSettings::ConfigSettings()
     SETTING(skirtDistance, 6000);
     SETTING(skirtLineCount, 1);
     SETTING(skirtMinLength, 0);
+    SETTING(bottomChamfer, 0);
 
     SETTING(initialSpeedupLayers, 4);
     SETTING(initialLayerSpeed, 20);

--- a/src/settings.h
+++ b/src/settings.h
@@ -128,6 +128,7 @@ public:
     int skirtDistance;
     int skirtLineCount;
     int skirtMinLength;
+    int bottomChamfer;
 
     //Retraction settings
     int retractionAmount;


### PR DESCRIPTION
This merge request adds an option to add a (45°) chamfer to the bottom of each model. 0.5 mm is usually a good value. This can be used to eliminate oversized bottom layers due to squishing ("Elephant's foot"). A slightly larger chamfer also makes the model easier to remove from the bed.
