### PR TITLE
Add wipe after retract feature.

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -107,7 +107,7 @@ private:
             gcode.setExtruderOffset(n, config.extruderOffset[n].p());
         gcode.setSwitchExtruderCode(config.preSwitchExtruderCode, config.postSwitchExtruderCode);
         gcode.setFlavor(config.gcodeFlavor);
-        gcode.setRetractionSettings(config.retractionAmount, config.retractionSpeed, config.retractionAmountExtruderSwitch, config.minimalExtrusionBeforeRetraction, config.retractionZHop, config.retractionAmountPrime);
+        gcode.setRetractionSettings(config.retractionAmount, config.retractionSpeed, config.retractionAmountExtruderSwitch, config.minimalExtrusionBeforeRetraction, config.retractionZHop, config.retractionAmountPrime, config.retractionWipe);
     }
 
     bool prepareModel(SliceDataStorage& storage, const std::vector<std::string> &files)

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -23,6 +23,8 @@ private:
     double retractionAmount;
     double retractionAmountPrime;
     int retractionZHop;
+    int retractionWipe;
+    vector<Point> retractionWipePath;
     double extruderSwitchRetraction;
     double minimalExtrusionBeforeRetraction;
     double extrusionAmountAtPreviousRetraction;
@@ -62,7 +64,7 @@ public:
     
     void setExtrusion(int layerThickness, int filamentDiameter, int flow);
     
-    void setRetractionSettings(int retractionAmount, int retractionSpeed, int extruderSwitchRetraction, int minimalExtrusionBeforeRetraction, int zHop, int retractionAmountPrime);
+    void setRetractionSettings(int retractionAmount, int retractionSpeed, int extruderSwitchRetraction, int minimalExtrusionBeforeRetraction, int zHop, int retractionAmountPrime, int retractionWipe);
     
     void setZ(int z);
     

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -58,6 +58,7 @@ ConfigSettings::ConfigSettings()
     SETTING(retractionSpeed, 45);
     SETTING(retractionAmountExtruderSwitch, 14500);
     SETTING(retractionMinimalDistance, 1500);
+    SETTING(retractionWipe, 0);
     SETTING(minimalExtrusionBeforeRetraction, 100);
     SETTING(retractionZHop, 0);
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -145,6 +145,7 @@ public:
     int retractionAmountExtruderSwitch;
     int retractionSpeed;
     int retractionMinimalDistance;
+    int retractionWipe;
     int minimalExtrusionBeforeRetraction;
     int retractionZHop;
 


### PR DESCRIPTION
The setting retractionWipe > 0 enables this feature and defines the
length of the wipe move.  After a retract the head will retrace the
print path before doing the z-hop.  This can help with stringing on
difficult materials (e.g. nylon) and also allows for a larger z-hop
to keep the head from hitting the print on travel moves.
Reference this issue from a while ago: https://github.com/daid/Cura/issues/291