### PR TITLE
Wipe Tower Offset

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -1,3 +1,6 @@
+// Altered by Adrian Bowyer 6 February 2015
+// Code added to allow the user to position the wipe tower
+
 #ifndef FFF_PROCESSOR_H
 #define FFF_PROCESSOR_H
 
@@ -317,12 +320,12 @@ private:
         if (config.wipeTowerSize > 0)
         {
             PolygonRef p = storage.wipeTower.newPoly();
-            p.add(Point(storage.modelMin.x - 3000, storage.modelMax.y + 3000));
-            p.add(Point(storage.modelMin.x - 3000, storage.modelMax.y + 3000 + config.wipeTowerSize));
-            p.add(Point(storage.modelMin.x - 3000 - config.wipeTowerSize, storage.modelMax.y + 3000 + config.wipeTowerSize));
-            p.add(Point(storage.modelMin.x - 3000 - config.wipeTowerSize, storage.modelMax.y + 3000));
+            p.add(Point(storage.modelMin.x - config.wipeTowerX, storage.modelMax.y + config.wipeTowerY));
+            p.add(Point(storage.modelMin.x - config.wipeTowerX, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize));
+            p.add(Point(storage.modelMin.x - config.wipeTowerX - config.wipeTowerSize, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize));
+            p.add(Point(storage.modelMin.x - config.wipeTowerX - config.wipeTowerSize, storage.modelMax.y + config.wipeTowerY));
 
-            storage.wipePoint = Point(storage.modelMin.x - 3000 - config.wipeTowerSize / 2, storage.modelMax.y + 3000 + config.wipeTowerSize / 2);
+            storage.wipePoint = Point(storage.modelMin.x - config.wipeTowerX - config.wipeTowerSize / 2, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize / 2);
         }
 
         if (config.raftBaseThickness > 0 && config.raftInterfaceThickness > 0)

--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -320,12 +320,12 @@ private:
         if (config.wipeTowerSize > 0)
         {
             PolygonRef p = storage.wipeTower.newPoly();
-            p.add(Point(storage.modelMin.x - config.wipeTowerX, storage.modelMax.y + config.wipeTowerY));
-            p.add(Point(storage.modelMin.x - config.wipeTowerX, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize));
-            p.add(Point(storage.modelMin.x - config.wipeTowerX - config.wipeTowerSize, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize));
-            p.add(Point(storage.modelMin.x - config.wipeTowerX - config.wipeTowerSize, storage.modelMax.y + config.wipeTowerY));
+            p.add(Point(storage.modelMin.x + config.wipeTowerX, storage.modelMax.y + config.wipeTowerY));
+            p.add(Point(storage.modelMin.x + config.wipeTowerX, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize));
+            p.add(Point(storage.modelMin.x + config.wipeTowerX - config.wipeTowerSize, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize));
+            p.add(Point(storage.modelMin.x + config.wipeTowerX - config.wipeTowerSize, storage.modelMax.y + config.wipeTowerY));
 
-            storage.wipePoint = Point(storage.modelMin.x - config.wipeTowerX - config.wipeTowerSize / 2, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize / 2);
+            storage.wipePoint = Point(storage.modelMin.x + config.wipeTowerX - config.wipeTowerSize / 2, storage.modelMax.y + config.wipeTowerY + config.wipeTowerSize / 2);
         }
 
         if (config.raftBaseThickness > 0 && config.raftInterfaceThickness > 0)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,3 +1,6 @@
+// Altered by Adrian Bowyer 6 February 2015
+// Code added to allow the user to position the wipe tower
+
 #include <cctype>
 #include <fstream>
 #include <stdio.h>
@@ -64,6 +67,8 @@ ConfigSettings::ConfigSettings()
     SETTING(enableCombing, COMBING_ALL);
     SETTING(enableOozeShield, 0);
     SETTING(wipeTowerSize, 0);
+    SETTING(wipeTowerX, 3000);
+    SETTING(wipeTowerY, 3000);
     SETTING(multiVolumeOverlap, 0);
     SETTING2(objectPosition.X, posx, 102500);
     SETTING2(objectPosition.Y, posy, 102500);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -67,7 +67,7 @@ ConfigSettings::ConfigSettings()
     SETTING(enableCombing, COMBING_ALL);
     SETTING(enableOozeShield, 0);
     SETTING(wipeTowerSize, 0);
-    SETTING(wipeTowerX, 3000);
+    SETTING(wipeTowerX, -3000);
     SETTING(wipeTowerY, 3000);
     SETTING(multiVolumeOverlap, 0);
     SETTING2(objectPosition.X, posx, 102500);

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,3 +1,6 @@
+// Altered by Adrian Bowyer 6 February 2015
+// Code added to allow the user to position the wipe tower
+
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
@@ -151,6 +154,8 @@ public:
     int enableCombing;
     int enableOozeShield;
     int wipeTowerSize;
+    int wipeTowerX;
+    int wipeTowerY;
     int multiVolumeOverlap;
 
     int initialSpeedupLayers;


### PR DESCRIPTION
This commit of our CuraEngine fork allows the user optionally to reposition the wipe tower.  This is useful for big prints that go near to the edge of the build bed becuase it allows you to put the tower in any unused place in the print.
