### PR TITLE
Add option to change print order of infill vs perimeters. Default prints...

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -44,6 +44,7 @@ ConfigSettings::ConfigSettings()
     SETTING(infillSpeed, 50);
     SETTING(infillPattern, INFILL_AUTOMATIC);
     SETTING(skinSpeed, 50);
+    SETTING(perimeterBeforeInfill, 0);
 
     SETTING(supportType, SUPPORT_TYPE_GRID);
     SETTING(supportAngle, -1);

--- a/src/settings.h
+++ b/src/settings.h
@@ -167,6 +167,7 @@ public:
     int infillSpeed;
     int infillPattern;
     int skinSpeed;
+    int perimeterBeforeInfill;
 
     //Support material
     int supportType;


### PR DESCRIPTION
... infill first as was changed in v15, but this can lead to surface quality issues where infill would show on surface. This adds the option to change the order.

See issue daid/Cura#1159

Another pull request for Cura to follow.