### PR TITLE
Fix retracts with dual extruder

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -764,7 +764,8 @@ private:
         if (config.wipeTowerSize < 1)
             return;
         //If we changed extruder, print the wipe/prime tower for this nozzle;
-        gcodeLayer.setAlwaysRetract(true);
+        if (config.enableCombing)
+            gcodeLayer.setCombBoundary(&storage.wipeTower);
         gcodeLayer.addPolygonsByOptimizer(storage.wipeTower, &supportConfig);
         Polygons fillPolygons;
         generateLineInfill(storage.wipeTower, fillPolygons, config.extrusionWidth, config.extrusionWidth, config.infillOverlap, 45 + 90 * (layerNr % 2));
@@ -772,7 +773,7 @@ private:
 
         //Make sure we wipe the old extruder on the wipe tower.
         gcodeLayer.addTravel(storage.wipePoint - config.extruderOffset[prevExtruder].p() + config.extruderOffset[gcodeLayer.getExtruder()].p());
-        gcodeLayer.setAlwaysRetract(!config.enableCombing);
+        gcodeLayer.setCombBoundary(nullptr);
     }
 };
 

--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -764,6 +764,7 @@ private:
         if (config.wipeTowerSize < 1)
             return;
         //If we changed extruder, print the wipe/prime tower for this nozzle;
+        gcodeLayer.setAlwaysRetract(true);
         gcodeLayer.addPolygonsByOptimizer(storage.wipeTower, &supportConfig);
         Polygons fillPolygons;
         generateLineInfill(storage.wipeTower, fillPolygons, config.extrusionWidth, config.extrusionWidth, config.infillOverlap, 45 + 90 * (layerNr % 2));
@@ -771,6 +772,7 @@ private:
 
         //Make sure we wipe the old extruder on the wipe tower.
         gcodeLayer.addTravel(storage.wipePoint - config.extruderOffset[prevExtruder].p() + config.extruderOffset[gcodeLayer.getExtruder()].p());
+        gcodeLayer.setAlwaysRetract(!config.enableCombing);
     }
 };
 


### PR DESCRIPTION
Just before moving to the wipe tower, the filament change retract is used
for the travel move instead of the normal retract.  This is
especially a problem with the wipe/prime tower.  Fix this so the
correct retract is used for the travel move, and the filament
retract difference is set after that.