### PR TITLE
Update README to display build steps as list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ How to Install
 
 In order to compile CuraEngine, either use CMake or start a project in your preferred IDE. 
 CMake compilation:
+
 1. Navigate to the CuraEngine directory and execute the following commands
 2. $ mkdir build && cd build
 3. $ cmake ..


### PR DESCRIPTION
This way the steps show up as a list and stand out so it's easier to see. I'm pretty sure this was the way it was meant to be but the missing new line rendered everything inline on the github page. 