### PR TITLE
Infinite loop in cura::FffPolygonGenerator::processDraftShield

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -341,7 +341,7 @@ void FffPolygonGenerator::processDraftShield(SliceDataStorage& storage, unsigned
     
     unsigned int max_screen_layer = (draft_shield_height - layer_height_0) / layer_height + 1;
     
-    int layer_skip = 200 / layer_height + 1;
+    int layer_skip = 100 / layer_height + 1;
     
     Polygons& draft_shield = storage.draft_protection_shield;
     for (unsigned int layer_nr = 0; layer_nr < totalLayers && layer_nr < max_screen_layer; layer_nr += layer_skip)

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -339,9 +339,9 @@ void FffPolygonGenerator::processDraftShield(SliceDataStorage& storage, unsigned
         return;
     }
     
-    int max_screen_layer = (draft_shield_height - layer_height_0) / layer_height + 1;
+    unsigned int max_screen_layer = (draft_shield_height - layer_height_0) / layer_height + 1;
     
-    int layer_skip = 200 / layer_height;
+    int layer_skip = 200 / layer_height + 1;
     
     Polygons& draft_shield = storage.draft_protection_shield;
     for (unsigned int layer_nr = 0; layer_nr < totalLayers && layer_nr < max_screen_layer; layer_nr += layer_skip)


### PR DESCRIPTION
When specifying Platform Adhesion = Brim and Draft Shield Height = 0.8 (which is the height of the first layer), the system enters an infinite loop.

If I understood the source code, `layer_skip` is an optimization to speed up process, but there is no increment after the "skip" in the following loop. This is why I added one to the value of `layer_skip`.

I also changed an `int` into `unsigned int`, to suppress a compiler warning.