### PR TITLE
send travel moves to GUI from GCodeExport

### DIFF
--- a/Cura.proto
+++ b/Cura.proto
@@ -62,6 +62,8 @@ message Polygon {
         SkirtType = 5;
         InfillType = 6;
         SupportInfillType = 7;
+        MoveCombingType = 8;
+        MoveRetractionType = 9;
     }
     Type type = 1;
     bytes points = 2;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -257,7 +257,7 @@ void FffGcodeWriter::processRaft(SliceDataStorage& storage, unsigned int totalLa
     { // raft base layer
         gcode.writeLayerComment(-3);
         gcode.writeComment("RAFT");
-        GCodePlanner gcode_layer(gcode, storage, &storage.retraction_config_per_extruder[extruder_nr], train->getSettingInMillimetersPerSecond("speed_travel"), retraction_combing, 0, train->getSettingInMicrons("machine_nozzle_size"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
+        GCodePlanner gcode_layer(command_socket, gcode, storage, &storage.retraction_config_per_extruder[extruder_nr], train->getSettingInMillimetersPerSecond("speed_travel"), retraction_combing, 0, train->getSettingInMicrons("machine_nozzle_size"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
         gcode_layer.setCombing(false);
         if (getSettingAsIndex("adhesion_extruder_nr") > 0)
             gcode_layer.setExtruder(extruder_nr);
@@ -276,7 +276,7 @@ void FffGcodeWriter::processRaft(SliceDataStorage& storage, unsigned int totalLa
     { // raft interface layer
         gcode.writeLayerComment(-2);
         gcode.writeComment("RAFT");
-        GCodePlanner gcode_layer(gcode, storage, &storage.retraction_config_per_extruder[extruder_nr], train->getSettingInMillimetersPerSecond("speed_travel"), retraction_combing, 0, train->getSettingInMicrons("machine_nozzle_size"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
+        GCodePlanner gcode_layer(command_socket, gcode, storage, &storage.retraction_config_per_extruder[extruder_nr], train->getSettingInMillimetersPerSecond("speed_travel"), retraction_combing, 0, train->getSettingInMicrons("machine_nozzle_size"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
         gcode_layer.setCombing(false);
         gcode.setZ(train->getSettingInMicrons("raft_base_thickness") + train->getSettingInMicrons("raft_interface_thickness"));
 
@@ -292,7 +292,7 @@ void FffGcodeWriter::processRaft(SliceDataStorage& storage, unsigned int totalLa
     { // raft surface layers
         gcode.writeLayerComment(-1);
         gcode.writeComment("RAFT");
-        GCodePlanner gcode_layer(gcode, storage, &storage.retraction_config_per_extruder[extruder_nr], train->getSettingInMillimetersPerSecond("speed_travel"), retraction_combing, 0, train->getSettingInMicrons("machine_nozzle_size"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
+        GCodePlanner gcode_layer(command_socket, gcode, storage, &storage.retraction_config_per_extruder[extruder_nr], train->getSettingInMillimetersPerSecond("speed_travel"), retraction_combing, 0, train->getSettingInMicrons("machine_nozzle_size"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
         gcode_layer.setCombing(false);
         gcode.setZ(train->getSettingInMicrons("raft_base_thickness") + train->getSettingInMicrons("raft_interface_thickness") + train->getSettingInMicrons("raft_surface_thickness")*raftSurfaceLayer);
 
@@ -335,7 +335,7 @@ void FffGcodeWriter::processLayer(SliceDataStorage& storage, unsigned int layer_
     gcode.writeLayerComment(layer_nr);
 
     int64_t comb_offset_from_outlines = storage.meshgroup->getExtruderTrain(gcode.getExtruderNr())->getSettingInMicrons("machine_nozzle_size") * 2; // TODO: only used when there is no second wall.
-    GCodePlanner gcode_layer(gcode, storage, &storage.retraction_config, getSettingInMillimetersPerSecond("speed_travel"), getSettingBoolean("retraction_combing"), layer_nr, comb_offset_from_outlines, getSettingBoolean("travel_avoid_other_parts"), getSettingInMicrons("travel_avoid_distance"));
+    GCodePlanner gcode_layer(command_socket, gcode, storage, &storage.retraction_config, getSettingInMillimetersPerSecond("speed_travel"), getSettingBoolean("retraction_combing"), layer_nr, comb_offset_from_outlines, getSettingBoolean("travel_avoid_other_parts"), getSettingInMicrons("travel_avoid_distance"));
 
     int z = storage.meshes[0].layers[layer_nr].printZ;         
     gcode.setZ(z);

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -8,7 +8,7 @@
 namespace cura {
 
 GCodeExport::GCodeExport()
-: output_stream(&std::cout), currentPosition(0,0,0), startPosition(INT32_MIN,INT32_MIN,0)
+: commandSocket(nullptr), output_stream(&std::cout), layer_nr(0), currentPosition(0,0,0), startPosition(INT32_MIN,INT32_MIN,0)
 {
     extrusion_amount = 0;
     current_extruder = 0;
@@ -26,6 +26,11 @@ GCodeExport::GCodeExport()
 
 GCodeExport::~GCodeExport()
 {
+}
+
+void GCodeExport::setCommandSocketAndLayerNr(CommandSocket* commandSocket_, unsigned int layer_nr_) {
+    commandSocket = commandSocket_;
+    layer_nr = layer_nr_;
 }
 
 void GCodeExport::setOutputStream(std::ostream* stream)
@@ -325,6 +330,15 @@ void GCodeExport::writeMove(int x, int y, int z, double speed, double extrusion_
             *output_stream << "G1";
         }else{
             *output_stream << "G0";
+                    
+            if (commandSocket) {
+                // we should send this travel as a non-retraction move
+                cura::Polygons travelPoly;
+                PolygonRef travel = travelPoly.newPoly();
+                travel.add(Point(currentPosition.x, currentPosition.y));
+                travel.add(Point(x, y));
+                commandSocket->sendPolygons(isRetracted ? MoveRetractionType : MoveCombingType, layer_nr, travelPoly, MM2INT(0.1));
+            }                    
         }
 
         if (currentSpeed != speed)

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -337,7 +337,7 @@ void GCodeExport::writeMove(int x, int y, int z, double speed, double extrusion_
                 PolygonRef travel = travelPoly.newPoly();
                 travel.add(Point(currentPosition.x, currentPosition.y));
                 travel.add(Point(x, y));
-                commandSocket->sendPolygons(isRetracted ? MoveRetractionType : MoveCombingType, layer_nr, travelPoly, MM2INT(0.1));
+                commandSocket->sendPolygons(isRetracted ? MoveRetractionType : MoveCombingType, layer_nr, travelPoly, isRetracted ? MM2INT(0.2) : MM2INT(0.1));
             }                    
         }
 

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -11,6 +11,7 @@
 #include "timeEstimate.h"
 #include "MeshGroup.h"
 #include "PrintFeature.h"
+#include "commandSocket.h"
 
 namespace cura {
 
@@ -163,10 +164,17 @@ private:
     TimeEstimateCalculator estimateCalculator;
     
     bool is_volumatric;
+
+    // for sending jump data
+    CommandSocket* commandSocket; 
+    unsigned int layer_nr;
+    
 public:
     
     GCodeExport();
     ~GCodeExport();
+    
+    void setCommandSocketAndLayerNr(CommandSocket* commandSocket, unsigned int layer_nr);
     
     void setOutputStream(std::ostream* stream);
     

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -31,10 +31,11 @@ void GCodePlanner::forceNewPathStart()
         paths[paths.size()-1].done = true;
 }
 
-GCodePlanner::GCodePlanner(GCodeExport& gcode, SliceDataStorage& storage, RetractionConfig* retraction_config_travel, double travelSpeed, bool retraction_combing, unsigned int layer_nr, int64_t comb_boundary_offset, bool travel_avoid_other_parts, int64_t travel_avoid_distance)
+GCodePlanner::GCodePlanner(CommandSocket* commandSocket, GCodeExport& gcode, SliceDataStorage& storage, RetractionConfig* retraction_config_travel, double travelSpeed, bool retraction_combing, unsigned int layer_nr, int64_t comb_boundary_offset, bool travel_avoid_other_parts, int64_t travel_avoid_distance)
 : gcode(gcode), storage(storage)
 , travelConfig(retraction_config_travel, "MOVE")
 {
+    gcode.setCommandSocketAndLayerNr(commandSocket, layer_nr);
     lastPosition = gcode.getPositionXY();
     travelConfig.setSpeed(travelSpeed);
     comb = nullptr;

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -8,6 +8,7 @@
 #include "utils/polygon.h"
 #include "utils/logoutput.h"
 #include "wallOverlap.h"
+#include "commandSocket.h"
 
 
 namespace cura 
@@ -87,7 +88,7 @@ public:
      * \param travel_avoid_other_parts Whether to avoid other layer parts when travaeling through air.
      * \param travel_avoid_distance The distance by which to avoid other layer parts when traveling through air.
      */
-    GCodePlanner(GCodeExport& gcode, SliceDataStorage& storage, RetractionConfig* retraction_config_travel, double travelSpeed, bool retraction_combing, unsigned int layer_nr, int64_t comb_boundary_offset, bool travel_avoid_other_parts, int64_t travel_avoid_distance);
+    GCodePlanner(CommandSocket* commandSocket, GCodeExport& gcode, SliceDataStorage& storage, RetractionConfig* retraction_config_travel, double travelSpeed, bool retraction_combing, unsigned int layer_nr, int64_t comb_boundary_offset, bool travel_avoid_other_parts, int64_t travel_avoid_distance);
     ~GCodePlanner();
 
     void setCombing(bool going_to_comb);

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -30,7 +30,9 @@ enum PolygonType
     SupportType,
     SkirtType,
     InfillType,
-    SupportInfillType
+    SupportInfillType,
+    MoveCombingType,
+    MoveRetractionType
 };
 
 


### PR DESCRIPTION
This will re-add the move/retraction view that Cura 15.04.2 had. I decided to send the travel moves as low-level as possible, which means they are being sent from the GCodeExport class. Use with https://github.com/Ultimaker/Cura/pull/410