### PR TITLE
always retract when combing is disabled

### DIFF
--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -165,6 +165,12 @@ void GCodePlanner::addTravel(Point p)
         was_combing = is_going_to_comb;
     }
     
+    if(comb == nullptr) {
+        // no combing? always retract!
+        path = getLatestPathWithConfig(&travelConfig);
+        path->retract = true;
+    }
+    
     addTravel_simple(p, path);
 }
 


### PR DESCRIPTION
Due to my new travel path display (https://github.com/Ultimaker/Cura/pull/410), I noticed that when I disable combing, that CuraEngine will refuse to do any retraction at all. So that means that "combing=no" and "retraction=yes" would yield exactly the same result as "retraction=no". Attached is a small patch so that the GCodePlanner will always advise a rectraction if combing is disabled. If both retraction and combing are disabled, the GCodeExporter will then ignore the advised retractions and issue moves.

Old behaviour:
retraction=yes combing=no 
=> no retractions at all

New behaviour:
retraction=yes combing=no
=> will retract for every move
