### PR TITLE
Keep Z-Hop active for multi-step moves

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -19,7 +19,7 @@ GCodeExport::GCodeExport()
     currentSpeed = 1;
     retractionPrimeSpeed = 1;
     isRetracted = false;
-    isZHopped = false;
+    isZHopped = 0;
     last_coasted_amount_mm3 = 0;
     setFlavor(EGCodeFlavor::REPRAP);
 }
@@ -294,7 +294,7 @@ void GCodeExport::writeMove(int x, int y, int z, double speed, double extrusion_
             if (isZHopped > 0)
             {
                 *output_stream << std::setprecision(3) << "G1 Z" << INT2MM(currentPosition.z) << "\n";
-                isZHopped = false;
+                isZHopped = 0;
             }
             extrusion_amount += (is_volumatric) ? last_coasted_amount_mm3 : last_coasted_amount_mm3 / getFilamentArea(current_extruder);   
             if (isRetracted)
@@ -351,7 +351,7 @@ void GCodeExport::writeMove(int x, int y, int z, double speed, double extrusion_
             " X" << INT2MM(gcode_pos.X) << 
             " Y" << INT2MM(gcode_pos.Y);
         if (z != currentPosition.z)
-            *output_stream << " Z" << INT2MM(z);
+            *output_stream << " Z" << INT2MM(z + isZHopped);
         if (extrusion_mm3_per_mm > 0.000001)
             *output_stream << " " << extruder_attr[current_extruder].extruderCharacter << std::setprecision(5) << extrusion_amount;
         *output_stream << "\n";
@@ -394,8 +394,8 @@ void GCodeExport::writeRetraction(RetractionConfig* config, bool force)
     }
     if (config->zHop > 0)
     {
-        *output_stream << std::setprecision(3) << "G1 Z" << INT2MM(currentPosition.z + config->zHop) << "\n";
-        isZHopped = true;
+        isZHopped = config->zHop;
+        *output_stream << std::setprecision(3) << "G1 Z" << INT2MM(currentPosition.z + isZHopped) << "\n";
     }
     extrusion_amount_at_previous_n_retractions.push_front(extrusion_amount);
     if (int(extrusion_amount_at_previous_n_retractions.size()) == config->retraction_count_max)

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -151,7 +151,7 @@ private:
     double currentSpeed;
     int zPos;
     bool isRetracted;
-    bool isZHopped;
+    double isZHopped;
 
     double last_coasted_amount_mm3; //!< The coasted amount of filament to be primed on the first next extrusion. (same type as GCodeExport::extrusion_amount)
     double retractionPrimeSpeed;

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -151,7 +151,7 @@ private:
     double currentSpeed;
     int zPos;
     bool isRetracted;
-    double isZHopped;
+    int isZHopped;
 
     double last_coasted_amount_mm3; //!< The coasted amount of filament to be primed on the first next extrusion. (same type as GCodeExport::extrusion_amount)
     double retractionPrimeSpeed;


### PR DESCRIPTION
I noticed that even with an extremely high z-hop like 1mm, my nozzle would sometimes:
1. retract
2. move up the 1mm
3. then move diagonally down and towards the retraction target point
4. if the retraction target point is close to the wall, the nozzle would already be very low there, as if no z-hop was enabled, and basically scrub over the wall

I tracked this down to the fact that if a non-extrusion move with Z change is issued during the retraction, then that Z value is used directly, which causes the diagonal down move I described in (3). So the fix is super easy: store the current Z-hop height and apply it to every non-extrusion move. 

That way, the nozzle will move over the retraction target point and then move down on top of the target point. This prevents the nozzle from scratching the wall.

Old GCODE example (with 2mm zhop to show the effect):
G10
G1 Z6.200
G0 X112.242 Y102.096 Z6.100
G1 Z6.100
G11
(as you can see, the G0 moves down diagonally)

New GCODE:
G10
G1 Z6.200
G0 X112.242 Y102.096 Z6.300
G1 Z6.100
G11
(here, G0 moves up diagonally to ensure that the zhop distance is kept from the surface)