### PR TITLE
fix retraction for isles < 0.8mm radius

### DIFF
--- a/src/comb.cpp
+++ b/src/comb.cpp
@@ -20,14 +20,26 @@ Polygons Comb::getLayerSecondWalls()
     {
         for (SliceLayerPart& part : mesh.layers[layer_nr].parts)
         {
-            if (part.insets.size() >= 2)
-            {
+            // we want the 2nd inner walls
+            if (part.insets.size() >= 2) {
                 layer_walls.add(part.insets[1]);
+                continue;
             }
-            else 
-            {
-                layer_walls.add(part.outline.offset(-offset_from_outlines));
+            // but we'll also take the inner wall if the 2nd doesn't exist
+            if (part.insets.size() >= 1) {
+                layer_walls.add(part.insets[0]);
+                continue;
             }
+            // and if there is no walls, we'll try to move inside from the outline
+            Polygons newOutline = part.outline.offset(-offset_from_outlines);
+            if(newOutline.polygonLength() > 0) {
+                layer_walls.add(newOutline);
+                continue;
+            }
+            // offset_from_outlines was so large that it completely destroyed our isle,
+            // so we'll just use the regular outline
+            layer_walls.add(part.outline);
+            continue;
         }
     }
     return layer_walls;

--- a/src/comb.cpp
+++ b/src/comb.cpp
@@ -64,7 +64,7 @@ Comb::~Comb()
         delete boundary_outside;
 }
 
-bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool startInside, bool endInside)
+bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool startInside, bool endInside, int64_t max_comb_distance_ignored)
 {
     if (shorterThen(endPoint - startPoint, max_comb_distance_ignored))
     {
@@ -117,7 +117,7 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool sta
     { // normal combing within part
         PolygonsPart part = partsView_inside.assemblePart(start_part_idx);
         combPaths.emplace_back();
-        LinePolygonsCrossings::comb(part, startPoint, endPoint, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside);
+        LinePolygonsCrossings::comb(part, startPoint, endPoint, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored);
         return true;
     }
     else 
@@ -159,7 +159,7 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool sta
             // start to boundary
             PolygonsPart part_begin = partsView_inside.assemblePart(start_part_idx); // comb through the starting part only
             combPaths.emplace_back();
-            LinePolygonsCrossings::comb(part_begin, startPoint, middle_from, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside);
+            LinePolygonsCrossings::comb(part_begin, startPoint, middle_from, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored);
         }
         
         // throught air from boundary to boundary
@@ -185,7 +185,7 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool sta
             }
             else
             {
-                LinePolygonsCrossings::comb(middle, from_outside, to_outside, combPaths.back(), offset_dist_to_get_from_on_the_polygon_to_outside);
+                LinePolygonsCrossings::comb(middle, from_outside, to_outside, combPaths.back(), offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored);
             }
         }
         else 
@@ -202,7 +202,7 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool sta
             // boundary to end
             PolygonsPart part_end = partsView_inside.assemblePart(end_part_idx); // comb through end part only
             combPaths.emplace_back();
-            LinePolygonsCrossings::comb(part_end, middle_to, endPoint, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside);
+            LinePolygonsCrossings::comb(part_end, middle_to, endPoint, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored);
         }
         
         return true;
@@ -276,9 +276,9 @@ bool LinePolygonsCrossings::lineSegmentCollidesWithBoundary()
 }
 
 
-void LinePolygonsCrossings::getCombingPath(CombPath& combPath)
+void LinePolygonsCrossings::getCombingPath(CombPath& combPath, int64_t max_comb_distance_ignored)
 {
-    if (shorterThen(endPoint - startPoint, Comb::max_comb_distance_ignored) || !lineSegmentCollidesWithBoundary())
+    if (shorterThen(endPoint - startPoint, max_comb_distance_ignored) || !lineSegmentCollidesWithBoundary())
     {
         //We're not crossing any boundaries. So skip the comb generation.
         combPath.push_back(startPoint); 

--- a/src/comb.h
+++ b/src/comb.h
@@ -113,7 +113,7 @@ private:
      * 
      * \param combPath Output parameter: the points along the combing path.
      */
-    void getCombingPath(CombPath& combPath);
+    void getCombingPath(CombPath& combPath, int64_t max_comb_distance_ignored = MM2INT(1.5));
     
     /*! 
      * Get the basic combing path, without shortcuts. The path goes straight toward the endPoint and follows the boundary when it hits it, until it passes the scanline again.
@@ -178,10 +178,10 @@ public:
      * \param endPoint Where to end the combing move.
      * \param combPath Output parameter: the combing path generated.
      */
-    static void comb(Polygons& boundary, Point startPoint, Point endPoint, CombPath& combPath, int64_t dist_to_move_boundary_point_outside)
+    static void comb(Polygons& boundary, Point startPoint, Point endPoint, CombPath& combPath, int64_t dist_to_move_boundary_point_outside, int64_t max_comb_distance_ignored = MM2INT(1.5))
     {
         LinePolygonsCrossings linePolygonsCrossings(boundary, startPoint, endPoint, dist_to_move_boundary_point_outside);
-        linePolygonsCrossings.getCombingPath(combPath);
+        linePolygonsCrossings.getCombingPath(combPath, max_comb_distance_ignored);
     };
 };
 
@@ -212,7 +212,6 @@ private:
     int64_t offset_from_outlines_outside; //!< Offset from the boundary of a part to a travel path which avoids it by this distance.
     static const int64_t max_moveOutside_distance2 = INT64_MAX; //!< Any point which is not inside should be considered outside.
     static const int64_t offset_dist_to_get_from_on_the_polygon_to_outside = 40; //!< in order to prevent on-boundary vs crossing boundary confusions (precision thing)
-    static const int64_t max_comb_distance_ignored = MM2INT(1.5); //!< If the direct path from start point to end point is shorter than this, go directly without any combing.
     static const int64_t offset_extra_start_end = 100; //!< Distance to move start point and end point toward eachother to extra avoid collision with the boundaries.
     
     bool avoid_other_parts; //!< Whether to perform inverse combing a.k.a. avoid parts.
@@ -257,7 +256,7 @@ public:
      * \param endInside Whether we want to end up inside the comb boundary
      * \return Whether combing has succeeded; otherwise a retraction is needed.
      */    
-    bool calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool startInside = false, bool endInside = false);
+    bool calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool startInside = false, bool endInside = false, int64_t max_comb_distance_ignored = MM2INT(1.5));
     
     /*!
      * Move \p p to inside the inner comb boundary with a \p distance from the boundary.

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -113,7 +113,7 @@ void GCodePlanner::addTravel(Point p)
     if (comb != nullptr && lastPosition != Point(0,0))
     {
         CombPaths combPaths;
-        if (comb->calc(lastPosition, p, combPaths, was_combing, is_going_to_comb))
+        if (comb->calc(lastPosition, p, combPaths, was_combing, is_going_to_comb, last_retraction_config->retraction_min_travel_distance))
         {
             bool retract = combPaths.size() > 1;
             { // check whether we want to retract


### PR DESCRIPTION
Please take a look at this screenshot:
<img width="1201" alt="screen shot 2015-09-21 at 11 50 31" src="https://cloud.githubusercontent.com/assets/417520/9991613/d2693e0a-606b-11e5-8c51-09d904f0cfc7.png">

The retraction minimum travel and minimum extrusion distance are both set to 0. Combing is enabled. So with those settings, I would expect CuraEngine to retract for any move that cannot be combed. But if you look at the area that I marked with the purple box, you see that there is a thin dark blue line between the red column and the main tower. I added the blue lines with https://github.com/Ultimaker/Cura/pull/410 and https://github.com/Ultimaker/CuraEngine/pull/242 so the thin blue line there shows is that the GCodeExport class from CuraEngine did NOT emit a retraction.

So to summarize: I setup the settings so that CuraEngine should retract for ANY jump that cannot be combed.. but it clearly failed to do so.

Here's a screenshot of the same slice after applying this patch:
<img width="1246" alt="screen shot 2015-09-21 at 14 16 11" src="https://cloud.githubusercontent.com/assets/417520/9991644/27eaa094-606c-11e5-85fb-e2a76bd81290.png">
As you can see, CuraEngine is now correctly doing retracted jumps (thick light blue lines) for everything that moves to or from the small side columns. 

I tracked the erroneous behavior in the unpatched CuraEngine down to two issues:

1. There was a hardcoded Comb::max_comb_distance_ignored = 1.5mm threshold in the Comb class. This alone prevents CuraEngine from handling any retraction shorter than 1.5mm correctly, which kind of defeats the whole purpose of the retraction_min_travel_distance user-configurable setting. So I replaced the hardcoded constant with a variable, which is now initialized to retraction_min_travel_distance. After this change, CuraEngine now correctly analyzes retractions, if the min travel distance is set below 1.5mm by the user. But that alone wasn't sufficient to get a correct slicing for my test object.

2. Comb::getLayerSecondWalls was implemented to either use the 2nd perimeter line OR to move offset_from_outlines from the outline of the object. offset_from_outlines is hardcoded to be 2*nozzle_size, which in my case would be 0.8mm. So the getLayerSecondWalls function would try to move the outline inside by 0.8mm for every isle that doesn't have at least 2 perimeter lines. In my object, the column radius is about 0.5mm, which means that getLayerSecondWalls reduced it to.. NOTHING. That's why CuraEngine wasn't emitting correct retraction jumps for my columns, even after fix (1).. because the getLayerSecondWalls was removing my small isles. So I reworked getLayerSecondWalls to:
2a. first try to use the 2nd perimeter line, like before
2b. then try to use the 1st perimeter line, if the object is too thin to have 2 perimeter lines
2c. third try to move the object outline inside by 0.8mm, like before. But only use this result, if there's any object left.
2.d if the isle is so small that we didn't find any point inside to jump to.. just use the outline directly


For any user that retains the default value of 1.5mm for retraction min travel, this patch should not change anything, because the constant that I replaced also had a hardcoded value of 1.5mm. But for retraction min travel values that are below 1.5mm, this patch will prevent CuraEngine from "overlooking" air gaps. And as you can see in the screenshots, for my test object, that makes the difference between randomly "combing" through thin air and retracting as it should. 
