### PR TITLE
Re-nable layer count using a consistent tag name

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -36,7 +36,7 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
     meshgroup_number++;
 
     unsigned int total_layers = storage.meshes[0].layers.size();
-    //gcode.writeComment("Layer count: %d", totalLayers);
+    gcode.writeComment("LAYER_COUNT: %d", totalLayers);
 
     bool has_raft = getSettingAsPlatformAdhesion("adhesion_type") == EPlatformAdhesion::RAFT;
     if (has_raft)


### PR DESCRIPTION
Patch a9db2813 disabled the Layer count comment as it was 'just a comment'. Re-enable it with a proper cased tag name so it can be used for very rough print time estimation purely based on layers.

Signed-off-by: Olliver Schinagl <o.schinagl@ultimaker.com>