### PR TITLE
Explicitly write a \n when finding a new line in a comment

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -172,7 +172,17 @@ void GCodeExport::updateTotalPrintTime(EPrintFeature print_feature)
 
 void GCodeExport::writeComment(std::string comment)
 {
-    *output_stream << ";" << comment << "\n";
+    *output_stream << ";";
+    for (unsigned int i = 0; i < comment.length(); i++)
+    {
+        if (comment[i] == '\n')
+        {
+            *output_stream << "\\n";
+        }else{
+            *output_stream << comment[i];
+        }
+    }
+    *output_stream << "\n";
 }
 
 void GCodeExport::writeTypeComment(const char* type)


### PR DESCRIPTION
This way the start_gcode and end_gcode that includes '\n's will not
have their commands executed since they now appear as commented out, within the same line.

Solves https://github.com/Ultimaker/Cura/issues/459 .