### PR TITLE
Accepts 'help' as a known command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,6 +317,11 @@ int main(int argc, char **argv)
     {
         slice(argc, argv);
     }
+    else if (stringcasecompare(argv[1], "help") == 0)
+    {
+        print_usage();
+        exit(0);
+    }
     else
     {
         cura::logError("Unknown command: %s\n", argv[1]);


### PR DESCRIPTION
'help' was being considered an unknown command and it also returned 1 as a return code when running './CuraEngine help'. If you agree, I believe that it should recognize it a known command and return 0 instead. 