### PR TITLE
Adding ENABLE_ARCUS option in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option (ENABLE_ARCUS
     "Enable support for ARCUS" ON)
 
 if (ENABLE_ARCUS)
+    message(STATUS "Building with Arcus")
     find_package(Arcus REQUIRED)
     add_definitions(-DARCUS)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,13 @@ project(CuraEngine)
 
 cmake_minimum_required(VERSION 2.8.12)
 
-find_package(Arcus REQUIRED)
+option (ENABLE_ARCUS
+    "Enable support for ARCUS" ON)
+
+if (ENABLE_ARCUS)
+    find_package(Arcus REQUIRED)
+    add_definitions(-DARCUS)
+endif ()
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.1)
     set(CMAKE_CXX_STANDARD 11)
@@ -78,12 +84,17 @@ set(engine_TEST
     LinearAlg2DTest
 )
 
-# Generating ProtoBuf protocol.
+# Generating ProtoBuf protocol
+if (ENABLE_ARCUS)
 protobuf_generate_cpp(engine_PB_SRCS engine_PB_HEADERS Cura.proto)
+endif ()
 
 # Compiling CuraEngine itself.
 add_library(_CuraEngine ${engine_SRCS} ${engine_PB_SRCS}) #First compile all of CuraEngine as library, allowing this to be re-used for tests.
-target_link_libraries(_CuraEngine clipper Arcus)
+target_link_libraries(_CuraEngine clipper)
+if (ENABLE_ARCUS)
+    target_link_libraries(_CuraEngine Arcus)
+endif ()
 
 set_target_properties(_CuraEngine PROPERTIES COMPILE_DEFINITIONS "VERSION=\"${CURA_ENGINE_VERSION}\"")
 

--- a/src/commandSocket.h
+++ b/src/commandSocket.h
@@ -8,10 +8,12 @@
 
 #include <memory>
 
+#ifdef ARCUS
 #include "Cura.pb.h"
+#endif
 
-namespace cura {
-
+namespace cura
+{
 
 class CommandSocket
 {
@@ -24,7 +26,8 @@ public:
      * \param port int of the port to connect with.
      */
     void connect(const std::string& ip, int port);
-    
+
+#ifdef ARCUS
     /*! 
      * Handler for ObjectList message. 
      * Loads all objects from the message and starts the slicing process
@@ -36,6 +39,7 @@ public:
      * This simply sets all the settings by using key value pair
      */
     void handleSettingList(cura::proto::SettingList* list);
+#endif
     
     /*!
      * Does nothing at the moment 
@@ -74,9 +78,11 @@ public:
     void sendGCodeLayer();
     void sendGCodePrefix(std::string prefix);
 
+#ifdef ARCUS
 private:
     class Private;
     const std::unique_ptr<Private> d;
+#endif
 };
 
 }//namespace cura


### PR DESCRIPTION
This adds the `ENABLE_ARCUS` option in the CMakeLists that allow you to compile cura without the Arcus and protobuf dependency, and allowing you an easier use as a standalone library

I know this is a little bit complicated since it adds much defines check and maybe not easy to maintain