### PR TITLE
Registering "SlicingFinished" message

### DIFF
--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -100,6 +100,7 @@ void CommandSocket::connect(const std::string& ip, int port)
     private_data->socket->registerMessageType(5, &cura::proto::ObjectPrintTime::default_instance());
     private_data->socket->registerMessageType(6, &cura::proto::SettingList::default_instance());
     private_data->socket->registerMessageType(7, &cura::proto::GCodePrefix::default_instance());
+    private_data->socket->registerMessageType(8, &cura::proto::SlicingFinished::default_instance());
 
     private_data->socket->connect(ip, port);
     


### PR DESCRIPTION
"The reason is that CuraEngine doesn't have the SlicingFinished message registered and so it sends it with the id 0 instead of 8. Then libArcus throws a UnknownMessageError exception because CuraEngineBackend didn't register the message SlicingFinished with id 0 but with 8."
- https://github.com/Ultimaker/Cura/issues/622#issuecomment-177592468
* Fixes https://github.com/Ultimaker/Cura/issues/622