### PR TITLE
Fix Cura not receiving print time

### DIFF
--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -149,6 +149,7 @@ void CommandSocket::connect(const std::string& ip, int port)
             FffProcessor::getInstance()->finalize();
             flushGcode();
             sendPrintTime();
+            sendSlicingFinished();
             slice_another_time = false; // TODO: remove this when multiple slicing with CuraEngine is safe
             //TODO: Support all-at-once/one-at-a-time printing
             //private_data->processor->processModel(private_data->object_to_slice.get());
@@ -304,6 +305,12 @@ void CommandSocket::sendPrintTime()
     private_data->socket->sendMessage(message);
 }
 
+void CommandSocket::sendSlicingFinished()
+{
+    auto done_message = std::make_shared<cura::proto::SlicingFinished>();
+    private_data->socket->sendMessage(done_message);
+}
+
 void CommandSocket::sendPrintMaterialForObject(int index, int extruder_nr, float print_time)
 {
 //     socket.sendInt32(CMD_OBJECT_PRINT_MATERIAL);
@@ -338,8 +345,6 @@ void CommandSocket::endSendSlicedObject()
         private_data->current_layer_offset = 0;
         private_data->sliced_object_list.reset();
         private_data->current_sliced_object = nullptr;
-        auto done_message = std::make_shared<cura::proto::SlicingFinished>();
-        private_data->socket->sendMessage(done_message);
     }
 }
 

--- a/src/commandSocket.h
+++ b/src/commandSocket.h
@@ -79,6 +79,11 @@ public:
     void sendPrintTime();
     
     /*!
+     * Notify that the slicing has finished.
+     */
+    void sendSlicingFinished();
+    
+    /*!
      * Does nothing at the moment
      */
     void sendPrintMaterialForObject(int index, int extruder_nr, float material_amount);


### PR DESCRIPTION
SlicingFinished must be sent after ObjectPrintTime because Cura restarts the Engine as soon as it receives the SlicingFinished message and never receives ObjectPrintTime message.