### PR TITLE
Misc cleanups

### DIFF
--- a/resources/command_line_settings.def.json
+++ b/resources/command_line_settings.def.json
@@ -1,40 +1,50 @@
 {
-    "version": 1, 
+    "version": 2,
     "name": "Command line setting defaults CuraEngine",
-    "author": "Ultimaker B.V.",
-    "categories": {
+    "metadata":
+    {
+        "author": "Ultimaker B.V."
+    },
+    "settings": {
         "command_line_settings": {
             "label": "Command Line Settings",
-            "settings": {
+            "type": "category",
+            "children": {
                 "center_object": {
                     "description": "Whether to center the object on the middle of the build platform (0,0), instead of using the coordinate system in which the object was saved.",
-                    "type": "boolean",
-                    "default": false
+                    "type": "bool",
+                    "label": "Center object",
+                    "default_value": true
                 },
                 "machine_print_temp_wait": {
                     "description": "Whether to wait for the nozzle temperature to be reached when preheating the nozzles at the start of the gcode.",
-                    "type": "boolean",
-                    "default": true
+                    "type": "bool",
+                    "label": "Machine print temp wait",
+                    "default_value": true
                 },
                 "mesh_position_x": {
                     "description": "Offset applied to the object in the x direction.",
                     "type": "float",
-                    "default": 0
+                    "label": "Mesh position x",
+                    "default_value": 0
                 },
                 "mesh_position_y": {
                     "description": "Offset applied to the object in the y direction.",
                     "type": "float",
-                    "default": 0
+                    "label": "Mesh position y",
+                    "default_value": 0
                 },
                 "mesh_position_z": {
                     "description": "Offset applied to the object in the z direction. With this you can perform what was used to call 'Object Sink'.",
                     "type": "float",
-                    "default": 0
+                    "label": "Mesh position z",
+                    "default_value": 0
                 },
                 "prime_tower_dir_outward": {
                     "description": "Whether to start printing in the middle of the prime tower and end up at the perimeter, or the other way around. This is only used for certain types of prime tower.",
-                    "type": "boolean",
-                    "default": false
+                    "type": "bool",
+                    "label": "Prime tower direction outward",
+                    "default_value": false
                 }
             }
         }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -778,6 +778,7 @@ void FffGcodeWriter::processSkin(GCodePlanner& gcode_layer, SliceMeshStorage* me
         if (bridge > -1)
         {
             pattern = EFillMethod::LINES;
+            skin_angle = bridge;
         } 
         Polygons* inner_skin_outline = nullptr;
         int offset_from_inner_skin_outline = 0;

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -329,7 +329,7 @@ void CommandSocket::sendLayerInfo(int layer_nr, int32_t z, int32_t height)
 #endif
 }
 
-void CommandSocket::sendPolygons(PrintFeatureType type, int layer_nr, Polygons& polygons, int line_width)
+void CommandSocket::sendPolygons(PrintFeatureType type, int layer_nr, const Polygons& polygons, int line_width)
 {
 #ifdef ARCUS
     if (polygons.size() == 0)

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -412,8 +412,6 @@ void CommandSocket::sendLayerData()
         private_data->current_layer_count = 0;
         private_data->current_layer_offset = 0;
         private_data->sliced_layers.clear();
-        auto done_message = std::make_shared<cura::proto::SlicingFinished>();
-        private_data->socket->sendMessage(done_message);
     }
 #endif
 }

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -400,7 +400,7 @@ void CommandSocket::sendLayerData()
 #ifdef ARCUS
     private_data->sliced_objects++;
     private_data->current_layer_offset = private_data->current_layer_count;
-    log("End sliced object called. Sending ", private_data->current_layer_count, " layers.");
+    log("End sliced object called. Sending %d layers.", private_data->current_layer_count);
 
     if (private_data->sliced_objects >= private_data->object_count)
     {

--- a/src/commandSocket.h
+++ b/src/commandSocket.h
@@ -59,12 +59,12 @@ public:
     /*! 
      * Send a polygon to the engine. This is used for the layerview in the GUI
      */
-    void sendPolygons(cura::PrintFeatureType type, int layer_nr, cura::Polygons& polygons, int line_width);
+    void sendPolygons(cura::PrintFeatureType type, int layer_nr, const cura::Polygons& polygons, int line_width);
 
     /*! 
      * Send a polygon to the engine if the command socket is instantiated. This is used for the layerview in the GUI
      */
-    static void sendPolygonsToCommandSocket(cura::PrintFeatureType type, int layer_nr, cura::Polygons& polygons, int line_width);
+    static void sendPolygonsToCommandSocket(cura::PrintFeatureType type, int layer_nr, const cura::Polygons& polygons, int line_width);
 
     /*! 
      * Send progress to GUI

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -53,9 +53,10 @@ void Mesh::finish()
     for(unsigned int i=0; i<faces.size(); i++)
     {
         MeshFace& face = faces[i];
-        face.connected_face_index[0] = getFaceIdxWithPoints(face.vertex_index[0], face.vertex_index[1], i); // faces are connected via the outside
-        face.connected_face_index[1] = getFaceIdxWithPoints(face.vertex_index[1], face.vertex_index[2], i);
-        face.connected_face_index[2] = getFaceIdxWithPoints(face.vertex_index[2], face.vertex_index[0], i);
+        // faces are connected via the outside
+        face.connected_face_index[0] = getFaceIdxWithPoints(face.vertex_index[0], face.vertex_index[1], i, face.vertex_index[2]);
+        face.connected_face_index[1] = getFaceIdxWithPoints(face.vertex_index[1], face.vertex_index[2], i, face.vertex_index[0]);
+        face.connected_face_index[2] = getFaceIdxWithPoints(face.vertex_index[2], face.vertex_index[0], i, face.vertex_index[1]);
     }
 }
 
@@ -116,17 +117,13 @@ See <a href="http://stackoverflow.com/questions/14066933/direct-way-of-computing
 
 
 */
-int Mesh::getFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx) const
+int Mesh::getFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx, int notFaceVertexIdx) const
 {
     std::vector<int> candidateFaces; // in case more than two faces meet at an edge, multiple candidates are generated
-    int notFaceVertexIdx = -1; // index of the third vertex of the face corresponding to notFaceIdx
     for(int f : vertices[idx0].connected_faces) // search through all faces connected to the first vertex and find those that are also connected to the second
     {
         if (f == notFaceIdx)
         {
-            for (int i = 0; i<3; i++) // find the vertex which is not idx0 or idx1
-                if (faces[f].vertex_index[i] != idx0 && faces[f].vertex_index[i] != idx1)
-                    notFaceVertexIdx = faces[f].vertex_index[i];
             continue;
         }
         if ( faces[f].vertex_index[0] == idx1 // && faces[f].vertex_index[1] == idx0 // next face should have the right direction!
@@ -139,8 +136,6 @@ int Mesh::getFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx) const
     if (candidateFaces.size() == 0) { cura::logError("Couldn't find face connected to face %i.\n", notFaceIdx); return -1; }
     if (candidateFaces.size() == 1) { return candidateFaces[0]; }
 
-
-    if (notFaceVertexIdx < 0) { cura::logError("Couldn't find third point on face %i.\n", notFaceIdx); return -1; }
 
     if (candidateFaces.size() % 2 == 0) cura::log("Warning! Edge with uneven number of faces connecting it!(%i)\n", candidateFaces.size()+1);
 

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -89,9 +89,10 @@ private:
     int findIndexOfVertex(const Point3& v); //!< find index of vertex close to the given point, or create a new vertex and return its index.
     /*!
     Get the index of the face connected to the face with index \p notFaceIdx, via vertices \p idx0 and \p idx1.
+    \p notFaceVertexIdx should be the third vertex of face \p notFaceIdx.
     In case multiple faces connect with the same edge, return the next counter-clockwise face when viewing from \p idx1 to \p idx0.
     */
-    int getFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx) const;
+    int getFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx, int notFaceVertexIdx) const;
 };
 
 }//namespace cura

--- a/src/settings/SettingRegistry.cpp
+++ b/src/settings/SettingRegistry.cpp
@@ -162,6 +162,7 @@ int SettingRegistry::loadJSONsettings(std::string filename, SettingsBase* settin
         bool found = getDefinitionFile(json_document["inherits"].GetString(), child_filename);
         if (!found)
         {
+            cura::logError("Inherited JSON file \"%s\" not found\n", json_document["inherits"].GetString());
             return -1;
         }
         err = loadJSONsettings(child_filename, settings_base, warn_base_file_duplicates); // load child first

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -452,7 +452,7 @@ void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool ext
 }
 
 
-Slicer::Slicer(Mesh* mesh, int initial, int thickness, int layer_count, bool keep_none_closed, bool extensive_stitching)
+Slicer::Slicer(const Mesh* mesh, int initial, int thickness, int layer_count, bool keep_none_closed, bool extensive_stitching)
 : mesh(mesh)
 {
     assert(layer_count > 0);
@@ -466,7 +466,7 @@ Slicer::Slicer(Mesh* mesh, int initial, int thickness, int layer_count, bool kee
     
     for(unsigned int mesh_idx = 0; mesh_idx < mesh->faces.size(); mesh_idx++)
     {
-        MeshFace& face = mesh->faces[mesh_idx];
+        const MeshFace& face = mesh->faces[mesh_idx];
         Point3 p0 = mesh->vertices[face.vertex_index[0]].p;
         Point3 p1 = mesh->vertices[face.vertex_index[1]].p;
         Point3 p2 = mesh->vertices[face.vertex_index[2]].p;

--- a/src/slicer.h
+++ b/src/slicer.h
@@ -124,7 +124,7 @@ public:
 
     const Mesh* mesh; //!< The sliced mesh
     
-    Slicer(Mesh* mesh, int initial, int thickness, int layer_count, bool keepNoneClosed, bool extensiveStitching);
+    Slicer(const Mesh* mesh, int initial, int thickness, int layer_count, bool keepNoneClosed, bool extensiveStitching);
     
     SlicerSegment project2D(Point3& p0, Point3& p1, Point3& p2, int32_t z) const
     {

--- a/src/slicer.h
+++ b/src/slicer.h
@@ -125,14 +125,25 @@ public:
     const Mesh* mesh; //!< The sliced mesh
     
     Slicer(const Mesh* mesh, int initial, int thickness, int layer_count, bool keepNoneClosed, bool extensiveStitching);
+
+    int64_t interp(int64_t x, int64_t x0, int64_t x1, int64_t y0, int64_t y1) const
+    {
+        int64_t dx_01 = x1 - x0;
+        int64_t num = (y1 - y0) * (x - x0);
+        num += num > 0 ? dx_01/2 : -dx_01/2; // add in offset to round result
+        int64_t y = y0 + num / dx_01;
+        return y;
+    }
     
     SlicerSegment project2D(Point3& p0, Point3& p1, Point3& p2, int32_t z) const
     {
         SlicerSegment seg;
-        seg.start.X = p0.x + int64_t(p1.x - p0.x) * int64_t(z - p0.z) / int64_t(p1.z - p0.z);
-        seg.start.Y = p0.y + int64_t(p1.y - p0.y) * int64_t(z - p0.z) / int64_t(p1.z - p0.z);
-        seg.end.X = p0.x + int64_t(p2.x - p0.x) * int64_t(z - p0.z) / int64_t(p2.z - p0.z);
-        seg.end.Y = p0.y + int64_t(p2.y - p0.y) * int64_t(z - p0.z) / int64_t(p2.z - p0.z);
+
+        seg.start.X = interp(z, p0.z, p1.z, p0.x, p1.x);
+        seg.start.Y = interp(z, p0.z, p1.z, p0.y, p1.y);
+        seg.end  .X = interp(z, p0.z, p2.z, p0.x, p2.x);
+        seg.end  .Y = interp(z, p0.z, p2.z, p0.y, p2.y);
+
         return seg;
     }
     

--- a/src/utils/gettime.h
+++ b/src/utils/gettime.h
@@ -2,11 +2,18 @@
 #ifndef GETTIME_H
 #define GETTIME_H
 
+// Use cpu usage time if available, otherwise wall clock time
+//#define USE_CPU_TIME
+
 #ifdef __WIN32
 #include <windows.h>
 #else
+#ifdef USE_CPU_TIME
+#include <sys/resource.h>
+#endif
 #include <sys/time.h>
 #include <stddef.h>
+#include <cassert>
 #endif
 
 namespace cura
@@ -16,9 +23,19 @@ static inline double getTime()
 #ifdef __WIN32
     return double(GetTickCount()) / 1000.0;
 #else
+#if USE_CPU_TIME
+    int ret;
+    struct rusage usage;
+    ret = getrusage(RUSAGE_SELF,&usage);
+    assert(ret==0);
+    double user_time =  double(usage.ru_utime.tv_sec) + double(usage.ru_utime.tv_usec) / 1000000.0;
+    double sys_time  =  double(usage.ru_stime.tv_sec) + double(usage.ru_stime.tv_usec) / 1000000.0;
+    return user_time + sys_time;
+#else
     struct timeval tv;
     gettimeofday(&tv, nullptr);
     return double(tv.tv_sec) + double(tv.tv_usec) / 1000000.0;
+#endif
 #endif
 }
 

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -55,6 +55,11 @@ public:
         return path->data();
     }
 
+    const void* data() const
+    {
+        return path->data();
+    }
+
     void add(const Point p)
     {
         path->push_back(p);

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -602,7 +602,7 @@ std::optional<ClosestPolygonPoint> PolygonUtils::findClose(Point from, const Pol
     }
     else
     {
-        bool bs_arg; // doesn't mean anything. Just to make clear we call the variable arguments of the constructor.
+        bool bs_arg = true; // doesn't mean anything. Just to make clear we call the variable arguments of the constructor.
         return std::optional<ClosestPolygonPoint>(bs_arg, best, best_point_poly_idx.point_idx, polygons[best_point_poly_idx.poly_idx], best_point_poly_idx.poly_idx);
     }
 }


### PR DESCRIPTION
This is 1 of 3 split / cleaned up PRs that replace PR #368. The combination of the 3 new PRs (PR #370, PR #371, PR #372) produces the same net effect as PR #368, but with easier to following history.

This branch has only the misc cleanups that are not required for the slicer speedup to function.

Here are the changes (in order of most likely to be wanted):

- More const correctness in places
- Fixed logging of number of layers
- Added error message when it can't find an inherited JSON file.
- Aligned bridge direction with calculated direction.
        The bridging is still terrible, but this at least gives it a chance of working.
- Removed sending of extra SlicingFinished message
        This was being sent in 2 places which was confusing my version of the front end
- Rounding during interpolation when calculating vertices from slicing
- Updated command_line_settings JSON file to version 2 format to match expected format of other JSON files.
- Printouts of various timings from slicing
