### PR TITLE
Added convexHull function for Polygons.

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -502,7 +502,7 @@ void FffPolygonGenerator::processDraftShield(SliceDataStorage& storage, unsigned
         draft_shield = draft_shield.unionPolygons(storage.getLayerOutlines(layer_nr, true));
     }
     
-    storage.draft_protection_shield = draft_shield.convexHull(draft_shield_dist);
+    storage.draft_protection_shield = draft_shield.approxConvexHull(draft_shield_dist);
 }
 
 void FffPolygonGenerator::processPlatformAdhesion(SliceDataStorage& storage)

--- a/src/skirt.cpp
+++ b/src/skirt.cpp
@@ -40,7 +40,7 @@ void generateSkirt(SliceDataStorage& storage, int distance, int count, int minLe
     
         if (get_convex_hull)
         {
-            skirt_polygons = skirt_polygons.convexHull(); 
+            skirt_polygons = skirt_polygons.approxConvexHull();
         } 
 
         skirt_primary_extruder.add(skirt_polygons);

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -503,13 +503,20 @@ public:
      * \return the convex hull (approximately)
      * 
      */
-    Polygons convexHull(int extra_outset = 0)
+    Polygons approxConvexHull(int extra_outset = 0)
     {
         int overshoot = 100000; // 10 cm (hardcoded value)
         
         return offset(overshoot, ClipperLib::jtRound).offset(-overshoot+extra_outset, ClipperLib::jtRound);
     }
     
+    /*!
+     * Convex hull of all the points in the polygons.
+     * \return the convex hull
+     *
+     */
+    Polygon convexHull() const;
+
     Polygons smooth(int remove_length, int min_area) //!< removes points connected to small lines
     {
         Polygons ret;


### PR DESCRIPTION
This is 1 of 3 split / cleaned up PRs that replace PR #368. The combination of the 3 new PRs (PR #370, PR #371, PR #372) produces the same net effect as PR #368, but with easier to following history.

This branch has only the addition of the convex hull function, convexHull().  The old function was renamed to approxConvexHull().
