### PR TITLE
MergeInfillLines changes

### DIFF
--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -13,10 +13,10 @@ void MergeInfillLines::writeCompensatedMove(Point& to, double speed, GCodePath& 
     double new_line_width_mm = INT2MM(new_line_width);
     double extrusion_mod = new_line_width_mm / old_line_width;
     double new_speed = speed;
-    if (adjust_speed_for_pressure)
+    if (speed_equalize_flow_enabled)
     {
         double speed_mod = old_line_width / new_line_width_mm;
-        new_speed = std::min(speed * speed_mod, speed_pressure_maximum);
+        new_speed = std::min(speed * speed_mod, speed_equalize_flow_max);
     }
     sendLineTo(last_path.config->type, to, last_path.getLineWidth());
     gcode.writeMove(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod);

--- a/src/MergeInfillLines.h
+++ b/src/MergeInfillLines.h
@@ -19,6 +19,8 @@ class MergeInfillLines
     
     GCodePathConfig& travelConfig; //!< The travel settings used to see whether a path is a travel path or an extrusion path
     int64_t nozzle_size; //!< The diameter of the hole in the nozzle
+    bool adjust_speed_for_pressure; //!< Should the speed be varied with extrusion width
+    double speed_pressure_maximum; //!< Maximum speed when adjusting speed for pressure
 
     /*!
      * Whether the next two extrusion paths are convertible to a single line segment, starting from the end point the of the last travel move at \p path_idx_first_move
@@ -62,8 +64,8 @@ public:
     /*!
      * Simple constructor only used by MergeInfillLines::isConvertible to easily convey the environment
      */
-    MergeInfillLines(GCodeExport& gcode, int layer_nr, std::vector<GCodePath>& paths, ExtruderPlan& extruder_plan, GCodePathConfig& travelConfig, int64_t nozzle_size) 
-    : gcode(gcode), layer_nr(layer_nr), paths(paths), extruder_plan(extruder_plan), travelConfig(travelConfig), nozzle_size(nozzle_size) { }
+    MergeInfillLines(GCodeExport& gcode, int layer_nr, std::vector<GCodePath>& paths, ExtruderPlan& extruder_plan, GCodePathConfig& travelConfig, int64_t nozzle_size, bool adjust_speed_for_pressure, double speed_pressure_maximum) 
+    : gcode(gcode), layer_nr(layer_nr), paths(paths), extruder_plan(extruder_plan), travelConfig(travelConfig), nozzle_size(nozzle_size), adjust_speed_for_pressure(adjust_speed_for_pressure), speed_pressure_maximum(speed_pressure_maximum) { }
     
     /*!
      * Check for lots of small moves and combine them into one large line.
@@ -73,11 +75,10 @@ public:
      * \param paths The paths currently under consideration
      * \param travelConfig The travel settings used to see whether a path is a travel path or an extrusion path
      * \param nozzle_size The diameter of the hole in the nozzle
-     * \param speed A factor used to scale the movement speed
      * \param path_idx Input/Output parameter: The current index in \p paths where to start combining and the current index after combining as output parameter.
      * \return Whether lines have been merged and normal path-to-gcode generation can be skipped for the current resulting \p path_idx .
      */
-    bool mergeInfillLines(double speed, unsigned int& path_idx);
+    bool mergeInfillLines(unsigned int& path_idx);
     
     /*!
      * send a line segment through the command socket from the previous point to the given point \p to

--- a/src/MergeInfillLines.h
+++ b/src/MergeInfillLines.h
@@ -19,8 +19,8 @@ class MergeInfillLines
     
     GCodePathConfig& travelConfig; //!< The travel settings used to see whether a path is a travel path or an extrusion path
     int64_t nozzle_size; //!< The diameter of the hole in the nozzle
-    bool adjust_speed_for_pressure; //!< Should the speed be varied with extrusion width
-    double speed_pressure_maximum; //!< Maximum speed when adjusting speed for pressure
+    bool speed_equalize_flow_enabled; //!< Should the speed be varied with extrusion width
+    double speed_equalize_flow_max; //!< Maximum speed when adjusting speed for flow
 
     /*!
      * Whether the next two extrusion paths are convertible to a single line segment, starting from the end point the of the last travel move at \p path_idx_first_move
@@ -64,8 +64,8 @@ public:
     /*!
      * Simple constructor only used by MergeInfillLines::isConvertible to easily convey the environment
      */
-    MergeInfillLines(GCodeExport& gcode, int layer_nr, std::vector<GCodePath>& paths, ExtruderPlan& extruder_plan, GCodePathConfig& travelConfig, int64_t nozzle_size, bool adjust_speed_for_pressure, double speed_pressure_maximum) 
-    : gcode(gcode), layer_nr(layer_nr), paths(paths), extruder_plan(extruder_plan), travelConfig(travelConfig), nozzle_size(nozzle_size), adjust_speed_for_pressure(adjust_speed_for_pressure), speed_pressure_maximum(speed_pressure_maximum) { }
+    MergeInfillLines(GCodeExport& gcode, int layer_nr, std::vector<GCodePath>& paths, ExtruderPlan& extruder_plan, GCodePathConfig& travelConfig, int64_t nozzle_size, bool speed_equalize_flow_enabled, double speed_equalize_flow_max) 
+    : gcode(gcode), layer_nr(layer_nr), paths(paths), extruder_plan(extruder_plan), travelConfig(travelConfig), nozzle_size(nozzle_size), speed_equalize_flow_enabled(speed_equalize_flow_enabled), speed_equalize_flow_max(speed_equalize_flow_max) { }
     
     /*!
      * Check for lots of small moves and combine them into one large line.

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -623,6 +623,7 @@ void GCodePlanner::writeGCode(GCodeExport& gcode)
     bool jerk_enabled = storage.getSettingBoolean("jerk_enabled");
     bool speed_for_pressure_enabled = storage.getSettingBoolean("speed_for_pressure_enabled");
     double speed_pressure_maximum = storage.getSettingInMillimetersPerSecond("speed_pressure_maximum");
+    int64_t nozzle_size = gcode.getNozzleSize(extruder);
 
     for(unsigned int extruder_plan_idx = 0; extruder_plan_idx < extruder_plans.size(); extruder_plan_idx++)
     {
@@ -656,8 +657,6 @@ void GCodePlanner::writeGCode(GCodeExport& gcode)
         extruder_plan.inserts.sort([](const NozzleTempInsert& a, const NozzleTempInsert& b) -> bool { 
                 return  a.path_idx < b.path_idx; 
             } );
-
-        int64_t nozzle_size = gcode.getNozzleSize(extruder);
 
         for(unsigned int path_idx = 0; path_idx < paths.size(); path_idx++)
         {


### PR DESCRIPTION
- Add setting to enable/disable automatic speed adjustment
- Add setting to remove hardcoded max speed
- Retrieve machine nozzle size from GCodeExport instead of hardcode 400 microns
- Moved some settings retrieval out of a nested loop
- Use the move_path's speed and travelSpeedFactor for the move path merge
- Use the last extrusion path's speed and extrudeSpeedFactor as the base speed for the extrusion merged path

Prior to this change it used the first of four path's (always a travel move) speed and factor as the base speed for the merged paths (regardless of whether they were extrusions or travel).