### PR TITLE
Fixes for Microsoft Visual Studio builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ if(NOT APPLE AND NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
 endif()
 
+if(WIN32)
+    add_definitions(/DNOMINMAX)
+endif()
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR} libs)
 
 add_library(clipper STATIC libs/clipper/clipper.cpp)

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -1,6 +1,8 @@
 /** Copyright (C) 2013 David Braam - Released under terms of the AGPLv3 License */
 #include <string.h>
+#ifndef WIN32
 #include <strings.h>
+#endif
 #include <stdio.h>
 
 #include "MeshGroup.h"

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -51,7 +51,7 @@ void PrimeTower::computePrimeTowerMax(SliceDataStorage& storage)
         
     extruder_count = storage.getSettingAsCount("machine_extruder_count");
     
-    int max_object_height_per_extruder[extruder_count]; 
+    int *max_object_height_per_extruder = (int*)alloca(sizeof(int)*extruder_count); 
     std::fill_n(max_object_height_per_extruder, extruder_count, -1); // unitialize all as -1
     { // compute max_object_height_per_extruder
         for (SliceMeshStorage& mesh : storage.meshes)

--- a/src/Weaver.cpp
+++ b/src/Weaver.cpp
@@ -2,7 +2,9 @@
 
 #include <cmath> // sqrt
 #include <fstream> // debug IO
+#ifndef WIN32
 #include <unistd.h>
+#endif
 
 #include "progress/Progress.h"
 #include "weaveDataStorage.h"

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -14,7 +14,7 @@
 
 #include <string> // stoi
 
-#ifdef _WIN32
+#ifdef WIN32
 #include <windows.h>
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef WIN32
 #include <sys/time.h>
+#endif
 #include <signal.h>
 #if defined(__linux__) || (defined(__APPLE__) && defined(__MACH__))
 #include <execinfo.h>

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -13,7 +13,7 @@ namespace cura {
 */
 void PathOrderOptimizer::optimize()
 {
-    bool picked[polygons.size()];
+    bool *picked = (bool*)alloca(sizeof(bool)*polygons.size());
     memset(picked, false, sizeof(bool) * polygons.size());/// initialized as falses
     
     for (PolygonRef poly : polygons) /// find closest point to initial starting point within each polygon +initialize picked
@@ -154,7 +154,7 @@ void LineOrderOptimizer::optimize()
 {
     int gridSize = 5000; // the size of the cells in the hash grid. TODO
     SparsePointGridInclusive<unsigned int> line_bucket_grid(gridSize);
-    bool picked[polygons.size()];
+    bool *picked = (bool*)alloca(sizeof(bool)*polygons.size());
     memset(picked, false, sizeof(bool) * polygons.size());/// initialized as falses
     
     for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++) /// find closest point to initial starting point within each polygon +initialize picked

--- a/src/settings/SettingRegistry.cpp
+++ b/src/settings/SettingRegistry.cpp
@@ -3,7 +3,11 @@
 
 #include <sstream>
 #include <iostream> // debug IO
+#ifndef WIN32
 #include <libgen.h> // dirname
+#else
+extern char *dirname(char *path);
+#endif
 #include <string>
 #include <cstring> // strtok (split string using delimiters) strcpy
 #include <fstream> // ifstream (to see if file exists)
@@ -150,7 +154,7 @@ int SettingRegistry::loadJSONsettings(std::string filename, SettingsBase* settin
     if (err) { return err; }
 
     { // add parent folder to search paths
-        char filename_cstr[filename.size()];
+        char *filename_cstr = (char*)alloca(filename.size());
         std::strcpy(filename_cstr, filename.c_str()); // copy the string because dirname(.) changes the input string!!!
         std::string folder_name = std::string(dirname(filename_cstr));
         search_paths.emplace(folder_name);
@@ -396,3 +400,15 @@ void SettingRegistry::_loadSettingValues(SettingConfig* config, const rapidjson:
 }
 
 }//namespace cura
+
+#ifdef WIN32
+#include <windows.h>
+
+char *dirname(char *path)
+{
+	static char folder_name[MAX_PATH + 1], *p;
+	GetFullPathNameA(path, _countof(folder_name), folder_name, &p);
+	p[-1] = 0;
+	return folder_name;
+}
+#endif

--- a/src/settings/SettingsToGV.h
+++ b/src/settings/SettingsToGV.h
@@ -6,7 +6,11 @@
 #include <stdio.h> // for file output
 #include <sstream>
 #include <iostream> // debug IO
+#ifndef WIN32
 #include <libgen.h> // dirname
+#else
+extern char *dirname(char *path);
+#endif
 #include <string>
 #include <algorithm> // find_if
 #include <regex> // regex_search

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -161,7 +161,7 @@ bool SettingsBaseVirtual::getSettingBoolean(std::string key) const
         return true;
     if (value == "yes")
         return true;
-    if (value == "true" or value == "True") //Python uses "True"
+    if (value == "true" || value == "True") //Python uses "True"
         return true;
     int num = atoi(value.c_str());
     return num != 0;

--- a/src/utils/gettime.h
+++ b/src/utils/gettime.h
@@ -2,14 +2,14 @@
 #ifndef GETTIME_H
 #define GETTIME_H
 
-#ifdef __WIN32
+#ifdef WIN32
     #include <windows.h>
 #else
+    #include <sys/time.h>
     #ifdef USE_CPU_TIME
     #include <sys/resource.h>
 #endif
 
-#include <sys/time.h>
 #include <stddef.h>
 #include <cassert>
 #endif
@@ -18,9 +18,9 @@ namespace cura
 {
 static inline double getTime()
 {
-#ifdef __WIN32
+#ifdef WIN32
     return double(GetTickCount()) / 1000.0;
-#else // not __WIN32
+#else // not WIN32
  #if USE_CPU_TIME // Use cpu usage time if available, otherwise wall clock time
     int ret;
     struct rusage usage;
@@ -34,7 +34,7 @@ static inline double getTime()
     gettimeofday(&tv, nullptr);
     return double(tv.tv_sec) + double(tv.tv_usec) / 1000000.0;
  #endif // USE_CPU_TIME
-#endif // __WIN32
+#endif // WIN32
 }
 
 class TimeKeeper

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -117,9 +117,9 @@ unsigned int Polygons::findInside(Point p, bool border_result)
         return false;
     }
     
-    int64_t min_x[size()];
+    int64_t *min_x = (int64_t*)alloca(sizeof(int64_t)*size());
     std::fill_n(min_x, size(), std::numeric_limits<int64_t>::max());  // initialize with int.max
-    int crossings[size()];
+    int *crossings = (int*)alloca(sizeof(int)*size());
     std::fill_n(crossings, size(), 0);  // initialize with zeros
     
     for (unsigned int poly_idx = 0; poly_idx < size(); poly_idx++)


### PR DESCRIPTION
Now builds with MSVC 2015. Changes are:
- Global define NOMINMAX in CMakeLists.txt
- #ifndef around strings.h, unistd.h, sys/time.h, libgen.h
- Variable-length arrays replaced with alloca() (it's not a C++ feature)
- Homegrown implementation of dirname() using Win32's GetFileFullPath()
- Rogue "or" replaced with ||
- References to macros __WIN32, _WIN32 replaced with WIN32

There will be a HUGE lot of warnings, since the cmake-generated project file specifies the "all warnings" option. Feel free to reduce the warning level to your own liking.

You still need to patch and rebuild protobuf, or you'll get three "unresolved symbol" errors. Functions google::protobuf::internal::GetEmptyString(), GetEmptyStringAlreadyInited() in generated_message_util.h should be declared as non-inline and moved to a source file (generated_message_util.cc is a good place).
