### PR TITLE
Fix constexpr function warning for C++14

### DIFF
--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -114,11 +114,11 @@ public:
         }
         return *this;
     }
-    constexpr T* operator->()
+    constexpr T* operator->() const
     {
         return instance;
     }
-    constexpr T& operator*() &
+    constexpr T& operator*() const&
     {
         return *instance;
     }
@@ -126,21 +126,14 @@ public:
     {
         return instance;
     }
-    constexpr T& value() &
+    constexpr T& value() const&
     {
         return *instance;
     }
     template<class U> 
     constexpr T value_or(U&& default_value) const&
     {
-        if (instance)
-        {
-            return *instance;
-        }
-        else
-        {
-            return default_value;
-        }
+        return instance ? *instance : default_value;
     }
     void swap(optional& other)
     {


### PR DESCRIPTION
Building using gcc 5.3.0 gives a warning for a bunch of the constexpr functions in optional.h because in C++14, constexpr functions will no longer be assumed to be const.  Also, the compiler warns that if statements aren't allowed in constexpr functions in some versions of C++.
 
See https://akrzemi1.wordpress.com/2013/06/20/constexpr-function-is-not-const/ for more info.