### PR TITLE
SparseGridLine for negative coordinates

### DIFF
--- a/src/utils/SparseLineGrid.h
+++ b/src/utils/SparseLineGrid.h
@@ -86,20 +86,16 @@ void SGI_THIS::insert(const Elem &elem)
         // nearest y coordinate of the cells in the next row
         coord_t nearest_next_y = SparseGrid<ElemT>::toLowerCoord(cell_y + ((nonzero_sign(cell_y) == y_dir || cell_y == 0) ? y_dir : coord_t(0)));
         grid_coord_t x_cell_end; // the X coord of the last cell to include from this row
-        coord_t corresponding_x; // the x coordinate corresponding to nearest_next_y
-        bool is_corresponding_x_whole; // does the real corresponding x not have a fractional portion
         if (y_diff == 0)
         {
-            is_corresponding_x_whole = false;
-            corresponding_x = end.X;
             x_cell_end = end_cell.X;
         }
         else
         {
             coord_t area = (end.X - start.X) * (nearest_next_y - start.Y);
-            is_corresponding_x_whole = ((area % y_diff) == 0);
-            corresponding_x = start.X + area / y_diff;
-            x_cell_end = SparseGrid<ElemT>::toGridCoord(corresponding_x + ((corresponding_x < 0) && !is_corresponding_x_whole));
+            // corresponding_x: the x coordinate corresponding to nearest_next_y
+            coord_t corresponding_x = start.X + area / y_diff;
+            x_cell_end = SparseGrid<ElemT>::toGridCoord(corresponding_x + ((corresponding_x < 0) && ((area % y_diff) != 0)));
             if (x_cell_end < start_cell.X)
             { // process at least one cell!
                 x_cell_end = x_cell_start;

--- a/src/utils/SparseLineGrid.h
+++ b/src/utils/SparseLineGrid.h
@@ -50,7 +50,7 @@ protected:
 
     /*! \brief Accessor for getting locations from elements. */
     Locator m_locator;
-    grid_coord_t sign(grid_coord_t z);
+    grid_coord_t nonzero_sign(grid_coord_t z);
 };
 
 
@@ -78,13 +78,13 @@ void SGI_THIS::insert(const Elem &elem)
     const GridPoint start_cell = SparseGrid<ElemT>::toGridPoint(start);
     const GridPoint end_cell = SparseGrid<ElemT>::toGridPoint(end);
     const coord_t y_diff = end.Y - start.Y;
+    const grid_coord_t y_dir = nonzero_sign(y_diff);
 
-    grid_coord_t y_dir = (y_diff >= 0)? 1 : -1;
     grid_coord_t x_cell_start = start_cell.X;
     for (grid_coord_t cell_y = start_cell.Y; cell_y * y_dir <= end_cell.Y * y_dir; cell_y += y_dir)
     { // for all Y from start to end
         // nearest y coordinate of the cells in the next row
-        coord_t nearest_next_y = SparseGrid<ElemT>::toLowerCoord(cell_y + ((sign(cell_y) == y_dir || cell_y == 0) ? y_dir : coord_t(0)));
+        coord_t nearest_next_y = SparseGrid<ElemT>::toLowerCoord(cell_y + ((nonzero_sign(cell_y) == y_dir || cell_y == 0) ? y_dir : coord_t(0)));
         grid_coord_t x_cell_end; // the X coord of the last cell to include from this row
         coord_t corresponding_x; // the x coordinate corresponding to nearest_next_y
         bool is_corresponding_x_whole; // does the real corresponding x not have a fractional portion
@@ -99,7 +99,7 @@ void SGI_THIS::insert(const Elem &elem)
             coord_t area = (end.X - start.X) * (nearest_next_y - start.Y);
             is_corresponding_x_whole = ((area % y_diff) == 0);
             corresponding_x = start.X + area / y_diff;
-            x_cell_end = SparseGrid<ElemT>::toGridCoord(corresponding_x + ((corresponding_x > 0) ? -is_corresponding_x_whole : !is_corresponding_x_whole));
+            x_cell_end = SparseGrid<ElemT>::toGridCoord(corresponding_x + ((corresponding_x < 0) && !is_corresponding_x_whole));
             if (x_cell_end < start_cell.X)
             { // process at least one cell!
                 x_cell_end = x_cell_start;
@@ -115,13 +115,16 @@ void SGI_THIS::insert(const Elem &elem)
                 return;
             }
         }
-        x_cell_start = x_cell_end + (is_corresponding_x_whole && SparseGrid<ElemT>::toLowerCoord(x_cell_end + 1) == corresponding_x);
+        // TODO: this causes at least a one cell overlap for each row, which
+        // includes extra cells when crossing precisely on the corners
+        // where positive slope where x > 0 and negative slope where x < 0
+        x_cell_start = x_cell_end;
     }
     assert(false && "We should have returned already before here!");
 }
 
 SGI_TEMPLATE
-typename SGI_THIS::grid_coord_t SGI_THIS::sign(grid_coord_t z)
+typename SGI_THIS::grid_coord_t SGI_THIS::nonzero_sign(grid_coord_t z)
 {
     return (z >= 0) - (z < 0);
 }
@@ -133,16 +136,16 @@ void SGI_THIS::debugHTML(std::string filename)
     for (std::pair<GridPoint, ElemT> cell:  SparseGrid<ElemT>::m_grid)
     {
         aabb.include(SparseGrid<ElemT>::toLowerCorner(cell.first));
-        aabb.include(SparseGrid<ElemT>::toLowerCorner(cell.first + GridPoint(sign(cell.first.X), sign(cell.first.Y))));
+        aabb.include(SparseGrid<ElemT>::toLowerCorner(cell.first + GridPoint(nonzero_sign(cell.first.X), nonzero_sign(cell.first.Y))));
     }
     SVG svg(filename.c_str(), aabb);
     for (std::pair<GridPoint, ElemT> cell:  SparseGrid<ElemT>::m_grid)
     {
         // doesn't draw cells at x = 0 or y = 0 correctly (should be double size)
         Point lb = SparseGrid<ElemT>::toLowerCorner(cell.first);
-        Point lt = SparseGrid<ElemT>::toLowerCorner(cell.first + GridPoint(0, sign(cell.first.Y)));
-        Point rt = SparseGrid<ElemT>::toLowerCorner(cell.first + GridPoint(sign(cell.first.X), sign(cell.first.Y)));
-        Point rb = SparseGrid<ElemT>::toLowerCorner(cell.first + GridPoint(sign(cell.first.X), 0));
+        Point lt = SparseGrid<ElemT>::toLowerCorner(cell.first + GridPoint(0, nonzero_sign(cell.first.Y)));
+        Point rt = SparseGrid<ElemT>::toLowerCorner(cell.first + GridPoint(nonzero_sign(cell.first.X), nonzero_sign(cell.first.Y)));
+        Point rb = SparseGrid<ElemT>::toLowerCorner(cell.first + GridPoint(nonzero_sign(cell.first.X), 0));
 //         svg.writePoint(lb, true, 1);
         svg.writeLine(lb, lt, SVG::Color::GRAY);
         svg.writeLine(lt, rt, SVG::Color::GRAY);

--- a/src/utils/SparseLineGrid.h
+++ b/src/utils/SparseLineGrid.h
@@ -86,8 +86,8 @@ void SGI_THIS::insert(const Elem &elem)
         // nearest y coordinate of the cells in the next row
         coord_t nearest_next_y = SparseGrid<ElemT>::toLowerCoord(cell_y + ((sign(cell_y) == y_dir || cell_y == 0) ? y_dir : coord_t(0)));
         grid_coord_t x_cell_end; // the X coord of the last cell to include from this row
-        coord_t corresponding_x;
-        bool is_corresponding_x_whole;
+        coord_t corresponding_x; // the x coordinate corresponding to nearest_next_y
+        bool is_corresponding_x_whole; // does the real corresponding x not have a fractional portion
         if (y_diff == 0)
         {
             is_corresponding_x_whole = false;


### PR DESCRIPTION
@BagelOrb ok, this attempt is with a better understanding of the algorithm and the intent.  Hopefully.

There are a couple of changes here.  For handling the negative coordinate space, there are two things needed: one is that nearest_next_y is one cell away in y_dir when y_dir matches the sign of cell_y (or at y == 0).  In particular, sometimes it needs to be -1, but the max with 0 always defeated.

The other thing is that if the real corresponding_x has a fraction in the negative x, it can end up off by one.  This is because the algorithm always walks left to right and assumes that truncation would always back off, but in the negative space, will advance.  This wouldn't happen if we walked in the direction of the sign of x, but that wouldn't work for lines that cross the line x=0, so there's a bit of messy fixing that off by one.

But...  having to compute whether there is a modulo makes it not that hard to also pick up the case where the line crosses precisely at the cell corner, so I did that too.  This fix is in two places, one when computing x_cell_end and then again when deciding whether to advance x_cell_start by one.