### PR TITLE
Allow firmware retract on machines without requiring Volumetric

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -14,6 +14,8 @@ namespace cura {
 GCodeExport::GCodeExport()
 : output_stream(&std::cout)
 , currentPosition(0,0,MM2INT(20))
+, is_volumatric(false)
+, firmware_retract(false)
 , layer_nr(0)
 {
     *output_stream << std::fixed;
@@ -42,6 +44,7 @@ GCodeExport::~GCodeExport()
 
 void GCodeExport::preSetup(const MeshGroup* meshgroup)
 {
+    firmware_retract = settings->getSettingBoolean("machine_firmware_retract");
     setFlavor(meshgroup->getSettingAsGCodeFlavor("machine_gcode_flavor"));
     use_extruder_offset_to_offset_coords = meshgroup->getSettingBoolean("machine_use_extruder_offset_to_offset_coords");
 
@@ -245,10 +248,6 @@ void GCodeExport::setFlavor(EGCodeFlavor flavor)
     if (flavor == EGCodeFlavor::BFB || flavor == EGCodeFlavor::REPRAP_VOLUMATRIC || flavor == EGCodeFlavor::ULTIGCODE)
     {
         firmware_retract = true;
-    }
-    else 
-    {
-        firmware_retract = false;
     }
 }
 


### PR DESCRIPTION
Marlin is quite fine doing firmware retractions without being in volumetric mode.  This allows one to use this by setting:

```
 "machine_settings": {
    "machine_firmware_retract": { "default": true }
}
```
