### PR TITLE
Adding <numeric> for GCC 6.x

### DIFF
--- a/src/utils/algorithm.h
+++ b/src/utils/algorithm.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <vector>
 #include <functional>
+#include <numeric>
 
 // extensions to algorithm.h from the standard library
 


### PR DESCRIPTION
Otherwise you will get something like:

```
In file included from /<<PKGBUILDDIR>>/src/FffPolygonGenerator.cpp:7:0:
/<<PKGBUILDDIR>>/src/utils/algorithm.h: In function ‘std::vector<long unsigned int> cura::order(const std::vector<_Tp>&)’:
/<<PKGBUILDDIR>>/src/utils/algorithm.h:30:5: error: ‘iota’ is not a member of ‘std’
     std::iota(order.begin(), order.end(), 0); // fill vector with 1, 2, 3,.. etc
     ^~~
```

* Fixes #407