### PR TITLE
Implementing std::reference_wrapper as the main member of PolygonRef

### DIFF
--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -8,1223 +8,1109 @@
 namespace cura 
 {
 
-bool PolygonRef::shorterThan(int64_t check_length) const
-{
-    const PolygonRef& polygon = *this;
-    const Point* p0 = &polygon.back();
-    int64_t length = 0;
-    for (const Point& p1 : polygon)
-    {
-        length += vSize(*p0 - p1);
-        if (length >= check_length)
-        {
-            return false;
-        }
-        p0 = &p1;
-    }
-    return true;
+bool PolygonRef::pShorterThan(int64_t check_length) const {
+	const PolygonRef& polygon = *this;
+	const Point* p0 = &polygon.back();
+	int64_t length = 0;
+	for (const Point& p1 : polygon) {
+		length += vSize(*p0 - p1);
+		if (length >= check_length) {
+			return false;
+		}
+		p0 = &p1;
+	}
+	return true;
 }
 
-bool PolygonRef::_inside(Point p, bool border_result) const
+bool PolygonRef::_inside(Point p, bool border_result)
 {
-    PolygonRef thiss = *this;
-    if (size() < 1)
-    {
-        return false;
-    }
-    
-    int crossings = 0;
-    Point p0 = back();
-    for(unsigned int n=0; n<size(); n++)
-    {
-        Point p1 = thiss[n];
-        // no tests unless the segment p0-p1 is at least partly at, or to right of, p.X
-        short comp = LinearAlg2D::pointLiesOnTheRightOfLine(p, p0, p1);
-        if (comp == 1)
-        {
-            crossings++;
-        }
-        else if (comp == 0)
-        {
-            return border_result;
-        }
-        p0 = p1;
-    }
-    return (crossings % 2) == 1;
+	PolygonRef thiss = *this;
+	if (size() < 1)
+	{
+		return false;
+	}
+
+	int crossings = 0;
+	Point p0 = back();
+	for (unsigned int n = 0; n<size(); n++)
+	{
+		Point p1 = thiss[n];
+		// no tests unless the segment p0-p1 is at least partly at, or to right of, p.X
+		short comp = LinearAlg2D::pointLiesOnTheRightOfLine(p, p0, p1);
+		if (comp == 1)
+		{
+			crossings++;
+		}
+		else if (comp == 0)
+		{
+			return border_result;
+		}
+		p0 = p1;
+	}
+	return (crossings % 2) == 1;
 }
 
 Polygons Polygons::approxConvexHull(int extra_outset)
 {
-    constexpr int overshoot = 100000; //10cm (hard-coded value).
+	constexpr int overshoot = 100000; //10cm (hard-coded value).
 
-    Polygons convex_hull;
-    //Perform the offset for each polygon one at a time.
-    //This is necessary because the polygons may overlap, in which case the offset could end up in an infinite loop.
-    //See http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Classes/ClipperOffset/_Body.htm
-    for (const ClipperLib::Path path : paths)
-    {
-        Polygons offset_result;
-        ClipperLib::ClipperOffset offsetter(1.2, 10.0);
-        offsetter.AddPath(path, ClipperLib::jtRound, ClipperLib::etClosedPolygon);
-        offsetter.Execute(offset_result.paths, overshoot);
-        convex_hull.add(offset_result);
-    }
-    return convex_hull.unionPolygons().offset(-overshoot + extra_outset, ClipperLib::jtRound);
+	Polygons convex_hull;
+	//Perform the offset for each polygon one at a time.
+	//This is necessary because the polygons may overlap, in which case the offset could end up in an infinite loop.
+	//See http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Classes/ClipperOffset/_Body.htm
+	for (const ClipperLib::Path path : paths)
+	{
+		Polygons offset_result;
+		ClipperLib::ClipperOffset offsetter(1.2, 10.0);
+		offsetter.AddPath(path, ClipperLib::jtRound, ClipperLib::etClosedPolygon);
+		offsetter.Execute(offset_result.paths, overshoot);
+		convex_hull.add(offset_result);
+	}
+	return convex_hull.unionPolygons().offset(-overshoot + extra_outset, ClipperLib::jtRound);
 }
 
 unsigned int Polygons::pointCount() const
 {
-    unsigned int count = 0;
-    for (const ClipperLib::Path& path : paths)
-    {
-        count += path.size();
-    }
-    return count;
+	unsigned int count = 0;
+	for (const ClipperLib::Path& path : paths)
+	{
+		count += path.size();
+	}
+	return count;
 }
 
 bool Polygons::inside(Point p, bool border_result) const
 {
-    int poly_count_inside = 0;
-    for (const ClipperLib::Path& poly : *this)
-    {
-        const int is_inside_this_poly = ClipperLib::PointInPolygon(p, poly);
-        if (is_inside_this_poly == -1)
-        {
-            return border_result;
-        }
-        poly_count_inside += is_inside_this_poly;
-    }
-    return (poly_count_inside % 2) == 1;
+	const Polygons& thiss = *this;
+	if (size() < 1)
+	{
+		return false;
+	}
+
+	int crossings = 0;
+	for (const ClipperLib::Path& poly : thiss)
+	{
+		Point p0 = poly.back();
+		for (const Point& p1 : poly)
+		{
+			short comp = LinearAlg2D::pointLiesOnTheRightOfLine(p, p0, p1);
+			if (comp == 1)
+			{
+				crossings++;
+			}
+			else if (comp == 0)
+			{
+				return border_result;
+			}
+			p0 = p1;
+		}
+	}
+	return (crossings % 2) == 1;
+}
+/*
+unsigned int Polygons::findInside(Point p, bool border_result){
+	Polygons& thiss = *this;
+	if (size() < 1){
+		return false;
+	}
+
+	int64_t min_x[size()];
+	std::fill_n(min_x, size(), std::numeric_limits<int64_t>::max());  // initialize with int.max
+	int crossings[size()];
+	std::fill_n(crossings, size(), 0);  // initialize with zeros
+
+	for (unsigned int poly_idx = 0; poly_idx < size(); poly_idx++){
+		PolygonRef poly = thiss[poly_idx];
+		Point p0 = poly.back();
+		for (Point& p1 : poly){
+			short comp = LinearAlg2D::pointLiesOnTheRightOfLine(p, p0, p1);
+			if (comp == 1){
+				crossings[poly_idx]++;
+				int64_t x;
+				if (p1.Y == p0.Y){
+					x = p0.X;
+				}
+				else{
+					x = p0.X + (p1.X - p0.X) * (p.Y - p0.Y) / (p1.Y - p0.Y);
+				}
+				if (x < min_x[poly_idx]){
+					min_x[poly_idx] = x;
+				}
+			}
+			else if (border_result && comp == 0){
+				return poly_idx;
+			}
+			p0 = p1;
+		}
+	}
+
+	int64_t min_x_uneven = std::numeric_limits<int64_t>::max();
+	unsigned int ret = NO_INDEX;
+	unsigned int n_unevens = 0;
+	for (unsigned int array_idx = 0; array_idx < size(); array_idx++){
+		if (crossings[array_idx] % 2 == 1){
+			n_unevens++;
+			if (min_x[array_idx] < min_x_uneven){
+				min_x_uneven = min_x[array_idx];
+				ret = array_idx;
+			}
+		}
+	}
+	if (n_unevens % 2 == 0) { ret = NO_INDEX; }
+	return ret;
+}
+*/
+Polygons Polygons::offset(int distance, ClipperLib::JoinType join_type, double miter_limit) const{
+	Polygons ret;
+	ClipperLib::ClipperOffset clipper(miter_limit, 10.0);
+	clipper.AddPaths(unionPolygons().paths, join_type, ClipperLib::etClosedPolygon);
+	clipper.MiterLimit = miter_limit;
+	clipper.Execute(ret.paths, distance);
+	return ret;
 }
 
-bool Polygons::insideOld(Point p, bool border_result) const
-{
-    const Polygons& thiss = *this;
-    if (size() < 1)
-    {
-        return false;
-    }
-    
-    int crossings = 0;
-    for (const ClipperLib::Path& poly : thiss)
-    {
-        Point p0 = poly.back();
-        for (const Point& p1 : poly)
-        {
-            short comp = LinearAlg2D::pointLiesOnTheRightOfLine(p, p0, p1);
-            if (comp == 1)
-            {
-                crossings++;
-            }
-            else if (comp == 0)
-            {
-                return border_result;
-            }
-            p0 = p1;
-        }
-    }
-    return (crossings % 2) == 1;
+Polygons PolygonRef::offset(int distance, ClipperLib::JoinType joinType, double miter_limit) const{
+	Polygons ret;
+	ClipperLib::ClipperOffset clipper(miter_limit, 10.0);
+	clipper.AddPath(path.get(), joinType, ClipperLib::etClosedPolygon);
+	clipper.MiterLimit = miter_limit;
+	clipper.Execute(ret.paths, distance);
+	return ret;
 }
 
-unsigned int Polygons::findInside(Point p, bool border_result)
-{
-    Polygons& thiss = *this;
-    if (size() < 1)
-    {
-        return false;
-    }
-    
-    int64_t min_x[size()];
-    std::fill_n(min_x, size(), std::numeric_limits<int64_t>::max());  // initialize with int.max
-    int crossings[size()];
-    std::fill_n(crossings, size(), 0);  // initialize with zeros
-    
-    for (unsigned int poly_idx = 0; poly_idx < size(); poly_idx++)
-    {
-        PolygonRef poly = thiss[poly_idx];
-        Point p0 = poly.back();
-        for(Point& p1 : poly)
-        {
-            short comp = LinearAlg2D::pointLiesOnTheRightOfLine(p, p0, p1);
-            if (comp == 1)
-            {
-                crossings[poly_idx]++;
-                int64_t x;
-                if (p1.Y == p0.Y)
-                {
-                    x = p0.X;
-                }
-                else 
-                {
-                    x = p0.X + (p1.X-p0.X) * (p.Y-p0.Y) / (p1.Y-p0.Y);
-                }
-                if (x < min_x[poly_idx])
-                {
-                    min_x[poly_idx] = x;
-                }
-            }
-            else if (border_result && comp == 0)
-            {
-                return poly_idx;
-            }
-            p0 = p1;
-        }
-    }
-    
-    int64_t min_x_uneven = std::numeric_limits<int64_t>::max();
-    unsigned int ret = NO_INDEX;
-    unsigned int n_unevens = 0;
-    for (unsigned int array_idx = 0; array_idx < size(); array_idx++)
-    {
-        if (crossings[array_idx] % 2 == 1)
-        {
-            n_unevens++;
-            if (min_x[array_idx] < min_x_uneven)
-            {
-                min_x_uneven = min_x[array_idx];
-                ret = array_idx;
-            }
-        }
-    }
-    if (n_unevens % 2 == 0) { ret = NO_INDEX; }
-    return ret;
+Polygon Polygons::convexHull() const{
+	// Implements Andrew's monotone chain convex hull algorithm
+	// See https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+
+	using IntPoint = ClipperLib::IntPoint;
+
+	size_t num_points = 0U;
+	for (const ClipperLib::Path& path : paths){
+		num_points += path.size();
+	}
+
+	std::vector<IntPoint> all_points;
+	all_points.reserve(num_points);
+	for (const ClipperLib::Path& path : paths){
+		for (const IntPoint& point : path){
+			all_points.push_back(point);
+		}
+	}
+
+	struct HullSort{
+		bool operator()(const IntPoint& a,
+			const IntPoint& b){
+			return (a.X < b.X) ||
+				(a.X == b.X && a.Y < b.Y);
+		}
+	};
+
+	std::sort(all_points.begin(), all_points.end(), HullSort());
+
+	// positive for left turn, 0 for straight, negative for right turn
+	auto ccw = [](const IntPoint& p0, const IntPoint& p1, const IntPoint& p2) -> int64_t {
+		IntPoint v01(p1.X - p0.X, p1.Y - p0.Y);
+		IntPoint v12(p2.X - p1.X, p2.Y - p1.Y);
+
+		return
+			static_cast<int64_t>(v01.X) * v12.Y -
+			static_cast<int64_t>(v01.Y) * v12.X;
+	};
+
+	Polygon hull_poly;
+	ClipperLib::Path& hull_points = *hull_poly;
+	hull_points.resize(num_points + 1);
+	// index to insert next hull point, also number of valid hull points
+	size_t hull_idx = 0;
+
+	// Build lower hull
+	for (size_t pt_idx = 0U; pt_idx != num_points; ++pt_idx){
+		while (hull_idx >= 2 &&
+			ccw(hull_points[hull_idx - 2], hull_points[hull_idx - 1],
+				all_points[pt_idx]) <= 0)
+		{
+			--hull_idx;
+		}
+		hull_points[hull_idx] = all_points[pt_idx];
+		++hull_idx;
+	}
+
+	// Build upper hull
+	size_t min_upper_hull_chain_end_idx = hull_idx + 1;
+	for (int pt_idx = num_points - 2; pt_idx >= 0; --pt_idx){
+		while (hull_idx >= min_upper_hull_chain_end_idx &&
+			ccw(hull_points[hull_idx - 2], hull_points[hull_idx - 1],
+				all_points[pt_idx]) <= 0){
+			--hull_idx;
+		}
+		hull_points[hull_idx] = all_points[pt_idx];
+		++hull_idx;
+	}
+
+	assert(hull_idx <= hull_points.size());
+
+	// Last point is duplicted with first.  It is removed in the resize.
+	hull_points.resize(hull_idx - 2);
+
+	return hull_poly;
 }
 
-Polygons Polygons::offset(int distance, ClipperLib::JoinType join_type, double miter_limit) const
-{
-    Polygons ret;
-    ClipperLib::ClipperOffset clipper(miter_limit, 10.0);
-    clipper.AddPaths(unionPolygons().paths, join_type, ClipperLib::etClosedPolygon);
-    clipper.MiterLimit = miter_limit;
-    clipper.Execute(ret.paths, distance);
-    return ret;
+void PolygonRef::simplify(int smallest_line_segment_squared, int allowed_error_distance_squared) {
+
+	if (size() < 3){
+		clear();
+		return;
+	}
+
+	// Algorithm Explanation:
+	// initial: 1
+	// after stage I: 2
+	// after first step of stage II: 3
+	//
+	//                       111111111111111111111111111
+	//                      1         22 332222         1
+	//                     1       222  3  3   222       1
+	//                    1      22    3   3      222     1
+	//                    1   222      3    3        2222 1
+	//                   1 222        3      3           221
+	//                  122          3       3              12
+	//                 12            3        3              1
+	//                 12           3          3             1
+	//                1 2          3            3            21
+	//               1  2          3            3            21
+	//               1  2         3              3          2  1
+	//              1    2        3               3         2  1
+	//              1    2       3                 3        2   1
+	//             1     2      3                  3        2   1
+	//              1    2      3                   3       2    1
+	//               1    2    3                     3      2    1
+	//                1   2   3                      3     2    1
+	//                 1  2   3                       3    2   1
+	//                  1  2 3                         3   2  1
+	//                   1 23                           3  2 1
+	//                    123                           3  21
+	//                     1                             321
+	//                                                    1
+	//
+	// this is neccesary in order to avoid the case where a long segment is followed by a lot of small segments would get simplified to a long segment going to the wrong end point
+	//  .......                _                 _______
+	// |                      /                 |
+	// |     would become    /    instead of    |
+	// |                    /                   |
+	//
+	// therefore every time a vert is removed the next is kept (for the moment)
+	//
+	// .......            ._._._._.         .___.___.          .________
+	// |                  |                 |                  |
+	// |    will  become  |    will become  |     will become  |
+	// |                  |                 |                  |
+	//
+
+	ClipperLib::Path this_path = path.get();
+	coord_t min_length_2 = std::min(smallest_line_segment_squared, allowed_error_distance_squared);
+
+	ListPolygon result_list_poly;
+	result_list_poly.emplace_back(path.get().front());
+
+	std::vector<ListPolyIt> skipped_verts;
+	// add the first point as starting point for the algorithm
+	// whether the first point has to be removed is checked separately afterwards
+	skipped_verts.emplace_back(result_list_poly, result_list_poly.begin());
+
+	char here_is_beyond_line = 0;{ 
+		// stage I: convert to a ListPolygon and remove verts, but don't remove verts just after removed verts (i.e. skip them)
+		Point prev = this_path[0];
+		auto skip = [this, &result_list_poly, &this_path, &prev, &skipped_verts](unsigned int& poly_idx){
+			poly_idx++;
+			if (poly_idx >= size())
+			{ // don't wrap around, the first point has already been added
+				return;
+			}
+			result_list_poly.emplace_back(this_path[poly_idx]);
+			prev = result_list_poly.back();
+			skipped_verts.emplace_back(result_list_poly, --result_list_poly.end());
+		};
+
+		for (unsigned int poly_idx = 1; poly_idx < size(); poly_idx++){
+			const Point& here = this_path[poly_idx];
+			const Point& next = this_path[(poly_idx + 1) % size()];
+			if (here == next){ 
+				// disregard duplicate points without skipping the next point
+				continue;
+			}
+			if (vSize2(here - prev) < min_length_2 && vSize2(next - here) < min_length_2){
+				// don't add [here] to the result
+				// skip checking whether the next point has to be removed for now
+				skip(poly_idx);
+				continue;
+			}
+			int64_t error2 = LinearAlg2D::getDist2FromLineSegment(prev, here, next, &here_is_beyond_line);
+			if (here_is_beyond_line == 0 && error2 < allowed_error_distance_squared){
+				// don't add [here] to the result
+				// skip checking whether the next point has to be removed for now
+				skip(poly_idx);
+			}
+			else{
+				result_list_poly.emplace_back(here);
+				prev = result_list_poly.back();
+			}
+		}
+	}
+
+	{ // stage II: keep removing skipped verts (and skip the next vert if it was a skipped vert)
+		auto skip = [&skipped_verts, &result_list_poly](unsigned int& skipped_vert_idx, const ListPolyIt skipped_vert, std::vector<ListPolyIt>& new_skipped_verts){
+			unsigned int next_skipped_vert_idx = skipped_vert_idx + 1;
+			if (next_skipped_vert_idx < skipped_verts.size() && skipped_vert.next() == skipped_verts[next_skipped_vert_idx]){
+				skipped_vert_idx++;
+				new_skipped_verts.emplace_back(skipped_verts[next_skipped_vert_idx]);
+			}
+			result_list_poly.erase(skipped_vert.it);
+		};
+		while (!skipped_verts.empty() && result_list_poly.size() >= 3){
+			std::vector<ListPolyIt> new_skipped_verts;
+
+			for (unsigned int skipped_vert_idx = 0; skipped_vert_idx < skipped_verts.size(); skipped_vert_idx++){
+				ListPolyIt skipped_vert = skipped_verts[skipped_vert_idx];
+				const Point& here = skipped_vert.p();
+				const Point& prev = skipped_vert.prev().p();
+
+				const Point& next = skipped_vert.next().p();
+				if (vSize2(here - prev) < min_length_2 && vSize2(next - here) < min_length_2){
+					// skip checking whether the next point has to be removed for now
+					skip(skipped_vert_idx, skipped_vert, new_skipped_verts);
+					continue;
+				}
+				int64_t error2 = LinearAlg2D::getDist2FromLineSegment(prev, here, next, &here_is_beyond_line);
+				if (here_is_beyond_line == 0 && error2 < allowed_error_distance_squared){
+					// skip checking whether the next point has to be removed for now
+					skip(skipped_vert_idx, skipped_vert, new_skipped_verts);
+				}
+				else
+				{
+					// keep the point
+				}
+			}
+			skipped_verts = new_skipped_verts;
+		}
+	}
+
+	clear();
+	if (result_list_poly.size() < 3){
+		return;
+	}
+	ListPolyIt::convertListPolygonToPolygon(result_list_poly, *this);
 }
 
-Polygons PolygonRef::offset(int distance, ClipperLib::JoinType joinType, double miter_limit) const
-{
-    Polygons ret;
-    ClipperLib::ClipperOffset clipper(miter_limit, 10.0);
-    clipper.AddPath(*path, joinType, ClipperLib::etClosedPolygon);
-    clipper.MiterLimit = miter_limit;
-    clipper.Execute(ret.paths, distance);
-    return ret;
+Polygons Polygons::getOutsidePolygons() const{
+	Polygons ret;
+	ClipperLib::Clipper clipper(clipper_init);
+	ClipperLib::PolyTree poly_tree;
+	constexpr bool paths_are_closed_polys = true;
+	clipper.AddPaths(paths, ClipperLib::ptSubject, paths_are_closed_polys);
+	clipper.Execute(ClipperLib::ctUnion, poly_tree);
+
+	for (int outer_poly_idx = 0; outer_poly_idx < poly_tree.ChildCount(); outer_poly_idx++){
+		ClipperLib::PolyNode* child = poly_tree.Childs[outer_poly_idx];
+		ret.emplace_back(child->Contour);
+	}
+	return ret;
 }
 
-Polygon Polygons::convexHull() const
-{
-    // Implements Andrew's monotone chain convex hull algorithm
-    // See https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+Polygons Polygons::removeEmptyHoles() const{
+	Polygons ret;
+	ClipperLib::Clipper clipper(clipper_init);
+	ClipperLib::PolyTree poly_tree;
+	constexpr bool paths_are_closed_polys = true;
+	clipper.AddPaths(paths, ClipperLib::ptSubject, paths_are_closed_polys);
+	clipper.Execute(ClipperLib::ctUnion, poly_tree);
 
-    using IntPoint = ClipperLib::IntPoint;
-
-    size_t num_points = 0U;
-    for (const ClipperLib::Path& path : paths)
-    {
-        num_points += path.size();
-    }
-
-    std::vector<IntPoint> all_points;
-    all_points.reserve(num_points);
-    for (const ClipperLib::Path& path : paths)
-    {
-        for (const IntPoint& point : path)
-        {
-            all_points.push_back(point);
-        }
-    }
-
-    struct HullSort
-    {
-        bool operator()(const IntPoint& a,
-                        const IntPoint& b)
-        {
-            return (a.X < b.X) ||
-                (a.X == b.X && a.Y < b.Y);
-        }
-    };
-
-    std::sort(all_points.begin(), all_points.end(), HullSort());
-
-    // positive for left turn, 0 for straight, negative for right turn
-    auto ccw = [](const IntPoint& p0, const IntPoint& p1, const IntPoint& p2) -> int64_t {
-        IntPoint v01(p1.X - p0.X, p1.Y - p0.Y);
-        IntPoint v12(p2.X - p1.X, p2.Y - p1.Y);
-
-        return
-            static_cast<int64_t>(v01.X) * v12.Y -
-            static_cast<int64_t>(v01.Y) * v12.X;
-    };
-
-    Polygon hull_poly;
-    ClipperLib::Path& hull_points = *hull_poly;
-    hull_points.resize(num_points+1);
-    // index to insert next hull point, also number of valid hull points
-    size_t hull_idx = 0;
-
-    // Build lower hull
-    for (size_t pt_idx = 0U; pt_idx != num_points; ++pt_idx)
-    {
-        while (hull_idx >= 2 &&
-               ccw(hull_points[hull_idx-2], hull_points[hull_idx-1],
-                   all_points[pt_idx]) <= 0)
-        {
-            --hull_idx;
-        }
-        hull_points[hull_idx] = all_points[pt_idx];
-        ++hull_idx;
-    }
-
-    // Build upper hull
-    size_t min_upper_hull_chain_end_idx = hull_idx+1;
-    for (int pt_idx = num_points-2; pt_idx >= 0; --pt_idx)
-    {
-        while (hull_idx >= min_upper_hull_chain_end_idx &&
-               ccw(hull_points[hull_idx-2], hull_points[hull_idx-1],
-                   all_points[pt_idx]) <= 0)
-        {
-            --hull_idx;
-        }
-        hull_points[hull_idx] = all_points[pt_idx];
-        ++hull_idx;
-    }
-
-    assert(hull_idx <= hull_points.size());
-
-    // Last point is duplicted with first.  It is removed in the resize.
-    hull_points.resize(hull_idx - 2);
-
-    return hull_poly;
+	removeEmptyHoles_processPolyTreeNode(poly_tree, ret);
+	return ret;
 }
 
-void PolygonRef::simplify(int smallest_line_segment_squared, int allowed_error_distance_squared){
-
-    if (size() < 3)
-    {
-        clear();
-        return;
-    }
-
-// Algorithm Explanation:
-// initial: 1
-// after stage I: 2
-// after first step of stage II: 3
-//
-//                       111111111111111111111111111
-//                      1         22 332222         1
-//                     1       222  3  3   222       1
-//                    1      22    3   3      222     1
-//                    1   222      3    3        2222 1
-//                   1 222        3      3           221
-//                  122          3       3              12
-//                 12            3        3              1
-//                 12           3          3             1
-//                1 2          3            3            21
-//               1  2          3            3            21
-//               1  2         3              3          2  1
-//              1    2        3               3         2  1
-//              1    2       3                 3        2   1
-//             1     2      3                  3        2   1
-//              1    2      3                   3       2    1
-//               1    2    3                     3      2    1
-//                1   2   3                      3     2    1
-//                 1  2   3                       3    2   1
-//                  1  2 3                         3   2  1
-//                   1 23                           3  2 1
-//                    123                           3  21
-//                     1                             321
-//                                                    1
-//
-// this is neccesary in order to avoid the case where a long segment is followed by a lot of small segments would get simplified to a long segment going to the wrong end point
-//  .......                _                 _______
-// |                      /                 |
-// |     would become    /    instead of    |
-// |                    /                   |
-//
-// therefore every time a vert is removed the next is kept (for the moment)
-//
-// .......            ._._._._.         .___.___.          .________
-// |                  |                 |                  |
-// |    will  become  |    will become  |     will become  |
-// |                  |                 |                  |
-//
-
-    ClipperLib::Path this_path = *path;
-    coord_t min_length_2 = std::min(smallest_line_segment_squared, allowed_error_distance_squared);
-
-    ListPolygon result_list_poly;
-    result_list_poly.emplace_back(path->front());
-
-    std::vector<ListPolyIt> skipped_verts;
-    // add the first point as starting point for the algorithm
-    // whether the first point has to be removed is checked separately afterwards
-    skipped_verts.emplace_back(result_list_poly, result_list_poly.begin());
-
-    char here_is_beyond_line = 0;
-    { // stage I: convert to a ListPolygon and remove verts, but don't remove verts just after removed verts (i.e. skip them)
-        Point prev = this_path[0];
-        auto skip = [this, &result_list_poly, &this_path, &prev, &skipped_verts](unsigned int& poly_idx)
-        {
-            poly_idx++;
-            if (poly_idx >= size())
-            { // don't wrap around, the first point has already been added
-                return;
-            }
-            result_list_poly.emplace_back(this_path[poly_idx]);
-            prev = result_list_poly.back();
-            skipped_verts.emplace_back(result_list_poly, --result_list_poly.end());
-        };
-
-        for (unsigned int poly_idx = 1; poly_idx < size(); poly_idx++)
-        {
-            const Point& here = this_path[poly_idx];
-            const Point& next = this_path[(poly_idx + 1) % size()];
-            if (here == next)
-            { // disregard duplicate points without skipping the next point
-                continue;
-            }
-            if ( vSize2(here - prev) < min_length_2 && vSize2(next - here) < min_length_2 )
-            {
-                // don't add [here] to the result
-                // skip checking whether the next point has to be removed for now
-                skip(poly_idx);
-                continue;
-            }
-            int64_t error2 = LinearAlg2D::getDist2FromLineSegment(prev, here, next, &here_is_beyond_line);
-            if (here_is_beyond_line == 0 && error2 < allowed_error_distance_squared)
-            {
-                // don't add [here] to the result
-                // skip checking whether the next point has to be removed for now
-                skip(poly_idx);
-            }
-            else
-            {
-                result_list_poly.emplace_back(here);
-                prev = result_list_poly.back();
-            }
-        }
-    }
-
-    { // stage II: keep removing skipped verts (and skip the next vert if it was a skipped vert)
-        auto skip = [&skipped_verts, &result_list_poly](unsigned int& skipped_vert_idx, const ListPolyIt skipped_vert, std::vector<ListPolyIt>& new_skipped_verts)
-        {
-            unsigned int next_skipped_vert_idx = skipped_vert_idx + 1;
-            if (next_skipped_vert_idx < skipped_verts.size() && skipped_vert.next() == skipped_verts[next_skipped_vert_idx])
-            {
-                skipped_vert_idx++;
-                new_skipped_verts.emplace_back(skipped_verts[next_skipped_vert_idx]);
-            }
-            result_list_poly.erase(skipped_vert.it);
-        };
-        while (!skipped_verts.empty() && result_list_poly.size() >= 3)
-        {
-            std::vector<ListPolyIt> new_skipped_verts;
-
-            for (unsigned int skipped_vert_idx = 0; skipped_vert_idx < skipped_verts.size(); skipped_vert_idx++)
-            {
-                ListPolyIt skipped_vert = skipped_verts[skipped_vert_idx];
-                const Point& here = skipped_vert.p();
-                const Point& prev = skipped_vert.prev().p();
-
-                const Point& next = skipped_vert.next().p();
-                if ( vSize2(here - prev) < min_length_2 && vSize2(next - here) < min_length_2 )
-                {
-                    // skip checking whether the next point has to be removed for now
-                    skip(skipped_vert_idx, skipped_vert, new_skipped_verts);
-                    continue;
-                }
-                int64_t error2 = LinearAlg2D::getDist2FromLineSegment(prev, here, next, &here_is_beyond_line);
-                if (here_is_beyond_line == 0 && error2 < allowed_error_distance_squared)
-                {
-                    // skip checking whether the next point has to be removed for now
-                    skip(skipped_vert_idx, skipped_vert, new_skipped_verts);
-                }
-                else
-                {
-                    // keep the point
-                }
-            }
-            skipped_verts = new_skipped_verts;
-        }
-    }
-
-    clear();
-    if (result_list_poly.size() < 3)
-    {
-        return;
-    }
-    ListPolyIt::convertListPolygonToPolygon(result_list_poly, *this);
+void Polygons::removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, Polygons& ret) const{
+	for (int outer_poly_idx = 0; outer_poly_idx < node.ChildCount(); outer_poly_idx++){
+		ClipperLib::PolyNode* child = node.Childs[outer_poly_idx];
+		ret.emplace_back(child->Contour);
+		for (int hole_node_idx = 0; hole_node_idx < child->ChildCount(); hole_node_idx++){
+			ClipperLib::PolyNode& hole_node = *child->Childs[hole_node_idx];
+			if (hole_node.ChildCount() > 0){
+				ret.emplace_back(hole_node.Contour);
+				removeEmptyHoles_processPolyTreeNode(hole_node, ret);
+			}
+		}
+	}
 }
 
-Polygons Polygons::getOutsidePolygons() const
-{
-    Polygons ret;
-    ClipperLib::Clipper clipper(clipper_init);
-    ClipperLib::PolyTree poly_tree;
-    constexpr bool paths_are_closed_polys = true;
-    clipper.AddPaths(paths, ClipperLib::ptSubject, paths_are_closed_polys);
-    clipper.Execute(ClipperLib::ctUnion, poly_tree);
+void PolygonRef::smooth_corner_complex(ListPolygon& poly, const Point p1, ListPolyIt& p0_it, ListPolyIt& p2_it, const int64_t shortcut_length){
+	// walk away from the corner until the shortcut > shortcut_length or it would smooth a piece inward
+	// - walk in both directions untill shortcut > shortcut_length 
+	// - stop walking in one direction if it would otherwise cut off a corner in that direction
+	// - same in the other direction
+	// - stop if both are cut off
+	// walk by updating p0_it and p2_it
+	int64_t shortcut_length2 = shortcut_length * shortcut_length;
+	bool forward_is_blocked = false;
+	bool forward_is_too_far = false;
+	bool backward_is_blocked = false;
+	bool backward_is_too_far = false;
+	while (p0_it.prev() != p2_it && p0_it != p2_it){ 
+		// condition to pragmatically prevent infinite loops
+		const bool forward_has_converged = forward_is_blocked || forward_is_too_far;
+		const bool backward_has_converged = backward_is_blocked || backward_is_too_far;
+		if (forward_has_converged && backward_has_converged){
+			if (forward_is_too_far && backward_is_too_far && vSize2(p0_it.prev().p() - p2_it.next().p()) < shortcut_length2){
+				//         o
+				//       /   \                                                  .
+				//      o     o
+				//      |     |
+				//      \     /                                                 .
+				//       |   |
+				//       \   /                                                  .
+				//        | |
+				//        o o
+				--p0_it;
+				++p2_it;
+				forward_is_too_far = false; // invalidate data
+				backward_is_too_far = false; // invalidate data
+				continue;
+			}
+			else{
+				break;
+			}
+		}
+		smooth_outward_step(p1, shortcut_length2, p0_it, p2_it, forward_is_blocked, backward_is_blocked, forward_is_too_far, backward_is_too_far);
+	}
 
-    for (int outer_poly_idx = 0; outer_poly_idx < poly_tree.ChildCount(); outer_poly_idx++)
-    {
-        ClipperLib::PolyNode* child = poly_tree.Childs[outer_poly_idx];
-        ret.emplace_back(child->Contour);
-    }
-    return ret;
-}
+	const Point v02 = p2_it.p() - p0_it.p();
+	const int64_t v02_size2 = vSize2(v02);
+	// set the following:
+	// p0_it = start point of line
+	// p2_it = end point of line
+	if (std::abs(v02_size2 - shortcut_length2) < shortcut_length * 10){ 
+	   // i.e. if (size2 < l * (l+10) && size2 > l * (l-10))
+	  // v02 is approximately shortcut length
+	  // handle this separately to avoid rounding problems below in the getPointOnLineWithDist function
+	  // p0_it and p2_it are already correct
+	}
+	else if (!backward_is_blocked && !forward_is_blocked){ 
+	   // introduce two new points
+	  //  1----b---->2
+	  //  ^   /
+	  //  |  /
+	  //  | /
+	  //  |/
+	  //  |a
+	  //  |
+	  //  0
+		const int64_t v02_size = sqrt(v02_size2);
 
-Polygons Polygons::removeEmptyHoles() const
-{
-    Polygons ret;
-    ClipperLib::Clipper clipper(clipper_init);
-    ClipperLib::PolyTree poly_tree;
-    constexpr bool paths_are_closed_polys = true;
-    clipper.AddPaths(paths, ClipperLib::ptSubject, paths_are_closed_polys);
-    clipper.Execute(ClipperLib::ctUnion, poly_tree);
-
-    bool remove_holes = true;
-    removeEmptyHoles_processPolyTreeNode(poly_tree, remove_holes, ret);
-    return ret;
-}
-
-Polygons Polygons::getEmptyHoles() const
-{
-    Polygons ret;
-    ClipperLib::Clipper clipper(clipper_init);
-    ClipperLib::PolyTree poly_tree;
-    constexpr bool paths_are_closed_polys = true;
-    clipper.AddPaths(paths, ClipperLib::ptSubject, paths_are_closed_polys);
-    clipper.Execute(ClipperLib::ctUnion, poly_tree);
-
-    bool remove_holes = false;
-    removeEmptyHoles_processPolyTreeNode(poly_tree, remove_holes, ret);
-    return ret;
-}
-
-void Polygons::removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, const bool remove_holes, Polygons& ret) const
-{
-    for (int outer_poly_idx = 0; outer_poly_idx < node.ChildCount(); outer_poly_idx++)
-    {
-        ClipperLib::PolyNode* child = node.Childs[outer_poly_idx];
-        if (remove_holes)
-        {
-            ret.emplace_back(child->Contour);
-        }
-        for (int hole_node_idx = 0; hole_node_idx < child->ChildCount(); hole_node_idx++)
-        {
-            ClipperLib::PolyNode& hole_node = *child->Childs[hole_node_idx];
-            if ((hole_node.ChildCount() > 0) == remove_holes)
-            {
-                ret.emplace_back(hole_node.Contour);
-                removeEmptyHoles_processPolyTreeNode(hole_node, remove_holes, ret);
-            }
-        }
-    }
-}
-
-bool PolygonRef::smooth_corner_complex(ListPolygon& poly, const Point p1, ListPolyIt& p0_it, ListPolyIt& p2_it, const int64_t shortcut_length)
-{
-    // walk away from the corner until the shortcut > shortcut_length or it would smooth a piece inward
-    // - walk in both directions untill shortcut > shortcut_length 
-    // - stop walking in one direction if it would otherwise cut off a corner in that direction
-    // - same in the other direction
-    // - stop if both are cut off
-    // walk by updating p0_it and p2_it
-    int64_t shortcut_length2 = shortcut_length * shortcut_length;
-    bool forward_is_blocked = false;
-    bool forward_is_too_far = false;
-    bool backward_is_blocked = false;
-    bool backward_is_too_far = false;
-    while (true)
-    {
-        const bool forward_has_converged = forward_is_blocked || forward_is_too_far;
-        const bool backward_has_converged = backward_is_blocked || backward_is_too_far;
-        if (forward_has_converged && backward_has_converged)
-        {
-            if (forward_is_too_far && backward_is_too_far && vSize2(p0_it.prev().p() - p2_it.next().p()) < shortcut_length2)
-            {
-                //         o
-                //       /   \                                                  .
-                //      o     o
-                //      |     |
-                //      \     /                                                 .
-                //       |   |
-                //       \   /                                                  .
-                //        | |
-                //        o o
-                --p0_it;
-                ++p2_it;
-                forward_is_too_far = false; // invalidate data
-                backward_is_too_far = false; // invalidate data
-                continue;
-            }
-            else
-            {
-                break;
-            }
-        }
-        smooth_outward_step(p1, shortcut_length2, p0_it, p2_it, forward_is_blocked, backward_is_blocked, forward_is_too_far, backward_is_too_far);
-        if (p0_it.prev() == p2_it || p0_it == p2_it)
-        { // stop if we went all the way around the polygon
-            // this should only be the case for hole polygons (?)
-            if (forward_is_too_far && backward_is_too_far)
-            {
-                // in case p0_it.prev() == p2_it :
-                //     /                                                .
-                //    /                /|
-                //   |       becomes  | |
-                //    \                \|
-                //     \                                                .
-                // in case p0_it == p2_it :
-                //     /                                                .
-                //    /    becomes     /|
-                //    \                \|
-                //     \                                                .
-                break;
-            }
-            else
-            {
-                // this whole polygon can be removed
-                return true;
-            }
-        }
-    }
-
-    const Point v02 = p2_it.p() - p0_it.p();
-    const int64_t v02_size2 = vSize2(v02);
-    // set the following:
-    // p0_it = start point of line
-    // p2_it = end point of line
-    if (std::abs(v02_size2 - shortcut_length2) < shortcut_length * 10) // i.e. if (size2 < l * (l+10) && size2 > l * (l-10))
-    { // v02 is approximately shortcut length
-        // handle this separately to avoid rounding problems below in the getPointOnLineWithDist function
-        // p0_it and p2_it are already correct
-    }
-    else if (!backward_is_blocked && !forward_is_blocked)
-    { // introduce two new points
-        //  1----b---->2
-        //  ^   /
-        //  |  /
-        //  | /
-        //  |/
-        //  |a
-        //  |
-        //  0
-        const int64_t v02_size = sqrt(v02_size2);
-
-        const ListPolyIt p0_2_it = p0_it.prev();
-        const ListPolyIt p2_2_it = p2_it.next();
-        const Point p2_2 = p2_2_it.p();
-        const Point p0_2 = p0_2_it.p();
-        const Point v02_2 = p0_2 - p2_2;
-        const int64_t v02_2_size = vSize(v02_2);
-        float progress = std::min(1.0, INT2MM(shortcut_length - v02_size) / INT2MM(v02_2_size - v02_size)); // account for rounding error when v02_2_size is approx equal to v02_size
-        assert(progress >= 0.0f && progress <= 1.0f && "shortcut length must be between last length and new length");
-        const Point new_p0 = p0_it.p() + (p0_2 - p0_it.p()) * progress;
-        p0_it = ListPolyIt::insertPointNonDuplicate(p0_2_it, p0_it, new_p0);
-        const Point new_p2 = p2_it.p() + (p2_2 - p2_it.p()) * progress;
-        p2_it = ListPolyIt::insertPointNonDuplicate(p2_it, p2_2_it, new_p2);
-    }
-    else if (!backward_is_blocked)
-    { // forward is blocked, back is open
-        //     |
-        //  1->b
-        //  ^  :
-        //  | /
-        //  0 :
-        //  |/
-        //  |a
-        //  |
-        //  0_2
-        const ListPolyIt p0_2_it = p0_it.prev();
-        const Point p0 = p0_it.p();
-        const Point p0_2 = p0_2_it.p();
-        const Point p2 = p2_it.p();
-        Point new_p0;
-        bool success = LinearAlg2D::getPointOnLineWithDist(p2, p0, p0_2, shortcut_length, new_p0);
-        // shortcut length must be possible given that last length was ok and new length is too long
-        if (success)
-        {
+		const ListPolyIt p0_2_it = p0_it.prev();
+		const ListPolyIt p2_2_it = p2_it.next();
+		const Point p2_2 = p2_2_it.p();
+		const Point p0_2 = p0_2_it.p();
+		const Point v02_2 = p0_2 - p2_2;
+		const int64_t v02_2_size = vSize(v02_2);
+		float progress = std::min(1.0, INT2MM(shortcut_length - v02_size) / INT2MM(v02_2_size - v02_size)); // account for rounding error when v02_2_size is approx equal to v02_size
+		assert(progress >= 0.0f && progress <= 1.0f && "shortcut length must be between last length and new length");
+		const Point new_p0 = p0_it.p() + (p0_2 - p0_it.p()) * progress;
+		p0_it = ListPolyIt(poly, poly.insert(p0_it.it, new_p0));
+		const Point new_p2 = p2_it.p() + (p2_2 - p2_it.p()) * progress;
+		p2_it = ListPolyIt(poly, poly.insert(p2_2_it.it, new_p2));
+	}
+	else if (!backward_is_blocked){ 
+	  // forward is blocked, back is open
+	  //     |
+	  //  1->b
+	  //  ^  :
+	  //  | /
+	  //  0 :
+	  //  |/
+	  //  |a
+	  //  |
+	  //  0_2
+		const ListPolyIt p0_2_it = p0_it.prev();
+		const Point p0 = p0_it.p();
+		const Point p0_2 = p0_2_it.p();
+		const Point p2 = p2_it.p();
+		Point new_p0;
+		bool success = LinearAlg2D::getPointOnLineWithDist(p2, p0, p0_2, shortcut_length, new_p0);
+		// shortcut length must be possible given that last length was ok and new length is too long
+		if (success)
+		{
 #ifdef ASSERT_INSANE_OUTPUT
-            assert(vSize(new_p0) < 300000);
+			assert(vSize(new_p0) < 300000);
 #endif // #ifdef ASSERT_INSANE_OUTPUT
-            p0_it = ListPolyIt::insertPointNonDuplicate(p0_2_it, p0_it, new_p0);
-        }
-        else
-        { // if not then a rounding error occured
-            if (vSize(p2 - p0_2) < vSize2(p2 - p0))
-            {
-                p0_it = p0_2_it; // start shortcut at 0
-            }
-        }
-    }
-    else if (!forward_is_blocked)
-    { // backward is blocked, front is open
-        //  1----2----b----------->2_2
-        //  ^      ,-'
-        //  |   ,-'
-        //--0.-'
-        //  a
-        const ListPolyIt p2_2_it = p2_it.next();
-        const Point p0 = p0_it.p();
-        const Point p2 = p2_it.p();
-        const Point p2_2 = p2_2_it.p();
-        Point new_p2;
-        bool success = LinearAlg2D::getPointOnLineWithDist(p0, p2, p2_2, shortcut_length, new_p2);
-        // shortcut length must be possible given that last length was ok and new length is too long
-        if (success)
-        {
+			p0_it = ListPolyIt(poly, poly.insert(p0_it.it, new_p0));
+		}
+		else
+		{ // if not then a rounding error occured
+			if (vSize(p2 - p0_2) < vSize2(p2 - p0))
+			{
+				p0_it = p0_2_it; // start shortcut at 0
+			}
+		}
+	}
+	else if (!forward_is_blocked)
+	{ // backward is blocked, front is open
+	  //  1----2----b----------->2_2
+	  //  ^      ,-'
+	  //  |   ,-'
+	  //--0.-'
+	  //  a
+		const ListPolyIt p2_2_it = p2_it.next();
+		const Point p0 = p0_it.p();
+		const Point p2 = p2_it.p();
+		const Point p2_2 = p2_2_it.p();
+		Point new_p2;
+		bool success = LinearAlg2D::getPointOnLineWithDist(p0, p2, p2_2, shortcut_length, new_p2);
+		// shortcut length must be possible given that last length was ok and new length is too long
+		if (success)
+		{
 #ifdef ASSERT_INSANE_OUTPUT
-            assert(vSize(new_p2) < 300000);
+			assert(vSize(new_p2) < 300000);
 #endif // #ifdef ASSERT_INSANE_OUTPUT
-            p2_it = ListPolyIt::insertPointNonDuplicate(p2_it, p2_2_it, new_p2);
-        }
-        else
-        { // if not then a rounding error occured
-            if (vSize(p2_2 - p0) < vSize2(p2 - p0))
-            {
-                p2_it = p2_2_it; // start shortcut at 0
-            }
-        }
-    }
-    else
-    {
-        //        |
-        //      __|2
-        //     | /  > shortcut cannot be of the desired length
-        //  ___|/                                                       .
-        //     0
-        // both are blocked and p0_it and p2_it are already correct
-    }
-    // delete all cut off points
-    while (p0_it.next() != p2_it)
-    {
-        p0_it.next().remove();
-    }
-    return false;
+			p2_it = ListPolyIt(poly, poly.insert(p2_it.next().it, new_p2));
+		}
+		else
+		{ // if not then a rounding error occured
+			if (vSize(p2_2 - p0) < vSize2(p2 - p0))
+			{
+				p2_it = p2_2_it; // start shortcut at 0
+			}
+		}
+	}
+	else
+	{
+		//        |
+		//      __|2
+		//     | /  > shortcut cannot be of the desired length
+		//  ___|/                                                       .
+		//     0
+		// both are blocked and p0_it and p2_it are already correct
+	}
+	// delete all cut off points
+	while (p0_it.next() != p2_it)
+	{
+		p0_it.next().remove();
+	}
 }
 
 void PolygonRef::smooth_outward_step(const Point p1, const int64_t shortcut_length2, ListPolyIt& p0_it, ListPolyIt& p2_it, bool& forward_is_blocked, bool& backward_is_blocked, bool& forward_is_too_far, bool& backward_is_too_far)
 {
-    const bool forward_has_converged = forward_is_blocked || forward_is_too_far;
-    const bool backward_has_converged = backward_is_blocked || backward_is_too_far;
-    const Point p0 = p0_it.p();
-    const Point p2 = p2_it.p();
-    bool walk_forward = !forward_has_converged && (backward_has_converged || (vSize2(p2 - p1) < vSize2(p0 - p1))); // whether to walk along the p1-p2 direction or in the p1-p0 direction
+	const bool forward_has_converged = forward_is_blocked || forward_is_too_far;
+	const bool backward_has_converged = backward_is_blocked || backward_is_too_far;
+	const Point p0 = p0_it.p();
+	const Point p2 = p2_it.p();
+	bool walk_forward = !forward_has_converged && (backward_has_converged || (vSize2(p2 - p1) < vSize2(p0 - p1))); // whether to walk along the p1-p2 direction or in the p1-p0 direction
 
-    if (walk_forward)
-    {
-        const ListPolyIt p2_2_it = p2_it.next();
-        const Point p2_2 = p2_2_it.p();
-        bool p2_is_left = LinearAlg2D::pointIsLeftOfLine(p2, p0, p2_2) >= 0;
-        if (!p2_is_left)
-        {
-            forward_is_blocked = true;
-            return;
-        }
+	if (walk_forward)
+	{
+		const ListPolyIt p2_2_it = p2_it.next();
+		const Point p2_2 = p2_2_it.p();
+		bool p2_is_left = LinearAlg2D::pointIsLeftOfLine(p2, p0, p2_2) >= 0;
+		if (!p2_is_left)
+		{
+			forward_is_blocked = true;
+			return;
+		}
 
-        const Point v02_2 = p2_2 - p0_it.p();
-        if (vSize2(v02_2) > shortcut_length2)
-        {
-            forward_is_too_far = true;
-            return;
-        }
+		const Point v02_2 = p2_2 - p0_it.p();
+		if (vSize2(v02_2) > shortcut_length2)
+		{
+			forward_is_too_far = true;
+			return;
+		}
 
-        p2_it = p2_2_it; // make one step in the forward direction
-        backward_is_blocked = false; // invalidate data about backward walking
-        backward_is_too_far = false;
-        return;
-    }
-    else
-    {
-        const ListPolyIt p0_2_it = p0_it.prev();
-        const Point p0_2 = p0_2_it.p();
-        bool p0_is_left = LinearAlg2D::pointIsLeftOfLine(p0, p0_2, p2) >= 0;
-        if (!p0_is_left)
-        {
-            backward_is_blocked = true;
-            return;
-        }
+		p2_it = p2_2_it; // make one step in the forward direction
+		backward_is_blocked = false; // invalidate data about backward walking
+		backward_is_too_far = false;
+		return;
+	}
+	else
+	{
+		const ListPolyIt p0_2_it = p0_it.prev();
+		const Point p0_2 = p0_2_it.p();
+		bool p0_is_left = LinearAlg2D::pointIsLeftOfLine(p0, p0_2, p2) >= 0;
+		if (!p0_is_left)
+		{
+			backward_is_blocked = true;
+			return;
+		}
 
-        const Point v02_2 = p2_it.p() - p0_2;
-        if (vSize2(v02_2) > shortcut_length2)
-        {
-            backward_is_too_far = true;
-            return;
-        }
+		const Point v02_2 = p2_it.p() - p0_2;
+		if (vSize2(v02_2) > shortcut_length2)
+		{
+			backward_is_too_far = true;
+			return;
+		}
 
-        p0_it = p0_2_it; // make one step in the backward direction
-        forward_is_blocked = false; // invalidate data about forward walking
-        forward_is_too_far = false;
-        return;
-    }
+		p0_it = p0_2_it; // make one step in the backward direction
+		forward_is_blocked = false; // invalidate data about forward walking
+		forward_is_too_far = false;
+		return;
+	}
 }
 
 void PolygonRef::smooth_corner_simple(ListPolygon& poly, const Point p0, const Point p1, const Point p2, const ListPolyIt p0_it, const ListPolyIt p1_it, const ListPolyIt p2_it, const Point v10, const Point v12, const Point v02, const int64_t shortcut_length, float cos_angle)
 {
-    //  1----b---->2
-    //  ^   /
-    //  |  /
-    //  | /
-    //  |/
-    //  |a
-    //  |
-    //  0
-    // ideally a1_size == b1_size
-    if (vSize2(v02) <= shortcut_length * (shortcut_length + 10) // v02 is approximately shortcut length
-        || (cos_angle > 0.9999 && LinearAlg2D::getDist2FromLine(p2, p0, p1) < 20 * 20)) // p1 is degenerate
-    {
-        // handle this separately to avoid rounding problems below in the getPointOnLineWithDist function
-        p1_it.remove();
-        // don't insert new elements
-    }
-    else
-    {
-        // compute the distance a1 == b1 to get vSize(ab)==shortcut_length with the given angle between v10 and v12
-        //       1
-        //      /|\                                                      .
-        //     / | \                                                     .
-        //    /  |  \                                                    .
-        //   /   |   \                                                   .
-        // a/____|____\b                                                 .
-        //       m
-        // use trigonometry on the right-angled triangle am1
-        double a1m_angle = acos(cos_angle) / 2;
-        const int64_t a1_size = shortcut_length / 2 / sin(a1m_angle);
-        if (a1_size * a1_size < vSize2(v10) && a1_size * a1_size < vSize2(v12))
-        {
-            Point a = p1 + normal(v10, a1_size);
-            Point b = p1 + normal(v12, a1_size);
+	//  1----b---->2
+	//  ^   /
+	//  |  /
+	//  | /
+	//  |/
+	//  |a
+	//  |
+	//  0
+	// ideally a1_size == b1_size
+	if (vSize2(v02) <= shortcut_length * (shortcut_length + 10) // v02 is approximately shortcut length
+		|| (cos_angle > 0.9999 && LinearAlg2D::getDist2FromLine(p2, p0, p1) < 20 * 20)) // p1 is degenerate
+	{
+		// handle this separately to avoid rounding problems below in the getPointOnLineWithDist function
+		p1_it.remove();
+		// don't insert new elements
+	}
+	else
+	{
+		// compute the distance a1 == b1 to get vSize(ab)==shortcut_length with the given angle between v10 and v12
+		//       1
+		//      /|\                                                      .
+		//     / | \                                                     .
+		//    /  |  \                                                    .
+		//   /   |   \                                                   .
+		// a/____|____\b                                                 .
+		//       m
+		// use trigonometry on the right-angled triangle am1
+		double a1m_angle = acos(cos_angle) / 2;
+		const int64_t a1_size = shortcut_length / 2 / sin(a1m_angle);
+		if (a1_size * a1_size < vSize2(v10) && a1_size * a1_size < vSize2(v12))
+		{
+			Point a = p1 + normal(v10, a1_size);
+			Point b = p1 + normal(v12, a1_size);
 #ifdef ASSERT_INSANE_OUTPUT
-            assert(vSize(a) < 300000);
-            assert(vSize(b) < 300000);
+			assert(vSize(a) < 300000);
+			assert(vSize(b) < 300000);
 #endif // #ifdef ASSERT_INSANE_OUTPUT
-            ListPolyIt::insertPointNonDuplicate(p0_it, p1_it, a);
-            ListPolyIt::insertPointNonDuplicate(p1_it, p2_it, b);
-            p1_it.remove();
-        }
-        else if (vSize2(v12) < vSize2(v10))
-        {
-            //     b
-            //  1->2
-            //  ^  |
-            //  | /
-            //  | |
-            //  |/
-            //  |a
-            //  |
-            //  0
-            const Point& b = p2_it.p();
-            Point a;
-            bool success = LinearAlg2D::getPointOnLineWithDist(b, p1, p0, shortcut_length, a);
-            // v02 has to be longer than ab!
-            if (success)
-            { // if not success then assume a is negligibly close to 0, but rounding errors caused a problem
+			p1_it.remove();
+			poly.insert(p2_it.it, a);
+			poly.insert(p2_it.it, b);
+		}
+		else if (vSize2(v12) < vSize2(v10))
+		{
+			//     b
+			//  1->2
+			//  ^  |
+			//  | /
+			//  | |
+			//  |/
+			//  |a
+			//  |
+			//  0
+			const Point& b = p2_it.p();
+			Point a;
+			bool success = LinearAlg2D::getPointOnLineWithDist(b, p1, p0, shortcut_length, a);
+			// v02 has to be longer than ab!
+			if (success)
+			{ // if not success then assume a is negligibly close to 0, but rounding errors caused a problem
 #ifdef ASSERT_INSANE_OUTPUT
-                assert(vSize(a) < 300000);
+				assert(vSize(a) < 300000);
 #endif // #ifdef ASSERT_INSANE_OUTPUT
-                ListPolyIt::insertPointNonDuplicate(p0_it, p1_it, a);
-            }
-            p1_it.remove();
-        }
-        else
-        {
-            //  1---------b----------->2
-            //  ^      ,-'
-            //  |   ,-'
-            //  0.-'
-            //  a
-            const Point& a = p0_it.p();
-            Point b;
-            bool success = LinearAlg2D::getPointOnLineWithDist(a, p1, p2, shortcut_length, b);
-            // v02 has to be longer than ab!
-            p1_it.remove();
-            if (success)
-            { // if not success then assume b is negligibly close to 2, but rounding errors caused a problem
+				poly.insert(p1_it.it, a);
+			}
+			p1_it.remove();
+		}
+		else
+		{
+			//  1---------b----------->2
+			//  ^      ,-'
+			//  |   ,-'
+			//  0.-'
+			//  a
+			const Point& a = p0_it.p();
+			Point b;
+			bool success = LinearAlg2D::getPointOnLineWithDist(a, p1, p2, shortcut_length, b);
+			// v02 has to be longer than ab!
+			p1_it.remove();
+			if (success)
+			{ // if not success then assume b is negligibly close to 2, but rounding errors caused a problem
 #ifdef ASSERT_INSANE_OUTPUT
-                assert(vSize(b) < 300000);
+				assert(vSize(b) < 300000);
 #endif // #ifdef ASSERT_INSANE_OUTPUT
-                ListPolyIt::insertPointNonDuplicate(p1_it, p2_it, b);
-            }
-        }
-    }
+				poly.insert(p2_it.it, b);
+			}
+		}
+	}
 }
 
 void PolygonRef::smooth_outward(float min_angle, int shortcut_length, PolygonRef result) const
 {
-// example of smoothed out corner:
-//
-//               6
-//               ^
-//               |
-// inside        |     outside
-//         2>3>4>5
-//         ^    /                   .
-//         |   /                    .
-//         1  /                     .
-//         ^ /                      .
-//         |/                       .
-//         |
-//         |
-//         0
+	// example of smoothed out corner:
+	//
+	//               6
+	//               ^
+	//               |
+	// inside        |     outside
+	//         2>3>4>5
+	//         ^    /                   .
+	//         |   /                    .
+	//         1  /                     .
+	//         ^ /                      .
+	//         |/                       .
+	//         |
+	//         |
+	//         0
 
-    int shortcut_length2 = shortcut_length * shortcut_length;
-    float cos_min_angle = cos(min_angle / 180 * M_PI);
+	int shortcut_length2 = shortcut_length * shortcut_length;
+	float cos_min_angle = cos(min_angle / 180 * M_PI);
 
-    ListPolygon poly;
-    ListPolyIt::convertPolygonToList(*this, poly);
+	ListPolygon poly;
+	ListPolyIt::convertPolygonToList(*this, poly);
 
-    { // remove duplicate vertices
-        ListPolyIt p1_it(poly, poly.begin());
-        do
-        {
-            ListPolyIt next = p1_it.next();
-            if (vSize2(p1_it.p() - next.p()) < 10 * 10)
-            {
-                p1_it.remove();
-            }
-            p1_it = next;
-        } while (p1_it != ListPolyIt(poly, poly.begin()));
-    }
+	{ // remove duplicate vertices
+		ListPolyIt p1_it(poly, poly.begin());
+		do
+		{
+			ListPolyIt next = p1_it.next();
+			if (vSize2(p1_it.p() - next.p()) < 10 * 10)
+			{
+				p1_it.remove();
+			}
+			p1_it = next;
+		} while (p1_it != ListPolyIt(poly, poly.begin()));
+	}
 
-    ListPolyIt p1_it(poly, poly.begin());
-    do
-    {
-        const Point p1 = p1_it.p();
-        ListPolyIt p0_it = p1_it.prev();
-        ListPolyIt p2_it = p1_it.next();
-        const Point p0 = p0_it.p();
-        const Point p2 = p2_it.p();
+	ListPolyIt p1_it(poly, poly.begin());
+	do
+	{
+		const Point p1 = p1_it.p();
+		ListPolyIt p0_it = p1_it.prev();
+		ListPolyIt p2_it = p1_it.next();
+		const Point p0 = p0_it.p();
+		const Point p2 = p2_it.p();
 
-        const Point v10 = p0 - p1;
-        const Point v12 = p2 - p1;
-        float cos_angle = INT2MM(INT2MM(dot(v10, v12))) / vSizeMM(v10) / vSizeMM(v12);
-        bool is_left_angle = LinearAlg2D::pointIsLeftOfLine(p1, p0, p2) > 0;
-        if (cos_angle > cos_min_angle && is_left_angle)
-        {
-            // angle is so sharp that it can be removed
-            Point v02 = p2_it.p() - p0_it.p();
-            if (vSize2(v02) >= shortcut_length2)
-            {
-                smooth_corner_simple(poly, p0, p1, p2, p0_it, p1_it, p2_it, v10, v12, v02, shortcut_length, cos_angle);
-            }
-            else
-            {
-                bool remove_poly = smooth_corner_complex(poly, p1, p0_it, p2_it, shortcut_length); // edits p0_it and p2_it!
-                if (remove_poly)
-                {
-                    // don't convert ListPolygon into result
-                    return;
-                }
-            }
-            // update:
-            p1_it = p2_it; // next point to consider for whether it's an internal corner
-        }
-        else
-        {
-            ++p1_it;
-        }
-    } while (p1_it != ListPolyIt(poly, poly.begin()));
+		const Point v10 = p0 - p1;
+		const Point v12 = p2 - p1;
+		float cos_angle = INT2MM(INT2MM(dot(v10, v12))) / vSizeMM(v10) / vSizeMM(v12);
+		bool is_left_angle = LinearAlg2D::pointIsLeftOfLine(p1, p0, p2) > 0;
+		if (cos_angle > cos_min_angle && is_left_angle)
+		{
+			// angle is so sharp that it can be removed
+			Point v02 = p2_it.p() - p0_it.p();
+			if (vSize2(v02) >= shortcut_length2)
+			{
+				smooth_corner_simple(poly, p0, p1, p2, p0_it, p1_it, p2_it, v10, v12, v02, shortcut_length, cos_angle);
+			}
+			else
+			{
+				smooth_corner_complex(poly, p1, p0_it, p2_it, shortcut_length); // edits p0_it and p2_it!
+			}
+			// update:
+			p1_it = p2_it; // next point to consider for whether it's an internal corner
+		}
+		else
+		{
+			++p1_it;
+		}
+	} while (p1_it != ListPolyIt(poly, poly.begin()));
 
-    ListPolyIt::convertListPolygonToPolygon(poly, result);
+	ListPolyIt::convertListPolygonToPolygon(poly, result);
 }
 
 Polygons Polygons::smooth_outward(float max_angle, int shortcut_length)
 {
-    Polygons ret;
-    for (unsigned int p = 0; p < size(); p++)
-    {
-        PolygonRef poly(paths[p]);
-        if (poly.size() < 3)
-        {
-            continue;
-        }
-        if (poly.size() == 3)
-        {
-            ret.add(poly);
-            continue;
-        }
-        poly.smooth_outward(max_angle, shortcut_length, ret.newPoly());
-        if (ret.back().size() < 3)
-        {
-            ret.paths.resize(ret.paths.size() - 1);
-        }
-    }
-    return ret;
+	Polygons ret;
+	for (unsigned int p = 0; p < size(); p++)
+	{
+		PolygonRef poly(paths[p]);
+		if (poly.size() < 3)
+		{
+			continue;
+		}
+		if (poly.size() == 3)
+		{
+			ret.add(poly);
+			continue;
+		}
+		poly.smooth_outward(max_angle, shortcut_length, ret.newPoly());
+		if (ret.back().size() < 3)
+		{
+			ret.paths.resize(ret.paths.size() - 1);
+		}
+	}
+	return ret;
 }
 
 void PolygonRef::smooth(int remove_length, PolygonRef result)
 {
-// a typical zigzag with the middle part to be removed by removing (1) :
-//
-//               3
-//               ^
-//               |
-//               |
-// inside        |     outside
-//          1--->2
-//          ^
-//          |
-//          |
-//          |
-//          0
-    PolygonRef& thiss = *this;
-    ClipperLib::Path* poly = result.path;
-    if (size() > 0)
-    {
-        poly->push_back(thiss[0]);
-    }
-    auto is_zigzag = [remove_length](const Point v02, const int64_t v02_size, const Point v12, const int64_t v12_size, const Point v13, const int64_t v13_size, const int64_t dot1, const int64_t dot2)
-    {
-        if (v12_size > remove_length)
-        { // v12 or v13 is too long
-            return false;
-        }
-        const bool p1_is_left_of_v02 = dot1 < 0;
-        if (!p1_is_left_of_v02)
-        { // removing p1 wouldn't smooth outward
-            return false;
-        }
-        const bool p2_is_left_of_v13 = dot2 > 0;
-        if (p2_is_left_of_v13)
-        { // l0123 doesn't constitute a zigzag ''|,,
-            return false;
-        }
-        if (-dot1 <= v02_size * v12_size / 2)
-        { // angle at p1 isn't sharp enough
-            return false;
-        }
-        if (-dot2 <= v13_size * v12_size / 2)
-        { // angle at p2 isn't sharp enough
-            return false;
-        }
-        return true;
-    };
-    Point v02 = thiss[2] - thiss[0];
-    Point v02T = turn90CCW(v02);
-    int64_t v02_size = vSize(v02);
-    bool force_push = false;
-    for (unsigned int poly_idx = 1; poly_idx < size(); poly_idx++)
-    {
-        const Point& p1 = thiss[poly_idx];
-        const Point& p2 = thiss[(poly_idx + 1) % size()];
-        const Point& p3 = thiss[(poly_idx + 2) % size()];
-        // v02 computed in last iteration
-        // v02_size as well
-        const Point v12 = p2 - p1;
-        const int64_t v12_size = vSize(v12);
-        const Point v13 = p3 - p1;
-        const int64_t v13_size = vSize(v13);
+	// a typical zigzag with the middle part to be removed by removing (1) :
+	//
+	//               3
+	//               ^
+	//               |
+	//               |
+	// inside        |     outside
+	//          1--->2
+	//          ^
+	//          |
+	//          |
+	//          |
+	//          0
+	PolygonRef& thiss = *this;
+	ClipperLib::Path& poly = result.path;
+	if (size() > 0)
+	{
+		poly.push_back(thiss[0]);
+	}
+	auto is_zigzag = [remove_length](const Point v02, const int64_t v02_size, const Point v12, const int64_t v12_size, const Point v13, const int64_t v13_size, const int64_t dot1, const int64_t dot2)
+	{
+		if (v12_size > remove_length)
+		{ // v12 or v13 is too long
+			return false;
+		}
+		const bool p1_is_left_of_v02 = dot1 < 0;
+		if (!p1_is_left_of_v02)
+		{ // removing p1 wouldn't smooth outward
+			return false;
+		}
+		const bool p2_is_left_of_v13 = dot2 > 0;
+		if (p2_is_left_of_v13)
+		{ // l0123 doesn't constitute a zigzag ''|,,
+			return false;
+		}
+		if (-dot1 <= v02_size * v12_size / 2)
+		{ // angle at p1 isn't sharp enough
+			return false;
+		}
+		if (-dot2 <= v13_size * v12_size / 2)
+		{ // angle at p2 isn't sharp enough
+			return false;
+		}
+		return true;
+	};
+	Point v02 = thiss[2] - thiss[0];
+	Point v02T = turn90CCW(v02);
+	int64_t v02_size = vSize(v02);
+	bool force_push = false;
+	for (unsigned int poly_idx = 1; poly_idx < size(); poly_idx++)
+	{
+		const Point& p1 = thiss[poly_idx];
+		const Point& p2 = thiss[(poly_idx + 1) % size()];
+		const Point& p3 = thiss[(poly_idx + 2) % size()];
+		// v02 computed in last iteration
+		// v02_size as well
+		const Point v12 = p2 - p1;
+		const int64_t v12_size = vSize(v12);
+		const Point v13 = p3 - p1;
+		const int64_t v13_size = vSize(v13);
 
-        // v02T computed in last iteration
-        const int64_t dot1 = dot(v02T, v12);
-        const Point v13T = turn90CCW(v13);
-        const int64_t dot2 = dot(v13T, v12);
-        bool push_point = force_push || !is_zigzag(v02, v02_size, v12, v12_size, v13, v13_size, dot1, dot2);
-        force_push = false;
-        if (push_point)
-        {
-            poly->push_back(p1);
-        }
-        else
-        {
-            // do not add the current one to the result
-            force_push = true; // ensure the next point is added; it cannot also be a zigzag
-        }
-        v02T = v13T;
-        v02 = v13;
-        v02_size = v13_size;
-    }
+		// v02T computed in last iteration
+		const int64_t dot1 = dot(v02T, v12);
+		const Point v13T = turn90CCW(v13);
+		const int64_t dot2 = dot(v13T, v12);
+		bool push_point = force_push || !is_zigzag(v02, v02_size, v12, v12_size, v13, v13_size, dot1, dot2);
+		force_push = false;
+		if (push_point)
+		{
+			poly.push_back(p1);
+		}
+		else
+		{
+			// do not add the current one to the result
+			force_push = true; // ensure the next point is added; it cannot also be a zigzag
+		}
+		v02T = v13T;
+		v02 = v13;
+		v02_size = v13_size;
+	}
 }
 
 Polygons Polygons::smooth(int remove_length)
 {
-    Polygons ret;
-    for (unsigned int p = 0; p < size(); p++)
-    {
-        PolygonRef poly(paths[p]);
-        if (poly.size() < 3)
-        {
-            continue;
-        }
-        if (poly.size() == 3)
-        {
-            ret.add(poly);
-            continue;
-        }
-        poly.smooth(remove_length, ret.newPoly());
-        PolygonRef back = ret.back();
-        if (back.size() < 3)
-        {
-            back.path->resize(back.path->size() - 1);
-        }
-    }
-    return ret;
+	Polygons ret;
+	for (unsigned int p = 0; p < size(); p++)
+	{
+		PolygonRef poly(paths[p]);
+		if (poly.size() < 3)
+		{
+			continue;
+		}
+		if (poly.size() == 3)
+		{
+			ret.add(poly);
+			continue;
+		}
+		poly.smooth(remove_length, ret.newPoly());
+		PolygonRef back = ret.back();
+		if (back.size() < 3)
+		{
+			back.path.get().resize(back.path.get().size() - 1);
+		}
+	}
+	return ret;
 }
 
 void PolygonRef::smooth2(int remove_length, PolygonRef result)
 {
-    PolygonRef& thiss = *this;
-    ClipperLib::Path* poly = result.path;
-    if (size() > 0)
-    {
-        poly->push_back(thiss[0]);
-    }
-    for (unsigned int poly_idx = 1; poly_idx < size(); poly_idx++)
-    {
-        Point& last = thiss[poly_idx - 1];
-        Point& now = thiss[poly_idx];
-        Point& next = thiss[(poly_idx + 1) % size()];
-        if (shorterThen(last - now, remove_length) && shorterThen(now - next, remove_length)) 
-        {
-            poly_idx++; // skip the next line piece (dont escalate the removal of edges)
-            if (poly_idx < size())
-            {
-                poly->push_back(thiss[poly_idx]);
-            }
-        }
-        else
-        {
-            poly->push_back(thiss[poly_idx]);
-        }
-    }
+	PolygonRef& thiss = *this;
+	ClipperLib::Path& poly = result.path;
+	if (size() > 0)
+	{
+		poly.push_back(thiss[0]);
+	}
+	for (unsigned int poly_idx = 1; poly_idx < size(); poly_idx++)
+	{
+		Point& last = thiss[poly_idx - 1];
+		Point& now = thiss[poly_idx];
+		Point& next = thiss[(poly_idx + 1) % size()];
+		if (shorterThan(last - now, remove_length) && shorterThan(now - next, remove_length))
+		{
+			poly_idx++; // skip the next line piece (dont escalate the removal of edges)
+			if (poly_idx < size())
+			{
+				poly.push_back(thiss[poly_idx]);
+			}
+		}
+		else
+		{
+			poly.push_back(thiss[poly_idx]);
+		}
+	}
 }
 
 Polygons Polygons::smooth2(int remove_length, int min_area)
 {
-    Polygons ret;
-    for (unsigned int p = 0; p < size(); p++)
-    {
-        PolygonRef poly(paths[p]);
-        if (poly.size() == 0)
-        {
-            continue;
-        }
-        if (poly.area() < min_area || poly.size() <= 5) // when optimally removing, a poly with 5 pieces results in a triangle. Smaller polys dont have area!
-        {
-            ret.add(poly);
-            continue;
-        }
-        if (poly.size() < 4)
-        {
-            ret.add(poly);
-        }
-        else
-        {
-            poly.smooth2(remove_length, ret.newPoly());
-        }
-    }
-    return ret;
+	Polygons ret;
+	for (unsigned int p = 0; p < size(); p++)
+	{
+		PolygonRef poly(paths[p]);
+		if (poly.size() == 0)
+		{
+			continue;
+		}
+		if (poly.area() < min_area || poly.size() <= 5) // when optimally removing, a poly with 5 pieces results in a triangle. Smaller polys dont have area!
+		{
+			ret.add(poly);
+			continue;
+		}
+		if (poly.size() < 4)
+		{
+			ret.add(poly);
+		}
+		else
+		{
+			poly.smooth2(remove_length, ret.newPoly());
+		}
+	}
+	return ret;
 }
 
 std::vector<PolygonsPart> Polygons::splitIntoParts(bool unionAll) const
 {
-    std::vector<PolygonsPart> ret;
-    ClipperLib::Clipper clipper(clipper_init);
-    ClipperLib::PolyTree resultPolyTree;
-    clipper.AddPaths(paths, ClipperLib::ptSubject, true);
-    if (unionAll)
-        clipper.Execute(ClipperLib::ctUnion, resultPolyTree, ClipperLib::pftNonZero, ClipperLib::pftNonZero);
-    else
-        clipper.Execute(ClipperLib::ctUnion, resultPolyTree);
+	std::vector<PolygonsPart> ret;
+	ClipperLib::Clipper clipper(clipper_init);
+	ClipperLib::PolyTree resultPolyTree;
+	clipper.AddPaths(paths, ClipperLib::ptSubject, true);
+	if (unionAll)
+		clipper.Execute(ClipperLib::ctUnion, resultPolyTree, ClipperLib::pftNonZero, ClipperLib::pftNonZero);
+	else
+		clipper.Execute(ClipperLib::ctUnion, resultPolyTree);
 
-    splitIntoParts_processPolyTreeNode(&resultPolyTree, ret);
-    return ret;
+	splitIntoParts_processPolyTreeNode(&resultPolyTree, ret);
+	return ret;
 }
 
 void Polygons::splitIntoParts_processPolyTreeNode(ClipperLib::PolyNode* node, std::vector<PolygonsPart>& ret) const
 {
-    for(int n=0; n<node->ChildCount(); n++)
-    {
-        ClipperLib::PolyNode* child = node->Childs[n];
-        PolygonsPart part;
-        part.add(child->Contour);
-        for(int i=0; i<child->ChildCount(); i++)
-        {
-            part.add(child->Childs[i]->Contour);
-            splitIntoParts_processPolyTreeNode(child->Childs[i], ret);
-        }
-        ret.push_back(part);
-    }
+	for (int n = 0; n<node->ChildCount(); n++)
+	{
+		ClipperLib::PolyNode* child = node->Childs[n];
+		PolygonsPart part;
+		part.add(child->Contour);
+		for (int i = 0; i<child->ChildCount(); i++)
+		{
+			part.add(child->Childs[i]->Contour);
+			splitIntoParts_processPolyTreeNode(child->Childs[i], ret);
+		}
+		ret.push_back(part);
+	}
 }
 
-unsigned int PartsView::getPartContaining(unsigned int poly_idx, unsigned int* boundary_poly_idx) 
+unsigned int PartsView::getPartContaining(unsigned int poly_idx, unsigned int* boundary_poly_idx)
 {
-    PartsView& partsView = *this;
-    for (unsigned int part_idx_now = 0; part_idx_now < partsView.size(); part_idx_now++)
-    {
-        std::vector<unsigned int>& partView = partsView[part_idx_now];
-        if (partView.size() == 0) { continue; }
-        std::vector<unsigned int>::iterator result = std::find(partView.begin(), partView.end(), poly_idx);
-        if (result != partView.end()) 
-        { 
-            if (boundary_poly_idx) { *boundary_poly_idx = partView[0]; }
-            return part_idx_now;
-        }
-    }
-    return NO_INDEX;
+	PartsView& partsView = *this;
+	for (unsigned int part_idx_now = 0; part_idx_now < partsView.size(); part_idx_now++)
+	{
+		std::vector<unsigned int>& partView = partsView[part_idx_now];
+		if (partView.size() == 0) { continue; }
+		std::vector<unsigned int>::iterator result = std::find(partView.begin(), partView.end(), poly_idx);
+		if (result != partView.end())
+		{
+			if (boundary_poly_idx) { *boundary_poly_idx = partView[0]; }
+			return part_idx_now;
+		}
+	}
+	return NO_INDEX;
 }
 
 PolygonsPart PartsView::assemblePart(unsigned int part_idx) const
 {
-    const PartsView& partsView = *this;
-    PolygonsPart ret;
-    if (part_idx != NO_INDEX)
-    {
-        for (unsigned int poly_idx_ff : partsView[part_idx])
-        {
-            ret.add(polygons[poly_idx_ff]);
-        }
-    }
-    return ret;
+	const PartsView& partsView = *this;
+	PolygonsPart ret;
+	if (part_idx != NO_INDEX)
+	{
+		for (unsigned int poly_idx_ff : partsView[part_idx])
+		{
+			ret.add(polygons[poly_idx_ff]);
+		}
+	}
+	return ret;
 }
 
-PolygonsPart PartsView::assemblePartContaining(unsigned int poly_idx, unsigned int* boundary_poly_idx) 
+PolygonsPart PartsView::assemblePartContaining(unsigned int poly_idx, unsigned int* boundary_poly_idx)
 {
-    PolygonsPart ret;
-    unsigned int part_idx = getPartContaining(poly_idx, boundary_poly_idx);
-    if (part_idx != NO_INDEX)
-    {
-        return assemblePart(part_idx);
-    }
-    return ret;
+	PolygonsPart ret;
+	unsigned int part_idx = getPartContaining(poly_idx, boundary_poly_idx);
+	if (part_idx != NO_INDEX)
+	{
+		return assemblePart(part_idx);
+	}
+	return ret;
 }
 
 PartsView Polygons::splitIntoPartsView(bool unionAll)
 {
-    Polygons reordered;
-    PartsView partsView(*this);
-    ClipperLib::Clipper clipper(clipper_init);
-    ClipperLib::PolyTree resultPolyTree;
-    clipper.AddPaths(paths, ClipperLib::ptSubject, true);
-    if (unionAll)
-        clipper.Execute(ClipperLib::ctUnion, resultPolyTree, ClipperLib::pftNonZero, ClipperLib::pftNonZero);
-    else
-        clipper.Execute(ClipperLib::ctUnion, resultPolyTree);
+	Polygons reordered;
+	PartsView partsView(*this);
+	ClipperLib::Clipper clipper(clipper_init);
+	ClipperLib::PolyTree resultPolyTree;
+	clipper.AddPaths(paths, ClipperLib::ptSubject, true);
+	if (unionAll)
+		clipper.Execute(ClipperLib::ctUnion, resultPolyTree, ClipperLib::pftNonZero, ClipperLib::pftNonZero);
+	else
+		clipper.Execute(ClipperLib::ctUnion, resultPolyTree);
 
-    splitIntoPartsView_processPolyTreeNode(partsView, reordered, &resultPolyTree);
-    
-    (*this) = reordered;
-    return partsView;
+	splitIntoPartsView_processPolyTreeNode(partsView, reordered, &resultPolyTree);
+
+	(*this) = reordered;
+	return partsView;
 }
 
 void Polygons::splitIntoPartsView_processPolyTreeNode(PartsView& partsView, Polygons& reordered, ClipperLib::PolyNode* node) const
 {
-    for(int n=0; n<node->ChildCount(); n++)
-    {
-        ClipperLib::PolyNode* child = node->Childs[n];
-        partsView.emplace_back();
-        unsigned int pos = partsView.size() - 1;
-        partsView[pos].push_back(reordered.size());
-        reordered.add(child->Contour);
-        for(int i = 0; i < child->ChildCount(); i++)
-        {
-            partsView[pos].push_back(reordered.size());
-            reordered.add(child->Childs[i]->Contour);
-            splitIntoPartsView_processPolyTreeNode(partsView, reordered, child->Childs[i]);
-        }
-    }
+	for (int n = 0; n<node->ChildCount(); n++)
+	{
+		ClipperLib::PolyNode* child = node->Childs[n];
+		partsView.emplace_back();
+		unsigned int pos = partsView.size() - 1;
+		partsView[pos].push_back(reordered.size());
+		reordered.add(child->Contour);
+		for (int i = 0; i < child->ChildCount(); i++)
+		{
+			partsView[pos].push_back(reordered.size());
+			reordered.add(child->Childs[i]->Contour);
+			splitIntoPartsView_processPolyTreeNode(partsView, reordered, child->Childs[i]);
+		}
+	}
 }
-
-
 
 }//namespace cura

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -28,919 +28,839 @@ class Polygons;
 
 class ListPolyIt;
 
-typedef std::list<Point> ListPolygon; //!< A polygon represented by a linked list instead of a vector
-typedef std::vector<ListPolygon> ListPolygons; //!< Polygons represented by a vector of linked lists instead of a vector of vectors
+typedef list<Point> ListPolygon; // a list of points that define a polygon. glm::vec2 used as the point instance here
+typedef vector<ListPolygon> ListPolygons; // a vectorized list of polygons, each item being a listpolygon from the previous
 
 const static int clipper_init = (0);
-#define NO_INDEX (std::numeric_limits<unsigned int>::max())
+static const int NO_INDEX = std::numeric_limits<unsigned int>::max();
 
-class PolygonRef
-{
-    ClipperLib::Path* path;
-    PolygonRef()
-    : path(nullptr)
-    {}
+static ClipperLib::Path nullPath;
+
+class PolygonRef {
+  // Reference wrapper is a copy assignable and move assignable wrapper around a reference to the 
+  // specified class (here, ClipperLib::Path)
+	std::reference_wrapper<ClipperLib::Path> path;
+	PolygonRef() : path(nullPath) {} // default constructor for a polygon ref, set path to be the nullpath type since
+  // nullptr is no longer a valid setting for the path here
 public:
-    PolygonRef(ClipperLib::Path& polygon)
-    : path(&polygon)
-    {}
-    
-    unsigned int size() const
-    {
-        return path->size();
-    }
+	// path is a clipper path - ordered sequence of vertices defining a geometric contour, open or closed
+	PolygonRef(ClipperLib::Path& polygon) : path(polygon) {} // another constructor for overloading
 
-    Point& operator[] (unsigned int index) const
-    {
-        POLY_ASSERT(index < size() && index >= 0);
-        return (*path)[index];
-    }
+  // Note: Accessing the path object is done by using path.get().(member_func). This simply accesses
+  // the reference stored in the actual reference_wrapper object.
+  
+	unsigned int size() const {
+		return path.get().size();
+	}
 
-    void* data()
-    {
-        return path->data();
-    }
+	Point& operator[] (unsigned int index) const {
+		POLY_ASSERT(index < size());
+		return (path.get())[index];
+	}
 
-    const void* data() const
-    {
-        return path->data();
-    }
+	void* data() {
+		return path.get().data();
+	}
 
-    void add(const Point p)
-    {
-        path->push_back(p);
-    }
+	const void* data() const {
+		return path.get().data();
+	}
 
-    PolygonRef& operator=(const PolygonRef& other) { path = other.path; return *this; }
+	void add(const Point p) {
+		path.get().push_back(p);
+	}
 
-    bool operator==(const PolygonRef& other) const =delete;
+	PolygonRef& operator=(const PolygonRef& other) { path = other.path; return *this; }
 
-    ClipperLib::Path& operator*() { return *path; }
-    
-    template <typename... Args>
-    void emplace_back(Args&&... args)
-    {
-        path->emplace_back(args...);
-    }
+	bool operator == (const PolygonRef& other) const = delete;
 
-    void remove(unsigned int index)
-    {
-        POLY_ASSERT(index < size() && index >= 0);
-        path->erase(path->begin() + index);
-    }
+	ClipperLib::Path& operator*() { return path; }
 
-    void clear()
-    {
-        path->clear();
-    }
+	template<typename... Args>
+	void emplace_back(Args&&...args) {
+		path.get().emplace_back(args...);
+	}
 
-    /*!
-     * On Y-axis positive upward displays, Orientation will return true if the polygon's orientation is counter-clockwise.
-     * 
-     * from http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Functions/Orientation.htm
-     */
-    bool orientation() const
-    {
-        return ClipperLib::Orientation(*path);
-    }
+	void remove(unsigned int index) {
+		POLY_ASSERT(index < size());
+		path.get().erase(path.get().begin() + index);
+	}
 
-    void reverse()
-    {
-        ClipperLib::ReversePath(*path);
-    }
+	void clear() {
+		path.get().clear();
+	}
 
-    Polygons offset(int distance, ClipperLib::JoinType joinType = ClipperLib::jtMiter, double miter_limit = 1.2) const;
+	// On y-axis pos upward displays, orientation will return true if the polygons winding orientation is counter-clockwise
 
-    int64_t polygonLength() const
-    {
-        int64_t length = 0;
-        Point p0 = (*path)[path->size()-1];
-        for(unsigned int n=0; n<path->size(); n++)
-        {
-            Point p1 = (*path)[n];
-            length += vSize(p0 - p1);
-            p0 = p1;
-        }
-        return length;
-    }
-    
-    bool shorterThan(int64_t check_length) const;
+	bool orientation() const {
+		return ClipperLib::Orientation(path.get());
+	}
 
-    Point min() const
-    {
-        Point ret = Point(POINT_MAX, POINT_MAX);
-        for(Point p : *path)
-        {
-            ret.X = std::min(ret.X, p.X);
-            ret.Y = std::min(ret.Y, p.Y);
-        }
-        return ret;
-    }
-    
-    Point max() const
-    {
-        Point ret = Point(POINT_MIN, POINT_MIN);
-        for(Point p : *path)
-        {
-            ret.X = std::max(ret.X, p.X);
-            ret.Y = std::max(ret.Y, p.Y);
-        }
-        return ret;
-    }
+	void reverse() {
+		ClipperLib::ReversePath(path.get());
+	}
 
-    double area() const
-    {
-        return ClipperLib::Area(*path);
-    }
-    
-    /*!
-     * Translate the whole polygon in some direction.
-     * 
-     * \param translation The direction in which to move the polygon
-     */
-    void translate(Point translation)
-    {
-        for (Point& p : *this)
-        {
-            p += translation;
-        }
-    }
+	Polygons offset(int distance, ClipperLib::JoinType joinType = ClipperLib::jtMiter, double miter_limit = 1.2) const;
 
-    Point centerOfMass() const
-    {
-        double x = 0, y = 0;
-        Point p0 = (*path)[path->size()-1];
-        for(unsigned int n=0; n<path->size(); n++)
-        {
-            Point p1 = (*path)[n];
-            double second_factor = (p0.X * p1.Y) - (p1.X * p0.Y);
+	int64_t polygonLength() const {
+		int64_t length = 0;
+		Point p0 = (path.get())[path.get().size() - 1];
+		for (unsigned int n = 0; n < path.get().size(); n++) {
+			Point p1 = (path.get())[n];
+			length += vSize(p0 - p1);
+			p0 = p1;
+		}
+		return length;
+	}
 
-            x += double(p0.X + p1.X) * second_factor;
-            y += double(p0.Y + p1.Y) * second_factor;
-            p0 = p1;
-        }
+	bool pShorterThan(int64_t check_length) const;
 
-        double area = Area(*path);
-        
-        x = x / 6 / area;
-        y = y / 6 / area;
+	Point min() const {
+		Point ret = Point(POINT_MAX, POINT_MAX);
+		for (Point p : path.get()) { // this is C++ syntax for a for-each style loop
+			ret.X = std::min(ret.X, p.X);
+			ret.Y = std::min(ret.Y, p.Y);
+		}
+		return ret;
+	}
 
-        return Point(x, y);
-    }
+	Point max() const {
+		Point ret = Point(POINT_MIN, POINT_MIN);
+		for (Point p : path.get()) {
+			ret.X = std::max(ret.X, p.X);
+			ret.Y = std::max(ret.Y, p.Y);
+		}
+		return ret;
+	}
 
-    Point closestPointTo(Point p)
-    {
-        Point ret = p;
-        float bestDist = FLT_MAX;
-        for(unsigned int n=0; n<path->size(); n++)
-        {
-            float dist = vSize2f(p - (*path)[n]);
-            if (dist < bestDist)
-            {
-                ret = (*path)[n];
-                bestDist = dist;
-            }
-        }
-        return ret;
-    }
-    
-    /*!
-     * Check if we are inside the polygon. We do this by tracing from the point towards the positive X direction,
-     * every line we cross increments the crossings counter. If we have an even number of crossings then we are not inside the polygon.
-     * Care needs to be taken, if p.Y exactly matches a vertex to the right of p, then we need to count 1 intersect if the
-     * outline passes vertically past; and 0 (or 2) intersections if that point on the outline is a 'top' or 'bottom' vertex.
-     * The easiest way to do this is to break out two cases for increasing and decreasing Y ( from p0 to p1 ).
-     * A segment is tested if pa.Y <= p.Y < pb.Y, where pa and pb are the points (from p0,p1) with smallest & largest Y.
-     * When both have the same Y, no intersections are counted but there is a special test to see if the point falls
-     * exactly on the line.
-     * 
-     * Returns false if outside, true if inside; if the point lies exactly on the border, will return 'border_result'.
-     * 
-     * \deprecated This function is no longer used, since the Clipper function is used by the function PolygonRef::inside(.)
-     * 
-     * \param p The point for which to check if it is inside this polygon
-     * \param border_result What to return when the point is exactly on the border
-     * \return Whether the point \p p is inside this polygon (or \p border_result when it is on the border)
-     */
-    bool _inside(Point p, bool border_result = false) const;
+	double area() const {
+		return ClipperLib::Area(path.get());
+	}
 
-    /*!
-     * Clipper function.
-     * Returns false if outside, true if inside; if the point lies exactly on the border, will return 'border_result'.
-     * 
-     * http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Functions/PointInPolygon.htm
-     */
-    bool inside(Point p, bool border_result = false) const
-    {
-        int res = ClipperLib::PointInPolygon(p, *path);
-        if (res == -1)
-        {
-            return border_result;
-        }
-        return res == 1;
-    }
-    
-    /*!
-     * Smooth out small perpendicular segments and store the result in \p result.
-     * Smoothing is performed by removing the inner most vertex of a line segment smaller than \p remove_length
-     * which has an angle with the next and previous line segment smaller than roughly 150*
-     * 
-     * Note that in its current implementation this function doesn't remove line segments with an angle smaller than 30*
-     * Such would be the case for an N shape.
-     * 
-     * \param remove_length The length of the largest segment removed
-     * \param result (output) The result polygon, assumed to be empty
-     */
-    void smooth(int remove_length, PolygonRef result);
+	// Translate the whole polygon in a direction
+	void translate(Point translation) {
+		for (Point& p : *this) {
+			p += translation;
+		}
+	}
 
-    /*!
-     * Smooth out sharp inner corners, by taking a shortcut which bypasses the corner
-     * 
-     * \param angle The maximum angle of inner corners to be smoothed out
-     * \param shortcut_length The desired length of the shortcut line segment introduced (shorter shortcuts may be unavoidable)
-     * \param result The resulting polygon
-     */
-    void smooth_outward(float angle, int shortcut_length, PolygonRef result) const;
+	Point centerOfMass() const {
+		double x = 0, y = 0;
+		Point p0 = (path.get())[path.get().size() - 1];
+		for (unsigned int n = 0; n < path.get().size(); n++) {
+			Point p1 = (path.get())[n];
+			double second_factor = (p0.X*p1.Y) - (p1.X*p0.Y);
 
-    /*!
-     * Smooth out the polygon and store the result in \p result.
-     * Smoothing is performed by removing vertices for which both connected line segments are smaller than \p remove_length
-     * 
-     * \param remove_length The length of the largest segment removed
-     * \param result (output) The result polygon, assumed to be empty
-     */
-    void smooth2(int remove_length, PolygonRef result);
+			x += double(p0.X + p1.X) * second_factor;
+			y += double(p0.Y + p1.Y) * second_factor;
+		}
+		double area = Area(path.get());
 
-    /*! 
-     * Removes consecutive line segments with same orientation and changes this polygon.
-     * 
-     * Removes verts which are connected to line segments which are both too small.
-     * Removes verts which detour from a direct line from the previous and next vert by a too small amount.
-     * 
-     * \param smallest_line_segment_squared maximal squared length of removed line segments
-     * \param allowed_error_distance_squared The square of the distance of the middle point to the line segment of the consecutive and previous point for which the middle point is removed
-     */
-    void simplify(int smallest_line_segment_squared = 100, int allowed_error_distance_squared = 25);
+		x = x / 6 / area;
+		y = y / 6 / area;
 
-    void pop_back()
-    { 
-        path->pop_back();
-    }
-    
-    ClipperLib::Path::reference back() const
-    {
-        return path->back();
-    }
-    
-    ClipperLib::Path::iterator begin()
-    {
-        return path->begin();
-    }
+		return Point(x, y);
+	}
 
-    ClipperLib::Path::iterator end()
-    {
-        return path->end();
-    }
+	Point closestPointTo(Point p) {
+		Point ret = p;
+		float bestDist = FLT_MAX;
 
-    ClipperLib::Path::const_iterator begin() const
-    {
-        return path->begin();
-    }
+		for (unsigned int n = 0; n < path.get().size(); n++) {
+			float dist = vSize2f(p - (path.get())[n]);
+			if (dist < bestDist) {
+				ret = (path.get())[n];
+				bestDist = dist;
+			}
+		}
+		return ret;
+	}
 
-    ClipperLib::Path::const_iterator end() const
-    {
-        return path->end();
-    }
 
-    friend class Polygons;
-    friend class Polygon;
+	/*!
+	* Check if we are inside the polygon. We do this by tracing from the point towards the positive X direction,
+	* every line we cross increments the crossings counter. If we have an even number of crossings then we are not inside the polygon.
+	* Care needs to be taken, if p.Y exactly matches a vertex to the right of p, then we need to count 1 intersect if the
+	* outline passes vertically past; and 0 (or 2) intersections if that point on the outline is a 'top' or 'bottom' vertex.
+	* The easiest way to do this is to break out two cases for increasing and decreasing Y ( from p0 to p1 ).
+	* A segment is tested if pa.Y <= p.Y < pb.Y, where pa and pb are the points (from p0,p1) with smallest & largest Y.
+	* When both have the same Y, no intersections are counted but there is a special test to see if the point falls
+	* exactly on the line.
+	*
+	* Returns false if outside, true if inside; if the point lies exactly on the border, will return 'border_result'.
+	*
+	* \deprecated This function is no longer used, since the Clipper function is used by the function PolygonRef::inside(.)
+	*
+	* \param p The point for which to check if it is inside this polygon
+	* \param border_result What to return when the point is exactly on the border
+	* \return Whether the point \p p is inside this polygon (or \p border_result when it is on the border)
+	*/
+	bool _inside(Point p, bool border_result = false);
+
+	/*!
+	* Clipper function.
+	* Returns false if outside, true if inside; if the point lies exactly on the border, will return 'border_result'.
+	*
+	* http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Functions/PointInPolygon.htm
+	*/
+	bool inside(Point p, bool border_result = false)
+	{
+		int res = ClipperLib::PointInPolygon(p, path.get());
+		if (res == -1)
+		{
+			return border_result;
+		}
+		return res == 1;
+	}
+
+	/*!
+	* Smooth out small perpendicular segments and store the result in \p result.
+	* Smoothing is performed by removing the inner most vertex of a line segment smaller than \p remove_length
+	* which has an angle with the next and previous line segment smaller than roughly 150*
+	*
+	* Note that in its current implementation this function doesn't remove line segments with an angle smaller than 30*
+	* Such would be the case for an N shape.
+	*
+	* \param remove_length The length of the largest segment removed
+	* \param result (output) The result polygon, assumed to be empty
+	*/
+	void smooth(int remove_length, PolygonRef result);
+
+	/*!
+	* Smooth out sharp inner corners, by taking a shortcut which bypasses the corner
+	*
+	* \param angle The maximum angle of inner corners to be smoothed out
+	* \param shortcut_length The desired length of the shortcut line segment introduced (shorter shortcuts may be unavoidable)
+	* \param result The resulting polygon
+	*/
+	void smooth_outward(float angle, int shortcut_length, PolygonRef result) const;
+
+	/*!
+	* Smooth out the polygon and store the result in \p result.
+	* Smoothing is performed by removing vertices for which both connected line segments are smaller than \p remove_length
+	*
+	* \param remove_length The length of the largest segment removed
+	* \param result (output) The result polygon, assumed to be empty
+	*/
+	void smooth2(int remove_length, PolygonRef result);
+
+	/*!
+	* Removes consecutive line segments with same orientation and changes this polygon.
+	*
+	* Removes verts which are connected to line segments which are both too small.
+	* Removes verts which detour from a direct line from the previous and next vert by a too small amount.
+	*
+	* \param smallest_line_segment_squared maximal squared length of removed line segments
+	* \param allowed_error_distance_squared The square of the distance of the middle point to the line segment of the consecutive and previous point for which the middle point is removed
+	*/
+	void simplify(int smallest_line_segment_squared = 100, int allowed_error_distance_squared = 25);
+
+	void pop_back()
+	{
+		path.get().pop_back();
+	}
+
+	ClipperLib::Path::reference back() const
+	{
+		return path.get().back();
+	}
+
+	ClipperLib::Path::iterator begin()
+	{
+		return path.get().begin();
+	}
+
+	ClipperLib::Path::iterator end()
+	{
+		return path.get().end();
+	}
+	// Changed to cbegin in declaration and in call to path
+	ClipperLib::Path::const_iterator begin() const
+	{
+		return path.get().begin();
+	}
+	// Changed to cend in declaration and in call to path
+	ClipperLib::Path::const_iterator end() const
+	{
+		return path.get().cend();
+	}
+
+	friend class Polygons;
+	friend class Polygon;
 
 private:
-    /*!
-     * Smooth out a simple corner consisting of two linesegments.
-     * 
-     * Auxiliary function for \ref smooth_outward
-     * 
-     * \param poly The polygon in which to find the corner
-     * \param p0 The point before the corner
-     * \param p1 The corner
-     * \param p2 The point after the corner
-     * \param p0_it Iterator to the point before the corner
-     * \param p1_it Iterator to the corner
-     * \param p2_it Iterator to the point after the corner
-     * \param v10 Vector from \p p1 to \p p0
-     * \param v12 Vector from \p p1 to \p p2
-     * \param v02 Vector from \p p0 to \p p2
-     * \param shortcut_length The desired length ofthe shortcutting line
-     * \param cos_angle The cosine on the angle in L 012
-     */
-    static void smooth_corner_simple(ListPolygon& poly, const Point p0, const Point p1, const Point p2, const ListPolyIt p0_it, const ListPolyIt p1_it, const ListPolyIt p2_it, const Point v10, const Point v12, const Point v02, const int64_t shortcut_length, float cos_angle);
+	/*!
+	* Smooth out a simple corner consisting of two linesegments.
+	*
+	* Auxiliary function for \ref smooth_outward
+	*
+	* \param poly The polygon in which to find the corner
+	* \param p0 The point before the corner
+	* \param p1 The corner
+	* \param p2 The point after the corner
+	* \param p0_it Iterator to the point before the corner
+	* \param p1_it Iterator to the corner
+	* \param p2_it Iterator to the point after the corner
+	* \param v10 Vector from \p p1 to \p p0
+	* \param v12 Vector from \p p1 to \p p2
+	* \param v02 Vector from \p p0 to \p p2
+	* \param shortcut_length The desired length ofthe shortcutting line
+	* \param cos_angle The cosine on the angle in L 012
+	*/
+	static void smooth_corner_simple(ListPolygon& poly, const Point p0, const Point p1, const Point p2, const ListPolyIt p0_it, const ListPolyIt p1_it, const ListPolyIt p2_it, const Point v10, const Point v12, const Point v02, const int64_t shortcut_length, float cos_angle);
 
-    /*!
-     * Smooth out a complex corner where the shortcut bypasses more than two line segments
-     * 
-     * Auxiliary function for \ref smooth_outward
-     * 
-     * \warning This function might try to remove the whole polygon
-     * Error code -1 means the whole polygon should be removed (which means it is a hole polygon)
-     * 
-     * 
-     * \param poly The polygon in which to find the corner
-     * \param p1 The corner point
-     * \param[in,out] p0_it Iterator to the last point checked before \p p1 to consider cutting off
-     * \param[in,out] p2_it Iterator to the last point checked after \p p1 to consider cutting off
-     * \param shortcut_length The desired length ofthe shortcutting line
-     * \return Whether this whole polygon whould be removed by the smoothing
-     */
-    static bool smooth_corner_complex(ListPolygon& poly, const Point p1, ListPolyIt& p0_it, ListPolyIt& p2_it, const int64_t shortcut_length);
+	/*!
+	* Smooth out a complex corner where the shortcut bypasses more than two line segments
+	*
+	* Auxiliary function for \ref smooth_outward
+	*
+	* \param poly The polygon in which to find the corner
+	* \param p1 The corner point
+	* \param[in,out] p0_it Iterator to the last point checked before \p p1 to consider cutting off
+	* \param[in,out] p2_it Iterator to the last point checked after \p p1 to consider cutting off
+	* \param shortcut_length The desired length ofthe shortcutting line
+	*/
+	static void smooth_corner_complex(ListPolygon& poly, const Point p1, ListPolyIt& p0_it, ListPolyIt& p2_it, const int64_t shortcut_length);
 
-    /*!
-     * Try to take a step away from the corner point in order to take a bigger shortcut.
-     * 
-     * Try to take the shortcut from a place as far away from the corner as the place we are taking the shortcut to.
-     * 
-     * Auxiliary function for \ref smooth_outward
-     * 
-     * \param[in] p1 The corner point
-     * \param[in] shortcut_length2 The square of the desired length ofthe shortcutting line
-     * \param[in,out] p0_it Iterator to the previously checked point somewhere beyond \p p1. Updated for the next iteration.
-     * \param[in,out] p2_it Iterator to the previously checked point somewhere before \p p1. Updated for the next iteration.
-     * \param[in,out] forward_is_blocked Whether trying another step forward is blocked by the smoothing outward condition. Updated for the next iteration.
-     * \param[in,out] backward_is_blocked Whether trying another step backward is blocked by the smoothing outward condition. Updated for the next iteration.
-     * \param[in,out] forward_is_too_far Whether trying another step forward is blocked by the shortcut length condition. Updated for the next iteration.
-     * \param[in,out] backward_is_too_far Whether trying another step backward is blocked by the shortcut length condition. Updated for the next iteration.
-     */
-    static void smooth_outward_step(const Point p1, const int64_t shortcut_length2, ListPolyIt& p0_it, ListPolyIt& p2_it, bool& forward_is_blocked, bool& backward_is_blocked, bool& forward_is_too_far, bool& backward_is_too_far);
+	/*!
+	* Try to take a step away from the corner point in order to take a bigger shortcut.
+	*
+	* Try to take the shortcut from a place as far away from the corner as the place we are taking the shortcut to.
+	*
+	* Auxiliary function for \ref smooth_outward
+	*
+	* \param[in] p1 The corner point
+	* \param[in] shortcut_length2 The square of the desired length ofthe shortcutting line
+	* \param[in,out] p0_it Iterator to the previously checked point somewhere beyond \p p1. Updated for the next iteration.
+	* \param[in,out] p2_it Iterator to the previously checked point somewhere before \p p1. Updated for the next iteration.
+	* \param[in,out] forward_is_blocked Whether trying another step forward is blocked by the smoothing outward condition. Updated for the next iteration.
+	* \param[in,out] backward_is_blocked Whether trying another step backward is blocked by the smoothing outward condition. Updated for the next iteration.
+	* \param[in,out] forward_is_too_far Whether trying another step forward is blocked by the shortcut length condition. Updated for the next iteration.
+	* \param[in,out] backward_is_too_far Whether trying another step backward is blocked by the shortcut length condition. Updated for the next iteration.
+	*/
+	static void smooth_outward_step(const Point p1, const int64_t shortcut_length2, ListPolyIt& p0_it, ListPolyIt& p2_it, bool& forward_is_blocked, bool& backward_is_blocked, bool& forward_is_too_far, bool& backward_is_too_far);
 };
 
 class Polygon : public PolygonRef
 {
-    ClipperLib::Path poly;
+	ClipperLib::Path poly;
 public:
-    Polygon()
-    : PolygonRef(poly)
-    {
-    }
+	Polygon()
+		: PolygonRef(poly)
+	{
+	}
 
-    Polygon(const PolygonRef& other)
-    : PolygonRef(poly)
-    {
-        poly = *other.path;
-    }
+	Polygon(const PolygonRef& other)
+		: PolygonRef(poly)
+	{
+		poly = other.path;
+	}
 };
 
 class PolygonsPart;
 
 class Polygons
 {
-    friend class Polygon;
-    friend class PolygonRef;
+	friend class Polygon;
+	friend class PolygonRef;
 protected:
-    ClipperLib::Paths paths;
+	ClipperLib::Paths paths;
 public:
-    unsigned int size() const
-    {
-        return paths.size();
-    }
+	unsigned int size() const
+	{
+		return paths.size();
+	}
 
-    unsigned int pointCount() const; //!< Return the amount of points in all polygons
+	unsigned int pointCount() const; //!< Return the amount of points in all polygons
 
-    PolygonRef operator[] (unsigned int index)
-    {
-        POLY_ASSERT(index < size() && index >= 0);
-        return PolygonRef(paths[index]);
-    }
-    const PolygonRef operator[] (unsigned int index) const
-    {
-        return const_cast<Polygons*>(this)->operator[](index);
-    }
-    ClipperLib::Paths::iterator begin()
-    {
-        return paths.begin();
-    }
-    ClipperLib::Paths::const_iterator begin() const
-    {
-        return paths.begin();
-    }
-    ClipperLib::Paths::iterator end()
-    {
-        return paths.end();
-    }
-    ClipperLib::Paths::const_iterator end() const
-    {
-        return paths.end();
-    }
-    void remove(unsigned int index)
-    {
-        POLY_ASSERT(index < size() && index >= 0);
-        paths.erase(paths.begin() + index);
-    }
-    void erase(ClipperLib::Paths::iterator start, ClipperLib::Paths::iterator end)
-    {
-        paths.erase(start, end);
-    }
-    void clear()
-    {
-        paths.clear();
-    }
-    void add(const PolygonRef& poly)
-    {
-        paths.push_back(*poly.path);
-    }
-    void add(Polygon&& other_poly)
-    {
-        paths.emplace_back(std::move(*other_poly));
-    }
-    void add(const Polygons& other)
-    {
-        for(unsigned int n=0; n<other.paths.size(); n++)
-            paths.push_back(other.paths[n]);
-    }
+	PolygonRef operator[] (unsigned int index)
+	{
+		POLY_ASSERT(index < size());
+		return PolygonRef(paths[index]);
+	}
+	const PolygonRef operator[] (unsigned int index) const
+	{
+		return const_cast<Polygons*>(this)->operator[](index);
+	}
+	ClipperLib::Paths::iterator begin()
+	{
+		return paths.begin();
+	}
+	ClipperLib::Paths::const_iterator begin() const
+	{
+		return paths.begin();
+	}
+	ClipperLib::Paths::iterator end()
+	{
+		return paths.end();
+	}
+	ClipperLib::Paths::const_iterator end() const
+	{
+		return paths.end();
+	}
+	void remove(unsigned int index)
+	{
+		POLY_ASSERT(index < size());
+		paths.erase(paths.begin() + index);
+	}
+	void erase(ClipperLib::Paths::iterator start, ClipperLib::Paths::iterator end)
+	{
+		paths.erase(start, end);
+	}
+	void clear()
+	{
+		paths.clear();
+		paths.shrink_to_fit();
+	}
+	void reserve(size_t reserve) {
+		paths.reserve(reserve);
+	}
+	void add(const PolygonRef& poly)
+	{
+		paths.push_back(poly.path);
+	}
+	void add(Polygon&& other_poly)
+	{
+		paths.emplace_back(std::move(*other_poly));
+	}
+	void add(const Polygons& other)
+	{
+		for (unsigned int n = 0; n<other.paths.size(); n++)
+			paths.push_back(other.paths[n]);
+	}
 
-    template<typename... Args>
-    void emplace_back(Args... args)
-    {
-        paths.emplace_back(args...);
-    }
+	template<typename... Args>
+	void emplace_back(Args... args)
+	{
+		paths.emplace_back(args...);
+	}
 
-    PolygonRef newPoly()
-    {
-        paths.emplace_back();
-        return PolygonRef(paths.back());
-    }
-    PolygonRef back()
-    {
-        return PolygonRef(paths.back());
-    }
+	PolygonRef newPoly()
+	{
+		paths.emplace_back();
+		return PolygonRef(paths.back());
+	}
+	PolygonRef back()
+	{
+		return PolygonRef(paths.back());
+	}
 
-    Polygons() {}
+	Polygons() {}
 
-    Polygons(const Polygons& other) { paths = other.paths; }
-    Polygons& operator=(const Polygons& other) { paths = other.paths; return *this; }
+	Polygons(const Polygons& other) { paths = other.paths; }
+	Polygons& operator=(const Polygons& other) { paths = other.paths; return *this; }
 
-    bool operator==(const Polygons& other) const =delete;
+	bool operator==(const Polygons& other) const = delete;
 
-    Polygons difference(const Polygons& other) const
-    {
-        Polygons ret;
-        ClipperLib::Clipper clipper(clipper_init);
-        clipper.AddPaths(paths, ClipperLib::ptSubject, true);
-        clipper.AddPaths(other.paths, ClipperLib::ptClip, true);
-        clipper.Execute(ClipperLib::ctDifference, ret.paths);
-        return ret;
-    }
-    Polygons unionPolygons(const Polygons& other) const
-    {
-        Polygons ret;
-        ClipperLib::Clipper clipper(clipper_init);
-        clipper.AddPaths(paths, ClipperLib::ptSubject, true);
-        clipper.AddPaths(other.paths, ClipperLib::ptSubject, true);
-        clipper.Execute(ClipperLib::ctUnion, ret.paths, ClipperLib::pftNonZero, ClipperLib::pftNonZero);
-        return ret;
-    }
-    /*!
-     * Union all polygons with each other (When polygons.add(polygon) has been called for overlapping polygons)
-     */
-    Polygons unionPolygons() const
-    {
-        return unionPolygons(Polygons());
-    }
-    Polygons intersection(const Polygons& other) const
-    {
-        Polygons ret;
-        ClipperLib::Clipper clipper(clipper_init);
-        clipper.AddPaths(paths, ClipperLib::ptSubject, true);
-        clipper.AddPaths(other.paths, ClipperLib::ptClip, true);
-        clipper.Execute(ClipperLib::ctIntersection, ret.paths);
-        return ret;
-    }
-    Polygons xorPolygons(const Polygons& other) const
-    {
-        Polygons ret;
-        ClipperLib::Clipper clipper(clipper_init);
-        clipper.AddPaths(paths, ClipperLib::ptSubject, true);
-        clipper.AddPaths(other.paths, ClipperLib::ptClip, true);
-        clipper.Execute(ClipperLib::ctXor, ret.paths);
-        return ret;
-    }
+	Polygons difference(const Polygons& other) const
+	{
+		Polygons ret;
+		ClipperLib::Clipper clipper(clipper_init);
+		clipper.AddPaths(paths, ClipperLib::ptSubject, true);
+		clipper.AddPaths(other.paths, ClipperLib::ptClip, true);
+		clipper.Execute(ClipperLib::ctDifference, ret.paths);
+		return ret;
+	}
+	Polygons unionPolygons(const Polygons& other) const
+	{
+		Polygons ret;
+		ClipperLib::Clipper clipper(clipper_init);
+		clipper.AddPaths(paths, ClipperLib::ptSubject, true);
+		clipper.AddPaths(other.paths, ClipperLib::ptSubject, true);
+		clipper.Execute(ClipperLib::ctUnion, ret.paths, ClipperLib::pftNonZero, ClipperLib::pftNonZero);
+		return ret;
+	}
+	/*!
+	* Union all polygons with each other (When polygons.add(polygon) has been called for overlapping polygons)
+	*/
+	Polygons unionPolygons() const
+	{
+		return unionPolygons(Polygons());
+	}
+	Polygons intersection(const Polygons& other) const
+	{
+		Polygons ret;
+		ClipperLib::Clipper clipper(clipper_init);
+		clipper.AddPaths(paths, ClipperLib::ptSubject, true);
+		clipper.AddPaths(other.paths, ClipperLib::ptClip, true);
+		clipper.Execute(ClipperLib::ctIntersection, ret.paths);
+		return ret;
+	}
+	Polygons xorPolygons(const Polygons& other) const
+	{
+		Polygons ret;
+		ClipperLib::Clipper clipper(clipper_init);
+		clipper.AddPaths(paths, ClipperLib::ptSubject, true);
+		clipper.AddPaths(other.paths, ClipperLib::ptClip, true);
+		clipper.Execute(ClipperLib::ctXor, ret.paths);
+		return ret;
+	}
 
-    Polygons offset(int distance, ClipperLib::JoinType joinType = ClipperLib::jtMiter, double miter_limit = 1.2) const;
+	Polygons offset(int distance, ClipperLib::JoinType joinType = ClipperLib::jtMiter, double miter_limit = 1.2) const;
 
-    Polygons offsetPolyLine(int distance, ClipperLib::JoinType joinType = ClipperLib::jtMiter) const
-    {
-        Polygons ret;
-        double miterLimit = 1.2;
-        ClipperLib::ClipperOffset clipper(miterLimit, 10.0);
-        clipper.AddPaths(paths, joinType, ClipperLib::etOpenSquare);
-        clipper.MiterLimit = miterLimit;
-        clipper.Execute(ret.paths, distance);
-        return ret;
-    }
-    
-    /*!
-     * Check if we are inside the polygon.
-     * 
-     * We do this by counting the number of polygons inside which this point lies.
-     * An odd number is inside, while an even number is outside.
-     * 
-     * Returns false if outside, true if inside; if the point lies exactly on the border, will return \p border_result.
-     * 
-     * \param p The point for which to check if it is inside this polygon
-     * \param border_result What to return when the point is exactly on the border
-     * \return Whether the point \p p is inside this polygon (or \p border_result when it is on the border)
-     */
-    bool inside(Point p, bool border_result = false) const;
+	Polygons offsetPolyLine(int distance, ClipperLib::JoinType joinType = ClipperLib::jtMiter) const
+	{
+		Polygons ret;
+		double miterLimit = 1.2;
+		ClipperLib::ClipperOffset clipper(miterLimit, 10.0);
+		clipper.AddPaths(paths, joinType, ClipperLib::etOpenSquare);
+		clipper.MiterLimit = miterLimit;
+		clipper.Execute(ret.paths, distance);
+		return ret;
+	}
 
-    /*!
-     * Check if we are inside the polygon. We do this by tracing from the point towards the positive X direction,
-     * every line we cross increments the crossings counter. If we have an even number of crossings then we are not inside the polygon.
-     * Care needs to be taken, if p.Y exactly matches a vertex to the right of p, then we need to count 1 intersect if the
-     * outline passes vertically past; and 0 (or 2) intersections if that point on the outline is a 'top' or 'bottom' vertex.
-     * The easiest way to do this is to break out two cases for increasing and decreasing Y ( from p0 to p1 ).
-     * A segment is tested if pa.Y <= p.Y < pb.Y, where pa and pb are the points (from p0,p1) with smallest & largest Y.
-     * When both have the same Y, no intersections are counted but there is a special test to see if the point falls
-     * exactly on the line.
-     * 
-     * Returns false if outside, true if inside; if the point lies exactly on the border, will return \p border_result.
-     * 
-     * \deprecated This function is old and no longer used. instead use \ref Polygons::inside
-     * 
-     * \param p The point for which to check if it is inside this polygon
-     * \param border_result What to return when the point is exactly on the border
-     * \return Whether the point \p p is inside this polygon (or \p border_result when it is on the border)
-     */
-    bool insideOld(Point p, bool border_result = false) const;
-    
-    /*!
-     * Find the polygon inside which point \p p resides. 
-     * 
-     * We do this by tracing from the point towards the positive X direction,
-     * every line we cross increments the crossings counter. If we have an even number of crossings then we are not inside the polygon.
-     * We then find the polygon with an uneven number of crossings which is closest to \p p.
-     * 
-     * If \p border_result, we return the first polygon which is exactly on \p p.
-     * 
-     * \param p The point for which to check in which polygon it is.
-     * \param border_result Whether a point exactly on a polygon counts as inside
-     * \return The index of the polygon inside which the point \p p resides
-     */
-    unsigned int findInside(Point p, bool border_result = false);
-    
-    /*!
-     * Approximates the convex hull of the polygons.
-     * \p extra_outset Extra offset outward
-     * \return the convex hull (approximately)
-     * 
-     */
-    Polygons approxConvexHull(int extra_outset = 0);
-    
-    /*!
-     * Convex hull of all the points in the polygons.
-     * \return the convex hull
-     *
-     */
-    Polygon convexHull() const;
+	/*!
+	* Check if we are inside the polygon. We do this by tracing from the point towards the positive X direction,
+	* every line we cross increments the crossings counter. If we have an even number of crossings then we are not inside the polygon.
+	* Care needs to be taken, if p.Y exactly matches a vertex to the right of p, then we need to count 1 intersect if the
+	* outline passes vertically past; and 0 (or 2) intersections if that point on the outline is a 'top' or 'bottom' vertex.
+	* The easiest way to do this is to break out two cases for increasing and decreasing Y ( from p0 to p1 ).
+	* A segment is tested if pa.Y <= p.Y < pb.Y, where pa and pb are the points (from p0,p1) with smallest & largest Y.
+	* When both have the same Y, no intersections are counted but there is a special test to see if the point falls
+	* exactly on the line.
+	*
+	* Returns false if outside, true if inside; if the point lies exactly on the border, will return \p border_result.
+	*
+	* \param p The point for which to check if it is inside this polygon
+	* \param border_result What to return when the point is exactly on the border
+	* \return Whether the point \p p is inside this polygon (or \p border_result when it is on the border)
+	*/
+	bool inside(Point p, bool border_result = false) const;
 
-    /*!
-     * Smooth out small perpendicular segments
-     * Smoothing is performed by removing the inner most vertex of a line segment smaller than \p remove_length
-     * which has an angle with the next and previous line segment smaller than roughly 150*
-     * 
-     * Note that in its current implementation this function doesn't remove line segments with an angle smaller than 30*
-     * Such would be the case for an N shape.
-     * 
-     * \param remove_length The length of the largest segment removed
-     * \return The smoothed polygon
-     */
-    Polygons smooth(int remove_length);
+	/*!
+	* Find the polygon inside which point \p p resides.
+	*
+	* We do this by tracing from the point towards the positive X direction,
+	* every line we cross increments the crossings counter. If we have an even number of crossings then we are not inside the polygon.
+	* We then find the polygon with an uneven number of crossings which is closest to \p p.
+	*
+	* If \p border_result, we return the first polygon which is exactly on \p p.
+	*
+	* \param p The point for which to check in which polygon it is.
+	* \param border_result Whether a point exactly on a polygon counts as inside
+	* \return The index of the polygon inside which the point \p p resides
+	*/
+	unsigned int findInside(Point p, bool border_result = false);
 
-    /*!
-     * Smooth out sharp inner corners, by taking a shortcut which bypasses the corner
-     * 
-     * \param angle The maximum angle of inner corners to be smoothed out
-     * \param shortcut_length The desired length of the shortcut line segment introduced (shorter shortcuts may be unavoidable)
-     * \return The resulting polygons
-     */
-    Polygons smooth_outward(float angle, int shortcut_length);
+	/*!
+	* Approximates the convex hull of the polygons.
+	* \p extra_outset Extra offset outward
+	* \return the convex hull (approximately)
+	*
+	*/
+	Polygons approxConvexHull(int extra_outset = 0);
 
-    Polygons smooth2(int remove_length, int min_area); //!< removes points connected to small lines
-    
-    /*!
-     * removes points connected to similarly oriented lines
-     * 
-     * \param smallest_line_segment maximal length of removed line segments
-     * \param allowed_error_distance The distance of the middle point to the line segment of the consecutive and previous point for which the middle point is removed
-     */
-    void simplify(int smallest_line_segment = 10, int allowed_error_distance = 5) 
-    {
-        int allowed_error_distance_squared = allowed_error_distance * allowed_error_distance;
-        int smallest_line_segment_squared = smallest_line_segment * smallest_line_segment;
-        Polygons& thiss = *this;
-        for (unsigned int p = 0; p < size(); p++)
-        {
-            thiss[p].simplify(smallest_line_segment_squared, allowed_error_distance_squared);
-            if (thiss[p].size() < 3)
-            {
-                remove(p);
-                p--;
-            }
-        }
-    }
+	/*!
+	* Convex hull of all the points in the polygons.
+	* \return the convex hull
+	*
+	*/
+	Polygon convexHull() const;
 
-    /*!
-     * Remove all but the polygons on the very outside.
-     * Exclude holes and parts within holes.
-     * \return the resulting polygons.
-     */
-    Polygons getOutsidePolygons() const;
+	/*!
+	* Smooth out small perpendicular segments
+	* Smoothing is performed by removing the inner most vertex of a line segment smaller than \p remove_length
+	* which has an angle with the next and previous line segment smaller than roughly 150*
+	*
+	* Note that in its current implementation this function doesn't remove line segments with an angle smaller than 30*
+	* Such would be the case for an N shape.
+	*
+	* \param remove_length The length of the largest segment removed
+	* \return The smoothed polygon
+	*/
+	Polygons smooth(int remove_length);
 
-    /*!
-     * Exclude holes which have no parts inside of them.
-     * \return the resulting polygons.
-     */
-    Polygons removeEmptyHoles() const;
+	/*!
+	* Smooth out sharp inner corners, by taking a shortcut which bypasses the corner
+	*
+	* \param angle The maximum angle of inner corners to be smoothed out
+	* \param shortcut_length The desired length of the shortcut line segment introduced (shorter shortcuts may be unavoidable)
+	* \return The resulting polygons
+	*/
+	Polygons smooth_outward(float angle, int shortcut_length);
 
-    /*!
-     * Return hole polygons which have no parts inside of them.
-     * \return the resulting polygons.
-     */
-    Polygons getEmptyHoles() const;
+	Polygons smooth2(int remove_length, int min_area); //!< removes points connected to small lines
 
-    /*!
-     * Split up the polygons into groups according to the even-odd rule.
-     * Each PolygonsPart in the result has an outline as first polygon, whereas the rest are holes.
-     */
-    std::vector<PolygonsPart> splitIntoParts(bool unionAll = false) const;
+													   /*!
+													   * removes points connected to similarly oriented lines
+													   *
+													   * \param smallest_line_segment maximal length of removed line segments
+													   * \param allowed_error_distance The distance of the middle point to the line segment of the consecutive and previous point for which the middle point is removed
+													   */
+	void simplify(int smallest_line_segment = 10, int allowed_error_distance = 5){
+		int allowed_error_distance_squared = allowed_error_distance * allowed_error_distance;
+		int smallest_line_segment_squared = smallest_line_segment * smallest_line_segment;
+		Polygons& thiss = *this;
+		for (unsigned int p = 0; p < size(); p++)
+		{
+			thiss[p].simplify(smallest_line_segment_squared, allowed_error_distance_squared);
+			if (thiss[p].size() < 3)
+			{
+				remove(p);
+				p--;
+			}
+		}
+	}
+
+	/*!
+	* Remove all but the polygons on the very outside.
+	* Exclude holes and parts within holes.
+	* \return the resulting polygons.
+	*/
+	Polygons getOutsidePolygons() const;
+
+	/*!
+	* Exclude holes which have no parts inside of them.
+	* \return the resulting polygons.
+	*/
+	Polygons removeEmptyHoles() const;
+
+	/*!
+	* Split up the polygons into groups according to the even-odd rule.
+	* Each PolygonsPart in the result has an outline as first polygon, whereas the rest are holes.
+	*/
+	std::vector<PolygonsPart> splitIntoParts(bool unionAll = false) const;
 private:
-    /*!
-     * recursive part of \ref Polygons::removeEmptyHoles and \ref Polygons::getEmptyHoles
-     * \param node The node of the polygons part to process
-     * \param remove_holes Whether to remove empty holes or everything but the empty holes
-     * \param ret Where to store polygons which are not empty holes
-     */
-    void removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, const bool remove_holes, Polygons& ret) const;
-    void splitIntoParts_processPolyTreeNode(ClipperLib::PolyNode* node, std::vector<PolygonsPart>& ret) const;
+	/*!
+	* recursive part of \ref Polygons::removeEmptyHoles
+	* \param node The node of the polygons part to process
+	* \param ret Where to store polygons which are not empty holes
+	*/
+	void removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, Polygons& ret) const;
+	void splitIntoParts_processPolyTreeNode(ClipperLib::PolyNode* node, std::vector<PolygonsPart>& ret) const;
 public:
-    /*!
-     * Split up the polygons into groups according to the even-odd rule.
-     * Each vector in the result has the index to an outline as first index, whereas the rest are indices to holes.
-     * 
-     * \warning Note that this function reorders the polygons!
-     */
-    PartsView splitIntoPartsView(bool unionAll = false);
+	/*!
+	* Split up the polygons into groups according to the even-odd rule.
+	* Each vector in the result has the index to an outline as first index, whereas the rest are indices to holes.
+	*
+	* \warning Note that this function reorders the polygons!
+	*/
+	PartsView splitIntoPartsView(bool unionAll = false);
 private:
-    void splitIntoPartsView_processPolyTreeNode(PartsView& partsView, Polygons& reordered, ClipperLib::PolyNode* node) const;
+	void splitIntoPartsView_processPolyTreeNode(PartsView& partsView, Polygons& reordered, ClipperLib::PolyNode* node) const;
 public:
-    /*!
-     * Removes polygons with area smaller than \p minAreaSize (note that minAreaSize is in mm^2, not in micron^2).
-     */
-    void removeSmallAreas(double minAreaSize)
-    {               
-        Polygons& thiss = *this;
-        for(unsigned int i=0; i<size(); i++)
-        {
-            double area = INT2MM(INT2MM(fabs(thiss[i].area())));
-            if (area < minAreaSize) // Only create an up/down skin if the area is large enough. So you do not create tiny blobs of "trying to fill"
-            {
-                remove(i);
-                i -= 1;
-            }
-        }
-    }
-    /*!
-     * Removes overlapping consecutive line segments which don't delimit a positive area.
-     */
-    void removeDegenerateVerts()
-    {
-        Polygons& thiss = *this;
-        for (unsigned int poly_idx = 0; poly_idx < size(); poly_idx++)
-        {
-            PolygonRef poly = thiss[poly_idx];
-            Polygon result;
-            
-            auto isDegenerate = [](Point& last, Point& now, Point& next)
-            {
-                Point last_line = now - last;
-                Point next_line = next - now;
-                return dot(last_line, next_line) == -1 * vSize(last_line) * vSize(next_line);
-            };
-            bool isChanged = false;
-            for (unsigned int idx = 0; idx < poly.size(); idx++)
-            {
-                Point& last = (result.size() == 0) ? poly.back() : result.back();
-                if (idx+1 == poly.size() && result.size() == 0) { break; }
-                Point& next = (idx+1 == poly.size())? result[0] : poly[idx+1];
-                if ( isDegenerate(last, poly[idx], next) )
-                { // lines are in the opposite direction
-                    // don't add vert to the result
-                    isChanged = true;
-                    while (result.size() > 1 && isDegenerate(result[result.size()-2], result.back(), next) )
-                    {
-                        result.pop_back();
-                    }
-                }
-                else 
-                {
-                    result.add(poly[idx]);
-                }
-            }
-            
-            if (isChanged)
-            {
-                if (result.size() > 2) 
-                {   
-                    *poly = *result;
-                }
-                else 
-                {
-                    thiss.remove(poly_idx);
-                    poly_idx--; // effectively the next iteration has the same poly_idx (referring to a new poly which is not yet processed)
-                }
-            }
-        }
-    }
-    /*!
-     * Removes the same polygons from this set (and also empty polygons).
-     * Polygons are considered the same if all points lie within [same_distance] of their counterparts.
-     */
-    Polygons remove(Polygons& to_be_removed, int same_distance = 0)
-    {
-        Polygons result;
-        for (unsigned int poly_keep_idx = 0; poly_keep_idx < size(); poly_keep_idx++)
-        {
-            PolygonRef poly_keep = (*this)[poly_keep_idx];
-            bool should_be_removed = false;
-            if (poly_keep.size() > 0) 
-//             for (int hole_poly_idx = 0; hole_poly_idx < to_be_removed.size(); hole_poly_idx++)
-            for (PolygonRef poly_rem : to_be_removed)
-            {
-//                 PolygonRef poly_rem = to_be_removed[hole_poly_idx];
-                if (poly_rem.size() != poly_keep.size() || poly_rem.size() == 0) continue;
-                
-                // find closest point, supposing this point aligns the two shapes in the best way
-                int closest_point_idx = 0;
-                int smallestDist2 = -1;
-                for (unsigned int point_rem_idx = 0; point_rem_idx < poly_rem.size(); point_rem_idx++)
-                {
-                    int dist2 = vSize2(poly_rem[point_rem_idx] - poly_keep[0]);
-                    if (dist2 < smallestDist2 || smallestDist2 < 0)
-                    {
-                        smallestDist2 = dist2;
-                        closest_point_idx = point_rem_idx;
-                    }
-                }
-                bool poly_rem_is_poly_keep = true;
-                // compare the two polygons on all points
-                if (smallestDist2 > same_distance * same_distance)
-                    continue;
-                for (unsigned int point_idx = 0; point_idx < poly_rem.size(); point_idx++)
-                {
-                    int dist2 = vSize2(poly_rem[(closest_point_idx + point_idx) % poly_rem.size()] - poly_keep[point_idx]);
-                    if (dist2 > same_distance * same_distance)
-                    {
-                        poly_rem_is_poly_keep = false;
-                        break;
-                    }
-                }
-                if (poly_rem_is_poly_keep)
-                {
-                    should_be_removed = true;
-                    break;
-                }
-            }
-            if (!should_be_removed)
-                result.add(poly_keep);
-            
-        }
-        return result;
-    }
+	/*!
+	* Removes polygons with area smaller than \p minAreaSize (note that minAreaSize is in mm^2, not in micron^2).
+	*/
+	void removeSmallAreas(double minAreaSize){
+		Polygons& thiss = *this;
+		for (unsigned int i = 0; i<size(); i++)
+		{
+			double area = INT2MM(INT2MM(fabs(thiss[i].area())));
+			if (area < minAreaSize) // Only create an up/down skin if the area is large enough. So you do not create tiny blobs of "trying to fill"
+			{
+				remove(i);
+				i -= 1;
+			}
+		}
+	}
+	/*!
+	* Removes overlapping consecutive line segments which don't delimit a positive area.
+	*/
+	void removeDegenerateVerts(){
+		Polygons& thiss = *this;
+		for (unsigned int poly_idx = 0; poly_idx < size(); poly_idx++){
+			PolygonRef poly = thiss[poly_idx];
+			Polygon result;
 
-    Polygons processEvenOdd() const
-    {
-        Polygons ret;
-        ClipperLib::Clipper clipper(clipper_init);
-        clipper.AddPaths(paths, ClipperLib::ptSubject, true);
-        clipper.Execute(ClipperLib::ctUnion, ret.paths);
-        return ret;
-    }
+			auto isDegenerate = [](Point& last, Point& now, Point& next){
+				Point last_line = now - last;
+				Point next_line = next - now;
+				return dot(last_line, next_line) == -1 * vSize(last_line) * vSize(next_line);
+			};
+			bool isChanged = false;
+			for (unsigned int idx = 0; idx < poly.size(); idx++){
+				Point& last = (result.size() == 0) ? poly.back() : result.back();
+				if (idx + 1 == poly.size() && result.size() == 0) { break; }
+				Point& next = (idx + 1 == poly.size()) ? result[0] : poly[idx + 1];
+				if (isDegenerate(last, poly[idx], next)){ 
+				  // lines are in the opposite direction
+				  // don't add vert to the result
+					isChanged = true;
+					while (result.size() > 1 && isDegenerate(result[result.size() - 2], result.back(), next)){
+						result.pop_back();
+					}
+				}
+				else{
+					result.add(poly[idx]);
+				}
+			}
+			if (isChanged){
+				if (result.size() > 2){
+					*poly = *result;
+				}
+				else{
+					thiss.remove(poly_idx);
+					poly_idx--; // effectively the next iteration has the same poly_idx (referring to a new poly which is not yet processed)
+				}
+			}
+		}
+	}
+	/*!
+	* Removes the same polygons from this set (and also empty polygons).
+	* Polygons are considered the same if all points lie within [same_distance] of their counterparts.
+	*/
+	Polygons remove(Polygons& to_be_removed, int same_distance = 0){
+		Polygons result;
+		for (unsigned int poly_keep_idx = 0; poly_keep_idx < size(); poly_keep_idx++){
+			PolygonRef poly_keep = (*this)[poly_keep_idx];
+			bool should_be_removed = false;
+			if (poly_keep.size() > 0)
+				//             for (int hole_poly_idx = 0; hole_poly_idx < to_be_removed.size(); hole_poly_idx++)
+				for (PolygonRef poly_rem : to_be_removed){
+					//                 PolygonRef poly_rem = to_be_removed[hole_poly_idx];
+					if (poly_rem.size() != poly_keep.size() || poly_rem.size() == 0) continue;
 
-    int64_t polygonLength() const
-    {
-        int64_t length = 0;
-        for(unsigned int i=0; i<paths.size(); i++)
-        {
-            Point p0 = paths[i][paths[i].size()-1];
-            for(unsigned int n=0; n<paths[i].size(); n++)
-            {
-                Point p1 = paths[i][n];
-                length += vSize(p0 - p1);
-                p0 = p1;
-            }
-        }
-        return length;
-    }
-    
-    Point min() const
-    {
-        Point ret = Point(POINT_MAX, POINT_MAX);
-        for(const ClipperLib::Path& polygon : paths)
-        {
-            for(Point p : polygon)
-            {
-                ret.X = std::min(ret.X, p.X);
-                ret.Y = std::min(ret.Y, p.Y);
-            }
-        }
-        return ret;
-    }
-    
-    Point max() const
-    {
-        Point ret = Point(POINT_MIN, POINT_MIN);
-        for(const ClipperLib::Path& polygon : paths)
-        {
-            for(Point p : polygon)
-            {
-                ret.X = std::max(ret.X, p.X);
-                ret.Y = std::max(ret.Y, p.Y);
-            }
-        }
-        return ret;
-    }
+					// find closest point, supposing this point aligns the two shapes in the best way
+					int closest_point_idx = 0;
+					int smallestDist2 = -1;
+					for (unsigned int point_rem_idx = 0; point_rem_idx < poly_rem.size(); point_rem_idx++){
+						int dist2 = vSize2(poly_rem[point_rem_idx] - poly_keep[0]);
+						if (dist2 < smallestDist2 || smallestDist2 < 0){
+							smallestDist2 = dist2;
+							closest_point_idx = point_rem_idx;
+						}
+					}
+					bool poly_rem_is_poly_keep = true;
+					// compare the two polygons on all points
+					if (smallestDist2 > same_distance * same_distance)
+						continue;
+					for (unsigned int point_idx = 0; point_idx < poly_rem.size(); point_idx++){
+						int dist2 = vSize2(poly_rem[(closest_point_idx + point_idx) % poly_rem.size()] - poly_keep[point_idx]);
+						if (dist2 > same_distance * same_distance){
+							poly_rem_is_poly_keep = false;
+							break;
+						}
+					}
+					if (poly_rem_is_poly_keep){
+						should_be_removed = true;
+						break;
+					}
+				}
+			if (!should_be_removed)
+				result.add(poly_keep);
 
-    void applyMatrix(const PointMatrix& matrix)
-    {
-        for(unsigned int i=0; i<paths.size(); i++)
-        {
-            for(unsigned int j=0; j<paths[i].size(); j++)
-            {
-                paths[i][j] = matrix.apply(paths[i][j]);
-            }
-        }
-    }
+		}
+		return result;
+	}
+
+	Polygons processEvenOdd() const{
+		Polygons ret;
+		ClipperLib::Clipper clipper(clipper_init);
+		clipper.AddPaths(paths, ClipperLib::ptSubject, true);
+		clipper.Execute(ClipperLib::ctUnion, ret.paths);
+		return ret;
+	}
+
+	int64_t polygonLength() const{
+		int64_t length = 0;
+		for (unsigned int i = 0; i<paths.size(); i++){
+			Point p0 = paths[i][paths[i].size() - 1];
+			for (unsigned int n = 0; n<paths[i].size(); n++){
+				Point p1 = paths[i][n];
+				length += vSize(p0 - p1);
+				p0 = p1;
+			}
+		}
+		return length;
+	}
+
+	Point min() const{
+		Point ret = Point(POINT_MAX, POINT_MAX);
+		for (const ClipperLib::Path& polygon : paths)
+		{
+			for (Point p : polygon)
+			{
+				ret.X = std::min(ret.X, p.X);
+				ret.Y = std::min(ret.Y, p.Y);
+			}
+		}
+		return ret;
+	}
+
+	Point max() const{
+		Point ret = Point(POINT_MIN, POINT_MIN);
+		for (const ClipperLib::Path& polygon : paths)
+		{
+			for (Point p : polygon)
+			{
+				ret.X = std::max(ret.X, p.X);
+				ret.Y = std::max(ret.Y, p.Y);
+			}
+		}
+		return ret;
+	}
+
+	void applyMatrix(const PointMatrix& matrix){
+		for (unsigned int i = 0; i<paths.size(); i++)
+		{
+			for (unsigned int j = 0; j<paths[i].size(); j++)
+			{
+				paths[i][j] = matrix.apply(paths[i][j]);
+			}
+		}
+	}
 };
 
 /*!
- * A single area with holes. The first polygon is the outline, while the rest are holes within this outline.
- * 
- * This class has little more functionality than Polygons, but serves to show that a specific instance is ordered such that the first Polygon is the outline and the rest are holes.
- */
+* A single area with holes. The first polygon is the outline, while the rest are holes within this outline.
+*
+* This class has little more functionality than Polygons, but serves to show that a specific instance is ordered such that the first Polygon is the outline and the rest are holes.
+*/
 class PolygonsPart : public Polygons
-{   
+{
 public:
-    PolygonRef outerPolygon() 
-    {
-        Polygons& thiss = *this;
-        return thiss[0];
-    }
-    
-    bool inside(Point p)
-    {
-        if (size() < 1)
-            return false;
-        if (!(*this)[0].inside(p))
-            return false;
-        for(unsigned int n=1; n<paths.size(); n++)
-        {
-            if ((*this)[n].inside(p))
-                return false;
-        }
-        return true;
-    }
+	PolygonRef outerPolygon(){
+		Polygons& thiss = *this;
+		return thiss[0];
+	}
+
+	bool inside(Point p){
+		if (size() < 1)
+			return false;
+		if (!(*this)[0].inside(p))
+			return false;
+		for (unsigned int n = 1; n<paths.size(); n++){
+			if ((*this)[n].inside(p))
+				return false;
+		}
+		return true;
+	}
 };
 
 /*!
- * Extension of vector<vector<unsigned int>> which is similar to a vector of PolygonParts, except the base of the container is indices to polygons into the original Polygons, instead of the polygons themselves
- */
+* Extension of vector<vector<unsigned int>> which is similar to a vector of PolygonParts, except the base of the container is indices to polygons into the original Polygons, instead of the polygons themselves
+*/
 class PartsView : public std::vector<std::vector<unsigned int>>
 {
 public:
-    Polygons& polygons;
-    PartsView(Polygons& polygons) : polygons(polygons) { }
-    /*!
-     * Get the index of the PolygonsPart of which the polygon with index \p poly_idx is part.
-     * 
-     * \param poly_idx The index of the polygon in \p polygons
-     * \param boundary_poly_idx Optional output parameter: The index of the boundary polygon of the part in \p polygons
-     * \return The PolygonsPart containing the polygon with index \p poly_idx
-     */
-    unsigned int getPartContaining(unsigned int poly_idx, unsigned int* boundary_poly_idx = nullptr);
-    /*!
-     * Assemble the PolygonsPart of which the polygon with index \p poly_idx is part.
-     * 
-     * \param poly_idx The index of the polygon in \p polygons
-     * \param boundary_poly_idx Optional output parameter: The index of the boundary polygon of the part in \p polygons
-     * \return The PolygonsPart containing the polygon with index \p poly_idx
-     */
-    PolygonsPart assemblePartContaining(unsigned int poly_idx, unsigned int* boundary_poly_idx = nullptr);
-    /*!
-     * Assemble the PolygonsPart of which the polygon with index \p poly_idx is part.
-     * 
-     * \param part_idx The index of the part
-     * \return The PolygonsPart with index \p poly_idx
-     */
-    PolygonsPart assemblePart(unsigned int part_idx) const;
+	Polygons& polygons;
+	PartsView(Polygons& polygons) : polygons(polygons) { }
+	/*!
+	* Get the index of the PolygonsPart of which the polygon with index \p poly_idx is part.
+	*
+	* \param poly_idx The index of the polygon in \p polygons
+	* \param boundary_poly_idx Optional output parameter: The index of the boundary polygon of the part in \p polygons
+	* \return The PolygonsPart containing the polygon with index \p poly_idx
+	*/
+	unsigned int getPartContaining(unsigned int poly_idx, unsigned int* boundary_poly_idx = nullptr);
+	/*!
+	* Assemble the PolygonsPart of which the polygon with index \p poly_idx is part.
+	*
+	* \param poly_idx The index of the polygon in \p polygons
+	* \param boundary_poly_idx Optional output parameter: The index of the boundary polygon of the part in \p polygons
+	* \return The PolygonsPart containing the polygon with index \p poly_idx
+	*/
+	PolygonsPart assemblePartContaining(unsigned int poly_idx, unsigned int* boundary_poly_idx = nullptr);
+	/*!
+	* Assemble the PolygonsPart of which the polygon with index \p poly_idx is part.
+	*
+	* \param part_idx The index of the part
+	* \return The PolygonsPart with index \p poly_idx
+	*/
+	PolygonsPart assemblePart(unsigned int part_idx) const;
 };
+
 
 }//namespace cura
 


### PR DESCRIPTION
As was discussed in one of the issues, I attempted to change PolygonRef to use a std::reference_wrapper instead of a raw pointer. This makes things generally feel safer and cleaner, imo, but also has the advantage of being generally easier to use: a std::reference_wrapper object can be inserted into the standard libraries container objects, unlike a regular reference.

HOWEVER, this means nullptr is no longer a check that works for PolygonRef. A std::reference_wrapper also has no default constructor - no way to set a null reference, after all. Instead, I defined a static instance of the ClipperLib::Path class called "nullPath". It should be initialized as empty - I'm not sure exactly how comparisons in the rest of the code would work, but it could be as simple as checking if the input path/path ref returns true for "path.empty()". That's me postulating, however. 

The ref can also be made constant - and constructing a new ref can be done with std::ref() or std::cref() for constant references. Seeing as how the polygonref class does allow for modification of the referred object though, I don't think that'll work or be necessary (as safe as const-ness can feel). 

EDIT: On looking further, it appears I used an older version of the polygon files as there are some differences between the two, even when I didn't have to change anything to make the new ref type work. Apologies about that! not sure what to do now, with that in mind...