### PR TITLE
Reinstate filament used comment for RepRap flavour gcode.

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -182,6 +182,10 @@ std::string GCodeExport::getFileHeader(const double* print_time, const std::vect
             prefix << ";NOZZLE_DIAMETER:" << float(INT2MM(getNozzleSize(0))) << new_line;
             // TODO: the second nozzle size isn't always initiated! ";NOZZLE_DIAMETER2:"
         }
+        else if (flavor == EGCodeFlavor::REPRAP)
+        {
+            prefix << ";Filament used: " << ((filament_used.size() >= 1)? filament_used[0] / (1000 * extruder_attr[0].filament_area) : 0) << "m" << new_line;
+        }
         return prefix.str();
     }
 }


### PR DESCRIPTION
This little addition writes a comment containing the total amount of filament used by the first extruder to RepRap flavour gcode files. The format of the comment is similar to that used by Cura 1.15.04 except that it doesn't include the weight estimate.

It has been tested with CuraEngine 2.3.1 and DuetWifi 1.16.
