### PR TITLE
Add infill_angles setting to determine the directions of the lines and zig zag infills.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -845,7 +845,8 @@ void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStor
     bool skin_alternate_rotation = mesh->getSettingBoolean("skin_alternate_rotation") && ( mesh->getSettingAsCount("top_layers") >= 4 || mesh->getSettingAsCount("bottom_layers") >= 4 );
 
     int infill_angle = 45;
-    if ((infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG))
+    // infill_angles.size() will be > 0 when infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG
+    if (infill_angles.size() > 0)
     {
         unsigned int combined_infill_layers = std::max(1U, round_divide(mesh->getSettingInMicrons("infill_sparse_thickness"), std::max(getSettingInMicrons("layer_height"), (coord_t)1)));
         infill_angle = infill_angles.at((layer_nr / combined_infill_layers) % infill_angles.size());
@@ -876,7 +877,7 @@ void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStor
     int skin_angle = 45;
     if (skin_pattern == EFillMethod::LINES || skin_pattern == EFillMethod::ZIG_ZAG)
     {
-        if ((infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG) && infill_angles.size() > 0)
+        if (infill_angles.size() > 0)
         {
             // skin line angles will follow the same sequence as the infill line angles
             // this should coincide with infill_angle so that the first top layer is orthogonal to the last infill layer

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -828,6 +828,25 @@ void FffGcodeWriter::addMeshLayerToGCode(SliceDataStorage& storage, SliceMeshSto
     }
 }
 
+static void parseIntegerList(const char *input, std::vector<int> *output) {
+    for(;;)
+    {
+        char *endp;
+        int val = strtol(input, &endp, 0);
+        if (endp != input)
+        {
+            output->push_back(val);
+            input = endp;
+            while (*input && isspace(*input))
+                ++input;
+            if (*input == ',')
+                ++input;
+        }
+        else
+            break;
+    }
+}
+
 void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStorage* mesh, SliceLayerPart& part, GCodePlanner& gcode_layer, int layer_nr)
 {
     bool skin_alternate_rotation = mesh->getSettingBoolean("skin_alternate_rotation") && ( mesh->getSettingAsCount("top_layers") >= 4 || mesh->getSettingAsCount("bottom_layers") >= 4 );

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -832,7 +832,7 @@ void FffGcodeWriter::addMeshLayerToGCode(SliceDataStorage& storage, SliceMeshSto
     for (int part_idx : part_order_optimizer.polyOrder)
     {
         SliceLayerPart& part = layer->parts[part_idx];
-        addMeshPartToGCode(storage, mesh, part, gcode_layer, layer_nr, infill_pattern, infill_angles);
+        addMeshPartToGCode(storage, mesh, part, gcode_layer, layer_nr);
     }
     if (mesh->getSettingAsSurfaceMode("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
     {
@@ -840,7 +840,7 @@ void FffGcodeWriter::addMeshLayerToGCode(SliceDataStorage& storage, SliceMeshSto
     }
 }
 
-void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStorage* mesh, SliceLayerPart& part, GCodePlanner& gcode_layer, int layer_nr, EFillMethod infill_pattern, const std::vector<int> &infill_angles)
+void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStorage* mesh, SliceLayerPart& part, GCodePlanner& gcode_layer, int layer_nr)
 {
     bool skin_alternate_rotation = mesh->getSettingBoolean("skin_alternate_rotation") && ( mesh->getSettingAsCount("top_layers") >= 4 || mesh->getSettingAsCount("bottom_layers") >= 4 );
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -885,8 +885,10 @@ void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStor
             // but if combined_infill_layers above is > 1 then the skin angles and the infill angles will be different
             skin_angle = mesh->infill_angles.at(layer_nr % mesh->infill_angles.size());
         }
-        else if(layer_nr & 1)
+        else if (layer_nr & 1)
+        {
             skin_angle += 90;
+        }
     }
     if (skin_alternate_rotation && ( layer_nr / 2 ) & 1)
         skin_angle -= 45;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -836,6 +836,17 @@ void FffGcodeWriter::addMeshLayerToGCode(SliceDataStorage& storage, SliceMeshSto
         }
     }
 
+    if (mesh->skin_angles.size() == 0)
+    {
+        mesh->skin_angles = mesh->getSettingAsIntegerList("skin_angles");
+        if (mesh->skin_angles.size() == 0)
+        {
+            // user has not specified any infill angles so use defaults
+            mesh->skin_angles.push_back(45);
+            mesh->skin_angles.push_back(135);
+        }
+    }
+
     for (int part_idx : part_order_optimizer.polyOrder)
     {
         SliceLayerPart& part = layer->parts[part_idx];
@@ -880,12 +891,9 @@ void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStor
     }
 
     int skin_angle = 45;
-    if (mesh->infill_angles.size() > 0)
+    if (mesh->skin_angles.size() > 0)
     {
-        // skin line angles will follow the same sequence as the infill line angles
-        // this should coincide with infill_angle so that the first top layer is orthogonal to the last infill layer
-        // but if combined_infill_layers above is > 1 then the skin angles and the infill angles will be different
-        skin_angle = mesh->infill_angles.at(layer_nr % mesh->infill_angles.size());
+        skin_angle = mesh->skin_angles.at(layer_nr % mesh->skin_angles.size());
     }
     if (skin_alternate_rotation && ( layer_nr / 2 ) & 1)
         skin_angle -= 45;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -828,25 +828,6 @@ void FffGcodeWriter::addMeshLayerToGCode(SliceDataStorage& storage, SliceMeshSto
     }
 }
 
-static void parseIntegerList(const char *input, std::vector<int> *output) {
-    for(;;)
-    {
-        char *endp;
-        int val = strtol(input, &endp, 0);
-        if (endp != input)
-        {
-            output->push_back(val);
-            input = endp;
-            while (*input && isspace(*input))
-                ++input;
-            if (*input == ',')
-                ++input;
-        }
-        else
-            break;
-    }
-}
-
 void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStorage* mesh, SliceLayerPart& part, GCodePlanner& gcode_layer, int layer_nr)
 {
     bool skin_alternate_rotation = mesh->getSettingBoolean("skin_alternate_rotation") && ( mesh->getSettingAsCount("top_layers") >= 4 || mesh->getSettingAsCount("bottom_layers") >= 4 );
@@ -856,11 +837,7 @@ void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStor
     std::vector<int> infill_angles;
     if ((infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG))
     {
-        std::string infill_angles_string = mesh->getSettingString("infill_angles");
-
-        if (!infill_angles_string.empty())
-            parseIntegerList(infill_angles_string.c_str(), &infill_angles);
-
+        infill_angles = mesh->getSettingAsIntegerList("infill_angles");
         if (infill_angles.size() == 0)
         {
             infill_angles.push_back(45);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -855,11 +855,21 @@ void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStor
     int infill_angle = 45;
     if ((infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG))
     {
-        unsigned int combined_infill_layers = std::max(1U, round_divide(mesh->getSettingInMicrons("infill_sparse_thickness"), std::max(getSettingInMicrons("layer_height"), (coord_t)1)));
-        if ((layer_nr / combined_infill_layers) & 1)
-        { // switch every [combined_infill_layers] layers
-            infill_angle += 90;
+        std::vector<int> infill_angles;
+
+        std::string infill_angles_string = mesh->getSettingString("infill_angles");
+
+        if (!infill_angles_string.empty())
+            parseIntegerList(infill_angles_string.c_str(), &infill_angles);
+
+        if (infill_angles.size() == 0)
+        {
+            infill_angles.push_back(45);
+            infill_angles.push_back(135);
         }
+
+        unsigned int combined_infill_layers = std::max(1U, round_divide(mesh->getSettingInMicrons("infill_sparse_thickness"), std::max(getSettingInMicrons("layer_height"), (coord_t)1)));
+        infill_angle = infill_angles.at((layer_nr / combined_infill_layers) % infill_angles.size());
     }
     
     int infill_line_distance = mesh->getSettingInMicrons("infill_line_distance");

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -820,14 +820,19 @@ void FffGcodeWriter::addMeshLayerToGCode(SliceDataStorage& storage, SliceMeshSto
     }
     part_order_optimizer.optimize();
 
-    EFillMethod infill_pattern = mesh->getSettingAsFillMethod("infill_pattern");
-    if ((infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG) && mesh->infill_angles.size() == 0)
+    if (mesh->infill_angles.size() == 0)
     {
         mesh->infill_angles = mesh->getSettingAsIntegerList("infill_angles");
         if (mesh->infill_angles.size() == 0)
         {
-            mesh->infill_angles.push_back(45);
-            mesh->infill_angles.push_back(135);
+            // user has not specified any infill angles so use defaults
+            mesh->infill_angles.push_back(45); // all infill patterns use 45 degrees
+            EFillMethod infill_pattern = mesh->getSettingAsFillMethod("infill_pattern");
+            if (infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG)
+            {
+                // lines and zig zag patterns default to also using 135 degrees
+                mesh->infill_angles.push_back(135);
+            }
         }
     }
 

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -333,9 +333,11 @@ private:
      * \param part The part to add
      * \param gcode_layer The initial planning of the gcode of the layer.
      * \param layer_nr The index of the layer to write the gcode of.
+     * \param infill_pattern The infill pattern to use.
+     * \param infill_angles A vector of possible infill angles.
      * 
      */
-    void addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStorage* mesh, SliceLayerPart& part, GCodePlanner& gcode_layer, int layer_nr);
+    void addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStorage* mesh, SliceLayerPart& part, GCodePlanner& gcode_layer, int layer_nr, EFillMethod infill_pattern, const std::vector<int> &infill_angles);
     
     /*!
      * Add thicker (multiple layers) sparse infill for a given part in a layer plan.

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -333,11 +333,9 @@ private:
      * \param part The part to add
      * \param gcode_layer The initial planning of the gcode of the layer.
      * \param layer_nr The index of the layer to write the gcode of.
-     * \param infill_pattern The infill pattern to use.
-     * \param infill_angles A vector of possible infill angles.
      * 
      */
-    void addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStorage* mesh, SliceLayerPart& part, GCodePlanner& gcode_layer, int layer_nr, EFillMethod infill_pattern, const std::vector<int> &infill_angles);
+    void addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStorage* mesh, SliceLayerPart& part, GCodePlanner& gcode_layer, int layer_nr);
     
     /*!
      * Add thicker (multiple layers) sparse infill for a given part in a layer plan.

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -458,6 +458,32 @@ SupportDistPriority SettingsBaseVirtual::getSettingAsSupportDistPriority(std::st
     return SupportDistPriority::XY_OVERRIDES_Z;
 }
 
+std::vector<int> SettingsBaseVirtual::getSettingAsIntegerList(std::string key) const
+{
+    std::vector<int> result;
+    std::string value_string = getSettingString(key);
+    if (!value_string.empty()) {
+        std::regex regex("([^,]+,?)");
+        // default constructor = end-of-sequence:
+        std::regex_token_iterator<std::string::iterator> rend;
+
+        int submatches[] = { 1 }; // match number and optional comma
+        std::regex_token_iterator<std::string::iterator> match_iter(value_string.begin(), value_string.end(), regex, submatches);
+        while (match_iter != rend)
+        {
+            std::string val = *match_iter++;
+            try
+            {
+                result.push_back(std::stoi(val));
+            }
+            catch (const std::invalid_argument& e)
+            {
+                logError("Couldn't read integer value (%s) in setting '%s'. Ignored.\n", val.c_str(), key.c_str());
+            }
+        }
+    }
+    return result;
+}
 
 }//namespace cura
 

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -471,7 +471,7 @@ std::vector<int> SettingsBaseVirtual::getSettingAsIntegerList(std::string key) c
         if (std::regex_search(value_string, list_contents_match, list_contents_regex) && list_contents_match.size() > 1)
         {
             std::string elements = list_contents_match.str(1);
-            std::regex element_regex("([^,]+,?)");
+            std::regex element_regex("\\s*(-?[0-9]+)\\s*,?");
             // default constructor = end-of-sequence:
             std::regex_token_iterator<std::string::iterator> rend;
 

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -253,6 +253,7 @@ public:
     FillPerimeterGapMode getSettingAsFillPerimeterGapMode(std::string key) const;
     CombingMode getSettingAsCombingMode(std::string key);
     SupportDistPriority getSettingAsSupportDistPriority(std::string key);
+    std::vector<int> getSettingAsIntegerList(std::string key) const;
 };
 
 class SettingRegistry;

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -158,6 +158,7 @@ public:
     GCodePathConfig perimeter_gap_config;
     std::vector<GCodePathConfig> infill_config;
     std::vector<int> infill_angles; //!< a list of angle values (in degrees) which is cycled through to determine the infill angle of each layer
+    std::vector<int> skin_angles; //!< a list of angle values (in degrees) which is cycled through to determine the skin angle of each layer
 
     SubDivCube* base_subdiv_cube;
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -156,7 +156,7 @@ public:
     GCodePathConfig insetX_config;
     GCodePathConfig skin_config;
     std::vector<GCodePathConfig> infill_config;
-    std::vector<int> infill_angles;
+    std::vector<int> infill_angles; //!< a list of angle values (in degrees) which is cycled through to determine the infill angle of each layer
 
     SubDivCube* base_subdiv_cube;
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -156,6 +156,7 @@ public:
     GCodePathConfig insetX_config;
     GCodePathConfig skin_config;
     std::vector<GCodePathConfig> infill_config;
+    std::vector<int> infill_angles;
 
     SubDivCube* base_subdiv_cube;
 


### PR DESCRIPTION

Before, the lines and zig zag infill patterns alternated the direction of the
infill lines between 45 and 135 degrees depending on the layer. Now, a new
setting "infill_angles" provides a comma separated list of angles that are
cycled through.

The rational behind this addition is that I have a part that requires the infill to be stronger in one direction and I could print that using s3d by specifying the infill angles so that more infill lies in the direction which needs to be strong.  I am moving as much as I can from using s3d to cura and therefore I need this capability (or an equivalent feature).

This works for me but I expect if you want to keep this functionality that you would like to refactor it. No problem, just say how it should be improved.