### PR TITLE
Use different skin pattern on first layer

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -864,7 +864,9 @@ void FffGcodeWriter::addMeshPartToGCode(SliceDataStorage& storage, SliceMeshStor
         processSingleLayerInfill(gcode_layer, mesh, part, layer_nr, infill_line_distance, infill_overlap, infill_angle);
     }
 
-    EFillMethod skin_pattern = mesh->getSettingAsFillMethod("top_bottom_pattern");
+    EFillMethod skin_pattern = (layer_nr == 0)?
+        mesh->getSettingAsFillMethod("top_bottom_pattern_0") :
+        mesh->getSettingAsFillMethod("top_bottom_pattern");
     int skin_angle = 45;
     if ((skin_pattern == EFillMethod::LINES || skin_pattern == EFillMethod::ZIG_ZAG) && layer_nr & 1)
     {
@@ -1064,7 +1066,9 @@ void FffGcodeWriter::processSkinAndPerimeterGaps(GCodePlanner& gcode_layer, Slic
         Polygons skin_polygons;
         Polygons skin_lines;
         
-        EFillMethod pattern = mesh->getSettingAsFillMethod("top_bottom_pattern");
+        EFillMethod pattern = (layer_nr == 0)?
+            mesh->getSettingAsFillMethod("top_bottom_pattern_0") :
+            mesh->getSettingAsFillMethod("top_bottom_pattern");
         int bridge = -1;
         if (layer_nr > 0)
             bridge = bridgeAngle(skin_part.outline, &mesh->layers[layer_nr-1]);


### PR DESCRIPTION
This pull req creates a setting to change the skin pattern for just the first layer. I like concentric skin for bed adhesion but not for anything else so this allows to set just the layer that does the bed adhesion to concentric.
I've used this for a while but now I decided to make a PR for it, it was tested on the Ultimaker 2 printer.