### PR TITLE
Remove areas of infill smaller than min_infill_area.

### DIFF
--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -31,7 +31,7 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
     {
         return;
     }
-    
+    int min_infill_area = mesh.getSettingInMillimeters("min_infill_area");
     for(unsigned int partNr = 0; partNr < layer.parts.size(); partNr++)
     {
         SliceLayerPart& part = layer.parts[partNr];
@@ -63,12 +63,22 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
         {
             if (static_cast<int>(layer_nr - downSkinCount) >= 0)
             {
-                downskin = downskin.difference(getInsidePolygons(mesh.layers[layer_nr - downSkinCount])); // skin overlaps with the walls
+                Polygons not_air = getInsidePolygons(mesh.layers[layer_nr - downSkinCount]);
+                if (min_infill_area > 0)
+                {
+                    not_air.removeSmallAreas(min_infill_area);
+                }
+                downskin = downskin.difference(not_air); // skin overlaps with the walls
             }
             
             if (static_cast<int>(layer_nr + upSkinCount) < static_cast<int>(mesh.layers.size()))
             {
-                upskin = upskin.difference(getInsidePolygons(mesh.layers[layer_nr + upSkinCount])); // skin overlaps with the walls
+                Polygons not_air = getInsidePolygons(mesh.layers[layer_nr + upSkinCount]);
+                if (min_infill_area > 0)
+                {
+                    not_air.removeSmallAreas(min_infill_area);
+                }
+                upskin = upskin.difference(not_air); // skin overlaps with the walls
             }
         }
         else 
@@ -80,6 +90,10 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
                 {
                     not_air = not_air.intersection(getInsidePolygons(mesh.layers[downskin_layer_nr]));
                 }
+                if (min_infill_area > 0)
+                {
+                    not_air.removeSmallAreas(min_infill_area);
+                }
                 downskin = downskin.difference(not_air); // skin overlaps with the walls
             }
             
@@ -89,6 +103,10 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
                 for (int upskin_layer_nr = layer_nr + 2; upskin_layer_nr < layer_nr + upSkinCount + 1; upskin_layer_nr++)
                 {
                     not_air = not_air.intersection(getInsidePolygons(mesh.layers[upskin_layer_nr]));
+                }
+                if (min_infill_area > 0)
+                {
+                    not_air.removeSmallAreas(min_infill_area);
                 }
                 upskin = upskin.difference(not_air); // skin overlaps with the walls
             }


### PR DESCRIPTION
When you have a small feature above an outer layer (e.g. raised text), the
area under the feature will be infill rather than skin and so the skin is
composed of multiple segments around the feature. Better surface quality is
obtained if the area under the raised feature is treated as skin thus allowing
more of the outer layer to be printed as a single segment. This setting
specifies the minimum area (in mm^2) of a filled region. Areas smaller than
this will be filled with skin rather than infill.