### PR TITLE
Add 'No Walls' combing mode to suppress combing when destination is a wall.

### DIFF
--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -142,8 +142,8 @@ Polygons GCodePlanner::computeCombBoundaryInside(CombingMode combing_mode)
         for (SliceMeshStorage& mesh : storage.meshes)
         {
             SliceLayer& layer = mesh.layers[layer_nr];
-            const CombingMode combing_mode = mesh.getSettingAsCombingMode("retraction_combing");
-            if (combing_mode == CombingMode::NO_SKIN || combing_mode == CombingMode::NO_WALLS)
+            const CombingMode mesh_combing_mode = mesh.getSettingAsCombingMode("retraction_combing");
+            if (mesh_combing_mode == CombingMode::NO_SKIN || mesh_combing_mode == CombingMode::NO_WALLS)
             {
                 for (SliceLayerPart& part : layer.parts)
                 {

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -349,7 +349,7 @@ public:
      * 
      * \param p The point to travel to
      */
-    GCodePath& addTravel(Point p);
+    GCodePath& addTravel(Point p, bool no_combing = false);
     
     /*!
      * Add a travel path to a certain point and retract if needed.

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -441,6 +441,10 @@ CombingMode SettingsBaseVirtual::getSettingAsCombingMode(std::string key)
     {
         return CombingMode::NO_SKIN;
     }
+    if (value == "nowalls")
+    {
+        return CombingMode::NO_WALLS;
+    }
     return CombingMode::ALL;
 }
 

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -159,7 +159,8 @@ enum class CombingMode
 {
     OFF,
     ALL,
-    NO_SKIN
+    NO_SKIN,
+    NO_WALLS
 };
 
 /*!


### PR DESCRIPTION

Print visual quality can suffer if a move to the start of an outer wall
line is combed because the excess "dribble" can reach the outer surface
(at least enough of it does to make a visual difference). This mod adds
the 'No Walls' combing mode which forces a retraction to be used when the
destination of the move is the first point in a wall.

I definitely see an improvement of print quality "downstream" of the z-seam when this mode is enabled. It's still rather experimental but I am creating the PR as it gives us something to discuss.

My intention was for this mode to only affect travel to outer walls but I don't yet understand the engine's code well enough to be sure that this is the case with this PR. Do you get a polygon for each of the walls of an area or just the outer wall?