### PR TITLE
Can now grow skin areas so that they become anchored by the infill above and below.

### DIFF
--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -113,16 +113,27 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
             }
         }
 
-        int anchor_skin_distance = mesh.getSettingInMicrons("anchor_skin_distance");
+        int anchor_skin_expand_distance = mesh.getSettingInMicrons("anchor_skin_expand_distance");
         
-        if (anchor_skin_distance > 0 && mesh.getSettingBoolean("anchor_upper_skin_in_infill"))
+        if (anchor_skin_expand_distance > 0)
         {
-            upskin = upskin.offset(-innermost_wall_line_width/2).offset(anchor_skin_distance).intersection(virgin_upskin);
-        }
+            int anchor_skin_shrink_distance = mesh.getSettingInMicrons("anchor_skin_shrink_distance");
 
-        if (anchor_skin_distance > 0 && mesh.getSettingBoolean("anchor_lower_skin_in_infill"))
-        {
-            downskin = downskin.offset(-innermost_wall_line_width/2).offset(anchor_skin_distance).intersection(virgin_upskin);
+            // skin areas are to be enlarged by anchor_skin_distance but before they are expanded
+            // the skin areas are shrunk by shrink_distance so that very narrow regions of skin
+            // (often caused by the model's surface having a steep incline) are removed first
+
+            anchor_skin_expand_distance += anchor_skin_shrink_distance; // increase the expansion distance to compensate for the shrinkage
+
+            if (mesh.getSettingBoolean("anchor_upper_skin_in_infill"))
+            {
+                upskin = upskin.offset(-anchor_skin_shrink_distance).offset(anchor_skin_expand_distance).intersection(virgin_upskin);
+            }
+
+            if (mesh.getSettingBoolean("anchor_lower_skin_in_infill"))
+            {
+                downskin = downskin.offset(-anchor_skin_shrink_distance).offset(anchor_skin_expand_distance).intersection(virgin_upskin);
+            }
         }
 
         Polygons skin = upskin.unionPolygons(downskin);

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -120,7 +120,7 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
             upskin = upskin.offset(-innermost_wall_line_width/2).offset(anchor_skin_distance).intersection(virgin_upskin);
         }
 
-        if (anchor_skin_distance && mesh.getSettingBoolean("anchor_lower_skin_in_infill"))
+        if (anchor_skin_distance > 0 && mesh.getSettingBoolean("anchor_lower_skin_in_infill"))
         {
             downskin = downskin.offset(-innermost_wall_line_width/2).offset(anchor_skin_distance).intersection(virgin_upskin);
         }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -32,7 +32,8 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
         return;
     }
     int min_infill_area = mesh.getSettingInMillimeters("min_infill_area");
-    int grow_skin_by = mesh.getSettingBoolean("anchor_skin_in_infill") ? static_cast<int>(mesh.getSettingInMicrons("infill_line_distance") * 1.4f) : 0;
+    int grow_upper_skin_by = mesh.getSettingBoolean("anchor_upper_skin_in_infill") ? static_cast<int>(mesh.getSettingInMicrons("infill_line_distance") * 1.4f) : 0;
+    int grow_lower_skin_by = mesh.getSettingBoolean("anchor_lower_skin_in_infill") ? static_cast<int>(mesh.getSettingInMicrons("infill_line_distance") * 1.4f) : 0;
     for(unsigned int partNr = 0; partNr < layer.parts.size(); partNr++)
     {
         SliceLayerPart& part = layer.parts[partNr];
@@ -114,11 +115,18 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
             }
         }
         
+        if (grow_upper_skin_by > 0)
+        {
+            upskin = upskin.offset(-innermost_wall_line_width/2).offset(grow_upper_skin_by).intersection(virgin_upskin);
+        }
+
+        if (grow_lower_skin_by > 0)
+        {
+            downskin = downskin.offset(-innermost_wall_line_width/2).offset(grow_lower_skin_by).intersection(virgin_upskin);
+        }
+
         Polygons skin = upskin.unionPolygons(downskin);
 
-        if(grow_skin_by > 0)
-            skin = skin.offset(grow_skin_by).intersection(virgin_upskin);
-        
         skin.removeSmallAreas(MIN_AREA_SIZE);
         
         for (PolygonsPart& skin_area_part : skin.splitIntoParts())

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -113,26 +113,26 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
             }
         }
 
-        int anchor_skin_expand_distance = mesh.getSettingInMicrons("anchor_skin_expand_distance");
+        int expand_skins_expand_distance = mesh.getSettingInMicrons("expand_skins_expand_distance");
         
-        if (anchor_skin_expand_distance > 0)
+        if (expand_skins_expand_distance > 0)
         {
-            int anchor_skin_shrink_distance = mesh.getSettingInMicrons("anchor_skin_shrink_distance");
+            int expand_skins_shrink_distance = mesh.getSettingInMicrons("expand_skins_shrink_distance");
 
-            // skin areas are to be enlarged by anchor_skin_distance but before they are expanded
+            // skin areas are to be enlarged by expand_distance but before they are expanded
             // the skin areas are shrunk by shrink_distance so that very narrow regions of skin
             // (often caused by the model's surface having a steep incline) are removed first
 
-            anchor_skin_expand_distance += anchor_skin_shrink_distance; // increase the expansion distance to compensate for the shrinkage
+            expand_skins_expand_distance += expand_skins_shrink_distance; // increase the expansion distance to compensate for the shrinkage
 
-            if (mesh.getSettingBoolean("anchor_upper_skin_in_infill"))
+            if (mesh.getSettingBoolean("expand_upper_skins"))
             {
-                upskin = upskin.offset(-anchor_skin_shrink_distance).offset(anchor_skin_expand_distance).intersection(virgin_upskin);
+                upskin = upskin.offset(-expand_skins_shrink_distance).offset(expand_skins_expand_distance).intersection(virgin_upskin);
             }
 
-            if (mesh.getSettingBoolean("anchor_lower_skin_in_infill"))
+            if (mesh.getSettingBoolean("expand_lower_skins"))
             {
-                downskin = downskin.offset(-anchor_skin_shrink_distance).offset(anchor_skin_expand_distance).intersection(virgin_upskin);
+                downskin = downskin.offset(-expand_skins_shrink_distance).offset(expand_skins_expand_distance).intersection(virgin_upskin);
             }
         }
 

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -32,8 +32,6 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
         return;
     }
     int min_infill_area = mesh.getSettingInMillimeters("min_infill_area");
-    int grow_upper_skin_by = mesh.getSettingBoolean("anchor_upper_skin_in_infill") ? static_cast<int>(mesh.getSettingInMicrons("infill_line_distance") * 1.4f) : 0;
-    int grow_lower_skin_by = mesh.getSettingBoolean("anchor_lower_skin_in_infill") ? static_cast<int>(mesh.getSettingInMicrons("infill_line_distance") * 1.4f) : 0;
     for(unsigned int partNr = 0; partNr < layer.parts.size(); partNr++)
     {
         SliceLayerPart& part = layer.parts[partNr];
@@ -114,15 +112,17 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
                 upskin = upskin.difference(not_air); // skin overlaps with the walls
             }
         }
+
+        int anchor_skin_distance = mesh.getSettingInMicrons("anchor_skin_distance");
         
-        if (grow_upper_skin_by > 0)
+        if (anchor_skin_distance > 0 && mesh.getSettingBoolean("anchor_upper_skin_in_infill"))
         {
-            upskin = upskin.offset(-innermost_wall_line_width/2).offset(grow_upper_skin_by).intersection(virgin_upskin);
+            upskin = upskin.offset(-innermost_wall_line_width/2).offset(anchor_skin_distance).intersection(virgin_upskin);
         }
 
-        if (grow_lower_skin_by > 0)
+        if (anchor_skin_distance && mesh.getSettingBoolean("anchor_lower_skin_in_infill"))
         {
-            downskin = downskin.offset(-innermost_wall_line_width/2).offset(grow_lower_skin_by).intersection(virgin_upskin);
+            downskin = downskin.offset(-innermost_wall_line_width/2).offset(anchor_skin_distance).intersection(virgin_upskin);
         }
 
         Polygons skin = upskin.unionPolygons(downskin);

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -32,6 +32,7 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
         return;
     }
     int min_infill_area = mesh.getSettingInMillimeters("min_infill_area");
+    int grow_skin_by = mesh.getSettingBoolean("anchor_skin_in_infill") ? static_cast<int>(mesh.getSettingInMicrons("infill_line_distance") * 1.4f) : 0;
     for(unsigned int partNr = 0; partNr < layer.parts.size(); partNr++)
     {
         SliceLayerPart& part = layer.parts[partNr];
@@ -42,6 +43,7 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
         }
 
         Polygons upskin = part.insets.back().offset(-innermost_wall_line_width / 2);
+        Polygons virgin_upskin = Polygons(upskin);
         Polygons downskin = (downSkinCount == 0) ? Polygons() : upskin;
         if (upSkinCount == 0) upskin = Polygons();
 
@@ -113,6 +115,9 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
         }
         
         Polygons skin = upskin.unionPolygons(downskin);
+
+        if(grow_skin_by > 0)
+            skin = skin.offset(grow_skin_by).intersection(virgin_upskin);
         
         skin.removeSmallAreas(MIN_AREA_SIZE);
         


### PR DESCRIPTION

If the anchor_skin_in_infill setting is true, skin areas are expanded by
an amount that is the infill line distance * 1.4. This should be sufficient
to ensure that the skin is anchored in the infill by at least the distance
between the infill lines.

Hi Tim,

This PR is what I really wanted to write when I did the minimum infill area PR a little time ago.

People (not only me) have been bleating at S3D to do something like this for a year or two. As far as I know, only slic3r currently behaves well in this regard. S3D (and Cura, for that matter) do not handle skins over sparse infill well. If you have a feature above a skin above sparse infill, it looks crap and is very weak. This PR should fix that.

Hope you like it (OK, if not the implementation, at least the idea!).

I realise that you are not using contributions at the moment due to some ongoing licensing issue but I would be grateful if you can consider this in the future.