### PR TITLE
Add combing_retract_before_outer_wall feature

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1104,7 +1104,7 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
 {
     bool compensate_overlap_0 = mesh->getSettingBoolean("travel_compensate_overlapping_walls_0_enabled");
     bool compensate_overlap_x = mesh->getSettingBoolean("travel_compensate_overlapping_walls_x_enabled");
-    bool retract_before_outer_wall = mesh->getSettingBoolean("combing_retract_before_outer_wall");
+    bool retract_before_outer_wall = mesh->getSettingBoolean("travel_retract_before_outer_wall");
     if (mesh->getSettingAsCount("wall_line_count") > 0)
     {
         bool spiralize = false;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -996,7 +996,6 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
 {
     bool compensate_overlap_0 = mesh->getSettingBoolean("travel_compensate_overlapping_walls_0_enabled");
     bool compensate_overlap_x = mesh->getSettingBoolean("travel_compensate_overlapping_walls_x_enabled");
-    bool retract_before_outer_wall = mesh->getSettingBoolean("combing_retract_before_outer_wall");
     if (mesh->getSettingAsCount("wall_line_count") > 0)
     {
         bool spiralize = false;
@@ -1026,13 +1025,13 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
                 if (!compensate_overlap_0)
                 {
                     WallOverlapComputation* wall_overlap_computation(nullptr);
-                    gcode_layer.addPolygonsByOptimizer(part.insets[0], &mesh->inset0_config, wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, retract_before_outer_wall);
+                    gcode_layer.addPolygonsByOptimizer(part.insets[0], &mesh->inset0_config, wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, true);
                 }
                 else
                 {
                     Polygons& outer_wall = part.insets[0];
                     WallOverlapComputation wall_overlap_computation(outer_wall, mesh->getSettingInMicrons("wall_line_width_0"));
-                    gcode_layer.addPolygonsByOptimizer(outer_wall, &mesh->inset0_config, &wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, retract_before_outer_wall);
+                    gcode_layer.addPolygonsByOptimizer(outer_wall, &mesh->inset0_config, &wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, true);
                 }
             }
             else

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -999,6 +999,7 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
 {
     bool compensate_overlap_0 = mesh->getSettingBoolean("travel_compensate_overlapping_walls_0_enabled");
     bool compensate_overlap_x = mesh->getSettingBoolean("travel_compensate_overlapping_walls_x_enabled");
+    bool retract_before_outer_wall = mesh->getSettingBoolean("combing_retract_before_outer_wall");
     if (mesh->getSettingAsCount("wall_line_count") > 0)
     {
         bool spiralize = false;
@@ -1028,13 +1029,13 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
                 if (!compensate_overlap_0)
                 {
                     WallOverlapComputation* wall_overlap_computation(nullptr);
-                    gcode_layer.addPolygonsByOptimizer(part.insets[0], &mesh->inset0_config, wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, true);
+                    gcode_layer.addPolygonsByOptimizer(part.insets[0], &mesh->inset0_config, wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, retract_before_outer_wall);
                 }
                 else
                 {
                     Polygons& outer_wall = part.insets[0];
                     WallOverlapComputation wall_overlap_computation(outer_wall, mesh->getSettingInMicrons("wall_line_width_0"));
-                    gcode_layer.addPolygonsByOptimizer(outer_wall, &mesh->inset0_config, &wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, true);
+                    gcode_layer.addPolygonsByOptimizer(outer_wall, &mesh->inset0_config, &wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, retract_before_outer_wall);
                 }
             }
             else

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -996,6 +996,7 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
 {
     bool compensate_overlap_0 = mesh->getSettingBoolean("travel_compensate_overlapping_walls_0_enabled");
     bool compensate_overlap_x = mesh->getSettingBoolean("travel_compensate_overlapping_walls_x_enabled");
+    bool retract_before_outer_wall = mesh->getSettingBoolean("combing_retract_before_outer_wall");
     if (mesh->getSettingAsCount("wall_line_count") > 0)
     {
         bool spiralize = false;
@@ -1025,13 +1026,13 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
                 if (!compensate_overlap_0)
                 {
                     WallOverlapComputation* wall_overlap_computation(nullptr);
-                    gcode_layer.addPolygonsByOptimizer(part.insets[0], &mesh->inset0_config, wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize);
+                    gcode_layer.addPolygonsByOptimizer(part.insets[0], &mesh->inset0_config, wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, retract_before_outer_wall);
                 }
                 else
                 {
                     Polygons& outer_wall = part.insets[0];
                     WallOverlapComputation wall_overlap_computation(outer_wall, mesh->getSettingInMicrons("wall_line_width_0"));
-                    gcode_layer.addPolygonsByOptimizer(outer_wall, &mesh->inset0_config, &wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize);
+                    gcode_layer.addPolygonsByOptimizer(outer_wall, &mesh->inset0_config, &wall_overlap_computation, z_seam_type, z_seam_pos, mesh->getSettingInMicrons("wall_0_wipe_dist"), spiralize, retract_before_outer_wall);
                 }
             }
             else

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -311,7 +311,7 @@ GCodePath& GCodePlanner::addTravel(Point p, bool always_retract)
     
     if (!combed) {
         // no combing? always retract!
-        if (!shorterThen(lastPosition - p, retraction_config.retraction_min_travel_distance))
+        if (always_retract || !shorterThen(lastPosition - p, retraction_config.retraction_min_travel_distance))
         {
             if (was_inside) // when the previous location was from printing something which is considered inside (not support or prime tower etc)
             {               // then move inside the printed part, so that we don't ooze on the outer wall while retraction, but on the inside of the print.

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -261,6 +261,14 @@ GCodePath& GCodePlanner::addTravel(Point p, bool always_retract)
         bool via_outside_makes_combing_fail = perform_z_hops && !perform_z_hops_only_when_collides;
         bool fail_on_unavoidable_obstacles = perform_z_hops && perform_z_hops_only_when_collides;
         combed = comb->calc(lastPosition, p, combPaths, was_inside, is_inside, retraction_config.retraction_min_travel_distance, via_outside_makes_combing_fail, fail_on_unavoidable_obstacles);
+
+        // if the distance was so short that no comb paths were generated but we are demanding
+        // a retraction, set combed to false again so that a non-combed retract move is generated below
+        if (always_retract && combed && combPaths.size() == 0)
+        {
+            combed = false;
+        }
+
         if (combed)
         {
             bool retract = always_retract || combPaths.size() > 1;

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -360,10 +360,10 @@ void GCodePlanner::addExtrusionMove(Point p, GCodePathConfig* config, SpaceFillT
     lastPosition = p;
 }
 
-void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, coord_t wall_0_wipe_dist, bool spiralize, bool retract_when_combing)
+void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, coord_t wall_0_wipe_dist, bool spiralize, bool always_retract)
 {
     Point p0 = polygon[start_idx];
-    addTravel(p0, retract_when_combing);
+    addTravel(p0, always_retract);
     for (unsigned int point_idx = 1; point_idx < polygon.size(); point_idx++)
     {
         Point p1 = polygon[(start_idx + point_idx) % polygon.size()];
@@ -408,7 +408,7 @@ void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig
     }
 }
 
-void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, EZSeamType z_seam_type, Point z_seam_pos, coord_t wall_0_wipe_dist, bool spiralize, bool retract_when_combing)
+void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, EZSeamType z_seam_type, Point z_seam_pos, coord_t wall_0_wipe_dist, bool spiralize, bool always_retract)
 {
     if (polygons.size() == 0)
     {
@@ -422,7 +422,7 @@ void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* c
     orderOptimizer.optimize();
     for (unsigned int poly_idx : orderOptimizer.polyOrder)
     {
-        addPolygon(polygons[poly_idx], orderOptimizer.polyStart[poly_idx], config, wall_overlap_computation, wall_0_wipe_dist, spiralize, retract_when_combing);
+        addPolygon(polygons[poly_idx], orderOptimizer.polyStart[poly_idx], config, wall_overlap_computation, wall_0_wipe_dist, spiralize, always_retract);
     }
 }
 void GCodePlanner::addLinesByOptimizer(Polygons& polygons, GCodePathConfig* config, SpaceFillType space_fill_type, int wipe_dist)

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -238,7 +238,7 @@ void GCodePlanner::moveInsideCombBoundary(int distance)
     }
 }
 
-GCodePath& GCodePlanner::addTravel(Point p, bool going_to_outer_wall)
+GCodePath& GCodePlanner::addTravel(Point p, bool always_retract)
 {
     GCodePath* path = nullptr;
     GCodePathConfig& travel_config = storage.travel_config_per_extruder[getExtruder()];
@@ -252,7 +252,6 @@ GCodePath& GCodePlanner::addTravel(Point p, bool going_to_outer_wall)
 
     const bool is_first_travel_of_extruder_after_switch = extruder_plans.back().paths.size() == 0 && (extruder_plans.size() > 1 || last_extruder_previous_layer != getExtruder());
     const bool bypass_combing = is_first_travel_of_extruder_after_switch && extr->getSettingBoolean("retraction_hop_after_extruder_switch");
-    const bool always_retract = going_to_outer_wall && extr->getSettingBoolean("combing_retract_before_outer_wall");
 
     if (comb != nullptr && !bypass_combing && lastPosition != no_point)
     {
@@ -361,10 +360,10 @@ void GCodePlanner::addExtrusionMove(Point p, GCodePathConfig* config, SpaceFillT
     lastPosition = p;
 }
 
-void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, coord_t wall_0_wipe_dist, bool spiralize, bool is_outer_wall)
+void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, coord_t wall_0_wipe_dist, bool spiralize, bool retract_when_combing)
 {
     Point p0 = polygon[start_idx];
-    addTravel(p0, is_outer_wall);
+    addTravel(p0, retract_when_combing);
     for (unsigned int point_idx = 1; point_idx < polygon.size(); point_idx++)
     {
         Point p1 = polygon[(start_idx + point_idx) % polygon.size()];
@@ -409,7 +408,7 @@ void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig
     }
 }
 
-void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, EZSeamType z_seam_type, Point z_seam_pos, coord_t wall_0_wipe_dist, bool spiralize, bool is_outer_wall)
+void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, EZSeamType z_seam_type, Point z_seam_pos, coord_t wall_0_wipe_dist, bool spiralize, bool retract_when_combing)
 {
     if (polygons.size() == 0)
     {
@@ -423,7 +422,7 @@ void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* c
     orderOptimizer.optimize();
     for (unsigned int poly_idx : orderOptimizer.polyOrder)
     {
-        addPolygon(polygons[poly_idx], orderOptimizer.polyStart[poly_idx], config, wall_overlap_computation, wall_0_wipe_dist, spiralize, is_outer_wall);
+        addPolygon(polygons[poly_idx], orderOptimizer.polyStart[poly_idx], config, wall_overlap_computation, wall_0_wipe_dist, spiralize, retract_when_combing);
     }
 }
 void GCodePlanner::addLinesByOptimizer(Polygons& polygons, GCodePathConfig* config, SpaceFillType space_fill_type, int wipe_dist)

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -299,12 +299,7 @@ GCodePath& GCodePlanner::addTravel(Point p, bool always_retract)
                 }
                 path = getLatestPathWithConfig(&travel_config, SpaceFillType::None);
                 path->retract = retract;
-                if (always_retract)
-                {
-                    // do a z-hop (if generally enabled)
-                    // not sure yet if this is a good or a bad thing to do
-                    path->perform_z_hop = perform_z_hops;
-                }
+                // don't perform a z-hop
                 for (Point& combPoint : combPath)
                 {
                     path->points.push_back(combPoint);

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -238,7 +238,7 @@ void GCodePlanner::moveInsideCombBoundary(int distance)
     }
 }
 
-GCodePath& GCodePlanner::addTravel(Point p)
+GCodePath& GCodePlanner::addTravel(Point p, bool always_retract)
 {
     GCodePath* path = nullptr;
     GCodePathConfig& travel_config = storage.travel_config_per_extruder[getExtruder()];
@@ -263,7 +263,7 @@ GCodePath& GCodePlanner::addTravel(Point p)
         combed = comb->calc(lastPosition, p, combPaths, was_inside, is_inside, retraction_config.retraction_min_travel_distance, via_outside_makes_combing_fail, fail_on_unavoidable_obstacles);
         if (combed)
         {
-            bool retract = combPaths.size() > 1;
+            bool retract = always_retract || combPaths.size() > 1;
             if (!retract)
             { // check whether we want to retract
                 if (combPaths.throughAir)
@@ -299,7 +299,12 @@ GCodePath& GCodePlanner::addTravel(Point p)
                 }
                 path = getLatestPathWithConfig(&travel_config, SpaceFillType::None);
                 path->retract = retract;
-                // don't perform a z-hop
+                if (always_retract)
+                {
+                    // do a z-hop (if generally enabled)
+                    // not sure yet if this is a good or a bad thing to do
+                    path->perform_z_hop = perform_z_hops;
+                }
                 for (Point& combPoint : combPath)
                 {
                     path->points.push_back(combPoint);
@@ -355,10 +360,10 @@ void GCodePlanner::addExtrusionMove(Point p, GCodePathConfig* config, SpaceFillT
     lastPosition = p;
 }
 
-void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, coord_t wall_0_wipe_dist, bool spiralize)
+void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, coord_t wall_0_wipe_dist, bool spiralize, bool retract_when_combing)
 {
     Point p0 = polygon[start_idx];
-    addTravel(p0);
+    addTravel(p0, retract_when_combing);
     for (unsigned int point_idx = 1; point_idx < polygon.size(); point_idx++)
     {
         Point p1 = polygon[(start_idx + point_idx) % polygon.size()];
@@ -403,7 +408,7 @@ void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig
     }
 }
 
-void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, EZSeamType z_seam_type, Point z_seam_pos, coord_t wall_0_wipe_dist, bool spiralize)
+void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, EZSeamType z_seam_type, Point z_seam_pos, coord_t wall_0_wipe_dist, bool spiralize, bool retract_when_combing)
 {
     if (polygons.size() == 0)
     {
@@ -417,7 +422,7 @@ void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* c
     orderOptimizer.optimize();
     for (unsigned int poly_idx : orderOptimizer.polyOrder)
     {
-        addPolygon(polygons[poly_idx], orderOptimizer.polyStart[poly_idx], config, wall_overlap_computation, wall_0_wipe_dist, spiralize);
+        addPolygon(polygons[poly_idx], orderOptimizer.polyStart[poly_idx], config, wall_overlap_computation, wall_0_wipe_dist, spiralize, retract_when_combing);
     }
 }
 void GCodePlanner::addLinesByOptimizer(Polygons& polygons, GCodePathConfig* config, SpaceFillType space_fill_type, int wipe_dist)

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -238,7 +238,7 @@ void GCodePlanner::moveInsideCombBoundary(int distance)
     }
 }
 
-GCodePath& GCodePlanner::addTravel(Point p, bool always_retract)
+GCodePath& GCodePlanner::addTravel(Point p, bool going_to_outer_wall)
 {
     GCodePath* path = nullptr;
     GCodePathConfig& travel_config = storage.travel_config_per_extruder[getExtruder()];
@@ -252,6 +252,7 @@ GCodePath& GCodePlanner::addTravel(Point p, bool always_retract)
 
     const bool is_first_travel_of_extruder_after_switch = extruder_plans.back().paths.size() == 0 && (extruder_plans.size() > 1 || last_extruder_previous_layer != getExtruder());
     const bool bypass_combing = is_first_travel_of_extruder_after_switch && extr->getSettingBoolean("retraction_hop_after_extruder_switch");
+    const bool always_retract = going_to_outer_wall && extr->getSettingBoolean("combing_retract_before_outer_wall");
 
     if (comb != nullptr && !bypass_combing && lastPosition != no_point)
     {
@@ -360,10 +361,10 @@ void GCodePlanner::addExtrusionMove(Point p, GCodePathConfig* config, SpaceFillT
     lastPosition = p;
 }
 
-void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, coord_t wall_0_wipe_dist, bool spiralize, bool retract_when_combing)
+void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, coord_t wall_0_wipe_dist, bool spiralize, bool is_outer_wall)
 {
     Point p0 = polygon[start_idx];
-    addTravel(p0, retract_when_combing);
+    addTravel(p0, is_outer_wall);
     for (unsigned int point_idx = 1; point_idx < polygon.size(); point_idx++)
     {
         Point p1 = polygon[(start_idx + point_idx) % polygon.size()];
@@ -408,7 +409,7 @@ void GCodePlanner::addPolygon(PolygonRef polygon, int start_idx, GCodePathConfig
     }
 }
 
-void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, EZSeamType z_seam_type, Point z_seam_pos, coord_t wall_0_wipe_dist, bool spiralize, bool retract_when_combing)
+void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation, EZSeamType z_seam_type, Point z_seam_pos, coord_t wall_0_wipe_dist, bool spiralize, bool is_outer_wall)
 {
     if (polygons.size() == 0)
     {
@@ -422,7 +423,7 @@ void GCodePlanner::addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* c
     orderOptimizer.optimize();
     for (unsigned int poly_idx : orderOptimizer.polyOrder)
     {
-        addPolygon(polygons[poly_idx], orderOptimizer.polyStart[poly_idx], config, wall_overlap_computation, wall_0_wipe_dist, spiralize, retract_when_combing);
+        addPolygon(polygons[poly_idx], orderOptimizer.polyStart[poly_idx], config, wall_overlap_computation, wall_0_wipe_dist, spiralize, is_outer_wall);
     }
 }
 void GCodePlanner::addLinesByOptimizer(Polygons& polygons, GCodePathConfig* config, SpaceFillType space_fill_type, int wipe_dist)

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -410,7 +410,7 @@ public:
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over each polygon printed
      * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
      */
-    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool always = false);
+    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool always_retract = false);
 
     /*!
      * Add lines to the gcode with optimized order.

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -348,8 +348,9 @@ public:
      * avoiding obstacles and comb along the boundary of parts.
      * 
      * \param p The point to travel to
+     * \param always_retract Whether to force a retraction to occur when travelling to this point.
      */
-    GCodePath& addTravel(Point p);
+    GCodePath& addTravel(Point p, bool always_retract = false);
     
     /*!
      * Add a travel path to a certain point and retract if needed.
@@ -387,8 +388,9 @@ public:
      * \param wall_overlap_computation The wall overlap compensation calculator for each given segment (optionally nullptr)
      * \param wall_0_wipe_dist The distance to travel along the polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over this polygon
+     * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
      */
-    void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false);
+    void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool retract_when_combing = false);
 
     /*!
      * Add polygons to the gcode with optimized order.
@@ -406,8 +408,9 @@ public:
      * \param z_seam_pos The location near where to start each part in case \p z_seam_type is 'back'
      * \param wall_0_wipe_dist The distance to travel along each polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over each polygon printed
+     * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
      */
-    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false);
+    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool retract_when_combing = false);
 
     /*!
      * Add lines to the gcode with optimized order.

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -348,9 +348,9 @@ public:
      * avoiding obstacles and comb along the boundary of parts.
      * 
      * \param p The point to travel to
-     * \param always_retract Whether to force a retraction to occur when travelling to this point.
+     * \param going_to_outer_wall Whether the point is located on an outer wall.
      */
-    GCodePath& addTravel(Point p, bool always_retract = false);
+    GCodePath& addTravel(Point p, bool going_to_outer_wall = false);
     
     /*!
      * Add a travel path to a certain point and retract if needed.
@@ -388,9 +388,9 @@ public:
      * \param wall_overlap_computation The wall overlap compensation calculator for each given segment (optionally nullptr)
      * \param wall_0_wipe_dist The distance to travel along the polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over this polygon
-     * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
+     * \param is_outer_wall Whether the polygon is an outer wall or not
      */
-    void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool retract_when_combing = false);
+    void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool is_outer_wall = false);
 
     /*!
      * Add polygons to the gcode with optimized order.
@@ -408,9 +408,9 @@ public:
      * \param z_seam_pos The location near where to start each part in case \p z_seam_type is 'back'
      * \param wall_0_wipe_dist The distance to travel along each polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over each polygon printed
-     * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
+     * \param is_outer_wall Whether the polygon is an outer wall or not
      */
-    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool retract_when_combing = false);
+    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool is_outer_wall = false);
 
     /*!
      * Add lines to the gcode with optimized order.

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -348,9 +348,9 @@ public:
      * avoiding obstacles and comb along the boundary of parts.
      * 
      * \param p The point to travel to
-     * \param going_to_outer_wall Whether the point is located on an outer wall.
+     * \param always_retract Whether to force a retraction to occur when travelling to this point.
      */
-    GCodePath& addTravel(Point p, bool going_to_outer_wall = false);
+    GCodePath& addTravel(Point p, bool always_retract = false);
     
     /*!
      * Add a travel path to a certain point and retract if needed.
@@ -388,9 +388,9 @@ public:
      * \param wall_overlap_computation The wall overlap compensation calculator for each given segment (optionally nullptr)
      * \param wall_0_wipe_dist The distance to travel along the polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over this polygon
-     * \param is_outer_wall Whether the polygon is an outer wall or not
+     * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
      */
-    void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool is_outer_wall = false);
+    void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool retract_when_combing = false);
 
     /*!
      * Add polygons to the gcode with optimized order.
@@ -408,9 +408,9 @@ public:
      * \param z_seam_pos The location near where to start each part in case \p z_seam_type is 'back'
      * \param wall_0_wipe_dist The distance to travel along each polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over each polygon printed
-     * \param is_outer_wall Whether the polygon is an outer wall or not
+     * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
      */
-    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool is_outer_wall = false);
+    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool retract_when_combing = false);
 
     /*!
      * Add lines to the gcode with optimized order.

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -390,7 +390,7 @@ public:
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over this polygon
      * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
      */
-    void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool retract_when_combing = false);
+    void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool always_retract = false);
 
     /*!
      * Add polygons to the gcode with optimized order.
@@ -410,7 +410,7 @@ public:
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over each polygon printed
      * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
      */
-    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool retract_when_combing = false);
+    void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool always = false);
 
     /*!
      * Add lines to the gcode with optimized order.

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -388,7 +388,7 @@ public:
      * \param wall_overlap_computation The wall overlap compensation calculator for each given segment (optionally nullptr)
      * \param wall_0_wipe_dist The distance to travel along the polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over this polygon
-     * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
+     * \param always_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
      */
     void addPolygon(PolygonRef polygon, int startIdx, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool always_retract = false);
 
@@ -408,7 +408,7 @@ public:
      * \param z_seam_pos The location near where to start each part in case \p z_seam_type is 'back'
      * \param wall_0_wipe_dist The distance to travel along each polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over each polygon printed
-     * \param retract_when_combing Whether to force the combing logic to use a retraction when moving to the start of the polygon (used for outer walls)
+     * \param always_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
      */
     void addPolygonsByOptimizer(Polygons& polygons, GCodePathConfig* config, WallOverlapComputation* wall_overlap_computation = nullptr, EZSeamType z_seam_type = EZSeamType::SHORTEST, Point z_seam_pos = Point(0, 0), coord_t wall_0_wipe_dist = 0, bool spiralize = false, bool always_retract = false);
 


### PR DESCRIPTION
When enabled, travel moves to the first point in an outer wall, always
use retraction.
