### PR TITLE
Fix jerk setting to be compatible with RepRap firmware.

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -889,15 +889,23 @@ void GCodeExport::writeJerk(double jerk)
 {
     if (current_jerk != jerk)
     {
-        if (getFlavor() == EGCodeFlavor::REPETIER)
+        if (getFlavor() == EGCodeFlavor::REPRAP)
         {
-            *output_stream << "M207 X";
+            const double jerkPerMin = jerk * 60;
+            *output_stream << "M566 X" << PrecisionedDouble{2, jerkPerMin} << " Y" << PrecisionedDouble{2, jerkPerMin} << new_line;
         }
         else
         {
-            *output_stream << "M205 X";
+            if (getFlavor() == EGCodeFlavor::REPETIER)
+            {
+                *output_stream << "M207 X";
+            }
+            else
+            {
+                *output_stream << "M205 X";
+            }
+            *output_stream << PrecisionedDouble{2, jerk} << new_line;
         }
-        *output_stream << PrecisionedDouble{2, jerk} << new_line;
         current_jerk = jerk;
         estimateCalculator.setMaxXyJerk(jerk);
     }

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -889,22 +889,19 @@ void GCodeExport::writeJerk(double jerk)
 {
     if (current_jerk != jerk)
     {
-        if (getFlavor() == EGCodeFlavor::REPRAP)
+        switch (getFlavor())
         {
-            const double jerkPerMin = jerk * 60;
-            *output_stream << "M566 X" << PrecisionedDouble{2, jerkPerMin} << " Y" << PrecisionedDouble{2, jerkPerMin} << new_line;
-        }
-        else
-        {
-            if (getFlavor() == EGCodeFlavor::REPETIER)
-            {
+            case EGCodeFlavor::REPRAP:
+                *output_stream << "M566 X" << PrecisionedDouble{2, jerk * 60} << " Y" << PrecisionedDouble{2, jerk * 60} << new_line;
+                break;
+            case EGCodeFlavor::REPETIER:
                 *output_stream << "M207 X";
-            }
-            else
-            {
+                *output_stream << PrecisionedDouble{2, jerk} << new_line;
+                break;
+            default:
                 *output_stream << "M205 X";
-            }
-            *output_stream << PrecisionedDouble{2, jerk} << new_line;
+                *output_stream << PrecisionedDouble{2, jerk} << new_line;
+                break;
         }
         current_jerk = jerk;
         estimateCalculator.setMaxXyJerk(jerk);


### PR DESCRIPTION
M205 was being output which RepRap doesn't understand. RepRap firmware
uses M566 instead to set jerk speeds and the units are mm/min.
