### PR TITLE
Spiralize better

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -126,11 +126,16 @@ void FffGcodeWriter::findLayerSeamsForSpiralize(SliceMeshStorage& mesh)
 
         if (layer_nr < mesh.layers.size())
         {
-            // use the vertex closest to Point(0, 0) for the first layer that has a part with insets
+            // use the vertex closest to the seam position for the first layer that has a part with insets
             // Doing this, we give the user some degree of control as to where the seam will be.
             // By moving the model on the bed they can move the start position of the seam and
             // this could be useful if the spiralization has a problem with a particular seam position
-            mesh.layers[layer_nr].seam_vertex_index = PolygonUtils::findClosest(Point(0, 0), mesh.layers[layer_nr].parts[0].insets[0][0]).point_idx;
+            Point seam_pos(0, 0);
+            if (mesh.getSettingAsZSeamType("z_seam_type") == EZSeamType::USER_SPECIFIED)
+            {
+                seam_pos = Point(mesh.getSettingInMicrons("z_seam_x"), mesh.getSettingInMicrons("z_seam_y"));
+            }
+            mesh.layers[layer_nr].seam_vertex_index = PolygonUtils::findClosest(seam_pos, mesh.layers[layer_nr].parts[0].insets[0][0]).point_idx;
             ++layer_nr;
         }
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -67,7 +67,7 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
     for (SliceMeshStorage& mesh : storage.meshes)
     {
         total_layers = std::max(total_layers, mesh.layers.size());
-        if (getSettingBoolean("magic_spiralize"))
+        if (mesh.getSettingBoolean("magic_spiralize"))
         {
             findLayerSeamsForSpiralize(mesh);
         }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -168,6 +168,7 @@ void FffGcodeWriter::findLayerSeamsForSpiralize(SliceMeshStorage& mesh)
 
                 if (seam_vertex_idx == first_seam_vertex_idx)
                 {
+                    logWarning("WARNING: findLayerSeamsForSpiralize() failed to find a suitable seam vertex on layer %d", layer_nr);
                     // this shouldn't happen!
                     break;
                 }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -126,10 +126,9 @@ void FffGcodeWriter::findLayerSeamsForSpiralize(SliceMeshStorage& mesh)
 
         if (layer_nr < mesh.layers.size())
         {
-            // use the vertex closest to the seam position for the first layer that has a part with insets
-            // Doing this, we give the user some degree of control as to where the seam will be.
-            // By moving the model on the bed they can move the start position of the seam and
-            // this could be useful if the spiralization has a problem with a particular seam position
+            // If the user has specified a z-seam location, use the vertex closest to that location for the seam vertex
+            // in the first layer that has a part with insets. This allows the user to alter the seam start location which
+            // could be useful if the spiralization has a problem with a particular seam path.
             Point seam_pos(0, 0);
             if (mesh.getSettingAsZSeamType("z_seam_type") == EZSeamType::USER_SPECIFIED)
             {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1010,7 +1010,7 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
             {
                 last_wall_seam_vertex_idx = -1;
             }
-            if (static_cast<int>(layer_nr) == mesh->getSettingAsCount("bottom_layers") && part.insets.size() > 0)
+            if (spiralize && static_cast<int>(layer_nr) == mesh->getSettingAsCount("bottom_layers"))
             { // on the last normal layer first make the outer wall normally and then start a second outer wall from the same hight, but gradually moving upward
                 WallOverlapComputation* wall_overlap_computation(nullptr);
                 int wall_0_wipe_dist(0);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1002,7 +1002,7 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
         bool spiralize = false;
         if (mesh->getSettingBoolean("magic_spiralize"))
         {
-            if (static_cast<int>(layer_nr) >= mesh->getSettingAsCount("bottom_layers"))
+            if (part.insets.size() > 0 && static_cast<int>(layer_nr) >= mesh->getSettingAsCount("bottom_layers"))
             {
                 spiralize = true;
             }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1006,7 +1006,7 @@ void FffGcodeWriter::processInsets(GCodePlanner& gcode_layer, SliceMeshStorage* 
             {
                 spiralize = true;
             }
-            else if (layer_nr == 0)
+            if (layer_nr == 0)
             {
                 last_wall_seam_vertex_idx = -1;
             }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -159,14 +159,12 @@ void FffGcodeWriter::findLayerSeamsForSpiralize(SliceMeshStorage& mesh)
             // now test the vertex following the candidate seam vertex and if it lies to the left or on the vector, it's good to use
             const int first_seam_vertex_idx = seam_vertex_idx;
             float a = LinearAlg2D::getAngleLeft(last_wall_seam_vertex_vector, last_wall_seam_vertex, wall[(seam_vertex_idx + 1) % n_points]);
-            //std::cerr << layer_nr << ": n_points= " << n_points << ", angle = " << a * 180/M_PI << "\n";
 
             while (a > M_PI)
             {
                 // the vertex was on the right of the vector so move the seam vertex on
                 seam_vertex_idx = (seam_vertex_idx + 1) % n_points;
                 a = LinearAlg2D::getAngleLeft(last_wall_seam_vertex_vector, last_wall_seam_vertex, wall[(seam_vertex_idx + 1) % n_points]);
-                //std::cerr << "new angle = " << a * 180/M_PI << "\n";
 
                 if (seam_vertex_idx == first_seam_vertex_idx)
                 {
@@ -177,7 +175,6 @@ void FffGcodeWriter::findLayerSeamsForSpiralize(SliceMeshStorage& mesh)
 
             // store result for use when spiralizing
             mesh.layers[layer_nr].seam_vertex_index = seam_vertex_idx;
-            //std::cerr << "layer " << layer_nr << ": " << seam_vertex_idx << "\n";
         }
     }
 }

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -439,6 +439,12 @@ private:
      * Add the end gcode and set all temperatures to zero.
      */
     void finalize();
+
+    /*!
+     * Calculate for each layer in the mesh the index of the vertex that is considered to be the seam
+     * \param mesh The mesh containing the layers to be spiralized
+     */
+    void findLayerSeamsForSpiralize(SliceMeshStorage& mesh);
 };
 
 }//namespace cura

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -448,20 +448,11 @@ void GCodePlanner::addLinesByOptimizer(Polygons& polygons, GCodePathConfig* conf
     }
 }
 
-void GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall)
+int GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall, int last_wall_seam_vertex_idx)
 {
     // The spiral has to continue on in an anti-clockwise direction from where the last layer finished, it can't jump backwards
 
     const int n_points = wall.size();
-
-    static int last_wall_seam_vertex_idx = -1; // the seam vertex of the last spiralized layer processed
-    static int last_layer_nr = 0;
-
-    if (layer_nr < last_layer_nr)
-    {
-        // slicing has restarted
-        last_wall_seam_vertex_idx = -1;
-    }
 
     // seam_vertex_idx is going to be the index of the seam vertex in the current wall polygon
     // initially we choose the vertex that is closest to the seam vertex in the last spiralized layer processed
@@ -528,9 +519,8 @@ void GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, 
         addExtrusionMove(Point(last_p + (p - last_p) * static_cast<double>(i) / n_points), config, SpaceFillType::Polygons, 1.0, true);
     }
 
-    // remember the seam vertex so we can do it all again for the next layer
-    last_wall_seam_vertex_idx = seam_vertex_idx;
-    last_layer_nr = layer_nr;
+    // return the seam vertex so we can do it all again for the next layer
+    return seam_vertex_idx;
 }
 
 void ExtruderPlan::forceMinimalLayerTime(double minTime, double minimalSpeed, double travelTime, double extrudeTime)

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -456,7 +456,7 @@ void GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, 
     const int n_points = wall.size();
     Polygons last_wall_polygons;
     last_wall_polygons.add(last_wall);
-    const int max_dist2 = config->getLineWidth() * config->getLineWidth();
+    const int max_dist2 = config->getLineWidth() * config->getLineWidth() * 4; // (2 * lineWidth)^2;
 
     double total_length = 0.0; // determine the length of the complete wall
     Point p0 = origin;

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -456,7 +456,7 @@ void GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, 
     const int n_points = wall.size();
     Polygons last_wall_polygons;
     last_wall_polygons.add(last_wall);
-    const int max_dist = MM2INT(config->getLineWidth() * 5);
+    const int max_dist2 = config->getLineWidth() * config->getLineWidth();
 
     double total_length = 0.0; // determine the length of the complete wall
     Point p0 = origin;
@@ -488,11 +488,11 @@ void GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, 
         Point last_p(p);
         if (last_wall.inside(last_p, false))
         {
-            PolygonUtils::moveOutside(last_wall_polygons, last_p, 0, max_dist);
+            PolygonUtils::moveOutside(last_wall_polygons, last_p, 0, max_dist2);
         }
         else if(!last_wall.inside(last_p, true))
         {
-            PolygonUtils::moveInside(last_wall_polygons, last_p, 0, max_dist);
+            PolygonUtils::moveInside(last_wall_polygons, last_p, 0, max_dist2);
         }
         // now interpolate between last_p and p depending on how far we have progressed along wall
 #if 0

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -495,11 +495,6 @@ void GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, 
             PolygonUtils::moveInside(last_wall_polygons, last_p, 0, max_dist2);
         }
         // now interpolate between last_p and p depending on how far we have progressed along wall
-#if 0
-        if(index == n_points)
-            addTravel_simple(p);
-        else
-#endif
         addExtrusionMove(last_p + (p - last_p) * (wall_length / total_length), config, SpaceFillType::Polygons, 1.0, true);
     }
 }

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -448,53 +448,17 @@ void GCodePlanner::addLinesByOptimizer(Polygons& polygons, GCodePathConfig* conf
     }
 }
 
-int GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall, int last_wall_seam_vertex_idx)
+void GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall, const int seam_vertex_idx, const int last_seam_vertex_idx)
 {
-    // The spiral has to continue on in an anti-clockwise direction from where the last layer finished, it can't jump backwards
+    const Point origin = (last_seam_vertex_idx >= 0) ? last_wall[last_seam_vertex_idx] : wall[seam_vertex_idx];
+    addTravel_simple(origin);
 
     const int n_points = wall.size();
+    Polygons last_wall_polygons;
+    last_wall_polygons.add(last_wall);
+    const int max_dist = MM2INT(config->getLineWidth() * 5);
 
-    // origin is where we start from
-    const Point origin = (last_wall_seam_vertex_idx < 0) ? lastPosition : last_wall[last_wall_seam_vertex_idx];
-
-    // seam_vertex_idx is going to be the index of the seam vertex in the current wall polygon
-    // initially we choose the vertex that is closest to the origin which will be the seam vertex in the last spiralized layer processed
-
-    int seam_vertex_idx = PolygonUtils::findClosest(origin, wall).point_idx;
-
-    if (last_wall_seam_vertex_idx >= 0)
-    {
-        // now we check that the vertex following the seam vertex is not to the right of the seam vertex in the last layer
-        // and if it is we move forward
-
-        // get the inward normal of the last layer seam vertex
-        Point last_wall_seam_vertex = last_wall[last_wall_seam_vertex_idx];
-        Point last_wall_seam_vertex_inward_normal = PolygonUtils::getVertexInwardNormal(last_wall, last_wall_seam_vertex_idx);
-
-        // create a vector from the normal so that we can then test the vertex following the candidate seam vertex to make sure it is on the correct side
-        Point last_wall_seam_vertex_vector = last_wall_seam_vertex + last_wall_seam_vertex_inward_normal;
-
-        // now test the vertex following the candidate seam vertex and if it lies to the left or on the vector, it's good to use
-        const int first_seam_vertex_idx = seam_vertex_idx;
-        float a = LinearAlg2D::getAngleLeft(last_wall_seam_vertex_vector, last_wall_seam_vertex, wall[(seam_vertex_idx + 1) % n_points]);
-        //std::cerr << layer_nr << ": angle = " << a * 180/M_PI << "\n";
-
-        while (a > M_PI)
-        {
-            // the vertex was on the right of the vector so move the seam vertex on
-            seam_vertex_idx = (seam_vertex_idx + 1) % n_points;
-            a = LinearAlg2D::getAngleLeft(last_wall_seam_vertex_vector, last_wall_seam_vertex, wall[(seam_vertex_idx + 1) % n_points]);
-            //std::cerr << "new angle = " << a * 180/M_PI << "\n";
-
-            if (seam_vertex_idx == first_seam_vertex_idx)
-            {
-                // this shouldn't happen!
-                break;
-            }
-        }
-    }
-
-    float total_length = 0.0;
+    double total_length = 0.0; // determine the length of the complete wall
     Point p0 = origin;
     for (int index = 1; index <= n_points; ++index)
     {
@@ -503,19 +467,23 @@ int GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, P
         p0 = p1;
     }
 
-    Polygons last_wall_polygons;
-    last_wall_polygons.add(last_wall);
-    const int max_dist = MM2INT(config->getLineWidth() * 5);
+    if (total_length == 0.0)
+    {
+        // nothing to do
+        return;
+    }
+
     // extrude to the points following the seam vertex
     // the last point is the seam vertex as the polygon is a loop
+    double wall_length = 0.0;
     p0 = origin;
-    float wall_length = 0.0;
     for (int index = 1; index <= n_points; ++index)
     {
         // p is a point from the current wall polygon
         const Point& p = wall[(seam_vertex_idx + index) % n_points];
         wall_length += vSizeMM(p - p0);
         p0 = p;
+
         // last_p is p shifted onto last_wall
         Point last_p(p);
         if (last_wall.inside(last_p, false))
@@ -534,9 +502,6 @@ int GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, P
 #endif
         addExtrusionMove(last_p + (p - last_p) * (wall_length / total_length), config, SpaceFillType::Polygons, 1.0, true);
     }
-
-    // return the seam vertex so we can do it all again for the next layer
-    return seam_vertex_idx;
 }
 
 void ExtruderPlan::forceMinimalLayerTime(double minTime, double minimalSpeed, double travelTime, double extrudeTime)

--- a/src/gcodePlanner.cpp
+++ b/src/gcodePlanner.cpp
@@ -454,10 +454,13 @@ int GCodePlanner::spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, P
 
     const int n_points = wall.size();
 
-    // seam_vertex_idx is going to be the index of the seam vertex in the current wall polygon
-    // initially we choose the vertex that is closest to the seam vertex in the last spiralized layer processed
+    // origin is where we start from
+    const Point origin = (last_wall_seam_vertex_idx < 0) ? lastPosition : last_wall[last_wall_seam_vertex_idx];
 
-    int seam_vertex_idx = PolygonUtils::findClosest((last_wall_seam_vertex_idx < 0) ? lastPosition : last_wall[last_wall_seam_vertex_idx], wall).point_idx;
+    // seam_vertex_idx is going to be the index of the seam vertex in the current wall polygon
+    // initially we choose the vertex that is closest to the origin which will be the seam vertex in the last spiralized layer processed
+
+    int seam_vertex_idx = PolygonUtils::findClosest(origin, wall).point_idx;
 
     if (last_wall_seam_vertex_idx >= 0)
     {

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -425,11 +425,12 @@ public:
      *
      * \param config The config with which to print the lines
      * \param wall The wall polygon to be spiralized
-     * \param last_wall The last wall polygon that was spiralized
-     * \param last_wall_seam_vertex_idx The index of the seam vertex of the last spiralized layer processed (-1 if this is the first layer to be spiralized)
-     * \return The index of the seam vertex in the wall polygon just processed
+     * \param last_wall The wall polygon that was spiralized below the current polygon (or \p wall if this is the first spiralized layer)
+     * \param seam_vertex_idx The index of this wall slice's seam vertex
+     * \param last_seam_vertex_idx The index of the seam vertex in the last wall (or -1 if this is the first spiralized layer)
      */
-    int spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall, int last_wall_seam_vertex_idx);
+    void spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall, int seam_vertex_idx, int last_seam_vertex_idx);
+
 
     /*!
      * Compute naive time estimates (without accounting for slow down at corners etc.) and naive material estimates (without accounting for MergeInfillLines)

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -419,6 +419,17 @@ public:
     void addLinesByOptimizer(Polygons& polygons, GCodePathConfig* config, SpaceFillType space_fill_type, int wipe_dist = 0);
 
     /*!
+     * Add a spiralized slice of wall that is interpolated in X/Y between \p last_wall and \p wall.
+     *
+     * At the start of the wall slice, the points are closest to \p last_wall and at the end of the polygon, the points are closest to \p wall.
+     *
+     * \param config The config with which to print the lines
+     * \param wall The wall polygon to be printed
+     * \param last_wall The last wall polygon that was printed
+     */
+    void spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall);
+
+    /*!
      * Compute naive time estimates (without accounting for slow down at corners etc.) and naive material estimates (without accounting for MergeInfillLines)
      * and store them in each ExtruderPlan and each GCodePath.
      * 

--- a/src/gcodePlanner.h
+++ b/src/gcodePlanner.h
@@ -424,10 +424,12 @@ public:
      * At the start of the wall slice, the points are closest to \p last_wall and at the end of the polygon, the points are closest to \p wall.
      *
      * \param config The config with which to print the lines
-     * \param wall The wall polygon to be printed
-     * \param last_wall The last wall polygon that was printed
+     * \param wall The wall polygon to be spiralized
+     * \param last_wall The last wall polygon that was spiralized
+     * \param last_wall_seam_vertex_idx The index of the seam vertex of the last spiralized layer processed (-1 if this is the first layer to be spiralized)
+     * \return The index of the seam vertex in the wall polygon just processed
      */
-    void spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall);
+    int spiralizeWallSlice(GCodePathConfig* config, PolygonRef wall, PolygonRef last_wall, int last_wall_seam_vertex_idx);
 
     /*!
      * Compute naive time estimates (without accounting for slow down at corners etc.) and naive material estimates (without accounting for MergeInfillLines)

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -92,10 +92,10 @@ int PathOrderOptimizer::getPolyStart(Point prev_point, int poly_idx)
 {
     switch (type)
     {
-        case EZSeamType::BACK:      return getClosestPointInPolygon(z_seam_pos, poly_idx); 
-        case EZSeamType::RANDOM:    return getRandomPointInPolygon(poly_idx); 
-        case EZSeamType::SHORTEST:  return getClosestPointInPolygon(prev_point, poly_idx);
-        default:                    return getClosestPointInPolygon(prev_point, poly_idx);
+        case EZSeamType::USER_SPECIFIED:    return getClosestPointInPolygon(z_seam_pos, poly_idx);
+        case EZSeamType::RANDOM:            return getRandomPointInPolygon(poly_idx);
+        case EZSeamType::SHORTEST:          return getClosestPointInPolygon(prev_point, poly_idx);
+        default:                            return getClosestPointInPolygon(prev_point, poly_idx);
     }
 }
 

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -398,7 +398,7 @@ EZSeamType SettingsBaseVirtual::getSettingAsZSeamType(std::string key) const
     if (value == "shortest")
         return EZSeamType::SHORTEST;
     if (value == "back")
-        return EZSeamType::BACK;
+        return EZSeamType::USER_SPECIFIED;
     return EZSeamType::SHORTEST;
 }
 

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -139,7 +139,7 @@ enum class EZSeamType
 {
     RANDOM,
     SHORTEST,
-    BACK
+    USER_SPECIFIED
 };
 
 enum class ESurfaceMode

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -87,6 +87,7 @@ public:
     int printZ;     //!< The height at which this layer needs to be printed. Can differ from sliceZ due to the raft.
     std::vector<SliceLayerPart> parts;  //!< An array of LayerParts which contain the actual data. The parts are printed one at a time to minimize travel outside of the 3D model.
     Polygons openPolyLines; //!< A list of lines which were never hooked up into a 2D polygon. (Currently unused in normal operation)
+    int seam_vertex_index; //!< the index of the layer's seam vertex (only used for spiralization)
 
     /*!
      * Get the all outlines of all layer parts in this layer.


### PR DESCRIPTION
This is an attempt to improve the performance of the spiralize feature. It's not perfect but it does at least make an excellent job of the watering can part (see https://github.com/Ultimaker/Cura/issues/1462). I can now print that with absolutely no visible seam whatsoever (it's really very smooth indeed).

It still needs more work and I would value some input to create a robust solution to the main problem which is reliably determining the right place to start the wall polygon for the current layer based on the last position in the last layer.

Also, this code assumes that the layers are processed sequentially with increasing layer number because it uses the previous layer outline when processing the current layer outline. With the move to multi-threaded processing I can see this breaking.

I hope we can at least use the basic idea in this PR to come up with a good solution.
