### PR TITLE
Multi-threaded support generation

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -364,7 +364,11 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage, unsigned int m
         // this is performed after the main support generation loop above, because it affects the joining of polygons
         // if this would be performed in the main loop then some support would not have been generated under the overhangs and consequently no support is generated for that,
         // meaning almost no support would be generated in some cases which definitely need support.
-        for (size_t layer_idx = 0; layer_idx < storage.support.supportLayers.size() && layer_idx < support_layer_count - (layerZdistanceTop - 1); layer_idx++)
+        const int max_checking_layer_idx = std::min(static_cast<int>(storage.support.supportLayers.size())
+                                                  , static_cast<int>(support_layer_count - (layerZdistanceTop - 1)));
+        const size_t max_checking_idx_size_t = std::max(0, max_checking_layer_idx);
+#pragma omp parallel for default(none) shared(supportAreas, support_layer_count, storage) schedule(dynamic)
+        for (size_t layer_idx = 0; layer_idx < max_checking_idx_size_t; layer_idx++)
         {
             supportAreas[layer_idx] = supportAreas[layer_idx].difference(storage.getLayerOutlines(layer_idx + layerZdistanceTop - 1, false));
         }

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -282,7 +282,10 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage, unsigned int m
             supportLayer_this = AreaSupport::join(supportLayer_last, supportLayer_this, join_distance, smoothing_distance, max_smoothing_angle, conical_support, conical_support_offset, conical_smallest_breadth);
         }
 
-        supportLayer_this = supportLayer_this.unionPolygons(storage.support.supportLayers[layer_idx].support_mesh);
+        if (storage.support.supportLayers[layer_idx].support_mesh.size() > 0)
+        { // handle support mesh
+            supportLayer_this = supportLayer_this.unionPolygons(storage.support.supportLayers[layer_idx].support_mesh);
+        }
 
         // move up from model
         if (layerZdistanceBottom > 0 && layer_idx >= layerZdistanceBottom)


### PR DESCRIPTION
This allows CuraEngine to use multiple processes for generating support, reducing computation time if support is enabled.

Implements CURA-3416.