### PR TITLE
Add only_grow_skin setting

### DIFF
--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -143,12 +143,28 @@ void generateSkinAreas(int layer_nr, SliceMeshStorage& mesh, const int innermost
 
             if (mesh.getSettingBoolean("expand_upper_skins"))
             {
-                upskin = upskin.offset(-min_skin_width_for_expansion).offset(expand_skins_expand_distance).unionPolygons(upskin).intersection(original_outline);
+                Polygons expanded_upskin = upskin.offset(-min_skin_width_for_expansion).offset(expand_skins_expand_distance);
+                if (mesh.getSettingBoolean("only_grow_skin"))
+                {
+                    upskin = expanded_upskin.unionPolygons(upskin).intersection(original_outline);
+                }
+                else
+                {
+                    upskin = expanded_upskin.intersection(original_outline);
+                }
             }
 
             if (mesh.getSettingBoolean("expand_lower_skins"))
             {
-                downskin = downskin.offset(-min_skin_width_for_expansion).offset(expand_skins_expand_distance).unionPolygons(downskin).intersection(original_outline);
+                Polygons expanded_downskin = downskin.offset(-min_skin_width_for_expansion).offset(expand_skins_expand_distance);
+                if (mesh.getSettingBoolean("only_grow_skin"))
+                {
+                    downskin = expanded_downskin.unionPolygons(downskin).intersection(original_outline);
+                }
+                else
+                {
+                    downskin = expanded_downskin.intersection(original_outline);
+                }
             }
         }
 


### PR DESCRIPTION
This is an additional option to the expand/shrink skins code to control whether the shrunk+expanded skin is unioned with the original skin shape or not. Doing the union means that the skin never ends up smaller than it's original size. Not doing the union means that the skin can end up smaller and even get removed completely. Some people could find the ability to remove the skin useful.