### PR TITLE
Feature improvement - make retract when moving to outer wall heed min travel distance

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -256,7 +256,7 @@ GCodePath& LayerPlan::addTravel(Point p, bool always_retract)
     const RetractionConfig& retraction_config = storage.retraction_config_per_extruder[getExtruder()];
 
     GCodePath* path = getLatestPathWithConfig(&travel_config, SpaceFillType::None);
-    if (always_retract && (!last_planned_position || !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))
+    if (always_retract && (!last_planned_position || !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance)))
     {
         // path is not shorter than min travel distance, force a retraction
         path->retract = true;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -284,7 +284,7 @@ GCodePath& LayerPlan::addTravel(Point p, bool always_retract)
         first_travel_destination = p;
         first_travel_destination_is_inside = is_inside;
     }
-    else if (always_retract && !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))
+    else if (always_retract && last_planned_position && !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))
     {
         // path is not shorter than min travel distance, force a retraction
         path->retract = true;
@@ -346,7 +346,7 @@ GCodePath& LayerPlan::addTravel(Point p, bool always_retract)
     }
     
     // no combing? retract only when path is not shorter than minimum travel distance
-    if (!combed && !is_first_travel_of_layer && !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))
+    if (!combed && last_planned_position && !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))
     {
         if (was_inside) // when the previous location was from printing something which is considered inside (not support or prime tower etc)
         {               // then move inside the printed part, so that we don't ooze on the outer wall while retraction, but on the inside of the print.

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -256,7 +256,7 @@ GCodePath& LayerPlan::addTravel(Point p, bool always_retract)
     const RetractionConfig& retraction_config = storage.retraction_config_per_extruder[getExtruder()];
 
     GCodePath* path = getLatestPathWithConfig(&travel_config, SpaceFillType::None);
-    if (always_retract && (!last_planned_position || !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance)))
+    if (always_retract && last_planned_position && !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))
     {
         // path is not shorter than min travel distance, force a retraction
         path->retract = true;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -280,7 +280,7 @@ GCodePath& LayerPlan::addTravel(Point p, bool always_retract)
     const bool is_first_travel_of_layer = !static_cast<bool>(last_planned_position);
     if (is_first_travel_of_layer)
     {
-        bypass_combing = true; // first travel move is boguous; it is added after this and the previous layer have been planned in LayerPlanBuffer::addConnectingTravelMove
+        bypass_combing = true; // first travel move is bogus; it is added after this and the previous layer have been planned in LayerPlanBuffer::addConnectingTravelMove
         first_travel_destination = p;
         first_travel_destination_is_inside = is_inside;
     }


### PR DESCRIPTION
When the retract when moving to outer wall feature was originally implemented, it didn't force the retract for small distance moves. Sometime later, that was added but I now think that it's better not to force a retraction when moving to an outer wall that is less than the retraction min travel distance.

Without this PR, it retracts even when moving between two outer walls that lie next to each other (i.e. the move distance is a single outer wall width) which is plainly ridiculous. I actually see a noticeable reduction in print quality when the retraction is forced for such a small move.