### PR TITLE
Don't add a connecting travel move that doesn't actually move in x/y.

### DIFF
--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -91,7 +91,7 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
     Point first_location_new_layer = path_above.points[0];
 
     // if the last planned position in the previous layer isn't the same as the first location of the new layer, travel to the new location
-    if(!prev_layer->last_planned_position || *prev_layer->last_planned_position != first_location_new_layer)
+    if (!prev_layer->last_planned_position || *prev_layer->last_planned_position != first_location_new_layer)
     {
         prev_layer->addTravel(first_location_new_layer);
     }

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -90,7 +90,11 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
 
     Point first_location_new_layer = path_above.points[0];
 
-    prev_layer->addTravel(first_location_new_layer);
+    // if the last planned position in the previous layer isn't the same as the first location of the new layer, travel to the new location
+    if(!prev_layer->last_planned_position || *prev_layer->last_planned_position != first_location_new_layer)
+    {
+        prev_layer->addTravel(first_location_new_layer);
+    }
 }
 
 void LayerPlanBuffer::processFanSpeedLayerTime()


### PR DESCRIPTION
LayerPlanBuffer::addConnectingTravelMove() was always adding a move from the last planned
position in the current layer to the first position in the next layer. In spiralize mode,
the move isn't required because the next layer starts at the same x/y as the current layer
but, worse than that, the move was causing the nozzle to bob down to the start height of
the current layer even though no x/y movement is required.