### PR TITLE
Always make support towers

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -170,7 +170,7 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage, unsigned int m
     const int supportMinAreaSqrt = mesh.getSettingInMicrons("support_minimal_diameter");
     const double supportTowerRoofAngle = mesh.getSettingInAngleRadians("support_tower_roof_angle");
     const bool use_towers = mesh.getSettingBoolean("support_use_towers") && supportMinAreaSqrt > 0;
-    const coord_t tower_top_layer_count = 6; // number of layers after which to conclude that a tiny support area needs a tower
+    const unsigned int tower_top_layer_count = 6; // number of layers after which to conclude that a tiny support area needs a tower
 
     const int layerThickness = storage.getSettingInMicrons("layer_height");
     const int supportXYDistance = mesh.getSettingInMicrons("support_xy_distance");
@@ -448,7 +448,7 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
 void AreaSupport::detectOverhangPoints(
     SliceDataStorage& storage,
     SliceMeshStorage& mesh, 
-    std::vector<std::vector<Polygons>>& overhang_points, // stores overhang_points along with the layer index at which the overhang point occurs)
+    std::vector<std::vector<Polygons>>& overhang_points, // stores overhang_points of each layer
     int layer_count,
     int supportMinAreaSqrt
 )

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -238,7 +238,7 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage, unsigned int m
     // computation
         
     
-    std::vector<std::pair<int, std::vector<Polygons>>> overhang_points; // stores overhang_points along with the layer index at which the overhang point occurs
+    std::vector<std::vector<Polygons>> overhang_points; // stores overhang_points of each layer
     if (use_towers)
     {
         AreaSupport::detectOverhangPoints(storage, mesh, overhang_points, layer_count, supportMinAreaSqrt);
@@ -269,7 +269,6 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage, unsigned int m
         }
     }
 
-    int overhang_points_pos = overhang_points.size() - 1;
     Polygons supportLayer_last;
     std::vector<Polygons> towerRoofs;
 
@@ -287,7 +286,7 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage, unsigned int m
             // handle straight walls
             AreaSupport::handleWallStruts(supportLayer_this, supportMinAreaSqrt, supportTowerDiameter);
             // handle towers
-            AreaSupport::handleTowers(supportLayer_this, towerRoofs, overhang_points, overhang_points_pos, layer_idx, towerRoofExpansionDistance, supportTowerDiameter, supportMinAreaSqrt, layer_count, z_layer_distance_tower);
+            AreaSupport::handleTowers(supportLayer_this, towerRoofs, overhang_points, layer_idx, towerRoofExpansionDistance, supportTowerDiameter, supportMinAreaSqrt, layer_count, z_layer_distance_tower);
         }
     
         if (layer_idx+1 < support_layer_count)
@@ -428,13 +427,16 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
 void AreaSupport::detectOverhangPoints(
     SliceDataStorage& storage,
     SliceMeshStorage& mesh, 
-    std::vector<std::pair<int, std::vector<Polygons>>>& overhang_points, // stores overhang_points along with the layer index at which the overhang point occurs)
+    std::vector<std::vector<Polygons>>& overhang_points, // stores overhang_points along with the layer index at which the overhang point occurs)
     int layer_count,
     int supportMinAreaSqrt
 )
 {
     ExtruderTrain* infill_extr = storage.meshgroup->getExtruderTrain(storage.getSettingAsIndex("support_infill_extruder_nr"));
     const unsigned int support_line_width = infill_extr->getSettingInMicrons("support_line_width");
+
+    overhang_points.resize(layer_count);
+
     for (int layer_idx = 0; layer_idx < layer_count; layer_idx++)
     {
         SliceLayer& layer = mesh.layers[layer_idx];
@@ -448,7 +450,7 @@ void AreaSupport::detectOverhangPoints(
                 {
                     part_poly_computed = part.outline.offset(-support_line_width / 2);
                 }
-                
+
                 if (part_poly.size() > 0)
                 {
                     Polygons part_poly_recomputed = part_poly.difference(storage.support.supportLayers[layer_idx].anti_overhang);
@@ -456,16 +458,9 @@ void AreaSupport::detectOverhangPoints(
                     {
                         continue;
                     }
-                    if (overhang_points.size() > 0 && overhang_points.back().first == layer_idx)
-                        overhang_points.back().second.push_back(part_poly_recomputed);
-                    else 
-                    {
-                        std::vector<Polygons> small_part_polys;
-                        small_part_polys.push_back(part_poly_recomputed);
-                        overhang_points.emplace_back<std::pair<int, std::vector<Polygons>>>(std::make_pair(layer_idx, small_part_polys));
-                    }
+                    std::vector<Polygons>& layer_overhang_points = overhang_points[layer_idx];
+                    layer_overhang_points.push_back(part_poly_recomputed);
                 }
-                
             }
         }
     }
@@ -476,8 +471,7 @@ void AreaSupport::detectOverhangPoints(
 void AreaSupport::handleTowers(
     Polygons& supportLayer_this,
     std::vector<Polygons>& towerRoofs,
-    std::vector<std::pair<int, std::vector<Polygons>>>& overhang_points,
-    int& overhang_points_pos,
+    std::vector<std::vector<Polygons>>& overhang_points,
     int layer_idx,
     int towerRoofExpansionDistance,
     int supportTowerDiameter,
@@ -486,19 +480,18 @@ void AreaSupport::handleTowers(
     int z_layer_distance_tower
 )
 {
-    // handle new tower roof tops
     int layer_overhang_point =  layer_idx + z_layer_distance_tower;
-    if (overhang_points_pos >= 0 && layer_overhang_point < layer_count && 
-        overhang_points[overhang_points_pos].first == layer_overhang_point) 
+    std::vector<Polygons>& overhang_points_here = overhang_points[layer_overhang_point]; // may be changed if an overhang point has a (smaller) overhang point directly below
+    // handle new tower roof tops
+    if (overhang_points_here.size() > 0)
     {
-        std::vector<Polygons>& overhang_points_here = overhang_points[overhang_points_pos].second;
         { // make sure we have the lowest point (make polys empty if they have small parts below)
-            if (overhang_points_pos > 0 && overhang_points[overhang_points_pos - 1].first == layer_overhang_point - 1)
+            if (layer_overhang_point < layer_count && overhang_points[layer_overhang_point - 1].size() > 0)
             {
-                std::vector<Polygons>& overhang_points_below = overhang_points[overhang_points_pos - 1].second;
+                std::vector<Polygons>& overhang_points_below = overhang_points[layer_overhang_point - 1];
                 for (Polygons& poly_here : overhang_points_here)
                 {
-                    for (Polygons& poly_below : overhang_points_below)
+                    for (const Polygons& poly_below : overhang_points_below)
                     {
                         poly_here = poly_here.difference(poly_below.offset(supportMinAreaSqrt*2));
                     }
@@ -506,9 +499,12 @@ void AreaSupport::handleTowers(
             }
         }
         for (Polygons& poly : overhang_points_here)
+        {
             if (poly.size() > 0)
+            {
                 towerRoofs.push_back(poly);
-        overhang_points_pos--;
+            }
+        }
     }
     
     // make tower roofs

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -481,6 +481,10 @@ void AreaSupport::handleTowers(
 )
 {
     int layer_overhang_point =  layer_idx + z_layer_distance_tower;
+    if (layer_overhang_point >= layer_count - 1)
+    {
+        return;
+    }
     std::vector<Polygons>& overhang_points_here = overhang_points[layer_overhang_point]; // may be changed if an overhang point has a (smaller) overhang point directly below
     // handle new tower roof tops
     if (overhang_points_here.size() > 0)

--- a/src/support.h
+++ b/src/support.h
@@ -59,14 +59,14 @@ private:
     /*!
      * Joins the layerpart outlines of all meshes and collects the overhang points (small areas).
      * \param storage input layer outline information
-     * \param overhang_points stores overhang_points along with the layer index at which the overhang point occurs
+     * \param overhang_points stores overhang_points of each layer
      * \param layer_count total number of layers
      * \param supportMinAreaSqrt diameter of the minimal area which can be supported without a specialized strut
      */
     static void detectOverhangPoints(
         SliceDataStorage& storage,
         SliceMeshStorage& mesh,
-        std::vector<std::pair<int, std::vector<Polygons>>>& overhang_points, 
+        std::vector<std::vector<Polygons>>& overhang_points,
         int layer_count,
         int supportMinAreaSqrt
     );
@@ -94,8 +94,7 @@ private:
      * From below the roof, the towers are added to the normal support layer and handled as normal support area.
      * \param supportLayer_this The support areas in the layer for which we are creating towers/struts
      * \param towerRoofs The parts of roofs which need to expand downward until they have the required diameter
-     * \param overhang_points stores overhang_points along with the layer index at which the overhang point occurs
-     * \param overhang_points_pos Index into \p overhang_points for the overhang points in the next layer
+     * \param overhang_points stores overhang_points of each layer
      * \param layer_idx The index of the layer at which to handle towers
      * \param towerRoofExpansionDistance The offset distance which determines the angle of the tower roof tops
      * \param supportTowerDiameter The diameter of the eventual tower, below the roof
@@ -106,8 +105,7 @@ private:
     static void handleTowers(
         Polygons& supportLayer_this,
         std::vector<Polygons>& towerRoofs,
-        std::vector<std::pair<int, std::vector<Polygons>>>& overhang_points,
-        int& overhang_points_pos,
+        std::vector<std::vector<Polygons>>& overhang_points,
         int layer_idx,
         int towerRoofExpansionDistance,
         int supportTowerDiameter,


### PR DESCRIPTION
Make Support Towers (thicker support towers with a slanted roof up to the to-be-supported part) when support generates thin support.

Also fixes some cases where towers are generated for top surfaces, but not all :(