### PR TITLE
Fix spiralization bugs that bite multi-material models

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -164,7 +164,7 @@ void FffGcodeWriter::findLayerSeamsForSpiralize(SliceDataStorage& storage, size_
         storage.spiralize_seam_vertex_indices[layer_nr] = 0;
 
         // iterate through extruders until we find a mesh that has a part with insets
-        const std::vector<unsigned int> &extruder_order = extruder_order_per_layer[layer_nr];
+        const std::vector<unsigned int>& extruder_order = extruder_order_per_layer[layer_nr];
         for (unsigned int extruder_idx = 0; !done_this_layer && extruder_idx < extruder_order.size(); ++extruder_idx)
         {
             const unsigned int extruder_nr = extruder_order[extruder_idx];

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -144,7 +144,7 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
     gcode.writeRetraction(storage.retraction_config_per_extruder[gcode.getExtruderNr()], force); // retract after finishing each meshgroup
 }
 
-int FffGcodeWriter::findSpiralizedLayerSeamVertexIndex(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const int layer_nr, const int last_layer_nr)
+unsigned int FffGcodeWriter::findSpiralizedLayerSeamVertexIndex(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const int layer_nr, const int last_layer_nr)
 {
     const SliceLayer& layer = mesh.layers[layer_nr];
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1154,7 +1154,7 @@ void FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
         const SliceLayer& wall_layer = mesh->layers[layer_nr];
         if (mesh->getSettingBoolean("magic_spiralize"))
         {
-            if (wall_layer.parts.size() == 0 || part.insets.size() == 0)
+            if (part.insets.size() == 0)
             {
                 // nothing to do
                 return;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1181,7 +1181,9 @@ void FffGcodeWriter::processInsets(LayerPlan& gcode_layer, const SliceMeshStorag
                 gcode_layer.addPolygonsByOptimizer(part.insets[0], &mesh_config.inset0_config, wall_overlap_computation, EZSeamType::SHORTEST, z_seam_pos, wall_0_wipe_dist);
             }
         }
-        // only spiralize the first part in the mesh, other parts won't be printed
+        // Only spiralize the first part in the mesh, any other parts will be printed using the normal, non-spiralize codepath.
+        // This sounds weird but actually does the right thing when you have a model that has multiple parts at the bottom that merge into
+        // one part higher up. Once all the parts have merged, layers above that level will be spiralized
         if (spiralize && &wall_layer.parts[0] == &part)
         {
             const std::vector<Polygons>& wall_insets = wall_layer.parts[0].insets;

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -398,6 +398,16 @@ private:
      */
     void processInsets(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage* mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr, EZSeamType z_seam_type, Point z_seam_pos) const;
     
+    /*!
+     * Generate the a spiralized wall for a given layer part.
+     * \param[in] storage where the slice data is stored.
+     * \param gcodeLayer The initial planning of the gcode of the layer.
+     * \param mesh The mesh for which to add to the layer plan \p gcodeLayer.
+     * \param mesh_config the line config with which to print a print feature
+     * \param part The part for which to create gcode
+     * \param layer_nr The current layer number.
+     */
+    void processSpiralizedWall(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage* mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr) const;
     
     /*!
      * Add the gcode of the top/bottom skin of the given part and of the perimeter gaps.
@@ -472,6 +482,15 @@ private:
      * \param total_layers The total number of layers
      */
     void findLayerSeamsForSpiralize(SliceDataStorage& storage, size_t total_layers);
+
+    /*!
+     * Calculate the index of the vertex that is considered to be the seam for the given layer
+     * \param storage where the slice data is stored.
+     * \param mesh the mesh containing the layer of interest
+     * \param layer_nr layer number of the layer whose seam verted index is required
+     * \param last_layer_nr layer number of the previous layer
+     */
+    int findSpiralizedLayerSeamVertexIndex(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const int layer_nr, const int last_layer_nr);
 };
 
 }//namespace cura

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -466,10 +466,11 @@ private:
     void finalize();
 
     /*!
-     * Calculate for each layer in the mesh the index of the vertex that is considered to be the seam
-     * \param mesh The mesh containing the layers to be spiralized
+     * Calculate for each layer the index of the vertex that is considered to be the seam
+     * \param storage where the slice data is stored.
+     * \param total_layers The total number of layers
      */
-    void findLayerSeamsForSpiralize(SliceMeshStorage& mesh);
+    void findLayerSeamsForSpiralize(SliceDataStorage& storage, size_t total_layers);
 };
 
 }//namespace cura

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -401,7 +401,7 @@ private:
     /*!
      * Generate the a spiralized wall for a given layer part.
      * \param[in] storage where the slice data is stored.
-     * \param gcodeLayer The initial planning of the gcode of the layer.
+     * \param[out] gcodeLayer The initial planning of the gcode of the layer.
      * \param mesh The mesh for which to add to the layer plan \p gcodeLayer.
      * \param mesh_config the line config with which to print a print feature
      * \param part The part for which to create gcode
@@ -489,8 +489,9 @@ private:
      * \param mesh the mesh containing the layer of interest
      * \param layer_nr layer number of the layer whose seam verted index is required
      * \param last_layer_nr layer number of the previous layer
+     * \return layer seam vertex index
      */
-    int findSpiralizedLayerSeamVertexIndex(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const int layer_nr, const int last_layer_nr);
+    unsigned int findSpiralizedLayerSeamVertexIndex(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const int layer_nr, const int last_layer_nr);
 };
 
 }//namespace cura

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -387,6 +387,7 @@ private:
     
     /*!
      * Generate the insets for the walls of a given layer part.
+     * \param[in] storage where the slice data is stored.
      * \param gcodeLayer The initial planning of the gcode of the layer.
      * \param mesh The mesh for which to add to the layer plan \p gcodeLayer.
      * \param mesh_config the line config with which to print a print feature
@@ -395,7 +396,7 @@ private:
      * \param z_seam_type dir3ective for where to start the outer paerimeter of a part
      * \param z_seam_pos The location near where to start the outer inset in case \p z_seam_type is 'back'
      */
-    void processInsets(LayerPlan& gcodeLayer, const SliceMeshStorage* mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr, EZSeamType z_seam_type, Point z_seam_pos) const;
+    void processInsets(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage* mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr, EZSeamType z_seam_type, Point z_seam_pos) const;
     
     
     /*!

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -393,7 +393,7 @@ void FffPolygonGenerator::processBasicWallsSkinInfill(SliceDataStorage& storage,
     // skin & infill
 //     Progress::messageProgressStage(Progress::Stage::SKIN, &time_keeper);
     int mesh_max_bottom_layer_count = 0;
-    if (mesh.getSettingBoolean("magic_spiralize"))
+    if (getSettingBoolean("magic_spiralize"))
     {
         mesh_max_bottom_layer_count = std::max(mesh_max_bottom_layer_count, mesh.getSettingAsCount("bottom_layers"));
     }
@@ -406,7 +406,7 @@ void FffPolygonGenerator::processBasicWallsSkinInfill(SliceDataStorage& storage,
         for (unsigned int layer_number = 0; layer_number < mesh.layers.size(); layer_number++)
         {
             logDebug("Processing skins and infill layer %i of %i\n", layer_number, mesh_layer_count);
-            if (!mesh.getSettingBoolean("magic_spiralize") || static_cast<int>(layer_number) < mesh_max_bottom_layer_count)    //Only generate up/downskin and infill for the first X layers when spiralize is choosen.
+            if (!getSettingBoolean("magic_spiralize") || static_cast<int>(layer_number) < mesh_max_bottom_layer_count)    //Only generate up/downskin and infill for the first X layers when spiralize is choosen.
             {
                 processSkinsAndInfill(mesh, layer_number, process_infill);
             }
@@ -531,7 +531,7 @@ void FffPolygonGenerator::processInsets(SliceMeshStorage& mesh, unsigned int lay
     if (mesh.getSettingAsSurfaceMode("magic_mesh_surface_mode") != ESurfaceMode::SURFACE)
     {
         int inset_count = mesh.getSettingAsCount("wall_line_count");
-        if (mesh.getSettingBoolean("magic_spiralize") && static_cast<int>(layer_nr) < mesh.getSettingAsCount("bottom_layers") && ((layer_nr % 2) + 2) % 2 == 1)//Add extra insets every 2 layers when spiralizing, this makes bottoms of cups watertight.
+        if (getSettingBoolean("magic_spiralize") && static_cast<int>(layer_nr) < mesh.getSettingAsCount("bottom_layers") && ((layer_nr % 2) + 2) % 2 == 1)//Add extra insets every 2 layers when spiralizing, this makes bottoms of cups watertight.
             inset_count += 5;
         int line_width_x = mesh.getSettingInMicrons("wall_line_width_x");
         int line_width_0 = mesh.getSettingInMicrons("wall_line_width_0");

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -793,7 +793,10 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 {
                     // set the extrusion temperature and wait for it to be achieved
                     gcode.writeTemperatureCommand(extruder, extruder_plan.extrusion_temperature.value_or(extruder_plan.required_start_temperature), true);
+                    // do the prime
                     gcode.writeUnretractionAndPrime();
+                    // retract before the move back to the print
+                    gcode.writeRetraction(retraction_config);
                 }
             }
         }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -791,13 +791,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 }
                 if (first_extrusion_move_is_spiralized)
                 {
-                    // get extruder up to extrusion temperature if that's greater than the start temperature
-                    if (extruder_plan.extrusion_temperature && *extruder_plan.extrusion_temperature > extruder_plan.required_start_temperature)
-                    {
-                        constexpr bool wait = true;
-                        gcode.writeTemperatureCommand(extruder, *extruder_plan.extrusion_temperature, wait);
-                    }
-                    // do the prime here before moving back to the print
+                    // set the extrusion temperature and wait for it to be achieved
+                    gcode.writeTemperatureCommand(extruder, extruder_plan.extrusion_temperature.value_or(extruder_plan.required_start_temperature), true);
                     gcode.writeUnretractionAndPrime();
                 }
             }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -774,31 +774,6 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 }
                 gcode.writeTemperatureCommand(prev_extruder, prev_extruder_temp, wait);
             }
-
-            if (!getPrimeTowerIsPlanned())
-            {
-                // when spiralizing, there should be no prime tower but to avoid huge blobs occuring at extruder changes
-                // we do the post extruder swap prime into thin air (before extruder is moved back to the print)
-                bool first_extrusion_move_is_spiralized = false;
-                std::vector<GCodePath>& paths = extruder_plan.paths;
-                for(unsigned int path_idx = 0; path_idx < paths.size(); path_idx++)
-                {
-                    if (!paths[path_idx].config->isTravelPath())
-                    {
-                        first_extrusion_move_is_spiralized = paths[path_idx].spiralize;
-                        break;
-                    }
-                }
-                if (first_extrusion_move_is_spiralized)
-                {
-                    // set the extrusion temperature and wait for it to be achieved
-                    gcode.writeTemperatureCommand(extruder, extruder_plan.extrusion_temperature.value_or(extruder_plan.required_start_temperature), true);
-                    // do the prime
-                    gcode.writeUnretractionAndPrime();
-                    // retract before the move back to the print
-                    gcode.writeRetraction(retraction_config);
-                }
-            }
         }
         else if (extruder_plan_idx == 0 && layer_nr != 0 && storage.meshgroup->getExtruderTrain(extruder)->getSettingBoolean("retract_at_layer_change"))
         {

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -195,7 +195,7 @@ public:
     std::vector<size_t> max_print_height_order; //!< Ordered indices into max_print_height_per_extruder: back() will return the extruder number with the highest print height.
 
     std::vector<int> spiralize_seam_vertex_indices; //!< the index of the seam vertex for each layer
-    std::vector<Polygons *> spiralize_wall_outlines; //!< the wall outline polygons for each layer
+    std::vector<Polygons* > spiralize_wall_outlines; //!< the wall outline polygons for each layer
 
     PrimeTower primeTower;
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -86,7 +86,6 @@ public:
     int printZ;     //!< The height at which this layer needs to be printed. Can differ from sliceZ due to the raft.
     std::vector<SliceLayerPart> parts;  //!< An array of LayerParts which contain the actual data. The parts are printed one at a time to minimize travel outside of the 3D model.
     Polygons openPolyLines; //!< A list of lines which were never hooked up into a 2D polygon. (Currently unused in normal operation)
-    int seam_vertex_index; //!< the index of the layer's seam vertex (only used for spiralization)
 
     /*!
      * Get the all outlines of all layer parts in this layer.
@@ -194,6 +193,9 @@ public:
     int max_print_height_second_to_last_extruder; //!< Used in multi-extrusion: the layer number beyond which all models are printed with the same extruder
     std::vector<int> max_print_height_per_extruder; //!< For each extruder the highest layer number at which it is used.
     std::vector<size_t> max_print_height_order; //!< Ordered indices into max_print_height_per_extruder: back() will return the extruder number with the highest print height.
+
+    std::vector<int> spiralize_seam_vertex_indices; //!< the index of the seam vertex for each layer
+    std::vector<Polygons *> spiralize_wall_outlines; //!< the wall outline polygons for each layer
 
     PrimeTower primeTower;
 


### PR DESCRIPTION
The current implementation assumes that the previous layer is in the same mesh as the current layer but that is not true when crossing the boundaries between materials. The main changes in this PR are:

1 - the seam vertex index for each layer is no longer stored in the layer's SliceLayer object. Instead, it is stored in a vector in SliceDataStorage. Another vector stores the wall outline polygons for each layer.

2 - findLayerSeamsForSpiralize() is no longer called for each mesh, it's called once and it processes all the meshes together and stores the seam vertex indices and wall outline polygons for each layer into the SliceDataStorage object.

3 - processInsets() is now passed the SliceDataStorage object and when spiralizing it retrieves the seam vertex index and wall outline polygons for the previous layer from there.

The code appears to work and single extruder prints look the same as before. Testing of multi-extruder prints is ongoing but is hindered by the fact that I don't have access to a multi-extruder machine.
Issues noticed so far are:

1 - When moving away from the spiral at an material change, if combing is enabled, it first moves backwards to a position on the spiral and from there it goes back to the prime position. No z-hop occurs. This tends to leave some extrusion at the point it moves back to. Turning off combing stops it doing that. Instead, it does a z-hop and then moves directly to the prime positions and looks to avoid contacting the spiral again like it does when combing is enabled.
2 - We're seeing some blobs occurring at the point where the material changes. They may change  when the combing is disabled, my tester has yet to provide feedback on that.

To summarise, I'm pretty happy with this code now but testing continues...
