### PR TITLE
CURA-3688: Fix compiler warnings

### DIFF
--- a/src/ExtruderTrain.h
+++ b/src/ExtruderTrain.h
@@ -10,7 +10,6 @@ namespace cura
 class ExtruderTrain : public SettingsBase
 {
     int extruder_nr;
-    bool is_used = false; //!< whether this extruder train is (probably) used during printing the current meshgroup
 public:
     int getExtruderNr();
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1158,7 +1158,7 @@ void FffGcodeWriter::processSingleLayerInfill(LayerPlan& gcode_layer, const Slic
     }
 }
 
-void FffGcodeWriter::processSpiralizedWall(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage* mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr) const
+void FffGcodeWriter::processSpiralizedWall(const SliceDataStorage& storage, LayerPlan& gcode_layer, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr) const
 {
     if (part.insets.size() == 0 || part.insets[0].size() == 0)
     {
@@ -1215,7 +1215,7 @@ void FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
         // one part higher up. Once all the parts have merged, layers above that level will be spiralized
         if (spiralize && &mesh->layers[layer_nr].parts[0] == &part)
         {
-            processSpiralizedWall(storage, gcode_layer, mesh, mesh_config, part, layer_nr);
+            processSpiralizedWall(storage, gcode_layer, mesh_config, part, layer_nr);
         }
         else
         {

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -415,12 +415,11 @@ private:
      * Generate the a spiralized wall for a given layer part.
      * \param[in] storage where the slice data is stored.
      * \param[out] gcodeLayer The initial planning of the gcode of the layer.
-     * \param mesh The mesh for which to add to the layer plan \p gcodeLayer.
      * \param mesh_config the line config with which to print a print feature
      * \param part The part for which to create gcode
      * \param layer_nr The current layer number.
      */
-    void processSpiralizedWall(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage* mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr) const;
+    void processSpiralizedWall(const SliceDataStorage& storage, LayerPlan& gcode_layer, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr) const;
     
     /*!
      * Add the gcode of the top/bottom skin of the given part and of the perimeter gaps.

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -842,7 +842,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
             else
                 speed *= extruder_plan.getExtrudeSpeedFactor();
 
-            if (MergeInfillLines(gcode, layer_nr, paths, extruder_plan, configs_storage.travel_config_per_extruder[extruder], nozzle_size, speed_equalize_flow_enabled, speed_equalize_flow_max).mergeInfillLines(path_idx)) // !! has effect on path_idx !!
+            if (MergeInfillLines(gcode, paths, extruder_plan, configs_storage.travel_config_per_extruder[extruder], nozzle_size, speed_equalize_flow_enabled, speed_equalize_flow_max).mergeInfillLines(path_idx)) // !! has effect on path_idx !!
             { // !! has effect on path_idx !!
                 // works when path_idx is the index of the travel move BEFORE the infill lines to be merged
                 continue;

--- a/src/MergeInfillLines.h
+++ b/src/MergeInfillLines.h
@@ -13,7 +13,6 @@ class MergeInfillLines
 {
 //     void merge(Point& from, Point& p0, Point& p1);
     GCodeExport& gcode; //!<  Where to write the combined line to
-    int layer_nr; //!< The current layer number
     std::vector<GCodePath>& paths; //!< The paths currently under consideration
     ExtruderPlan& extruder_plan; //!< The extruder plan of the paths currently under consideration
     
@@ -64,9 +63,8 @@ public:
     /*!
      * Simple constructor only used by MergeInfillLines::isConvertible to easily convey the environment
      */
-    MergeInfillLines(GCodeExport& gcode, int layer_nr, std::vector<GCodePath>& paths, ExtruderPlan& extruder_plan, const GCodePathConfig& travelConfig, int64_t nozzle_size, bool speed_equalize_flow_enabled, double speed_equalize_flow_max)
+    MergeInfillLines(GCodeExport& gcode, std::vector<GCodePath>& paths, ExtruderPlan& extruder_plan, const GCodePathConfig& travelConfig, int64_t nozzle_size, bool speed_equalize_flow_enabled, double speed_equalize_flow_max)
     : gcode(gcode)
-    , layer_nr(layer_nr)
     , paths(paths)
     , extruder_plan(extruder_plan)
     , travelConfig(travelConfig)

--- a/src/Wireframe2gcode.cpp
+++ b/src/Wireframe2gcode.cpp
@@ -110,7 +110,7 @@ void Wireframe2gcode::writeGCode()
                 writeMoveWithRetract(part.connection.from);
                 for (unsigned int segment_idx = 0; segment_idx < part.connection.segments.size(); segment_idx++)
                 {
-                    handle_segment(layer, part, segment_idx);
+                    handle_segment(part, segment_idx);
                 }
             }
             
@@ -308,7 +308,7 @@ void Wireframe2gcode::strategy_compensate(WeaveConnectionPart& part, unsigned in
     
     gcode.writeExtrusion(newTop, speedUp * newLength / orrLength, extrusion_mm3_per_mm_connection * orrLength / newLength);
 }
-void Wireframe2gcode::handle_segment(WeaveLayer& layer, WeaveConnectionPart& part, unsigned int segment_idx) 
+void Wireframe2gcode::handle_segment(WeaveConnectionPart& part, unsigned int segment_idx)
 {
     WeaveConnectionSegment& segment = part.connection.segments[segment_idx];
     

--- a/src/Wireframe2gcode.cpp
+++ b/src/Wireframe2gcode.cpp
@@ -60,7 +60,7 @@ void Wireframe2gcode::writeGCode()
     // bottom:
     Polygons empty_outlines;
     writeFill(wireFrame.bottom_infill.roof_insets, empty_outlines, 
-              [this](Wireframe2gcode& thiss, WeaveRoofPart& inset, WeaveConnectionPart& part, unsigned int segment_idx) { 
+              [this](Wireframe2gcode&, WeaveConnectionPart& part, unsigned int segment_idx) {
                     WeaveConnectionSegment& segment = part.connection.segments[segment_idx]; 
                     if (segment.segmentType == WeaveSegmentType::MOVE || segment.segmentType == WeaveSegmentType::DOWN_AND_FLAT) // this is the case when an inset overlaps with a hole 
                     {
@@ -71,7 +71,7 @@ void Wireframe2gcode::writeGCode()
                     }
                 }   
             , 
-              [this](Wireframe2gcode& thiss, WeaveConnectionSegment& segment) { 
+              [this](Wireframe2gcode&, WeaveConnectionSegment& segment) {
                     if (segment.segmentType == WeaveSegmentType::MOVE)
                         writeMoveWithRetract(segment.to);
                     else if (segment.segmentType == WeaveSegmentType::DOWN_AND_FLAT)
@@ -136,11 +136,11 @@ void Wireframe2gcode::writeGCode()
         
         // roofs:
         gcode.setZ(layer.z1);
-        std::function<void (Wireframe2gcode& thiss, WeaveRoofPart& inset, WeaveConnectionPart& part, unsigned int segment_idx)>
+        std::function<void (Wireframe2gcode&, WeaveConnectionPart& part, unsigned int segment_idx)>
             handle_roof = &Wireframe2gcode::handle_roof_segment;
         writeFill(layer.roofs.roof_insets, layer.roofs.roof_outlines,
                   handle_roof,
-                [this](Wireframe2gcode& thiss, WeaveConnectionSegment& segment) { // handle flat segments
+                [this](Wireframe2gcode&, WeaveConnectionSegment& segment) { // handle flat segments
                     if (segment.segmentType == WeaveSegmentType::MOVE)
                     {
                         writeMoveWithRetract(segment.to);
@@ -344,7 +344,7 @@ void Wireframe2gcode::handle_segment(WeaveConnectionPart& part, unsigned int seg
 
 
 
-void Wireframe2gcode::handle_roof_segment(WeaveRoofPart& inset, WeaveConnectionPart& part, unsigned int segment_idx)
+void Wireframe2gcode::handle_roof_segment(WeaveConnectionPart& part, unsigned int segment_idx)
 {
     WeaveConnectionSegment& segment = part.connection.segments[segment_idx];
     Point3 from = (segment_idx == 0)? part.connection.from : part.connection.segments[segment_idx - 1].to;
@@ -403,8 +403,8 @@ void Wireframe2gcode::handle_roof_segment(WeaveRoofPart& inset, WeaveConnectionP
 
 
 void Wireframe2gcode::writeFill(std::vector<WeaveRoofPart>& infill_insets, Polygons& roof_outlines
-    , std::function<void (Wireframe2gcode& thiss, WeaveRoofPart& inset, WeaveConnectionPart& part, unsigned int segment_idx)> connectionHandler
-    , std::function<void (Wireframe2gcode& thiss, WeaveConnectionSegment& p)> flatHandler)
+    , std::function<void (Wireframe2gcode&, WeaveConnectionPart& part, unsigned int segment_idx)> connectionHandler
+    , std::function<void (Wireframe2gcode&, WeaveConnectionSegment& p)> flatHandler)
 {
         
     // bottom:
@@ -432,7 +432,7 @@ void Wireframe2gcode::writeFill(std::vector<WeaveRoofPart>& infill_insets, Polyg
             writeMoveWithRetract(first_extrusion_from);
             for (unsigned int segment_idx = first_segment_idx; segment_idx < segments.size(); segment_idx++)
             {
-                connectionHandler(*this, inset, inset_part, segment_idx);
+                connectionHandler(*this, inset_part, segment_idx);
             }
             
             gcode.writeTypeComment(PrintFeatureType::InnerWall); // top

--- a/src/Wireframe2gcode.h
+++ b/src/Wireframe2gcode.h
@@ -91,8 +91,8 @@ private:
     void finalize();
     
     void writeFill(std::vector<WeaveRoofPart>& infill_insets, Polygons& outlines
-        , std::function<void (Wireframe2gcode& thiss, WeaveRoofPart& inset, WeaveConnectionPart& part, unsigned int segment_idx)> connectionHandler
-        , std::function<void (Wireframe2gcode& thiss, WeaveConnectionSegment& p)> flatHandler);
+        , std::function<void (Wireframe2gcode&, WeaveConnectionPart& part, unsigned int segment_idx)> connectionHandler
+        , std::function<void (Wireframe2gcode&, WeaveConnectionSegment& p)> flatHandler);
     
     /*!
      * Function for writing the gcode for a diagonally down movement of a connection.
@@ -138,11 +138,10 @@ private:
     /*!
      * Function for writing the gcode of a segment in the connection between two roof insets / floor outsets.
      * 
-     * \param inset The inset in which the segment is
      * \param part the part in which the segment is
      * \param segment_idx The index of the segment in the \p part
      */
-    void handle_roof_segment(WeaveRoofPart& inset, WeaveConnectionPart& part, unsigned int segment_idx);
+    void handle_roof_segment(WeaveConnectionPart& part, unsigned int segment_idx);
     
     /*!
      * Write a move action to gcode, inserting a retraction if neccesary.

--- a/src/Wireframe2gcode.h
+++ b/src/Wireframe2gcode.h
@@ -130,11 +130,10 @@ private:
     /*!
      * Function writing the gcode of a segment in the connection between two layers.
      * 
-     * \param layer The layer in which the segment is
      * \param part The part in which the segment is
      * \param segment_idx The index of the segment in the \p part
      */
-    void handle_segment(WeaveLayer& layer, WeaveConnectionPart& part, unsigned int segment_idx);
+    void handle_segment(WeaveConnectionPart& part, unsigned int segment_idx);
     
     /*!
      * Function for writing the gcode of a segment in the connection between two roof insets / floor outsets.

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -1,4 +1,5 @@
 #include "utils/logoutput.h"
+#include "utils/macros.h"
 #include "commandSocket.h"
 #include "FffProcessor.h"
 #include "progress/Progress.h"
@@ -36,6 +37,7 @@ class Listener : public Arcus::SocketListener
 public:
     void stateChanged(Arcus::SocketState::SocketState newState) override
     {
+      UNUSED_PARAM(newState);
     }
 
     void messageReceived() override
@@ -605,6 +607,7 @@ void CommandSocket::sendProgress(float amount)
 void CommandSocket::sendProgressStage(Progress::Stage stage)
 {
     // TODO
+    UNUSED_PARAM(stage);
 }
 
 void CommandSocket::sendPrintTimeMaterialEstimates()
@@ -630,6 +633,9 @@ void CommandSocket::sendPrintTimeMaterialEstimates()
 
 void CommandSocket::sendPrintMaterialForObject(int index, int extruder_nr, float print_time)
 {
+    UNUSED_PARAM(index);
+    UNUSED_PARAM(extruder_nr);
+    UNUSED_PARAM(print_time);
 //     socket.sendInt32(CMD_OBJECT_PRINT_MATERIAL);
 //     socket.sendInt32(12);
 //     socket.sendInt32(index);

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -1,3 +1,6 @@
+//Copyright (c) 2017 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
 #include "utils/logoutput.h"
 #include "utils/macros.h"
 #include "commandSocket.h"
@@ -35,9 +38,8 @@ CommandSocket* CommandSocket::instance = nullptr; // instantiate instance
 class Listener : public Arcus::SocketListener
 {
 public:
-    void stateChanged(Arcus::SocketState::SocketState newState) override
+    void stateChanged(Arcus::SocketState::SocketState) override
     {
-      UNUSED_PARAM(newState);
     }
 
     void messageReceived() override
@@ -631,16 +633,9 @@ void CommandSocket::sendPrintTimeMaterialEstimates()
 #endif
 }
 
-void CommandSocket::sendPrintMaterialForObject(int index, int extruder_nr, float print_time)
+void CommandSocket::sendPrintMaterialForObject(int, int, float)
 {
-    UNUSED_PARAM(index);
-    UNUSED_PARAM(extruder_nr);
-    UNUSED_PARAM(print_time);
-//     socket.sendInt32(CMD_OBJECT_PRINT_MATERIAL);
-//     socket.sendInt32(12);
-//     socket.sendInt32(index);
-//     socket.sendInt32(extruder_nr);
-//     socket.sendFloat32(print_time);
+    //Do nothing.
 }
 
 void CommandSocket::sendLayerData()

--- a/src/infill/NoZigZagConnectorProcessor.cpp
+++ b/src/infill/NoZigZagConnectorProcessor.cpp
@@ -1,4 +1,6 @@
-/** Copyright (C) 2016 Ultimaker - Released under terms of the AGPLv3 License */
+//Copyright (c) 2017 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
 #include "../utils/macros.h"
 
 #include "NoZigZagConnectorProcessor.h"
@@ -7,15 +9,14 @@
 namespace cura 
 {
 
-void NoZigZagConnectorProcessor::registerVertex(const Point& vertex)
+void NoZigZagConnectorProcessor::registerVertex(const Point&)
 {
-    UNUSED_PARAM(vertex);
+    //No need to add anything.
 }
 
-void NoZigZagConnectorProcessor::registerScanlineSegmentIntersection(const Point& intersection, bool scanline_is_even)
+void NoZigZagConnectorProcessor::registerScanlineSegmentIntersection(const Point&, bool)
 {
-    UNUSED_PARAM(intersection);
-    UNUSED_PARAM(scanline_is_even);
+    //No need to add anything.
 }
 
 void NoZigZagConnectorProcessor::registerPolyFinished()

--- a/src/infill/NoZigZagConnectorProcessor.cpp
+++ b/src/infill/NoZigZagConnectorProcessor.cpp
@@ -1,4 +1,6 @@
 /** Copyright (C) 2016 Ultimaker - Released under terms of the AGPLv3 License */
+#include "../utils/macros.h"
+
 #include "NoZigZagConnectorProcessor.h"
 
 
@@ -7,12 +9,13 @@ namespace cura
 
 void NoZigZagConnectorProcessor::registerVertex(const Point& vertex)
 {
-
+    UNUSED_PARAM(vertex);
 }
 
 void NoZigZagConnectorProcessor::registerScanlineSegmentIntersection(const Point& intersection, bool scanline_is_even)
 {
-
+    UNUSED_PARAM(intersection);
+    UNUSED_PARAM(scanline_is_even);
 }
 
 void NoZigZagConnectorProcessor::registerPolyFinished()

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -1,0 +1,8 @@
+/** Copyright (C) 2017 Ultimaker - Released under terms of the AGPLv3 License */
+#ifndef UTILS_MACROS_H
+#define UTILS_MACROS_H
+
+// macro to suppress unused parameter warnings from the compiler
+#define UNUSED_PARAM(param) (void)(param)
+
+#endif // UTILS_MACROS_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -5,11 +5,16 @@
 #include <cppunit/ui/text/TestRunner.h>
 #include <cppunit/XmlOutputter.h>
 
+#include <../src/utils/macros.h>
+
 /*!
  * \brief Runs the test cases.
  */
 int main(int argc,char** argv)
 {
+    UNUSED_PARAM(argc);
+    UNUSED_PARAM(argv);
+
     CppUnit::TextUi::TestRunner runner;
     
     //Set the output type to be JUnit-style XML.


### PR DESCRIPTION
Still one warning remains, but that's caused by the generated code of protobuf:
```
CuraEngine/build/Cura.pb.cc:6234:48: warning: unused parameter 'output' [-Wunused-parameter]
     ::google::protobuf::io::CodedOutputStream* output) const {
                                                ^
```

The callback functions in `Wireframe2gcode.cpp` can be bound to be member functions, which requires a self-reference at the first parameter, so to suppress those warnings, I removed the name of the parameter.