### PR TITLE
Fix crash when definition has more extruder trains than extruder count

### DIFF
--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -429,7 +429,7 @@ void CommandSocket::handleObjectList(cura::proto::ObjectList* list, const google
             int extruder_nr = extruder.id();
             if (extruder_nr >= extruder_count)
             {
-                logWarning("Definition has more extruder trains than extruder count suggests, ignoring extra extruder trains.");
+                logWarning("Definition has more extruder trains than extruder count suggests, ignoring extra extruder trains.\n");
                 break;
             }
             ExtruderTrain* train = meshgroup->getExtruderTrain(extruder_nr);

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -418,7 +418,8 @@ void CommandSocket::handleObjectList(cura::proto::ObjectList* list, const google
     }
 
     { // load extruder settings
-        for (int extruder_nr = 0; extruder_nr < FffProcessor::getInstance()->getSettingAsCount("machine_extruder_count"); extruder_nr++)
+        int extruder_count = FffProcessor::getInstance()->getSettingAsCount("machine_extruder_count");
+        for (int extruder_nr = 0; extruder_nr < extruder_count; extruder_nr++)
         { // initialize remaining extruder trains and load the defaults
             meshgroup->createExtruderTrain(extruder_nr); // create new extruder train objects or use already existing ones
         }
@@ -426,6 +427,11 @@ void CommandSocket::handleObjectList(cura::proto::ObjectList* list, const google
         for (auto extruder : settings_per_extruder_train)
         {
             int extruder_nr = extruder.id();
+            if (extruder_nr >= extruder_count)
+            {
+                logWarning("Definition has more extruder trains than extruder count suggests, ignoring extra extruder trains.");
+                break;
+            }
             ExtruderTrain* train = meshgroup->getExtruderTrain(extruder_nr);
             for (auto setting : extruder.settings().settings())
             {


### PR DESCRIPTION
CuraEngine crashes when a definition defines more extruder trains in its def.json file metadata than specified in the machine_extruder_count setting. This PR fixes that crash, ignoring settings for the extra extruder_trains.

See https://github.com/Ultimaker/Cura/pull/1521 for a usecase of having a lower machine_extruder_count than defined extruder_trains: more easily defining printers with a variable number of extruder trains (eg custom dual- or quad-extrusion printers)