### PR TITLE
Fix loading extruders when there are more extruders than machine_extruder_count 

### DIFF
--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -428,13 +428,18 @@ void CommandSocket::handleObjectList(cura::proto::ObjectList* list, const google
             meshgroup->createExtruderTrain(extruder_nr); // create new extruder train objects or use already existing ones
         }
 
+        bool logged_extra_extruders = false;
         for (auto extruder : settings_per_extruder_train)
         {
             int extruder_nr = extruder.id();
             if (extruder_nr >= extruder_count)
             {
-                logWarning("Definition has more extruder trains than extruder count suggests, ignoring extra extruder trains.\n");
-                break;
+                if (!logged_extra_extruders)
+                {
+                    log("Definition has more extruder trains than extruder count suggests, ignoring extra extruder trains.\n");
+                    logged_extra_extruders = true;
+                }
+                continue;
             }
             ExtruderTrain* train = meshgroup->getExtruderTrain(extruder_nr);
             for (auto setting : extruder.settings().settings())


### PR DESCRIPTION
This PR is a followup to https://github.com/Ultimaker/CuraEngine/pull/501. That PR fixed a crash, but did not introduce the correct behavior for cases when there are more extruder definitions than machine_extruder_count.

The previous fix ignored any extruder that came in after an extruder_nr that was too high was encountered. It turns out the extruders may not come in in a specific order, so this would often ignore too many extruders.