### PR TITLE
Time estimate per print feature

### DIFF
--- a/Cura.proto
+++ b/Cura.proto
@@ -90,9 +90,21 @@ message GCodeLayer {
 }
 
 
-message PrintTimeMaterialEstimates { // The print time for the whole print and material estimates for the extruder
-    float time = 1; // Total time estimate
-    repeated MaterialEstimates materialEstimates = 2; // materialEstimates data
+message PrintTimeMaterialEstimates { // The print time for each feature and material estimates for the extruder
+    // Time estimate in each feature
+    float time_none = 1;
+    float time_inset_0 = 2;
+    float time_inset_x = 3;
+    float time_skin = 4;
+    float time_support = 5;
+    float time_skirt = 6;
+    float time_infill = 7;
+    float time_support_infill = 8;
+    float time_travel = 9;
+    float time_retract = 10;
+    float time_support_interface = 11;
+
+    repeated MaterialEstimates materialEstimates = 12; // materialEstimates data
 }
 
 message MaterialEstimates {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1666,7 +1666,7 @@ void FffGcodeWriter::addPrimeTower(const SliceDataStorage& storage, LayerPlan& g
 
 void FffGcodeWriter::finalize()
 {
-    double print_time = gcode.getTotalPrintTime();
+    double print_time = gcode.getSumTotalPrintTimes();
     std::vector<double> filament_used;
     std::vector<std::string> material_ids;
     for (int extr_nr = 0; extr_nr < getSettingAsCount("machine_extruder_count"); extr_nr++)

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -128,13 +128,13 @@ public:
     }
 
     /*!
-     * Get the total estimated print time in seconds
+     * Get the total estimated print time in seconds for each feature
      * 
-     * \return total print time in seconds
+     * \return total print time in seconds for each feature
      */
-    double getTotalPrintTime()
+    std::unordered_map<PrintFeatureType, double> getTotalPrintTimes()
     {
-        return gcode.getTotalPrintTime();
+        return gcode.getTotalPrintTimes();
     }
 
     /*!

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -132,9 +132,9 @@ public:
      * 
      * \return total print time in seconds for each feature
      */
-    std::vector<double> getTotalPrintTimes()
+    std::vector<double> getTotalPrintTimePerFeature()
     {
-        return gcode.getTotalPrintTimes();
+        return gcode.getTotalPrintTimePerFeature();
     }
 
     /*!

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -132,7 +132,7 @@ public:
      * 
      * \return total print time in seconds for each feature
      */
-    std::unordered_map<PrintFeatureType, double> getTotalPrintTimes()
+    std::vector<double> getTotalPrintTimes()
     {
         return gcode.getTotalPrintTimes();
     }

--- a/src/FffProcessor.h
+++ b/src/FffProcessor.h
@@ -134,13 +134,13 @@ public:
     }
 
     /*!
-     * Get the total estimated print time in seconds
+     * Get the total estimated print time in seconds for each feature
      * 
-     * \return total print time in seconds
+     * \return total print time in seconds for each feature
      */
-    double getTotalPrintTime()
+    std::unordered_map<PrintFeatureType, double> getTotalPrintTimes()
     {
-        return gcode_writer.getTotalPrintTime();
+        return gcode_writer.getTotalPrintTimes();
     }
 
     /*!

--- a/src/FffProcessor.h
+++ b/src/FffProcessor.h
@@ -138,7 +138,7 @@ public:
      * 
      * \return total print time in seconds for each feature
      */
-    std::unordered_map<PrintFeatureType, double> getTotalPrintTimes()
+    std::vector<double> getTotalPrintTimes()
     {
         return gcode_writer.getTotalPrintTimes();
     }

--- a/src/FffProcessor.h
+++ b/src/FffProcessor.h
@@ -138,9 +138,9 @@ public:
      * 
      * \return total print time in seconds for each feature
      */
-    std::vector<double> getTotalPrintTimes()
+    std::vector<double> getTotalPrintTimePerFeature()
     {
-        return gcode_writer.getTotalPrintTimes();
+        return gcode_writer.getTotalPrintTimePerFeature();
     }
 
     /*!

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -880,7 +880,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                     )
                     {
                         sendLineTo(paths[path_idx+2].config->type, paths[path_idx+2].points.back(), paths[path_idx+2].getLineWidth());
-                        gcode.writeExtrusion(paths[path_idx+2].points.back(), speed, paths[path_idx+1].getExtrusionMM3perMM());
+                        gcode.writeExtrusion(paths[path_idx+2].points.back(), speed, paths[path_idx+1].getExtrusionMM3perMM(), paths[path_idx+2].config->type);
                         path_idx += 2;
                     }
                     else 
@@ -888,7 +888,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         for(unsigned int point_idx = 0; point_idx < path.points.size(); point_idx++)
                         {
                             sendLineTo(path.config->type, path.points[point_idx], path.getLineWidth());
-                            gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM());
+                            gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), path.config->type);
                         }
                     }
                 }
@@ -921,7 +921,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         p0 = p1;
                         gcode.setZ(z + layer_thickness * length / totalLength);
                         sendLineTo(path.config->type, path.points[point_idx], path.getLineWidth());
-                        gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM());
+                        gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), path.config->type);
                     }
                 }
                 path_idx--; // the last path_idx didnt spiralize, so it's not part of the current spiralize path
@@ -1089,10 +1089,10 @@ bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, unsigned int extruder_
         for(unsigned int point_idx = 0; point_idx <= point_idx_before_start; point_idx++)
         {
             sendLineTo(path.config->type, path.points[point_idx], path.getLineWidth());
-            gcode.writeExtrusion(path.points[point_idx], extrude_speed, path.getExtrusionMM3perMM());
+            gcode.writeExtrusion(path.points[point_idx], extrude_speed, path.getExtrusionMM3perMM(), path.config->type);
         }
         sendLineTo(path.config->type, start, path.getLineWidth());
-        gcode.writeExtrusion(start, extrude_speed, path.getExtrusionMM3perMM());
+        gcode.writeExtrusion(start, extrude_speed, path.getExtrusionMM3perMM(), path.config->type);
     }
 
     // write coasting path

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -19,7 +19,7 @@ void MergeInfillLines::writeCompensatedMove(Point& to, double speed, GCodePath& 
         new_speed = std::min(speed * speed_mod, speed_equalize_flow_max);
     }
     sendLineTo(last_path.config->type, to, last_path.getLineWidth());
-    gcode.writeExtrusion(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod);
+    gcode.writeExtrusion(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod, last_path.config->type);
 }
     
 bool MergeInfillLines::mergeInfillLines(unsigned int& path_idx)

--- a/src/PrintFeature.h
+++ b/src/PrintFeature.h
@@ -16,7 +16,8 @@ enum class PrintFeatureType: unsigned char
     SupportInfill,
     MoveCombing,
     MoveRetraction,
-    SupportInterface
+    SupportInterface,
+    NumPrintFeatureTypes
 };
 
 

--- a/src/PrintFeature.h
+++ b/src/PrintFeature.h
@@ -6,18 +6,18 @@ namespace cura
 
 enum class PrintFeatureType: unsigned char
 {
-    NoneType, // used to mark unspecified jumps in polygons. libArcus depends on it
-    OuterWall,
-    InnerWall,
-    Skin,
-    Support,
-    SkirtBrim,
-    Infill,
-    SupportInfill,
-    MoveCombing,
-    MoveRetraction,
-    SupportInterface,
-    NumPrintFeatureTypes
+    NoneType = 0, // used to mark unspecified jumps in polygons. libArcus depends on it
+    OuterWall = 1,
+    InnerWall = 2,
+    Skin = 3,
+    Support = 4,
+    SkirtBrim = 5,
+    Infill = 6,
+    SupportInfill = 7,
+    MoveCombing = 8,
+    MoveRetraction = 9,
+    SupportInterface = 10,
+    NumPrintFeatureTypes = 11 // used to find the number of feature types in this enum
 };
 
 

--- a/src/Wireframe2gcode.cpp
+++ b/src/Wireframe2gcode.cpp
@@ -7,7 +7,7 @@
 #include "utils/logoutput.h"
 #include "weaveDataStorage.h"
 #include "progress/Progress.h"
-
+#include "PrintFeature.h"
 #include "pathOrderOptimizer.h" //For skirt/brim.
 
 namespace cura 
@@ -51,7 +51,7 @@ void Wireframe2gcode::writeGCode()
         writeMoveWithRetract(bottom_part[bottom_part.size()-1]);
         for (Point& segment_to : bottom_part)
         {
-            gcode.writeExtrusion(segment_to, speedBottom, extrusion_mm3_per_mm_flat);
+            gcode.writeExtrusion(segment_to, speedBottom, extrusion_mm3_per_mm_flat, PrintFeatureType::Skin);
         }
     }
     
@@ -67,7 +67,7 @@ void Wireframe2gcode::writeGCode()
                         writeMoveWithRetract(segment.to); 
                     } else 
                     {
-                        gcode.writeExtrusion(segment.to, speedBottom, extrusion_mm3_per_mm_connection);
+                        gcode.writeExtrusion(segment.to, speedBottom, extrusion_mm3_per_mm_connection, PrintFeatureType::Skin);
                     }
                 }   
             , 
@@ -77,7 +77,7 @@ void Wireframe2gcode::writeGCode()
                     else if (segment.segmentType == WeaveSegmentType::DOWN_AND_FLAT)
                         return; // do nothing
                     else 
-                        gcode.writeExtrusion(segment.to, speedBottom, extrusion_mm3_per_mm_flat);
+                        gcode.writeExtrusion(segment.to, speedBottom, extrusion_mm3_per_mm_flat, PrintFeatureType::Skin);
                 }
             );
     Progress::messageProgressStage(Progress::Stage::EXPORT, nullptr);
@@ -127,7 +127,7 @@ void Wireframe2gcode::writeGCode()
                         writeMoveWithRetract(segment.to);
                     } else 
                     {
-                        gcode.writeExtrusion(segment.to, speedFlat, extrusion_mm3_per_mm_flat);
+                        gcode.writeExtrusion(segment.to, speedFlat, extrusion_mm3_per_mm_flat, PrintFeatureType::OuterWall);
                         gcode.writeDelay(flat_delay);
                     }
                 }
@@ -149,7 +149,7 @@ void Wireframe2gcode::writeGCode()
                         // do nothing
                     } else 
                     {   
-                        gcode.writeExtrusion(segment.to, speedFlat, extrusion_mm3_per_mm_flat);
+                        gcode.writeExtrusion(segment.to, speedFlat, extrusion_mm3_per_mm_flat, PrintFeatureType::Skin);
                         gcode.writeDelay(flat_delay);
                     }
                 });
@@ -181,7 +181,7 @@ void Wireframe2gcode::go_down(WeaveConnectionPart& part, unsigned int segment_id
         gcode.writeTravel(from, speedDown);
     if (straight_first_when_going_down <= 0)
     {
-        gcode.writeExtrusion(segment.to, speedDown, extrusion_mm3_per_mm_connection);
+        gcode.writeExtrusion(segment.to, speedDown, extrusion_mm3_per_mm_connection, PrintFeatureType::OuterWall);
     } else 
     {
         Point3& to = segment.to;
@@ -193,14 +193,14 @@ void Wireframe2gcode::go_down(WeaveConnectionPart& part, unsigned int segment_id
         int64_t new_length = (up - from).vSize() + (to - up).vSize() + 5;
         int64_t orr_length = vec.vSize();
         double enlargement = new_length / orr_length;
-        gcode.writeExtrusion(up, speedDown*enlargement, extrusion_mm3_per_mm_connection / enlargement);
-        gcode.writeExtrusion(to, speedDown*enlargement, extrusion_mm3_per_mm_connection / enlargement);
+        gcode.writeExtrusion(up, speedDown*enlargement, extrusion_mm3_per_mm_connection / enlargement, PrintFeatureType::OuterWall);
+        gcode.writeExtrusion(to, speedDown*enlargement, extrusion_mm3_per_mm_connection / enlargement, PrintFeatureType::OuterWall);
     }
     gcode.writeDelay(bottom_delay);
     if (up_dist_half_speed > 0)
     {
         
-        gcode.writeExtrusion(Point3(0,0,up_dist_half_speed) + gcode.getPosition(), speedUp / 2, extrusion_mm3_per_mm_connection * 2);
+        gcode.writeExtrusion(Point3(0,0,up_dist_half_speed) + gcode.getPosition(), speedUp / 2, extrusion_mm3_per_mm_connection * 2, PrintFeatureType::OuterWall);
     }
 }
 
@@ -209,7 +209,7 @@ void Wireframe2gcode::go_down(WeaveConnectionPart& part, unsigned int segment_id
 void Wireframe2gcode::strategy_knot(WeaveConnectionPart& part, unsigned int segment_idx)
 {
     WeaveConnectionSegment& segment = part.connection.segments[segment_idx];
-    gcode.writeExtrusion(segment.to, speedUp, extrusion_mm3_per_mm_connection);
+    gcode.writeExtrusion(segment.to, speedUp, extrusion_mm3_per_mm_connection, PrintFeatureType::OuterWall);
     Point3 next_vector;
     if (segment_idx + 1 < part.connection.segments.size())
     {
@@ -259,7 +259,7 @@ void Wireframe2gcode::strategy_retract(WeaveConnectionPart& part, unsigned int s
         Point3 vec = to - from;
         Point3 lowering = vec * retract_hop_dist / 2 / vec.vSize();
         Point3 lower = to - lowering;
-        gcode.writeExtrusion(lower, speedUp, extrusion_mm3_per_mm_connection);
+        gcode.writeExtrusion(lower, speedUp, extrusion_mm3_per_mm_connection, PrintFeatureType::OuterWall);
         gcode.writeRetraction(retraction_config);
         gcode.writeTravel(to + lowering, speedUp);
         gcode.writeDelay(top_retract_pause);
@@ -268,7 +268,7 @@ void Wireframe2gcode::strategy_retract(WeaveConnectionPart& part, unsigned int s
         
     } else 
     {
-        gcode.writeExtrusion(to, speedUp, extrusion_mm3_per_mm_connection);
+        gcode.writeExtrusion(to, speedUp, extrusion_mm3_per_mm_connection, PrintFeatureType::OuterWall);
         gcode.writeRetraction(retraction_config);
         gcode.writeTravel(to + Point3(0, 0, retract_hop_dist), speedFlat);
         gcode.writeDelay(top_retract_pause);
@@ -306,7 +306,7 @@ void Wireframe2gcode::strategy_compensate(WeaveConnectionPart& part, unsigned in
     int64_t orrLength = (segment.to - from).vSize() + next_vector.vSize() + 1; // + 1 in order to avoid division by zero
     int64_t newLength = (newTop - from).vSize() + (next_point - newTop).vSize() + 1; // + 1 in order to avoid division by zero
     
-    gcode.writeExtrusion(newTop, speedUp * newLength / orrLength, extrusion_mm3_per_mm_connection * orrLength / newLength);
+    gcode.writeExtrusion(newTop, speedUp * newLength / orrLength, extrusion_mm3_per_mm_connection * orrLength / newLength, PrintFeatureType::OuterWall);
 }
 void Wireframe2gcode::handle_segment(WeaveConnectionPart& part, unsigned int segment_idx)
 {
@@ -385,12 +385,12 @@ void Wireframe2gcode::handle_roof_segment(WeaveConnectionPart& part, unsigned in
                     detoured -= next_dir;
                 }
                 
-                gcode.writeExtrusion(detoured, speedUp, extrusion_mm3_per_mm_connection);
+                gcode.writeExtrusion(detoured, speedUp, extrusion_mm3_per_mm_connection, PrintFeatureType::Skin);
 
             }
             break;
         case WeaveSegmentType::DOWN:
-            gcode.writeExtrusion(segment.to, speedDown, extrusion_mm3_per_mm_connection);
+            gcode.writeExtrusion(segment.to, speedDown, extrusion_mm3_per_mm_connection, PrintFeatureType::Skin);
             gcode.writeDelay(roof_outer_delay);
             break;
         case WeaveSegmentType::FLAT:
@@ -628,7 +628,7 @@ void Wireframe2gcode::processSkirt()
         for (unsigned int point_idx = 0; point_idx < poly.size(); point_idx++)
         {
             Point& p = poly[(point_idx + order.polyStart[poly_idx] + 1) % poly.size()];
-            gcode.writeExtrusion(p, getSettingInMillimetersPerSecond("skirt_brim_speed"), getSettingInMillimeters("skirt_brim_line_width") * INT2MM(initial_layer_thickness));
+            gcode.writeExtrusion(p, getSettingInMillimetersPerSecond("skirt_brim_speed"), getSettingInMillimeters("skirt_brim_line_width") * INT2MM(initial_layer_thickness), PrintFeatureType::SkirtBrim);
         }
     }
 }

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -629,18 +629,18 @@ void CommandSocket::sendPrintTimeMaterialEstimates()
     logDebug("Sending print time and material estimates.\n");
     auto message = std::make_shared<cura::proto::PrintTimeMaterialEstimates>();
 
-    std::unordered_map<PrintFeatureType, double> time_estimates = FffProcessor::getInstance()->getTotalPrintTimes();
-    message->set_time_infill(time_estimates[PrintFeatureType::Infill]);
-    message->set_time_inset_0(time_estimates[PrintFeatureType::OuterWall]);
-    message->set_time_inset_x(time_estimates[PrintFeatureType::InnerWall]);
-    message->set_time_none(time_estimates[PrintFeatureType::NoneType]);
-    message->set_time_retract(time_estimates[PrintFeatureType::MoveRetraction]);
-    message->set_time_skin(time_estimates[PrintFeatureType::Skin]);
-    message->set_time_skirt(time_estimates[PrintFeatureType::SkirtBrim]);
-    message->set_time_support(time_estimates[PrintFeatureType::Support]);
-    message->set_time_support_infill(time_estimates[PrintFeatureType::SupportInfill]);
-    message->set_time_support_interface(time_estimates[PrintFeatureType::SupportInterface]);
-    message->set_time_travel(time_estimates[PrintFeatureType::MoveCombing]);
+    std::vector<double> time_estimates = FffProcessor::getInstance()->getTotalPrintTimes();
+    message->set_time_infill(time_estimates[static_cast<unsigned char>(PrintFeatureType::Infill)]);
+    message->set_time_inset_0(time_estimates[static_cast<unsigned char>(PrintFeatureType::OuterWall)]);
+    message->set_time_inset_x(time_estimates[static_cast<unsigned char>(PrintFeatureType::InnerWall)]);
+    message->set_time_none(time_estimates[static_cast<unsigned char>(PrintFeatureType::NoneType)]);
+    message->set_time_retract(time_estimates[static_cast<unsigned char>(PrintFeatureType::MoveRetraction)]);
+    message->set_time_skin(time_estimates[static_cast<unsigned char>(PrintFeatureType::Skin)]);
+    message->set_time_skirt(time_estimates[static_cast<unsigned char>(PrintFeatureType::SkirtBrim)]);
+    message->set_time_support(time_estimates[static_cast<unsigned char>(PrintFeatureType::Support)]);
+    message->set_time_support_infill(time_estimates[static_cast<unsigned char>(PrintFeatureType::SupportInfill)]);
+    message->set_time_support_interface(time_estimates[static_cast<unsigned char>(PrintFeatureType::SupportInterface)]);
+    message->set_time_travel(time_estimates[static_cast<unsigned char>(PrintFeatureType::MoveCombing)]);
     int num_extruders = FffProcessor::getInstance()->getSettingAsCount("machine_extruder_count");
     for (int extruder_nr (0); extruder_nr < num_extruders; ++extruder_nr)
     {

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -629,7 +629,18 @@ void CommandSocket::sendPrintTimeMaterialEstimates()
     logDebug("Sending print time and material estimates.\n");
     auto message = std::make_shared<cura::proto::PrintTimeMaterialEstimates>();
 
-    message->set_time(FffProcessor::getInstance()->getTotalPrintTime());
+    std::unordered_map<PrintFeatureType, double> time_estimates = FffProcessor::getInstance()->getTotalPrintTimes();
+    message->set_time_infill(time_estimates[PrintFeatureType::Infill]);
+    message->set_time_inset_0(time_estimates[PrintFeatureType::OuterWall]);
+    message->set_time_inset_x(time_estimates[PrintFeatureType::InnerWall]);
+    message->set_time_none(time_estimates[PrintFeatureType::NoneType]);
+    message->set_time_retract(time_estimates[PrintFeatureType::MoveRetraction]);
+    message->set_time_skin(time_estimates[PrintFeatureType::Skin]);
+    message->set_time_skirt(time_estimates[PrintFeatureType::SkirtBrim]);
+    message->set_time_support(time_estimates[PrintFeatureType::Support]);
+    message->set_time_support_infill(time_estimates[PrintFeatureType::SupportInfill]);
+    message->set_time_support_interface(time_estimates[PrintFeatureType::SupportInterface]);
+    message->set_time_travel(time_estimates[PrintFeatureType::MoveCombing]);
     int num_extruders = FffProcessor::getInstance()->getSettingAsCount("machine_extruder_count");
     for (int extruder_nr (0); extruder_nr < num_extruders; ++extruder_nr)
     {

--- a/src/commandSocket.cpp
+++ b/src/commandSocket.cpp
@@ -629,7 +629,7 @@ void CommandSocket::sendPrintTimeMaterialEstimates()
     logDebug("Sending print time and material estimates.\n");
     auto message = std::make_shared<cura::proto::PrintTimeMaterialEstimates>();
 
-    std::vector<double> time_estimates = FffProcessor::getInstance()->getTotalPrintTimes();
+    std::vector<double> time_estimates = FffProcessor::getInstance()->getTotalPrintTimePerFeature();
     message->set_time_infill(time_estimates[static_cast<unsigned char>(PrintFeatureType::Infill)]);
     message->set_time_inset_0(time_estimates[static_cast<unsigned char>(PrintFeatureType::OuterWall)]);
     message->set_time_inset_x(time_estimates[static_cast<unsigned char>(PrintFeatureType::InnerWall)]);

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -377,7 +377,7 @@ double GCodeExport::getTotalFilamentUsed(int extruder_nr)
     return extruder_attr[extruder_nr].totalFilament;
 }
 
-std::vector<double> GCodeExport::getTotalPrintTimes()
+std::vector<double> GCodeExport::getTotalPrintTimePerFeature()
 {
     return total_print_times;
 }
@@ -385,7 +385,7 @@ std::vector<double> GCodeExport::getTotalPrintTimes()
 double GCodeExport::getSumTotalPrintTimes()
 {
     double sum = 0.0;
-    for(double item : getTotalPrintTimes())
+    for(double item : getTotalPrintTimePerFeature())
     {
         sum += item;
     }

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -267,8 +267,9 @@ public:
      * 
      * \param p location to go to
      * \param speed movement speed
+     * \param feature the feature that's currently printing
      */
-    void writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm);
+    void writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
 
     /*!
      * Go to a X/Y location with the z-hopped Z value
@@ -288,8 +289,9 @@ public:
      * 
      * \param p location to go to
      * \param speed movement speed
+     * \param feature the feature that's currently printing
      */
-    void writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm);
+    void writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
 private:
     /*!
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
@@ -312,8 +314,9 @@ private:
      * \param z build plate z
      * \param speed movement speed
      * \param extrusion_mm3_per_mm flow
+     * \param feature the print feature that's currently printing
      */
-    void writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm);
+    void writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
 
     /*!
      * Write the F, X, Y, Z and E value (if they are not different from the last)
@@ -322,10 +325,10 @@ private:
      * 
      * This function also applies the gcode offset by calling \ref GCodeExport::getGcodePos
      * This function updates the \ref GCodeExport::total_bounding_box
-     * It estimates the time in \ref GCodeExport::estimateCalculator
+     * It estimates the time in \ref GCodeExport::estimateCalculator for the correct feature
      * It updates \ref GCodeExport::currentPosition, \ref GCodeExport::current_e_value and \ref GCodeExport::currentSpeed
      */
-    void writeFXYZE(double speed, int x, int y, int z, double e);
+    void writeFXYZE(double speed, int x, int y, int z, double e, PrintFeatureType feature);
 
     /*!
      * The writeTravel and/or writeExtrusion when flavor == BFB
@@ -334,8 +337,9 @@ private:
      * \param z build plate z
      * \param speed movement speed
      * \param extrusion_mm3_per_mm flow
+     * \param feature print feature to track print time for
      */
-    void writeMoveBFB(int x, int y, int z, double speed, double extrusion_mm3_per_mm);
+    void writeMoveBFB(int x, int y, int z, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
 public:
     /*!
      * Get ready for extrusion moves:

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -116,7 +116,7 @@ private:
     int currentFanSpeed;
     EGCodeFlavor flavor;
 
-    std::unordered_map<PrintFeatureType, double> total_print_times; //!< The total estimated print time in seconds for each feature
+    std::vector<double> total_print_times; //!< The total estimated print time in seconds for each feature
     TimeEstimateCalculator estimateCalculator;
     
     bool is_volumatric;
@@ -227,7 +227,7 @@ public:
      * 
      * \return total print time in seconds for each feature
      */
-    std::unordered_map<PrintFeatureType, double> getTotalPrintTimes();
+    std::vector<double> getTotalPrintTimes();
     /*!
      * Get the total print time in seconds for the complete print
      * 

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -116,7 +116,7 @@ private:
     int currentFanSpeed;
     EGCodeFlavor flavor;
 
-    double totalPrintTime; //!< The total estimated print time in seconds
+    std::unordered_map<PrintFeatureType, double> total_print_times; //!< The total estimated print time in seconds for each feature
     TimeEstimateCalculator estimateCalculator;
     
     bool is_volumatric;
@@ -223,11 +223,17 @@ public:
     double getTotalFilamentUsed(int extruder_nr);
 
     /*!
-     * Get the total estimated print time in seconds
+     * Get the total estimated print time in seconds for each feature
      * 
-     * \return total print time in seconds
+     * \return total print time in seconds for each feature
      */
-    double getTotalPrintTime();
+    std::unordered_map<PrintFeatureType, double> getTotalPrintTimes();
+    /*!
+     * Get the total print time in seconds for the complete print
+     * 
+     * \return total print time in seconds for the complete print
+     */
+    double getSumTotalPrintTimes();
     void updateTotalPrintTime();
     void resetTotalPrintTimeAndFilament();
     

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -227,7 +227,7 @@ public:
      * 
      * \return total print time in seconds for each feature
      */
-    std::vector<double> getTotalPrintTimes();
+    std::vector<double> getTotalPrintTimePerFeature();
     /*!
      * Get the total print time in seconds for the complete print
      * 

--- a/src/timeEstimate.cpp
+++ b/src/timeEstimate.cpp
@@ -221,23 +221,35 @@ void TimeEstimateCalculator::plan(Position newPos, double feedrate, PrintFeature
     blocks.push_back(block);
 }
 
-double TimeEstimateCalculator::calculate()
+std::unordered_map<PrintFeatureType, double> TimeEstimateCalculator::calculate()
 {
     reverse_pass();
     forward_pass();
     recalculate_trapezoids();
     
-    double totalTime = extra_time;
+    std::unordered_map<PrintFeatureType, double> totals = {
+        {PrintFeatureType::NoneType, extra_time}, // Extra time (pause for minimum layer time, etc) is marked as NoneType
+        {PrintFeatureType::Infill, 0},
+        {PrintFeatureType::InnerWall, 0},
+        {PrintFeatureType::MoveCombing, 0},
+        {PrintFeatureType::MoveRetraction, 0},
+        {PrintFeatureType::OuterWall, 0},
+        {PrintFeatureType::Skin, 0},
+        {PrintFeatureType::SkirtBrim, 0},
+        {PrintFeatureType::Support, 0},
+        {PrintFeatureType::SupportInfill, 0},
+        {PrintFeatureType::SupportInterface, 0}
+    };
     for(unsigned int n=0; n<blocks.size(); n++)
     {
         Block& block = blocks[n];
         double plateau_distance = block.decelerate_after - block.accelerate_until;
         
-        totalTime += acceleration_time_from_distance(block.initial_feedrate, block.accelerate_until, block.acceleration);
-        totalTime += plateau_distance / block.nominal_feedrate;
-        totalTime += acceleration_time_from_distance(block.final_feedrate, (block.distance - block.decelerate_after), block.acceleration);
+        totals[block.feature] += acceleration_time_from_distance(block.initial_feedrate, block.accelerate_until, block.acceleration);
+        totals[block.feature] += plateau_distance / block.nominal_feedrate;
+        totals[block.feature] += acceleration_time_from_distance(block.final_feedrate, (block.distance - block.decelerate_after), block.acceleration);
     }
-    return totalTime;
+    return totals;
 }
 
 // The kernel called by accelerationPlanner::calculate() when scanning the plan from last to first entry.

--- a/src/timeEstimate.cpp
+++ b/src/timeEstimate.cpp
@@ -127,11 +127,13 @@ void TimeEstimateCalculator::calculate_trapezoid_for_block(Block *block, double 
     block->final_feedrate = final_feedrate;
 }                    
 
-void TimeEstimateCalculator::plan(Position newPos, double feedrate)
+void TimeEstimateCalculator::plan(Position newPos, double feedrate, PrintFeatureType feature)
 {
     Block block;
     memset(&block, 0, sizeof(block));
-    
+
+    block.feature = feature;
+
     block.maxTravel = 0;
     for(unsigned int n=0; n<NUM_AXIS; n++)
     {

--- a/src/timeEstimate.h
+++ b/src/timeEstimate.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <vector>
 
+#include "PrintFeature.h"
+
 namespace cura
 {
 
@@ -54,6 +56,8 @@ public:
         double acceleration;
         Position delta;
         Position absDelta;
+
+        PrintFeatureType feature;
     };
 
 private:
@@ -80,7 +84,7 @@ public:
      */
     void setFirmwareDefaults(const SettingsBaseVirtual* settings_base);
     void setPosition(Position newPos);
-    void plan(Position newPos, double feedRate);
+    void plan(Position newPos, double feedRate, PrintFeatureType feature);
     void addTime(double time);
     void setAcceleration(double acc); //!< Set the default acceleration to \p acc
     void setMaxXyJerk(double jerk); //!< Set the max xy jerk to \p jerk

--- a/src/timeEstimate.h
+++ b/src/timeEstimate.h
@@ -93,7 +93,7 @@ public:
 
     void reset();
     
-    std::unordered_map<PrintFeatureType, double> calculate();
+    std::vector<double> calculate();
 private:
     void reverse_pass();
     void forward_pass();

--- a/src/timeEstimate.h
+++ b/src/timeEstimate.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <unordered_map>
 
 #include "PrintFeature.h"
 
@@ -92,7 +93,7 @@ public:
 
     void reset();
     
-    double calculate();
+    std::unordered_map<PrintFeatureType, double> calculate();
 private:
     void reverse_pass();
     void forward_pass();


### PR DESCRIPTION
This PR lets curaengine send a time estimate for each of the print features, like support, infill, skin, etc. That lets you know where the printer spends most of its time, so you can adjust the speeds more effectively. For example you could see that the print takes 9h but 7h of that is skin, then changing the skin speed is better than changing the outer wall speed.

The normal time estimate looks the same but it only lists the details of each print feature in the tooltip of the normal time estimate. I can't make a screenshot because it's a tooltip.

Uranium: https://github.com/Ultimaker/Uranium/pull/247
Cura: https://github.com/Ultimaker/Cura/pull/1794