### PR TITLE
M204 S argument deprecated

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1015,7 +1015,7 @@ void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
     {
         if (current_acceleration != acceleration)
         {
-            *output_stream << "M204 S" << PrecisionedDouble{0, acceleration} << new_line; // Print and Travel acceleration
+            *output_stream << "M204 P" << PrecisionedDouble{0, acceleration} << " T" << PrecisionedDouble{0, acceleration} << new_line; // Print and Travel acceleration
             current_acceleration = acceleration;
             estimateCalculator.setAcceleration(acceleration);
         }


### PR DESCRIPTION
RRF does not support S as an option and it has been deprecated in Marlin.  This uses the newer P and T options.

https://github.com/MarlinFirmware/Marlin/blob/1.1.x/Marlin/Marlin_main.cpp#L7581

http://marlinfw.org/docs/gcode/M204.html