### PR TITLE
Make user specified z seam position immune to position of part on platform

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -160,7 +160,7 @@ unsigned int FffGcodeWriter::findSpiralizedLayerSeamVertexIndex(const SliceDataS
         Point seam_pos(0, 0);
         if (mesh.getSettingAsZSeamType("z_seam_type") == EZSeamType::USER_SPECIFIED)
         {
-            seam_pos = Point(mesh.getSettingInMicrons("z_seam_x"), mesh.getSettingInMicrons("z_seam_y"));
+            seam_pos = mesh.getZSeamOrigin();
         }
         return PolygonUtils::findClosest(seam_pos, layer.parts[0].insets[0][0]).point_idx;
     }
@@ -965,8 +965,7 @@ void FffGcodeWriter::addMeshLayerToGCode_meshSurfaceMode(const SliceDataStorage&
     }
 
     EZSeamType z_seam_type = mesh.getSettingAsZSeamType("z_seam_type");
-    Point z_seam_pos(mesh.getSettingInMicrons("z_seam_x"), mesh.getSettingInMicrons("z_seam_y"));
-    gcode_layer.addPolygonsByOptimizer(polygons, &mesh_config.inset0_config, nullptr, z_seam_type, z_seam_pos, mesh.getSettingInMicrons("wall_0_wipe_dist"), getSettingBoolean("magic_spiralize"));
+    gcode_layer.addPolygonsByOptimizer(polygons, &mesh_config.inset0_config, nullptr, z_seam_type, mesh.getZSeamOrigin(), mesh.getSettingInMicrons("wall_0_wipe_dist"), getSettingBoolean("magic_spiralize"));
 
     addMeshOpenPolyLinesToGCode(mesh, mesh_config, gcode_layer, layer_nr);
 }
@@ -1014,9 +1013,8 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
 
 
     EZSeamType z_seam_type = mesh.getSettingAsZSeamType("z_seam_type");
-    Point z_seam_pos(mesh.getSettingInMicrons("z_seam_x"), mesh.getSettingInMicrons("z_seam_y"));
     Point layer_start_position = Point(train->getSettingInMicrons("layer_start_x"), train->getSettingInMicrons("layer_start_y"));
-    PathOrderOptimizer part_order_optimizer(layer_start_position, z_seam_pos, z_seam_type);
+    PathOrderOptimizer part_order_optimizer(layer_start_position, mesh.getZSeamOrigin(), z_seam_type);
     for(unsigned int partNr = 0; partNr < layer.parts.size(); partNr++)
     {
         part_order_optimizer.addPolygon(layer.parts[partNr].insets[0][0]);
@@ -1057,8 +1055,7 @@ void FffGcodeWriter::addMeshPartToGCode(const SliceDataStorage& storage, const S
     }
 
     EZSeamType z_seam_type = mesh.getSettingAsZSeamType("z_seam_type");
-    Point z_seam_pos(mesh.getSettingInMicrons("z_seam_x"), mesh.getSettingInMicrons("z_seam_y"));
-    added_something = added_something | processInsets(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, layer_nr, z_seam_type, z_seam_pos);
+    added_something = added_something | processInsets(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, layer_nr, z_seam_type, mesh.getZSeamOrigin());
 
     if (!mesh.getSettingBoolean("infill_before_walls"))
     {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -886,17 +886,20 @@ std::vector<unsigned int> FffGcodeWriter::getUsedExtrudersOnLayerExcludingStarti
     return ret;
 }
 
-std::vector<unsigned int> FffGcodeWriter::calculateMeshOrder(const SliceDataStorage& storage, int extruder_nr) const
+std::vector<unsigned int> FffGcodeWriter::calculateMeshOrder(SliceDataStorage& storage, int extruder_nr) const
 {
     OrderOptimizer<unsigned int> mesh_idx_order_optimizer;
 
     for (unsigned int mesh_idx = 0; mesh_idx < storage.meshes.size(); mesh_idx++)
     {
-        const SliceMeshStorage& mesh = storage.meshes[mesh_idx];
+        SliceMeshStorage& mesh = storage.meshes[mesh_idx];
         if (mesh.getExtruderIsUsed(extruder_nr))
         {
             const Mesh& mesh_data = storage.meshgroup->meshes[mesh_idx];
             const Point3 middle = (mesh_data.getAABB().min + mesh_data.getAABB().max) / 2;
+            mesh.middle.x = middle.x;
+            mesh.middle.y = middle.y;
+            mesh.middle.z = middle.z;
             mesh_idx_order_optimizer.addItem(Point(middle.x, middle.y), mesh_idx);
         }
     }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -886,20 +886,17 @@ std::vector<unsigned int> FffGcodeWriter::getUsedExtrudersOnLayerExcludingStarti
     return ret;
 }
 
-std::vector<unsigned int> FffGcodeWriter::calculateMeshOrder(SliceDataStorage& storage, int extruder_nr) const
+std::vector<unsigned int> FffGcodeWriter::calculateMeshOrder(const SliceDataStorage& storage, int extruder_nr) const
 {
     OrderOptimizer<unsigned int> mesh_idx_order_optimizer;
 
     for (unsigned int mesh_idx = 0; mesh_idx < storage.meshes.size(); mesh_idx++)
     {
-        SliceMeshStorage& mesh = storage.meshes[mesh_idx];
+        const SliceMeshStorage& mesh = storage.meshes[mesh_idx];
         if (mesh.getExtruderIsUsed(extruder_nr))
         {
             const Mesh& mesh_data = storage.meshgroup->meshes[mesh_idx];
             const Point3 middle = (mesh_data.getAABB().min + mesh_data.getAABB().max) / 2;
-            mesh.middle.x = middle.x;
-            mesh.middle.y = middle.y;
-            mesh.middle.z = middle.z;
             mesh_idx_order_optimizer.addItem(Point(middle.x, middle.y), mesh_idx);
         }
     }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -160,7 +160,7 @@ unsigned int FffGcodeWriter::findSpiralizedLayerSeamVertexIndex(const SliceDataS
         Point seam_pos(0, 0);
         if (mesh.getSettingAsZSeamType("z_seam_type") == EZSeamType::USER_SPECIFIED)
         {
-            seam_pos = mesh.getZSeamOrigin();
+            seam_pos = mesh.getZSeamHint();
         }
         return PolygonUtils::findClosest(seam_pos, layer.parts[0].insets[0][0]).point_idx;
     }
@@ -962,7 +962,7 @@ void FffGcodeWriter::addMeshLayerToGCode_meshSurfaceMode(const SliceDataStorage&
     }
 
     EZSeamType z_seam_type = mesh.getSettingAsZSeamType("z_seam_type");
-    gcode_layer.addPolygonsByOptimizer(polygons, &mesh_config.inset0_config, nullptr, z_seam_type, mesh.getZSeamOrigin(), mesh.getSettingInMicrons("wall_0_wipe_dist"), getSettingBoolean("magic_spiralize"));
+    gcode_layer.addPolygonsByOptimizer(polygons, &mesh_config.inset0_config, nullptr, z_seam_type, mesh.getZSeamHint(), mesh.getSettingInMicrons("wall_0_wipe_dist"), getSettingBoolean("magic_spiralize"));
 
     addMeshOpenPolyLinesToGCode(mesh, mesh_config, gcode_layer, layer_nr);
 }
@@ -1011,7 +1011,7 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
 
     EZSeamType z_seam_type = mesh.getSettingAsZSeamType("z_seam_type");
     Point layer_start_position = Point(train->getSettingInMicrons("layer_start_x"), train->getSettingInMicrons("layer_start_y"));
-    PathOrderOptimizer part_order_optimizer(layer_start_position, mesh.getZSeamOrigin(), z_seam_type);
+    PathOrderOptimizer part_order_optimizer(layer_start_position, mesh.getZSeamHint(), z_seam_type);
     for(unsigned int partNr = 0; partNr < layer.parts.size(); partNr++)
     {
         part_order_optimizer.addPolygon(layer.parts[partNr].insets[0][0]);
@@ -1052,7 +1052,7 @@ void FffGcodeWriter::addMeshPartToGCode(const SliceDataStorage& storage, const S
     }
 
     EZSeamType z_seam_type = mesh.getSettingAsZSeamType("z_seam_type");
-    added_something = added_something | processInsets(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, layer_nr, z_seam_type, mesh.getZSeamOrigin());
+    added_something = added_something | processInsets(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, layer_nr, z_seam_type, mesh.getZSeamHint());
 
     if (!mesh.getSettingBoolean("infill_before_walls"))
     {

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -312,7 +312,7 @@ private:
      * \param extruder_nr The extruder for which to determine the order
      * \return A vector of mesh indices ordered on print order for that extruder.
      */
-    std::vector<unsigned int> calculateMeshOrder(const SliceDataStorage& storage, int extruder_nr) const;
+    std::vector<unsigned int> calculateMeshOrder(SliceDataStorage& storage, int extruder_nr) const;
 
     /*!
      * Add a single layer from a single mesh-volume to the layer plan \p gcodeLayer in mesh surface mode.

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -312,7 +312,7 @@ private:
      * \param extruder_nr The extruder for which to determine the order
      * \return A vector of mesh indices ordered on print order for that extruder.
      */
-    std::vector<unsigned int> calculateMeshOrder(SliceDataStorage& storage, int extruder_nr) const;
+    std::vector<unsigned int> calculateMeshOrder(const SliceDataStorage& storage, int extruder_nr) const;
 
     /*!
      * Add a single layer from a single mesh-volume to the layer plan \p gcodeLayer in mesh surface mode.

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -192,6 +192,17 @@ bool SliceMeshStorage::getExtruderIsUsed(int extruder_nr, int layer_nr) const
     return false;
 }
 
+Point SliceMeshStorage::getZSeamHint() const
+{
+    Point pos(getSettingInMicrons("z_seam_x"), getSettingInMicrons("z_seam_y"));
+    if (getSettingBoolean("z_seam_relative"))
+    {
+        Point3 middle = bounding_box.getMiddle();
+        pos += Point(middle.x, middle.y);
+    }
+    return pos;
+}
+
 std::vector<RetractionConfig> SliceDataStorage::initializeRetractionConfigs()
 {
     std::vector<RetractionConfig> ret;

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -212,10 +212,15 @@ public:
     bool getExtruderIsUsed(int extruder_nr, int layer_nr) const;
 
     /*!
-     * \return the start point on each layer as specified by the user relative to centre of the mesh's bounding box
+     * \return the mesh's user specified z seam hint
      */
     Point getZSeamOrigin() const {
-        return Point(middle.x + getSettingInMicrons("z_seam_x"), middle.y + getSettingInMicrons("z_seam_y"));
+        Point pos(getSettingInMicrons("z_seam_x"), getSettingInMicrons("z_seam_y"));
+        if(getSettingBoolean("z_seam_relative"))
+        {
+            pos += Point(middle.x, middle.y);
+        }
+        return pos;
     }
 };
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -184,11 +184,13 @@ public:
 
     std::vector<int> infill_angles; //!< a list of angle values (in degrees) which is cycled through to determine the infill angle of each layer
     std::vector<int> skin_angles; //!< a list of angle values (in degrees) which is cycled through to determine the skin angle of each layer
+    Point3 middle; //!< the middle of the mesh's AABB
     SubDivCube* base_subdiv_cube;
 
     SliceMeshStorage(SettingsBaseVirtual* settings, unsigned int slice_layer_count)
     : SettingsMessenger(settings)
     , layer_nr_max_filled_layer(0)
+    , middle(0, 0, 0)
     , base_subdiv_cube(nullptr)
     {
         layers.resize(slice_layer_count);

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -210,6 +210,13 @@ public:
      * \return whether a particular extruder is used by this mesh on a particular layer
      */
     bool getExtruderIsUsed(int extruder_nr, int layer_nr) const;
+
+    /*!
+     * \return the start point on each layer as specified by the user relative to centre of the mesh's bounding box
+     */
+    Point getZSeamOrigin() const {
+        return Point(middle.x + getSettingInMicrons("z_seam_x"), middle.y + getSettingInMicrons("z_seam_y"));
+    }
 };
 
 class SliceDataStorage : public SettingsMessenger, NoCopy

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -214,14 +214,7 @@ public:
     /*!
      * \return the mesh's user specified z seam hint
      */
-    Point getZSeamOrigin() const {
-        Point pos(getSettingInMicrons("z_seam_x"), getSettingInMicrons("z_seam_y"));
-        if(getSettingBoolean("z_seam_relative"))
-        {
-            pos += Point(middle.x, middle.y);
-        }
-        return pos;
-    }
+    Point getZSeamHint() const;
 };
 
 class SliceDataStorage : public SettingsMessenger, NoCopy

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -184,13 +184,13 @@ public:
 
     std::vector<int> infill_angles; //!< a list of angle values (in degrees) which is cycled through to determine the infill angle of each layer
     std::vector<int> skin_angles; //!< a list of angle values (in degrees) which is cycled through to determine the skin angle of each layer
-    Point3 middle; //!< the middle of the mesh's AABB
+    AABB3D bounding_box; //!< the mesh's bounding box
     SubDivCube* base_subdiv_cube;
 
-    SliceMeshStorage(SettingsBaseVirtual* settings, unsigned int slice_layer_count)
-    : SettingsMessenger(settings)
+    SliceMeshStorage(Mesh* mesh, unsigned int slice_layer_count)
+    : SettingsMessenger(mesh)
     , layer_nr_max_filled_layer(0)
-    , middle(0, 0, 0)
+    , bounding_box(mesh->getAABB())
     , base_subdiv_cube(nullptr)
     {
         layers.resize(slice_layer_count);


### PR DESCRIPTION
What this PR does is make the user specified z seam origin relative to the mesh's BB rather than being an
absolute position on the platform. The rational behind this is that without the PR, the z seam will change position depending on where the part is on the platform. With the PR, the z seam will not change position when the part is moved and if the part is multiplied, all the parts will have exactly the same z seams.

This appears to work OK but should we have a setting to control whether the z seam position is absolute (as it is now) or relative (as in this PR)?