### PR TITLE
Add setting to change horizontal expansion for layer 0

### DIFF
--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -766,7 +766,9 @@ void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool ext
     for (PolygonRef polyline : open_polylines)
     {
         if (polyline.size() > 0)
+        {
             openPolylines.add(polyline);
+        }
     }
 
     //Remove all the tiny polygons, or polygons that are not closed. As they do not contribute to the actual print.
@@ -780,8 +782,10 @@ void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool ext
     polygons.removeDegenerateVerts(); // remove verts connected to overlapping line segments
 
     int xy_offset = mesh->getSettingInMicrons("xy_offset");
-    if(is_initial_layer)
+    if (is_initial_layer)
+    {
         xy_offset = mesh->getSettingInMicrons("xy_offset_layer_0");
+    }
 
     if (xy_offset != 0)
     {

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -734,7 +734,7 @@ ClosePolygonResult SlicerLayer::findPolygonPointClosestTo(Point input)
     return ret;
 }
 
-void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool extensive_stitching)
+void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool extensive_stitching, bool is_initial_layer)
 {
     Polygons open_polylines;
 
@@ -780,6 +780,9 @@ void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool ext
     polygons.removeDegenerateVerts(); // remove verts connected to overlapping line segments
 
     int xy_offset = mesh->getSettingInMicrons("xy_offset");
+    if(is_initial_layer)
+        xy_offset = mesh->getSettingInMicrons("xy_offset_layer_0");
+
     if (xy_offset != 0)
     {
         polygons = polygons.offset(xy_offset);
@@ -892,7 +895,7 @@ Slicer::Slicer(Mesh* mesh, int initial, int thickness, int slice_layer_count, bo
 #pragma omp parallel for default(none) shared(mesh,layers_ref) firstprivate(keep_none_closed, extensive_stitching)
     for(unsigned int layer_nr=0; layer_nr<layers_ref.size(); layer_nr++)
     {
-        layers_ref[layer_nr].makePolygons(mesh, keep_none_closed, extensive_stitching);
+        layers_ref[layer_nr].makePolygons(mesh, keep_none_closed, extensive_stitching, layer_nr == 0);
     }
 
     mesh->expandXY(mesh->getSettingInMicrons("xy_offset"));

--- a/src/slicer.h
+++ b/src/slicer.h
@@ -57,10 +57,11 @@ public:
      * Connect the segments into polygons for this layer of this \p mesh
      *
      * \param[in] mesh The mesh data for which we are connecting sliced segments (The face data is used)
-     * \param keepNoneClosed Whether to throw away the data for segments which we couldn't stitch into a polygon
-     * \param extensiveStitching Whether to perform extra work to try and close polylines into polygons when there are large gaps
+     * \param keep_none_closed Whether to throw away the data for segments which we couldn't stitch into a polygon
+     * \param extensive_stitching Whether to perform extra work to try and close polylines into polygons when there are large gaps
+     * \param is_initial_layer Whether this is the first layer of the mesh data
      */
-    void makePolygons(const Mesh* mesh, bool keepNoneClosed, bool extensiveStitching);
+    void makePolygons(const Mesh* mesh, bool keep_none_closed, bool extensive_stitching, bool is_initial_layer);
 
 protected:
     /*!


### PR DESCRIPTION
This PR adds functionality to change the Horizontal Expansion for the first layer only. This can be used to compensate for "elephant's foot".

See https://github.com/Ultimaker/Cura/issues/1573 for discussion
Also see Cura PR https://github.com/Ultimaker/Cura/pull/2031