### PR TITLE
Add support for real reprap flavor gcode

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1035,7 +1035,7 @@ void GCodeExport::writeJerk(double jerk)
         {
             *output_stream << "M207 X";
         }
-        else if(getFlavor() == EGCodeFlavor::REPRAP)
+        else if (getFlavor() == EGCodeFlavor::REPRAP)
         {
             *output_stream << "M566 X" << PrecisionedDouble{2, jerk * 60} << " Y" << PrecisionedDouble{2, jerk * 60} << new_line;
         }

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -36,7 +36,7 @@ GCodeExport::GCodeExport()
     current_max_z_feedrate = -1;
 
     isZHopped = 0;
-    setFlavor(EGCodeFlavor::REPRAP);
+    setFlavor(EGCodeFlavor::MARLIN);
     initial_bed_temp = 0;
 
     extruder_count = 0;
@@ -254,7 +254,7 @@ void GCodeExport::setFlavor(EGCodeFlavor flavor)
     else
         for(int n=0; n<MAX_EXTRUDERS; n++)
             extruder_attr[n].extruderCharacter = 'E';
-    if (flavor == EGCodeFlavor::ULTIGCODE || flavor == EGCodeFlavor::REPRAP_VOLUMATRIC)
+    if (flavor == EGCodeFlavor::ULTIGCODE || flavor == EGCodeFlavor::MARLIN_VOLUMATRIC)
     {
         is_volumatric = true;
     }
@@ -263,7 +263,7 @@ void GCodeExport::setFlavor(EGCodeFlavor flavor)
         is_volumatric = false;
     }
 
-    if (flavor == EGCodeFlavor::BFB || flavor == EGCodeFlavor::REPRAP_VOLUMATRIC || flavor == EGCodeFlavor::ULTIGCODE)
+    if (flavor == EGCodeFlavor::BFB || flavor == EGCodeFlavor::MARLIN_VOLUMATRIC || flavor == EGCodeFlavor::ULTIGCODE)
     {
         firmware_retract = true;
     }
@@ -1013,7 +1013,7 @@ void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
         if (current_acceleration != acceleration)
         {
             // Print and Travel acceleration
-            if (getFlavor() == EGCodeFlavor::REPRAP_REPRAP)
+            if (getFlavor() == EGCodeFlavor::REPRAP)
             {
                 *output_stream << "M201" << " X" << PrecisionedDouble{0, acceleration} << " Y" << PrecisionedDouble{0, acceleration} << new_line;
             }
@@ -1035,7 +1035,7 @@ void GCodeExport::writeJerk(double jerk)
         {
             *output_stream << "M207 X";
         }
-        else if(getFlavor() == EGCodeFlavor::REPRAP_REPRAP)
+        else if(getFlavor() == EGCodeFlavor::REPRAP)
         {
             *output_stream << "M566 X" << PrecisionedDouble{2, jerk * 60} << " Y" << PrecisionedDouble{2, jerk * 60} << new_line;
         }
@@ -1053,7 +1053,7 @@ void GCodeExport::writeMaxZFeedrate(double max_z_feedrate)
 {
     if (current_max_z_feedrate != max_z_feedrate)
     {
-        if (getFlavor() == EGCodeFlavor::REPRAP_REPRAP)
+        if (getFlavor() == EGCodeFlavor::REPRAP)
         {
             *output_stream << "M203 Z" << PrecisionedDouble{2, max_z_feedrate * 60} << new_line;
         }

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1015,7 +1015,7 @@ void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
             // Print and Travel acceleration
             if (getFlavor() == EGCodeFlavor::REPRAP)
             {
-                *output_stream << "M201" << " X" << PrecisionedDouble{0, acceleration} << " Y" << PrecisionedDouble{0, acceleration} << new_line;
+                *output_stream << "M204" << " P" << PrecisionedDouble{0, acceleration} << " T" << PrecisionedDouble{0, acceleration} << new_line;
             }
             else
             {

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1012,7 +1012,15 @@ void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
     {
         if (current_acceleration != acceleration)
         {
-            *output_stream << "M204 S" << PrecisionedDouble{0, acceleration} << new_line; // Print and Travel acceleration
+            // Print and Travel acceleration
+            if (getFlavor() == EGCodeFlavor::REPRAP_REPRAP)
+            {
+                *output_stream << "M201" << " X" << PrecisionedDouble{0, acceleration} << " Y" << PrecisionedDouble{0, acceleration} << new_line;
+            }
+            else
+            {
+                *output_stream << "M204 S" << PrecisionedDouble{0, acceleration} << new_line;
+            }
             current_acceleration = acceleration;
             estimateCalculator.setAcceleration(acceleration);
         }
@@ -1026,6 +1034,10 @@ void GCodeExport::writeJerk(double jerk)
         if (getFlavor() == EGCodeFlavor::REPETIER)
         {
             *output_stream << "M207 X";
+        }
+        else if(getFlavor() == EGCodeFlavor::REPRAP_REPRAP)
+        {
+            *output_stream << "M566 X" << PrecisionedDouble{2, jerk * 60} << " Y" << PrecisionedDouble{2, jerk * 60} << new_line;
         }
         else
         {
@@ -1041,7 +1053,14 @@ void GCodeExport::writeMaxZFeedrate(double max_z_feedrate)
 {
     if (current_max_z_feedrate != max_z_feedrate)
     {
-        *output_stream << "M203 Z" << PrecisionedDouble{2, max_z_feedrate} << new_line;
+        if (getFlavor() == EGCodeFlavor::REPRAP_REPRAP)
+        {
+            *output_stream << "M203 Z" << PrecisionedDouble{2, max_z_feedrate * 60} << new_line;
+        }
+        else
+        {
+            *output_stream << "M203 Z" << PrecisionedDouble{2, max_z_feedrate} << new_line;
+        }
         current_max_z_feedrate = max_z_feedrate;
         estimateCalculator.setMaxZFeedrate(max_z_feedrate);
     }

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1031,19 +1031,18 @@ void GCodeExport::writeJerk(double jerk)
 {
     if (current_jerk != jerk)
     {
-        if (getFlavor() == EGCodeFlavor::REPETIER)
+        switch (getFlavor())
         {
-            *output_stream << "M207 X";
+            case EGCodeFlavor::REPETIER:
+                *output_stream << "M207 X" << PrecisionedDouble{2, jerk} << new_line;
+                break;
+            case EGCodeFlavor::REPRAP:
+                *output_stream << "M566 X" << PrecisionedDouble{2, jerk * 60} << " Y" << PrecisionedDouble{2, jerk * 60} << new_line;
+                break;
+            default:
+                *output_stream << "M205 X" << PrecisionedDouble{2, jerk} << " Y" << PrecisionedDouble{2, jerk} << new_line;
+                break;
         }
-        else if (getFlavor() == EGCodeFlavor::REPRAP)
-        {
-            *output_stream << "M566 X" << PrecisionedDouble{2, jerk * 60} << " Y" << PrecisionedDouble{2, jerk * 60} << new_line;
-        }
-        else
-        {
-            *output_stream << "M205 X" << PrecisionedDouble{2, jerk} << " Y";
-        }
-        *output_stream << PrecisionedDouble{2, jerk} << new_line;
         current_jerk = jerk;
         estimateCalculator.setMaxXyJerk(jerk);
     }

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -29,17 +29,17 @@ std::string toString(EGCodeFlavor flavor)
             return "Makerbot";
         case EGCodeFlavor::ULTIGCODE:
             return "UltiGCode";
-        case EGCodeFlavor::REPRAP_VOLUMATRIC:
-            return "RepRap(Volumetric)";
+        case EGCodeFlavor::MARLIN_VOLUMATRIC:
+            return "Marlin(Volumetric)";
         case EGCodeFlavor::GRIFFIN:
             return "Griffin";
         case EGCodeFlavor::REPETIER:
             return "Repetier";
-        case EGCodeFlavor::REPRAP_REPRAP:
-            return "RepRap(RepRap)";
         case EGCodeFlavor::REPRAP:
-        default:
             return "RepRap";
+        case EGCodeFlavor::MARLIN:
+        default:
+            return "Marlin";
     }
 }
 
@@ -350,12 +350,12 @@ EGCodeFlavor SettingsBaseVirtual::getSettingAsGCodeFlavor(std::string key) const
     else if (value == "MACH3")
         return EGCodeFlavor::MACH3;
     else if (value == "RepRap (Volumatric)")
-        return EGCodeFlavor::REPRAP_VOLUMATRIC;
+        return EGCodeFlavor::MARLIN_VOLUMATRIC;
     else if (value == "Repetier")
         return EGCodeFlavor::REPETIER;
     else if (value == "RepRap (RepRap)")
-        return EGCodeFlavor::REPRAP_REPRAP;
-    return EGCodeFlavor::REPRAP;
+        return EGCodeFlavor::REPRAP;
+    return EGCodeFlavor::MARLIN;
 }
 
 EFillMethod SettingsBaseVirtual::getSettingAsFillMethod(std::string key) const

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -35,6 +35,8 @@ std::string toString(EGCodeFlavor flavor)
             return "Griffin";
         case EGCodeFlavor::REPETIER:
             return "Repetier";
+        case EGCodeFlavor::REPRAP_REPRAP:
+            return "RepRap(RepRap)";
         case EGCodeFlavor::REPRAP:
         default:
             return "RepRap";
@@ -351,6 +353,8 @@ EGCodeFlavor SettingsBaseVirtual::getSettingAsGCodeFlavor(std::string key) const
         return EGCodeFlavor::REPRAP_VOLUMATRIC;
     else if (value == "Repetier")
         return EGCodeFlavor::REPETIER;
+    else if (value == "RepRap (RepRap)")
+        return EGCodeFlavor::REPRAP_REPRAP;
     return EGCodeFlavor::REPRAP;
 }
 

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -25,14 +25,14 @@ namespace cura
 enum class EGCodeFlavor
 {
 /**
- * RepRap flavored GCode is Marlin/Sprinter/Repetier based GCode.
+ * Marlin flavored GCode is Marlin/Sprinter based GCode.
  *  This is the most commonly used GCode set.
  *  G0 for moves, G1 for extrusion.
  *  E values give mm of filament extrusion.
  *  Retraction is done on E values with G1. Start/end code is added.
  *  M106 Sxxx and M107 are used to turn the fan on/off.
  **/
-    REPRAP = 0,
+    MARLIN = 0,
 /**
  * UltiGCode flavored is Marlin based GCode.
  *  UltiGCode uses less settings on the slicer and puts more settings in the firmware. This makes for more hardware/material independed GCode.
@@ -75,7 +75,7 @@ enum class EGCodeFlavor
  *  Retraction is done with G10 and G11. Retraction settings are ignored. G10 S1 is used for multi-extruder switch retraction.
  *  M106 Sxxx and M107 are used to turn the fan on/off.
  **/
-    REPRAP_VOLUMATRIC = 5,
+    MARLIN_VOLUMATRIC = 5,
 /**
  * Griffin flavored is Marlin based GCode.
  *  This is a type of RepRap used for machines with multiple extruder trains.
@@ -92,7 +92,7 @@ enum class EGCodeFlavor
 /**
  * Real RepRap GCode suitable for printers using RepRap firmware (e.g. Duet controllers)
  **/
-    REPRAP_REPRAP = 8,
+    REPRAP = 8,
 };
 
 /*!

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -88,6 +88,11 @@ enum class EGCodeFlavor
     GRIFFIN = 6,
 
     REPETIER = 7,
+
+/**
+ * Real RepRap GCode suitable for printers using RepRap firmware (e.g. Duet controllers)
+ **/
+    REPRAP_REPRAP = 8,
 };
 
 /*!


### PR DESCRIPTION
Rather than trying to code around the support for legacy Marlin, I think it's better to have a new gcode flavor that is compatible with the RepRap firmware. This PR adds the REPRAP_REPRAP gcode flavor and adds the ability to output acceleration, jerk and max z feedrate in gcode suitable for that firmware.