### PR TITLE
Mb travel accel mods

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1881,7 +1881,8 @@ void FffGcodeWriter::finalize()
     }
     if (getSettingBoolean("acceleration_enabled"))
     {
-        gcode.writeAcceleration(getSettingInMillimetersPerSecond("machine_acceleration"));
+        gcode.writePrintAcceleration(getSettingInMillimetersPerSecond("machine_acceleration"));
+        gcode.writeTravelAcceleration(getSettingInMillimetersPerSecond("machine_acceleration"));
     }
     if (getSettingBoolean("jerk_enabled"))
     {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -811,7 +811,14 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
             if (acceleration_enabled)
             {
-                gcode.writeAcceleration(path.config->getAcceleration(), path.config->isTravelPath());
+                if (path.config->isTravelPath())
+                {
+                    gcode.writeTravelAcceleration(path.config->getAcceleration());
+                }
+                else
+                {
+                    gcode.writePrintAcceleration(path.config->getAcceleration());
+                }
             }
             if (jerk_enabled)
             {

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1005,7 +1005,6 @@ void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
         if (m_code != 0)
         {
             *output_stream << "M" << m_code << " X" << PrecisionedDouble{0, acceleration} << " Y" << PrecisionedDouble{0, acceleration} << new_line;
-            estimateCalculator.setAcceleration(acceleration);
         }
     }
     else
@@ -1022,9 +1021,9 @@ void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
                 *output_stream << "M204 S" << PrecisionedDouble{0, acceleration} << new_line;
             }
             current_acceleration = acceleration;
-            estimateCalculator.setAcceleration(acceleration);
         }
     }
+    estimateCalculator.setAcceleration(acceleration);
 }
 
 void GCodeExport::writeJerk(double jerk)

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1007,19 +1007,33 @@ void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
             *output_stream << "M" << m_code << " X" << PrecisionedDouble{0, acceleration} << " Y" << PrecisionedDouble{0, acceleration} << new_line;
         }
     }
+    else if (getFlavor() == EGCodeFlavor::REPRAP)
+    {
+        if (for_travel_moves)
+        {
+            if (current_travel_acceleration != acceleration)
+            {
+                // set travel acceleration
+                *output_stream << "M204 T" << PrecisionedDouble{0, acceleration} << new_line;
+                current_travel_acceleration = acceleration;
+            }
+        }
+        else
+        {
+            if (current_acceleration != acceleration)
+            {
+                // set print acceleration
+                *output_stream << "M204 P" << PrecisionedDouble{0, acceleration} << new_line;
+                current_acceleration = acceleration;
+            }
+        }
+    }
     else
     {
         if (current_acceleration != acceleration)
         {
             // Print and Travel acceleration
-            if (getFlavor() == EGCodeFlavor::REPRAP)
-            {
-                *output_stream << "M204" << " P" << PrecisionedDouble{0, acceleration} << " T" << PrecisionedDouble{0, acceleration} << new_line;
-            }
-            else
-            {
-                *output_stream << "M204 S" << PrecisionedDouble{0, acceleration} << new_line;
-            }
+            *output_stream << "M204 S" << PrecisionedDouble{0, acceleration} << new_line;
             current_acceleration = acceleration;
         }
     }

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1030,6 +1030,7 @@ void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
     }
     else
     {
+        // MARLIN, etc.
         if (current_acceleration != acceleration)
         {
             // Print and Travel acceleration

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -30,7 +30,7 @@ GCodeExport::GCodeExport()
     total_print_times = std::vector<double>(static_cast<unsigned char>(PrintFeatureType::NumPrintFeatureTypes), 0.0);
 
     currentSpeed = 1;
-    current_acceleration = -1;
+    current_print_acceleration = -1;
     current_travel_acceleration = -1;
     current_jerk = -1;
     current_max_z_feedrate = -1;
@@ -981,63 +981,56 @@ void GCodeExport::writeBedTemperatureCommand(double temperature, bool wait)
     *output_stream << PrecisionedDouble{1, temperature} << new_line;
 }
 
-void GCodeExport::writeAcceleration(double acceleration, bool for_travel_moves)
+void GCodeExport::writePrintAcceleration(double acceleration)
 {
-    if (getFlavor() == EGCodeFlavor::REPETIER)
+    switch (getFlavor())
     {
-        int m_code = 0;
-        if (for_travel_moves)
-        {
-            if (current_travel_acceleration != acceleration)
+        case EGCodeFlavor::REPETIER:
+            if (current_print_acceleration != acceleration)
             {
-                m_code = 202;   // set travel acceleration
-                current_travel_acceleration = acceleration;
+                *output_stream << "M201 X" << PrecisionedDouble{0, acceleration} << " Y" << PrecisionedDouble{0, acceleration} << new_line;
             }
-        }
-        else
-        {
-            if (current_acceleration != acceleration)
+            break;
+        case EGCodeFlavor::REPRAP:
+            if (current_print_acceleration != acceleration)
             {
-                m_code = 201;  // set print acceleration
-                current_acceleration = acceleration;
-            }
-        }
-        if (m_code != 0)
-        {
-            *output_stream << "M" << m_code << " X" << PrecisionedDouble{0, acceleration} << " Y" << PrecisionedDouble{0, acceleration} << new_line;
-        }
-    }
-    else if (getFlavor() == EGCodeFlavor::REPRAP)
-    {
-        if (for_travel_moves)
-        {
-            if (current_travel_acceleration != acceleration)
-            {
-                // set travel acceleration
-                *output_stream << "M204 T" << PrecisionedDouble{0, acceleration} << new_line;
-                current_travel_acceleration = acceleration;
-            }
-        }
-        else
-        {
-            if (current_acceleration != acceleration)
-            {
-                // set print acceleration
                 *output_stream << "M204 P" << PrecisionedDouble{0, acceleration} << new_line;
-                current_acceleration = acceleration;
             }
-        }
+            break;
+        default:
+            // MARLIN, etc. only have one acceleration for both print and travel
+            if (current_print_acceleration != acceleration)
+            {
+                *output_stream << "M204 S" << PrecisionedDouble{0, acceleration} << new_line;
+            }
+            break;
     }
-    else
+    current_print_acceleration = acceleration;
+    estimateCalculator.setAcceleration(acceleration);
+}
+
+void GCodeExport::writeTravelAcceleration(double acceleration)
+{
+    switch (getFlavor())
     {
-        // MARLIN, etc.
-        if (current_acceleration != acceleration)
-        {
-            // Print and Travel acceleration
-            *output_stream << "M204 S" << PrecisionedDouble{0, acceleration} << new_line;
-            current_acceleration = acceleration;
-        }
+        case EGCodeFlavor::REPETIER:
+            if (current_travel_acceleration != acceleration)
+            {
+                *output_stream << "M202 X" << PrecisionedDouble{0, acceleration} << " Y" << PrecisionedDouble{0, acceleration} << new_line;
+            }
+            break;
+        case EGCodeFlavor::REPRAP:
+            if (current_travel_acceleration != acceleration)
+            {
+                *output_stream << "M204 T" << PrecisionedDouble{0, acceleration} << new_line;
+            }
+            break;
+        default:
+            // MARLIN, etc. only have one acceleration for both print and travel
+            writePrintAcceleration(acceleration);
+            break;
     }
+    current_travel_acceleration = acceleration;
     estimateCalculator.setAcceleration(acceleration);
 }
 

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -100,8 +100,8 @@ private:
     double current_e_value; //!< The last E value written to gcode (in mm or mm^3)
     Point3 currentPosition; //!< The last build plate coordinates written to gcode (which might be different from actually written gcode coordinates when the extruder offset is encoded in the gcode)
     double currentSpeed; //!< The current speed (F values / 60) in mm/s
-    double current_acceleration; //!< The current acceleration in the XY direction (in mm/s^2)
-    double current_travel_acceleration; //!< The current acceleration in the XY direction used for travel moves if different from current_acceleration (in mm/s^2) (Only used for Repetier flavor)
+    double current_print_acceleration; //!< The current acceleration (in mm/s^2) used for print moves (and also for travel moves if the gcode flavor doesn't have separate travel acceleration)
+    double current_travel_acceleration; //!< The current acceleration (in mm/s^2) used for travel moves for those gcode flavors that have separate print and travel accelerations
     double current_jerk; //!< The current jerk in the XY direction (in mm/s^3)
     double current_max_z_feedrate; //!< The current max z speed (in mm/s)
 
@@ -415,9 +415,14 @@ public:
     void writeBedTemperatureCommand(double temperature, bool wait = false);
 
     /*!
-     * Write the command for setting the acceleration to a specific value
+     * Write the command for setting the acceleration for print moves to a specific value
      */
-    void writeAcceleration(double acceleration, bool for_travel_moves = false);
+    void writePrintAcceleration(double acceleration);
+
+    /*!
+     * Write the command for setting the acceleration for travel moves to a specific value
+     */
+    void writeTravelAcceleration(double acceleration);
 
     /*!
      * Write the command for setting the jerk to a specific value


### PR DESCRIPTION
This little PR fixes a small bug when generating repetier flavor gcode (the time estimate calculator was not getting updated as it should) and adds support for separate print and travel accelerations in reprap gcode.