### PR TITLE
Correct the infill mesh areas added to the comb boundary when combing mode is NO_SKIN.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -156,7 +156,7 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode)
                         // for infill mesh parts, add the outlines of its skin parts to the comb boundary
                         for (const SkinPart& skin_part : part.skin_parts)
                         {
-                            comb_boundary.add(skin_part.outline[0]);
+                            comb_boundary.add(skin_part.outline.outerPolygon());
                         }
                     }
                     else

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -146,27 +146,17 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode)
         for (const SliceMeshStorage& mesh : storage.meshes)
         {
             const SliceLayer& layer = mesh.layers[layer_nr];
-            const bool is_infill_mesh = mesh.getSettingBoolean("infill_mesh");
+            if (mesh.getSettingBoolean("infill_mesh")) {
+                continue;
+            }
             if (mesh.getSettingAsCombingMode("retraction_combing") == CombingMode::NO_SKIN)
             {
                 for (const SliceLayerPart& part : layer.parts)
                 {
-                    if (is_infill_mesh)
-                    {
-                        // for infill mesh parts, add the outlines of its skin parts to the comb boundary
-                        for (const SkinPart& skin_part : part.skin_parts)
-                        {
-                            comb_boundary.add(skin_part.outline.outerPolygon());
-                        }
-                    }
-                    else
-                    {
-                        // for non-infill mesh parts, add the outline of its infill to the comb boundary
-                        comb_boundary.add(part.infill_area);
-                    }
+                    comb_boundary.add(part.infill_area);
                 }
             }
-            else if (!is_infill_mesh)
+            else
             {
                 layer.getSecondOrInnermostWalls(comb_boundary);
             }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -146,19 +146,28 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode)
         for (const SliceMeshStorage& mesh : storage.meshes)
         {
             const SliceLayer& layer = mesh.layers[layer_nr];
+            const bool is_infill_mesh = mesh.getSettingBoolean("infill_mesh");
             if (mesh.getSettingAsCombingMode("retraction_combing") == CombingMode::NO_SKIN)
             {
                 for (const SliceLayerPart& part : layer.parts)
                 {
-                    comb_boundary.add(part.infill_area);
+                    if (is_infill_mesh)
+                    {
+                        // for infill mesh parts, add the outlines of its skin parts to the comb boundary
+                        for (const SkinPart& skin_part : part.skin_parts)
+                        {
+                            comb_boundary.add(skin_part.outline[0]);
+                        }
+                    }
+                    else
+                    {
+                        // for non-infill mesh parts, add the outline of its infill to the comb boundary
+                        comb_boundary.add(part.infill_area);
+                    }
                 }
             }
-            else
+            else if (!is_infill_mesh)
             {
-                if (mesh.getSettingBoolean("infill_mesh"))
-                {
-                    continue;
-                }
                 layer.getSecondOrInnermostWalls(comb_boundary);
             }
         }


### PR DESCRIPTION
It was adding the area of the infill mesh's infill but this just makes a hole in the
comb boundary the shape of the infill mesh. Now, it adds the outlines of the skin areas
in the infill mesh (rather than the infill area).

Fixes #560.