### PR TITLE
Added cool_fan_min_layer setting

### DIFF
--- a/src/FanSpeedLayerTime.h
+++ b/src/FanSpeedLayerTime.h
@@ -15,6 +15,7 @@ public:
     double cool_fan_speed_min;
     double cool_fan_speed_max;
     double cool_min_speed;
+    int cool_fan_min_layer;
     int cool_fan_full_layer;
 };
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -273,6 +273,7 @@ void FffGcodeWriter::setConfigFanSpeedLayerTime(SliceDataStorage& storage)
         fan_speed_layer_time_settings.cool_fan_speed_min = train->getSettingInPercentage("cool_fan_speed_min");
         fan_speed_layer_time_settings.cool_fan_speed_max = train->getSettingInPercentage("cool_fan_speed_max");
         fan_speed_layer_time_settings.cool_min_speed = train->getSettingInMillimetersPerSecond("cool_min_speed");
+        fan_speed_layer_time_settings.cool_fan_min_layer = train->getSettingAsLayerNumber("cool_fan_min_layer");
         fan_speed_layer_time_settings.cool_fan_full_layer = train->getSettingAsLayerNumber("cool_fan_full_layer");
         if (!train->getSettingBoolean("cool_fan_enabled"))
         {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -720,7 +720,7 @@ void ExtruderPlan::processFanSpeedAndMinimalLayerTime(bool force_minimal_layer_t
         && !this->is_raft_layer // don't apply initial layer fan speed speedup to raft, but to model layers
     )
     {
-        //Slow down the fan on the layers below the [cool_fan_full_layer], where layer 0 is speed 0.
+        // Slow down the fan on the layers below the [cool_fan_full_layer], where layer cool_fan_min_layer is speed cool_fan_speed_0.
         fan_speed = fan_speed_layer_time_settings.cool_fan_speed_0 + (fan_speed - fan_speed_layer_time_settings.cool_fan_speed_0) * std::max(0, layer_nr - fan_speed_layer_time_settings.cool_fan_min_layer) / (fan_speed_layer_time_settings.cool_fan_full_layer - fan_speed_layer_time_settings.cool_fan_min_layer);
     }
 }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -715,7 +715,7 @@ void ExtruderPlan::processFanSpeedAndMinimalLayerTime(bool force_minimal_layer_t
     */
     if (layer_nr < fan_speed_layer_time_settings.cool_fan_full_layer
         && layer_nr >= fan_speed_layer_time_settings.cool_fan_min_layer
-        && totalLayerTime > fan_speed_layer_time_settings.cool_min_layer_time_fan_speed_max
+        && (!force_minimal_layer_time || totalLayerTime > fan_speed_layer_time_settings.cool_min_layer_time_fan_speed_max)
         && fan_speed_layer_time_settings.cool_fan_full_layer > 0 // don't apply initial layer fan speed speedup if disabled.
         && !this->is_raft_layer // don't apply initial layer fan speed speedup to raft, but to model layers
     )

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -650,7 +650,7 @@ TimeMaterialEstimates ExtruderPlan::computeNaiveTimeEstimates(Point starting_pos
 
 void ExtruderPlan::processFanSpeedAndMinimalLayerTime(bool force_minimal_layer_time, Point starting_position)
 {
-    TimeMaterialEstimates estimates = computeNaiveTimeEstimates(starting_position);
+    computeNaiveTimeEstimates(starting_position);
     totalPrintTime = estimates.getTotalTime();
     if (force_minimal_layer_time)
     {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -594,7 +594,6 @@ void ExtruderPlan::forceMinimalLayerTime(double minTime, double minimalSpeed, do
 }
 TimeMaterialEstimates ExtruderPlan::computeNaiveTimeEstimates(Point starting_position)
 {
-    TimeMaterialEstimates ret;
     Point p0 = starting_position;
 
     bool was_retracted = false; // wrong assumption; won't matter that much. (TODO)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -687,7 +687,8 @@ void ExtruderPlan::processFanSpeedAndMinimalLayerTime(bool force_minimal_layer_t
     {
         fan_speed = fan_speed_layer_time_settings.cool_fan_speed_max;
     }
-    else if (force_minimal_layer_time && totalLayerTime < fan_speed_layer_time_settings.cool_min_layer_time_fan_speed_max)
+    else if (force_minimal_layer_time && totalLayerTime < fan_speed_layer_time_settings.cool_min_layer_time_fan_speed_max &&
+             fan_speed_layer_time_settings.cool_min_layer_time_fan_speed_max > fan_speed_layer_time_settings.cool_min_layer_time)
     { 
         // when forceMinimalLayerTime didn't change the extrusionSpeedFactor, we adjust the fan speed
         double fan_speed_diff = fan_speed_layer_time_settings.cool_fan_speed_max - fan_speed_layer_time_settings.cool_fan_speed_min;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -715,6 +715,7 @@ void ExtruderPlan::processFanSpeedAndMinimalLayerTime(bool force_minimal_layer_t
     */
     if (layer_nr < fan_speed_layer_time_settings.cool_fan_full_layer
         && layer_nr >= fan_speed_layer_time_settings.cool_fan_min_layer
+        && totalLayerTime > fan_speed_layer_time_settings.cool_min_layer_time_fan_speed_max
         && fan_speed_layer_time_settings.cool_fan_full_layer > 0 // don't apply initial layer fan speed speedup if disabled.
         && !this->is_raft_layer // don't apply initial layer fan speed speedup to raft, but to model layers
     )


### PR DESCRIPTION

The fans are off until this layer is reached. Then the normal ramp up to max speed occurs.

When set to the default value of 0, the original behaviour is preserved.