### PR TITLE
Rename GCodePath::getLineWidth() to GCodePath::getLineWidthForLayerView().

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -900,7 +900,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         && shorterThen(paths[path_idx+2].points.back() - paths[path_idx+1].points.back(), 2 * nozzle_size) // consecutive extrusion is close by
                     )
                     {
-                        sendLineTo(paths[path_idx+2].config->type, paths[path_idx+2].points.back(), paths[path_idx+2].getLineWidth());
+                        sendLineTo(paths[path_idx+2].config->type, paths[path_idx+2].points.back(), paths[path_idx+2].getLineWidthForLayerView());
                         gcode.writeExtrusion(paths[path_idx+2].points.back(), speed, paths[path_idx+1].getExtrusionMM3perMM(), paths[path_idx+2].config->type);
                         path_idx += 2;
                     }
@@ -908,7 +908,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                     {
                         for(unsigned int point_idx = 0; point_idx < path.points.size(); point_idx++)
                         {
-                            sendLineTo(path.config->type, path.points[point_idx], path.getLineWidth());
+                            sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
                             gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), path.config->type);
                         }
                     }
@@ -942,7 +942,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         length += vSizeMM(p0 - p1);
                         p0 = p1;
                         gcode.setZ(z + layer_thickness * length / totalLength);
-                        sendLineTo(path.config->type, path.points[point_idx], path.getLineWidth());
+                        sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
                         gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), path.config->type);
                     }
                     // for layer display only - the loop finished at the seam vertex but as we started from
@@ -954,7 +954,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                     // vertex would not be shifted (as it's the last vertex in the sequence). The smoother the model,
                     // the less the vertices are shifted and the less obvious is the ridge. If the layer display
                     // really displayed a spiral rather than slices of a spiral, this would not be required.
-                    sendLineTo(path.config->type, path.points[0], path.getLineWidth());
+                    sendLineTo(path.config->type, path.points[0], path.getLineWidthForLayerView());
                 }
                 path_idx--; // the last path_idx didnt spiralize, so it's not part of the current spiralize path
             }
@@ -1120,10 +1120,10 @@ bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, unsigned int extruder_
     { // write normal extrude path:
         for(unsigned int point_idx = 0; point_idx <= point_idx_before_start; point_idx++)
         {
-            sendLineTo(path.config->type, path.points[point_idx], path.getLineWidth());
+            sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
             gcode.writeExtrusion(path.points[point_idx], extrude_speed, path.getExtrusionMM3perMM(), path.config->type);
         }
-        sendLineTo(path.config->type, start, path.getLineWidth());
+        sendLineTo(path.config->type, start, path.getLineWidthForLayerView());
         gcode.writeExtrusion(start, extrude_speed, path.getExtrusionMM3perMM(), path.config->type);
     }
 

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -18,7 +18,7 @@ void MergeInfillLines::writeCompensatedMove(Point& to, double speed, GCodePath& 
         double speed_mod = old_line_width / new_line_width_mm;
         new_speed = std::min(speed * speed_mod, speed_equalize_flow_max);
     }
-    sendLineTo(last_path.config->type, to, last_path.getLineWidth());
+    sendLineTo(last_path.config->type, to, last_path.getLineWidthForLayerView());
     gcode.writeExtrusion(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod, last_path.config->type);
 }
     

--- a/src/pathPlanning/GCodePath.cpp
+++ b/src/pathPlanning/GCodePath.cpp
@@ -31,7 +31,7 @@ double GCodePath::getExtrusionMM3perMM()
     return flow * config->getExtrusionMM3perMM();
 }
 
-int GCodePath::getLineWidth()
+int GCodePath::getLineWidthForLayerView()
 {
     return flow * config->getLineWidth() * config->getFlowPercentage() / 100.0;
 }

--- a/src/pathPlanning/GCodePath.h
+++ b/src/pathPlanning/GCodePath.h
@@ -74,7 +74,7 @@ public:
      * Get the actual line width (modulated by the flow)
      * \return the actual line width as shown in layer view
      */
-    int getLineWidth();
+    int getLineWidthForLayerView();
 };
 
 }//namespace cura


### PR DESCRIPTION
This avoids confusion as there's another getLineWidth() in use.