### PR TITLE
[For discussion] Overlap area computation changes

### DIFF
--- a/src/utils/PolygonProximityLinker.cpp
+++ b/src/utils/PolygonProximityLinker.cpp
@@ -191,11 +191,15 @@ void PolygonProximityLinker::findProximatePoints(const ListPolyIt a_point_it, Li
 
     int64_t dist = sqrt(dist2);
 
-    if (shorterThen(closest - b_from, 10))
+    // increased these distances - previously they were 10 and that had the effect of creating very short
+    // line segments that typically occurred when you have a tube section that has two walls surrounding a hole
+    // and the outer wall is printed after the inner wall - the short segments that are introduced are not getting
+    // flow reduced and so you get an ugly spike on the layer view where each short segment occurs
+    if (shorterThen(closest - b_from, 50))
     {
         addProximityLink(a_point_it, b_from_it, dist, ProximityPointLinkType::NORMAL);
     }
-    else if (shorterThen(closest - b_to, 10))
+    else if (shorterThen(closest - b_to, 50))
     {
         addProximityLink(a_point_it, b_to_it, dist, ProximityPointLinkType::NORMAL);
     }

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -133,21 +133,11 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
     // check whether the line segment overlaps with the point if one of the line segments is just a point
     if (from == to)
     {
-        if (LinearAlg2D::pointIsProjectedBeyondLine(from, other_from, other_to) != 0)
-        {
-            return 0;
-        }
-        const int64_t overlap_length_2 = vSize(other_to - other_from); //Twice the length of the overlap area, alongside the lines.
-        return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
+        return 0;
     }
     if (other_from == other_to)
     {
-        if (LinearAlg2D::pointIsProjectedBeyondLine(other_from, from, to) != 0)
-        {
-            return 0;
-        }
-        const int64_t overlap_length_2 = vSize(from - to); //Twice the length of the overlap area, alongside the lines.
-        return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
+        return 0;
     }
 
     short from_rel = LinearAlg2D::pointIsProjectedBeyondLine(from, other_from, other_to);

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -170,7 +170,9 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
         const Point vec = from - to;
         const int64_t other_to_proj = dot(other_to - to, vec) / vSize(vec);
 
-        const int64_t overlap_length_2 = to_proj + other_to_proj; //Twice the length of the overlap area, alongside the lines.
+        // calculate the overlap area as the length of the region where the lines overlap times the width of that region which is
+        // the line width minus the average distance between the two lines
+        const int64_t overlap_length_2 = to_proj + other_to_proj;
         const int64_t overlap_width_2 = line_width * 2 - std::sqrt(LinearAlg2D::getDist2FromLineSegment(from, other_to, to)) - std::sqrt(LinearAlg2D::getDist2FromLineSegment(other_from, to, other_to));
         return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
     }
@@ -191,7 +193,9 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
         const Point vec = to - from;
         const int64_t other_from_proj = dot(other_from - from, vec) / vSize(vec);
 
-        const int64_t overlap_length_2 = from_proj + other_from_proj; //Twice the length of the overlap area, alongside the lines.
+        // calculate the overlap area as the length of the region where the lines overlap times the width of that region which is
+        // the line width minus the average distance between the two lines
+        const int64_t overlap_length_2 = from_proj + other_from_proj;
         const int64_t overlap_width_2 = line_width * 2 - std::sqrt(LinearAlg2D::getDist2FromLineSegment(from, other_from, to)) - std::sqrt(LinearAlg2D::getDist2FromLineSegment(other_from, from, other_to));
         return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
     }
@@ -199,6 +203,8 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
     // shortest segment is overlapped completely - use the length of whichever segment is shortest
     const int64_t len = vSize(to - from);
     const int64_t other_len = vSize(other_to - other_from);
+    // calculate the overlap area as the length of the region where the lines overlap times the width of that region which is
+    // the line width minus the average distance between the two lines
     if (len <= other_len)
     {
         const int64_t overlap_width_2 = line_width * 2 - std::sqrt(LinearAlg2D::getDist2FromLineSegment(other_from, from, other_to)) - std::sqrt(LinearAlg2D::getDist2FromLineSegment(other_from, to, other_to));

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -62,6 +62,7 @@ float WallOverlapComputation::getFlow(const Point& from, const Point& to)
         //           to other
 
         bool are_in_same_general_direction = dot(from - to, to_other_it.p() - to_other_next_it.p()) > 0;
+#if 0
         // handle multiple points  linked to [to]
         //   o<<<T<<<F
         //     / |
@@ -85,7 +86,7 @@ float WallOverlapComputation::getFlow(const Point& from, const Point& to)
         {
             overlap_area += handlePotentialOverlap(from_it, to_it, to_link, to_other_it, to_other_it);
         }
-
+#endif
         // handle normal case where the segment from-to overlaps with another segment
         //   o<<<T<<<F
         //       |   |

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -172,6 +172,7 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
         const int64_t other_to_proj = dot(other_to - to, vec) / vSize(vec);
 
         const int64_t overlap_length_2 = to_proj + other_to_proj; //Twice the length of the overlap area, alongside the lines.
+        const int64_t overlap_width_2 = line_width * 2 - std::sqrt(LinearAlg2D::getDist2FromLineSegment(from, other_to, to)) - std::sqrt(LinearAlg2D::getDist2FromLineSegment(other_from, to, other_to));
         return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
     }
     if (to_rel != 0 && to_rel == other_to_rel && from_rel == 0 && other_from_rel == 0)
@@ -192,6 +193,7 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
         const int64_t other_from_proj = dot(other_from - from, vec) / vSize(vec);
 
         const int64_t overlap_length_2 = from_proj + other_from_proj; //Twice the length of the overlap area, alongside the lines.
+        const int64_t overlap_width_2 = line_width * 2 - std::sqrt(LinearAlg2D::getDist2FromLineSegment(from, other_from, to)) - std::sqrt(LinearAlg2D::getDist2FromLineSegment(other_from, from, other_to));
         return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
     }
 

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -195,11 +195,8 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
         return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
     }
 
-    //More complex case.
-    const Point from_middle = other_to + from; // don't divide by two just yet
-    const Point to_middle = other_from + to; // don't divide by two just yet
-
-    const int64_t overlap_length_2 = vSize(from_middle - to_middle); //(An approximation of) twice the length of the overlap area, alongside the lines.
+    // use the length of whichever segment is shortest
+    const int64_t overlap_length_2 = 2 * std::min(vSize(to - from), vSize(other_to - other_from));
     return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
 }
 

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -128,8 +128,6 @@ int64_t WallOverlapComputation::handlePotentialOverlap(const ListPolyIt from_it,
 
 int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Point to, const int64_t to_dist, const Point other_from, const Point other_to, const int64_t from_dist)
 {
-    const int64_t overlap_width_2 = line_width * 2 - from_dist - to_dist; //Twice the width of the overlap area, perpendicular to the lines.
-
     // check whether the line segment overlaps with the point if one of the line segments is just a point
     if (from == to)
     {

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -150,54 +150,7 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
         // O<------O   .            O------>O
         //         :   :                     \_
         //         '   O------->O             O------>O
-
-        // It used to return 0 here but that doesn't work very well when you have a curved wall that overlaps
-        // with another wall that has a smaller radius (i.e. when you have concentric circular walls one inside the other.
-
-        // It was reducing the width of the segments between the "corners" but at each corner there was a spike because
-        // the width was not being reduced at all, so it looked like this: ____/\____/\____ (this shows the ___ segments in
-        // a straight line but, of course, in reality their orientation would be changing as they progress around the curved wall).
-
-        // So I have this "theory" that at each of the corners, there's a little diamond shaped area that wasn't getting flow reduced
-        // when 0 was being returned and, therefore, the code below tries to approximate an area for that little diamond shape.
-
-        // It's pure speculation but does appear to remove almost all of the spikes.
-
-        const int64_t len = vSize(to - from);
-        const int64_t other_len = vSize(other_to - other_from);
-        int64_t overlap_width_2 = line_width * 2;
-        if (len <= other_len)
-        {
-            // use length of from -> to
-            if (from_rel < 0)
-            {
-                // segment is closer to other_from
-                overlap_width_2 -= 2 * std::min(vSize(to - other_from), vSize(from - other_from));
-            }
-            else
-            {
-                // segment is closer to other_to
-                overlap_width_2 -= 2 * std::min(vSize(to - other_to), vSize(from - other_to));
-            }
-            const int64_t overlap_length_2 = len * 2;
-            return overlap_length_2 * overlap_width_2 / 4;
-        }
-        else
-        {
-            // use length of other_from -> other_to
-            if (other_from_rel < 0)
-            {
-                // segment is closer to from
-                overlap_width_2 -= 2 * std::min(vSize(other_to - from), vSize(other_from - from));
-            }
-            else
-            {
-                // segment is closer to to
-                overlap_width_2 -= 2 * std::min(vSize(other_to - to), vSize(other_from - to));
-            }
-            const int64_t overlap_length_2 = other_len * 2;
-            return overlap_length_2 * overlap_width_2 / 4;
-        }
+        return 0;
     }
 
     if (from_rel != 0 && from_rel == other_from_rel && to_rel == 0 && other_to_rel == 0)

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -197,9 +197,21 @@ int64_t WallOverlapComputation::getApproxOverlapArea(const Point from, const Poi
         return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
     }
 
-    // use the length of whichever segment is shortest
-    const int64_t overlap_length_2 = 2 * std::min(vSize(to - from), vSize(other_to - other_from));
-    return overlap_length_2 * overlap_width_2 / 4; //Area = width * height.
+    // shortest segment is overlapped completely - use the length of whichever segment is shortest
+    const int64_t len = vSize(to - from);
+    const int64_t other_len = vSize(other_to - other_from);
+    if (len <= other_len)
+    {
+        const int64_t overlap_width_2 = line_width * 2 - std::sqrt(LinearAlg2D::getDist2FromLineSegment(other_from, from, other_to)) - std::sqrt(LinearAlg2D::getDist2FromLineSegment(other_from, to, other_to));
+        const int64_t overlap_length_2 = len * 2;
+        return overlap_length_2 * overlap_width_2 / 4;
+    }
+    else
+    {
+        const int64_t overlap_width_2 = line_width * 2 - std::sqrt(LinearAlg2D::getDist2FromLineSegment(from, other_from, to)) - std::sqrt(LinearAlg2D::getDist2FromLineSegment(from, other_to, to));
+        const int64_t overlap_length_2 = other_len * 2;
+        return overlap_length_2 * overlap_width_2 / 4;
+    }
 }
 
 bool WallOverlapComputation::getIsPassed(const ProximityPointLink& link_a, const ProximityPointLink& link_b)

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -109,7 +109,7 @@ float WallOverlapComputation::getFlow(const Point& from, const Point& to)
 
 int64_t WallOverlapComputation::handlePotentialOverlap(const ListPolyIt from_it, const ListPolyIt to_it, const ProximityPointLink& to_link, const ListPolyIt from_other_it, const ListPolyIt to_other_it)
 {
-    if (from_it == to_other_it && from_it == from_other_it)
+    if (from_it == to_other_it && to_it == from_other_it)
     { // don't compute overlap with a line and itself
         return 0;
     }


### PR DESCRIPTION
These are the changes I refer to in #577. I am currently using this code and it gives better results (when viewed in the layer view) than the original code. The original code is too aggressive when you have a cylinder with walls whose thickness is such that overlap compensation occurs. In that situation, one of the walls reduces to almost nothing when it shouldn't.
As I've mentioned before, I don't really understand the original code and the comments are not sufficient to really get a grip on what it is doing so it would be good if the original author(s) could chime in here.