### PR TITLE
Implemented separate flow setting for layer 0

### DIFF
--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -27,7 +27,7 @@ std::vector<double> PathConfigStorage::getLineWidthFactorPerExtruder(const Slice
     return ret;
 }
 
-GCodePathConfig createPerimeterGapConfig(const SliceMeshStorage& mesh, int layer_thickness)
+GCodePathConfig createPerimeterGapConfig(const SliceMeshStorage& mesh, int layer_nr, int layer_thickness)
 {
     // The perimeter gap config follows the skin config, but has a different line width:
     // wall_line_width_x divided by two because the gaps are between 0 and 1 times the wall line width
@@ -42,49 +42,49 @@ GCodePathConfig createPerimeterGapConfig(const SliceMeshStorage& mesh, int layer
             PrintFeatureType::Skin
             , perimeter_gaps_line_width
             , layer_thickness
-            , mesh.getSettingInPercentage("material_flow")
+            , ((layer_nr == 0) ? mesh.getSettingInPercentage("material_flow_layer_0") : mesh.getSettingInPercentage("material_flow"))
             , GCodePathConfig::SpeedDerivatives{perimeter_gaps_speed, mesh.getSettingInMillimetersPerSecond("acceleration_topbottom"), mesh.getSettingInMillimetersPerSecond("jerk_topbottom")}
         );
 }
 
-PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder)
+PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, int layer_nr, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder)
 : inset0_config(
     PrintFeatureType::OuterWall
     , mesh.getSettingInMicrons("wall_line_width_0") * line_width_factor_per_extruder[mesh.getSettingAsExtruderNr("wall_0_extruder_nr")]
     , layer_thickness
-    , mesh.getSettingInPercentage("material_flow")
+    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_wall_0"), mesh.getSettingInMillimetersPerSecond("acceleration_wall_0"), mesh.getSettingInMillimetersPerSecond("jerk_wall_0")}
 )
 , insetX_config(
     PrintFeatureType::InnerWall
     , mesh.getSettingInMicrons("wall_line_width_x") * line_width_factor_per_extruder[mesh.getSettingAsExtruderNr("wall_x_extruder_nr")]
     , layer_thickness
-    , mesh.getSettingInPercentage("material_flow")
+    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_wall_x"), mesh.getSettingInMillimetersPerSecond("acceleration_wall_x"), mesh.getSettingInMillimetersPerSecond("jerk_wall_x")}
 )
 , skin_config(
     PrintFeatureType::Skin
     , mesh.getSettingInMicrons("skin_line_width") * line_width_factor_per_extruder[mesh.getSettingAsExtruderNr("top_bottom_extruder_nr")]
     , layer_thickness
-    , mesh.getSettingInPercentage("material_flow")
+    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_topbottom"), mesh.getSettingInMillimetersPerSecond("acceleration_topbottom"), mesh.getSettingInMillimetersPerSecond("jerk_topbottom")}
 )
 , roofing_config(
     PrintFeatureType::Skin
     , mesh.getSettingInMicrons("roofing_line_width")
     , layer_thickness
-    , mesh.getSettingInPercentage("material_flow")
+    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_roofing"), mesh.getSettingInMillimetersPerSecond("acceleration_roofing"), mesh.getSettingInMillimetersPerSecond("jerk_roofing")}
 )
 , ironing_config(
     PrintFeatureType::Skin
     , mesh.getSettingInMicrons("skin_line_width")
     , layer_thickness
-    , mesh.getSettingInPercentage("material_flow")
+    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_ironing"), mesh.getSettingInMillimetersPerSecond("acceleration_ironing"), mesh.getSettingInMillimetersPerSecond("jerk_ironing")}
 )
 
-, perimeter_gap_config(createPerimeterGapConfig(mesh, layer_thickness))
+, perimeter_gap_config(createPerimeterGapConfig(mesh, layer_nr, layer_thickness))
 {
     infill_config.reserve(MAX_INFILL_COMBINE);
     for (int combine_idx = 0; combine_idx < MAX_INFILL_COMBINE; combine_idx++)
@@ -93,7 +93,7 @@ PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh
                 PrintFeatureType::Infill
                 , mesh.getSettingInMicrons("infill_line_width") * (combine_idx + 1) * line_width_factor_per_extruder[mesh.getSettingAsExtruderNr("infill_extruder_nr")]
                 , layer_thickness
-                , mesh.getSettingInPercentage("material_flow")
+                , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
                 , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_infill"), mesh.getSettingInMillimetersPerSecond("acceleration_infill"), mesh.getSettingInMillimetersPerSecond("jerk_infill")}
             );
     }
@@ -113,35 +113,35 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
             PrintFeatureType::SupportInterface
             , adhesion_extruder_train->getSettingInMicrons("raft_base_line_width")
             , adhesion_extruder_train->getSettingInMicrons("raft_base_thickness")
-            , adhesion_extruder_train->getSettingInPercentage("material_flow")
+            , adhesion_extruder_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_base_speed"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_base_acceleration"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_base_jerk")}
         )
 , raft_interface_config(
             PrintFeatureType::Support
             , adhesion_extruder_train->getSettingInMicrons("raft_interface_line_width")
             , adhesion_extruder_train->getSettingInMicrons("raft_interface_thickness")
-            , adhesion_extruder_train->getSettingInPercentage("material_flow")
+            , adhesion_extruder_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_interface_speed"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_interface_acceleration"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_interface_jerk")}
         )
 , raft_surface_config(
             PrintFeatureType::SupportInterface
             , adhesion_extruder_train->getSettingInMicrons("raft_surface_line_width")
             , adhesion_extruder_train->getSettingInMicrons("raft_surface_thickness")
-            , adhesion_extruder_train->getSettingInPercentage("material_flow")
+            , adhesion_extruder_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_surface_speed"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_surface_acceleration"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_surface_jerk")}
         )
 , support_roof_config(
             PrintFeatureType::SupportInterface
             , support_roof_train->getSettingInMicrons("support_roof_line_width") * line_width_factor_per_extruder[support_roof_extruder_nr]
             , layer_thickness
-            , support_roof_train->getSettingInPercentage("material_flow")
+            , support_roof_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
             , GCodePathConfig::SpeedDerivatives{support_roof_train->getSettingInMillimetersPerSecond("speed_support_roof"), support_roof_train->getSettingInMillimetersPerSecond("acceleration_support_roof"), support_roof_train->getSettingInMillimetersPerSecond("jerk_support_roof")}
         )
 , support_bottom_config(
             PrintFeatureType::SupportInterface
             , support_bottom_train->getSettingInMicrons("support_bottom_line_width") * line_width_factor_per_extruder[support_bottom_extruder_nr]
             , layer_thickness
-            , support_bottom_train->getSettingInPercentage("material_flow")
+            , support_bottom_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
             , GCodePathConfig::SpeedDerivatives{support_bottom_train->getSettingInMillimetersPerSecond("speed_support_bottom"), support_bottom_train->getSettingInMillimetersPerSecond("acceleration_support_bottom"), support_bottom_train->getSettingInMillimetersPerSecond("jerk_support_bottom")}
         )
 {
@@ -164,7 +164,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
                 , train->getSettingInMicrons("skirt_brim_line_width")
                     * ((storage.getSettingAsPlatformAdhesion("adhesion_type") == EPlatformAdhesion::RAFT) ? 1.0 : line_width_factor_per_extruder[extruder_nr]) // cause it's also used for the draft/ooze shield
                 , layer_thickness
-                , train->getSettingInPercentage("material_flow")
+                , train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
                 , GCodePathConfig::SpeedDerivatives{train->getSettingInMillimetersPerSecond("skirt_brim_speed"), train->getSettingInMillimetersPerSecond("acceleration_skirt_brim"), train->getSettingInMillimetersPerSecond("jerk_skirt_brim")}
             );
         prime_tower_config_per_extruder.emplace_back(
@@ -180,7 +180,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
     mesh_configs.reserve(storage.meshes.size());
     for (const SliceMeshStorage& mesh_storage : storage.meshes)
     {
-        mesh_configs.emplace_back(mesh_storage, layer_thickness, line_width_factor_per_extruder);
+        mesh_configs.emplace_back(mesh_storage, layer_nr, layer_thickness, line_width_factor_per_extruder);
     }
 
     support_infill_config.reserve(MAX_INFILL_COMBINE);
@@ -191,7 +191,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
             PrintFeatureType::Support
             , support_infill_train->getSettingInMicrons("support_line_width") * (combine_idx + 1) * support_infill_line_width_factor
             , layer_thickness
-            , support_infill_train->getSettingInPercentage("material_flow")
+            , support_infill_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
             , GCodePathConfig::SpeedDerivatives{support_infill_train->getSettingInMillimetersPerSecond("speed_support_infill"), support_infill_train->getSettingInMillimetersPerSecond("acceleration_support_infill"), support_infill_train->getSettingInMillimetersPerSecond("jerk_support_infill")}
         );
     }

--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -203,10 +203,10 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
     }
 }
 
-void PathConfigStorage::MeshPathConfigs::smoothAllSpeeds(GCodePathConfig::SpeedDerivatives first_layer_config, int layer_nr, int max_speed_layer)
+void PathConfigStorage::MeshPathConfigs::smoothAllSpeeds(const GCodePathConfig::SpeedDerivatives& first_layer_config, const GCodePathConfig::SpeedDerivatives& first_layer_wall_config, int layer_nr, int max_speed_layer)
 {
-    inset0_config.smoothSpeed(              first_layer_config, layer_nr, max_speed_layer);
-    insetX_config.smoothSpeed(              first_layer_config, layer_nr, max_speed_layer);
+    inset0_config.smoothSpeed(              first_layer_wall_config, layer_nr, max_speed_layer);
+    insetX_config.smoothSpeed(              first_layer_wall_config, layer_nr, max_speed_layer);
     skin_config.smoothSpeed(                first_layer_config, layer_nr, max_speed_layer);
     ironing_config.smoothSpeed(             first_layer_config, layer_nr, max_speed_layer);
     perimeter_gap_config.smoothSpeed(       first_layer_config, layer_nr, max_speed_layer);
@@ -287,7 +287,13 @@ void cura::PathConfigStorage::handleInitialLayerSpeedup(const SliceDataStorage& 
                     , mesh.getSettingInMillimetersPerSecond("jerk_print_layer_0")
             };
 
-            mesh_configs[mesh_idx].smoothAllSpeeds(initial_layer_speed_config, layer_nr, initial_speedup_layer_count);
+            GCodePathConfig::SpeedDerivatives initial_layer_wall_speed_config{
+                    mesh.getSettingInMillimetersPerSecond("speed_walls_layer_0")
+                    , mesh.getSettingInMillimetersPerSecond("acceleration_walls_layer_0")
+                    , mesh.getSettingInMillimetersPerSecond("jerk_walls_layer_0")
+            };
+
+            mesh_configs[mesh_idx].smoothAllSpeeds(initial_layer_speed_config, initial_layer_wall_speed_config, layer_nr, initial_speedup_layer_count);
             mesh_configs[mesh_idx].roofing_config.smoothSpeed(initial_layer_speed_config, layer_nr, initial_speedup_layer_count);
         }
     }

--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -3,6 +3,7 @@
 
 #include "settings.h" // MAX_INFILL_COMBINE
 #include "../sliceDataStorage.h" // SliceDataStorage
+#include "../raft.h"
 
 
 namespace cura
@@ -27,7 +28,7 @@ std::vector<double> PathConfigStorage::getLineWidthFactorPerExtruder(const Slice
     return ret;
 }
 
-GCodePathConfig createPerimeterGapConfig(const SliceMeshStorage& mesh, int layer_nr, int layer_thickness)
+GCodePathConfig createPerimeterGapConfig(const SliceMeshStorage& mesh, const std::string& flow_setting_name, int layer_thickness)
 {
     // The perimeter gap config follows the skin config, but has a different line width:
     // wall_line_width_x divided by two because the gaps are between 0 and 1 times the wall line width
@@ -42,49 +43,49 @@ GCodePathConfig createPerimeterGapConfig(const SliceMeshStorage& mesh, int layer
             PrintFeatureType::Skin
             , perimeter_gaps_line_width
             , layer_thickness
-            , ((layer_nr == 0) ? mesh.getSettingInPercentage("material_flow_layer_0") : mesh.getSettingInPercentage("material_flow"))
+            , mesh.getSettingInPercentage(flow_setting_name)
             , GCodePathConfig::SpeedDerivatives{perimeter_gaps_speed, mesh.getSettingInMillimetersPerSecond("acceleration_topbottom"), mesh.getSettingInMillimetersPerSecond("jerk_topbottom")}
         );
 }
 
-PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, int layer_nr, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder)
+PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const std::string& flow_setting_name, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder)
 : inset0_config(
     PrintFeatureType::OuterWall
     , mesh.getSettingInMicrons("wall_line_width_0") * line_width_factor_per_extruder[mesh.getSettingAsExtruderNr("wall_0_extruder_nr")]
     , layer_thickness
-    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+    , mesh.getSettingInPercentage(flow_setting_name)
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_wall_0"), mesh.getSettingInMillimetersPerSecond("acceleration_wall_0"), mesh.getSettingInMillimetersPerSecond("jerk_wall_0")}
 )
 , insetX_config(
     PrintFeatureType::InnerWall
     , mesh.getSettingInMicrons("wall_line_width_x") * line_width_factor_per_extruder[mesh.getSettingAsExtruderNr("wall_x_extruder_nr")]
     , layer_thickness
-    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+    , mesh.getSettingInPercentage(flow_setting_name)
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_wall_x"), mesh.getSettingInMillimetersPerSecond("acceleration_wall_x"), mesh.getSettingInMillimetersPerSecond("jerk_wall_x")}
 )
 , skin_config(
     PrintFeatureType::Skin
     , mesh.getSettingInMicrons("skin_line_width") * line_width_factor_per_extruder[mesh.getSettingAsExtruderNr("top_bottom_extruder_nr")]
     , layer_thickness
-    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+    , mesh.getSettingInPercentage(flow_setting_name)
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_topbottom"), mesh.getSettingInMillimetersPerSecond("acceleration_topbottom"), mesh.getSettingInMillimetersPerSecond("jerk_topbottom")}
 )
 , roofing_config(
     PrintFeatureType::Skin
     , mesh.getSettingInMicrons("roofing_line_width")
     , layer_thickness
-    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+    , mesh.getSettingInPercentage(flow_setting_name)
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_roofing"), mesh.getSettingInMillimetersPerSecond("acceleration_roofing"), mesh.getSettingInMillimetersPerSecond("jerk_roofing")}
 )
 , ironing_config(
     PrintFeatureType::Skin
     , mesh.getSettingInMicrons("skin_line_width")
     , layer_thickness
-    , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+    , mesh.getSettingInPercentage(flow_setting_name)
     , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_ironing"), mesh.getSettingInMillimetersPerSecond("acceleration_ironing"), mesh.getSettingInMillimetersPerSecond("jerk_ironing")}
 )
 
-, perimeter_gap_config(createPerimeterGapConfig(mesh, layer_nr, layer_thickness))
+, perimeter_gap_config(createPerimeterGapConfig(mesh, flow_setting_name, layer_thickness))
 {
     infill_config.reserve(MAX_INFILL_COMBINE);
     for (int combine_idx = 0; combine_idx < MAX_INFILL_COMBINE; combine_idx++)
@@ -93,7 +94,7 @@ PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh
                 PrintFeatureType::Infill
                 , mesh.getSettingInMicrons("infill_line_width") * (combine_idx + 1) * line_width_factor_per_extruder[mesh.getSettingAsExtruderNr("infill_extruder_nr")]
                 , layer_thickness
-                , mesh.getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+                , mesh.getSettingInPercentage(flow_setting_name)
                 , GCodePathConfig::SpeedDerivatives{mesh.getSettingInMillimetersPerSecond("speed_infill"), mesh.getSettingInMillimetersPerSecond("acceleration_infill"), mesh.getSettingInMillimetersPerSecond("jerk_infill")}
             );
     }
@@ -109,39 +110,40 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
 , support_roof_train(storage.meshgroup->getExtruderTrain(support_roof_extruder_nr))
 , support_bottom_train(storage.meshgroup->getExtruderTrain(support_bottom_extruder_nr))
 , line_width_factor_per_extruder(PathConfigStorage::getLineWidthFactorPerExtruder(storage, layer_nr))
+, flow_setting_name((layer_nr == 0 - Raft::getTotalExtraLayers(storage)) ? "material_flow_layer_0" : "material_flow")
 , raft_base_config(
             PrintFeatureType::SupportInterface
             , adhesion_extruder_train->getSettingInMicrons("raft_base_line_width")
             , adhesion_extruder_train->getSettingInMicrons("raft_base_thickness")
-            , adhesion_extruder_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+            , adhesion_extruder_train->getSettingInPercentage(flow_setting_name)
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_base_speed"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_base_acceleration"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_base_jerk")}
         )
 , raft_interface_config(
             PrintFeatureType::Support
             , adhesion_extruder_train->getSettingInMicrons("raft_interface_line_width")
             , adhesion_extruder_train->getSettingInMicrons("raft_interface_thickness")
-            , adhesion_extruder_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+            , adhesion_extruder_train->getSettingInPercentage(flow_setting_name)
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_interface_speed"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_interface_acceleration"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_interface_jerk")}
         )
 , raft_surface_config(
             PrintFeatureType::SupportInterface
             , adhesion_extruder_train->getSettingInMicrons("raft_surface_line_width")
             , adhesion_extruder_train->getSettingInMicrons("raft_surface_thickness")
-            , adhesion_extruder_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+            , adhesion_extruder_train->getSettingInPercentage(flow_setting_name)
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_surface_speed"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_surface_acceleration"), adhesion_extruder_train->getSettingInMillimetersPerSecond("raft_surface_jerk")}
         )
 , support_roof_config(
             PrintFeatureType::SupportInterface
             , support_roof_train->getSettingInMicrons("support_roof_line_width") * line_width_factor_per_extruder[support_roof_extruder_nr]
             , layer_thickness
-            , support_roof_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+            , support_roof_train->getSettingInPercentage(flow_setting_name)
             , GCodePathConfig::SpeedDerivatives{support_roof_train->getSettingInMillimetersPerSecond("speed_support_roof"), support_roof_train->getSettingInMillimetersPerSecond("acceleration_support_roof"), support_roof_train->getSettingInMillimetersPerSecond("jerk_support_roof")}
         )
 , support_bottom_config(
             PrintFeatureType::SupportInterface
             , support_bottom_train->getSettingInMicrons("support_bottom_line_width") * line_width_factor_per_extruder[support_bottom_extruder_nr]
             , layer_thickness
-            , support_bottom_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+            , support_bottom_train->getSettingInPercentage(flow_setting_name)
             , GCodePathConfig::SpeedDerivatives{support_bottom_train->getSettingInMillimetersPerSecond("speed_support_bottom"), support_bottom_train->getSettingInMillimetersPerSecond("acceleration_support_bottom"), support_bottom_train->getSettingInMillimetersPerSecond("jerk_support_bottom")}
         )
 {
@@ -164,7 +166,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
                 , train->getSettingInMicrons("skirt_brim_line_width")
                     * ((storage.getSettingAsPlatformAdhesion("adhesion_type") == EPlatformAdhesion::RAFT) ? 1.0 : line_width_factor_per_extruder[extruder_nr]) // cause it's also used for the draft/ooze shield
                 , layer_thickness
-                , train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+                , train->getSettingInPercentage(flow_setting_name)
                 , GCodePathConfig::SpeedDerivatives{train->getSettingInMillimetersPerSecond("skirt_brim_speed"), train->getSettingInMillimetersPerSecond("acceleration_skirt_brim"), train->getSettingInMillimetersPerSecond("jerk_skirt_brim")}
             );
         prime_tower_config_per_extruder.emplace_back(
@@ -180,7 +182,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
     mesh_configs.reserve(storage.meshes.size());
     for (const SliceMeshStorage& mesh_storage : storage.meshes)
     {
-        mesh_configs.emplace_back(mesh_storage, layer_nr, layer_thickness, line_width_factor_per_extruder);
+        mesh_configs.emplace_back(mesh_storage, flow_setting_name, layer_thickness, line_width_factor_per_extruder);
     }
 
     support_infill_config.reserve(MAX_INFILL_COMBINE);
@@ -191,7 +193,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
             PrintFeatureType::Support
             , support_infill_train->getSettingInMicrons("support_line_width") * (combine_idx + 1) * support_infill_line_width_factor
             , layer_thickness
-            , support_infill_train->getSettingInPercentage((layer_nr == 0)? "material_flow_layer_0" : "material_flow")
+            , support_infill_train->getSettingInPercentage(flow_setting_name)
             , GCodePathConfig::SpeedDerivatives{support_infill_train->getSettingInMillimetersPerSecond("speed_support_infill"), support_infill_train->getSettingInMillimetersPerSecond("acceleration_support_infill"), support_infill_train->getSettingInMillimetersPerSecond("jerk_support_infill")}
         );
     }

--- a/src/settings/PathConfigStorage.h
+++ b/src/settings/PathConfigStorage.h
@@ -43,7 +43,7 @@ public:
         GCodePathConfig ironing_config;
         GCodePathConfig perimeter_gap_config;
 
-        MeshPathConfigs(const SliceMeshStorage& mesh, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder);
+        MeshPathConfigs(const SliceMeshStorage& mesh, int layer_nr, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder);
         void smoothAllSpeeds(const GCodePathConfig::SpeedDerivatives& first_layer_config, const GCodePathConfig::SpeedDerivatives& first_layer_wall_config, int layer_nr, int max_speed_layer);
     };
 

--- a/src/settings/PathConfigStorage.h
+++ b/src/settings/PathConfigStorage.h
@@ -44,7 +44,7 @@ public:
         GCodePathConfig perimeter_gap_config;
 
         MeshPathConfigs(const SliceMeshStorage& mesh, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder);
-        void smoothAllSpeeds(GCodePathConfig::SpeedDerivatives first_layer_config, int layer_nr, int max_speed_layer);
+        void smoothAllSpeeds(const GCodePathConfig::SpeedDerivatives& first_layer_config, const GCodePathConfig::SpeedDerivatives& first_layer_wall_config, int layer_nr, int max_speed_layer);
     };
 
     GCodePathConfig raft_base_config;

--- a/src/settings/PathConfigStorage.h
+++ b/src/settings/PathConfigStorage.h
@@ -31,6 +31,7 @@ private:
 
     const std::vector<double> line_width_factor_per_extruder;
     static std::vector<double> getLineWidthFactorPerExtruder(const SliceDataStorage& storage, int layer_nr);
+    const std::string flow_setting_name;
 public:
     class MeshPathConfigs
     {
@@ -43,7 +44,7 @@ public:
         GCodePathConfig ironing_config;
         GCodePathConfig perimeter_gap_config;
 
-        MeshPathConfigs(const SliceMeshStorage& mesh, int layer_nr, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder);
+        MeshPathConfigs(const SliceMeshStorage& mesh, const std::string& flow_setting_name, int layer_thickness, const std::vector<double>& line_width_factor_per_extruder);
         void smoothAllSpeeds(const GCodePathConfig::SpeedDerivatives& first_layer_config, const GCodePathConfig::SpeedDerivatives& first_layer_wall_config, int layer_nr, int max_speed_layer);
     };
 


### PR DESCRIPTION
Now uses material_flow_layer_0 for everything on layer 0.

However, it doesn't alter the flow used for layers < 0, should it?

This PR is built on top of #596.