### PR TITLE
Update currentSpeed in writeZHopStart() and writeZHopEnd().

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -816,7 +816,8 @@ void GCodeExport::writeZhopStart(int hop_height)
     if (hop_height > 0)
     {
         isZHopped = hop_height;
-        *output_stream << "G1 F" << PrecisionedDouble{1, current_max_z_feedrate * 60} << " Z" << MMtoStream{current_layer_z + isZHopped} << new_line;
+        currentSpeed = current_max_z_feedrate * 60;
+        *output_stream << "G1 F" << PrecisionedDouble{1, currentSpeed} << " Z" << MMtoStream{current_layer_z + isZHopped} << new_line;
         total_bounding_box.includeZ(current_layer_z + isZHopped);
         assert(current_max_z_feedrate > 0.0 && "Z feedrate should be positive");
     }
@@ -828,7 +829,8 @@ void GCodeExport::writeZhopEnd()
     {
         isZHopped = 0;
         currentPosition.z = current_layer_z;
-        *output_stream << "G1 F" << PrecisionedDouble{1, current_max_z_feedrate * 60} << " Z" << MMtoStream{current_layer_z} << new_line;
+        currentSpeed = current_max_z_feedrate * 60;
+        *output_stream << "G1 F" << PrecisionedDouble{1, currentSpeed} << " Z" << MMtoStream{current_layer_z} << new_line;
         assert(current_max_z_feedrate > 0.0 && "Z feedrate should be positive");
     }
 }


### PR DESCRIPTION
It wasn't being updated and so the Z feedrate used was subsequently used for X/Y moves.

Should help with https://github.com/Ultimaker/Cura/issues/2371.