### PR TITLE
Sync z-hop with layer changes

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -280,7 +280,23 @@ EGCodeFlavor GCodeExport::getFlavor() const
 
 void GCodeExport::setZ(int z)
 {
-    this->current_layer_z = z;
+    if (isZHopped)
+    {
+        // adjust the current z-hop height for the new layer z
+        isZHopped = current_layer_z + isZHopped - z;
+        if (isZHopped < 0)
+        {
+            isZHopped = 0;
+        }
+        if (isZHopped == 0)
+        {
+            // the new layer height is the same as the previous z-hop height
+            // so the z-hop height has become 0 and we need to update currentPosition.z
+            // to match
+            currentPosition.z = z;
+        }
+    }
+    current_layer_z = z;
 }
 
 Point3 GCodeExport::getPosition() const


### PR DESCRIPTION

Before, if there was z-hop at a layer change, any travel move in the the new layer before
the first extrusion would have been done with that much z-hop above the new layer z so it
would have involved changing z again.

See also #599 and https://github.com/Ultimaker/Cura/issues/2371.