### PR TITLE
Add setting to only iron on the highest layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(engine_SRCS # Except main.cpp.
 
     src/infill/NoZigZagConnectorProcessor.cpp
     src/infill/ZigzagConnectorProcessor.cpp
+    src/infill/SpaceFillingTreeFill.cpp
     src/infill/SpaghettiInfill.cpp
     src/infill/SpaghettiInfillPathGenerator.cpp
     src/infill/SubDivCube.cpp
@@ -127,13 +128,16 @@ set(engine_SRCS # Except main.cpp.
     src/utils/polygonUtils.cpp
     src/utils/polygon.cpp
     src/utils/ProximityPointLink.cpp
+    src/utils/SpaceFillingTree.cpp
 )
 
 # List of tests. For each test there must be a file tests/${NAME}.cpp and a file tests/${NAME}.h.
 set(engine_TEST_INFILL
+    SpaceFillingTreeFillTest
 )
 set(engine_TEST_UTILS
     SparseGridTest
+    IntPointTest
     LinearAlg2DTest
     PolygonUtilsTest
     PolygonTest

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,7 +10,7 @@ The .h files contain different steps called from the main.cpp file. The main.cpp
 
 The slicing process follows the following global steps:
 * Load 3D model
-* Analize and fix 3D model
+* Analyze and fix 3D model
 * Slice 3D model into 2D layers
 * Build LayerParts from sliced layers
 * Generate Insets

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -300,7 +300,7 @@ void FffGcodeWriter::setConfigRetraction(SliceDataStorage& storage)
         ExtruderTrain* train = storage.meshgroup->getExtruderTrain(extruder);
         RetractionConfig& retraction_config = storage.retraction_config_per_extruder[extruder];
         retraction_config.distance = (train->getSettingBoolean("retraction_enable"))? train->getSettingInMillimeters("retraction_amount") : 0;
-        retraction_config.prime_volume = std::max(0.0, train->getSettingInCubicMillimeters("retraction_extra_prime_amount"));
+        retraction_config.prime_volume = train->getSettingInCubicMillimeters("retraction_extra_prime_amount");
         retraction_config.speed = train->getSettingInMillimetersPerSecond("retraction_retract_speed");
         retraction_config.primeSpeed = train->getSettingInMillimetersPerSecond("retraction_prime_speed");
         retraction_config.zHop = train->getSettingInMicrons("retraction_hop");

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -347,12 +347,19 @@ void FffGcodeWriter::setInfillAndSkinAngles(SliceMeshStorage& mesh)
         if (mesh.infill_angles.size() == 0)
         {
             // user has not specified any infill angles so use defaults
-            mesh.infill_angles.push_back(45); // all infill patterns use 45 degrees
             EFillMethod infill_pattern = mesh.getSettingAsFillMethod("infill_pattern");
-            if (infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG)
+            if (infill_pattern == EFillMethod::CROSS || infill_pattern == EFillMethod::CROSS_3D)
             {
-                // lines and zig zag patterns default to also using 135 degrees
-                mesh.infill_angles.push_back(135);
+                mesh.infill_angles.push_back(22); // put most infill lines in between 45 and 0 degrees
+            }
+            else
+            {
+                mesh.infill_angles.push_back(45); // generally all infill patterns use 45 degrees
+                if (infill_pattern == EFillMethod::LINES || infill_pattern == EFillMethod::ZIG_ZAG)
+                {
+                    // lines and zig zag patterns default to also using 135 degrees
+                    mesh.infill_angles.push_back(135);
+                }
             }
         }
     }
@@ -528,7 +535,8 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
         Polygons raftLines;
         double fill_angle = 0;
-        Infill infill_comp(EFillMethod::LINES, wall, offset_from_poly_outline, gcode_layer.configs_storage.raft_base_config.getLineWidth(), train->getSettingInMicrons("raft_base_line_spacing"), fill_overlap, fill_angle, z, extra_infill_shift);
+        constexpr bool zig_zaggify_infill = false;
+        Infill infill_comp(EFillMethod::LINES, zig_zaggify_infill, wall, offset_from_poly_outline, gcode_layer.configs_storage.raft_base_config.getLineWidth(), train->getSettingInMicrons("raft_base_line_spacing"), fill_overlap, fill_angle, z, extra_infill_shift);
         infill_comp.generate(raft_polygons, raftLines);
         gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_base_config, SpaceFillType::Lines);
 
@@ -572,7 +580,8 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Polygons raftLines;
         int offset_from_poly_outline = 0;
         double fill_angle = train->getSettingAsCount("raft_surface_layers") > 0 ? 45 : 90;
-        Infill infill_comp(EFillMethod::ZIG_ZAG, storage.raftOutline, offset_from_poly_outline, gcode_layer.configs_storage.raft_interface_config.getLineWidth(), train->getSettingInMicrons("raft_interface_line_spacing"), fill_overlap, fill_angle, z, extra_infill_shift);
+        constexpr bool zig_zaggify_infill = true;
+        Infill infill_comp(EFillMethod::ZIG_ZAG, zig_zaggify_infill, storage.raftOutline, offset_from_poly_outline, gcode_layer.configs_storage.raft_interface_config.getLineWidth(), train->getSettingInMicrons("raft_interface_line_spacing"), fill_overlap, fill_angle, z, extra_infill_shift);
         infill_comp.generate(raft_polygons, raftLines);
         gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_interface_config, SpaceFillType::Lines);
 
@@ -610,7 +619,8 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Polygons raft_lines;
         int offset_from_poly_outline = 0;
         double fill_angle = 90 * raftSurfaceLayer;
-        Infill infill_comp(EFillMethod::ZIG_ZAG, storage.raftOutline, offset_from_poly_outline, gcode_layer.configs_storage.raft_surface_config.getLineWidth(), train->getSettingInMicrons("raft_surface_line_spacing"), fill_overlap, fill_angle, z, extra_infill_shift);
+        constexpr bool zig_zaggify_infill = true;
+        Infill infill_comp(EFillMethod::ZIG_ZAG, zig_zaggify_infill, storage.raftOutline, offset_from_poly_outline, gcode_layer.configs_storage.raft_surface_config.getLineWidth(), train->getSettingInMicrons("raft_surface_line_spacing"), fill_overlap, fill_angle, z, extra_infill_shift);
         infill_comp.generate(raft_polygons, raft_lines);
         gcode_layer.addLinesByOptimizer(raft_lines, gcode_layer.configs_storage.raft_surface_config, SpaceFillType::Lines);
 
@@ -1144,6 +1154,7 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
         {
             const unsigned int infill_line_width = mesh_config.infill_config[combine_idx].getLineWidth();
             EFillMethod infill_pattern = mesh.getSettingAsFillMethod("infill_pattern");
+            const bool zig_zaggify_infill = mesh.getSettingBoolean("zig_zaggify_infill");
             Polygons infill_polygons;
             Polygons infill_lines;
             for (unsigned int density_idx = 0; density_idx < part.infill_area_per_combine_per_density.size(); density_idx++)
@@ -1156,8 +1167,15 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                     infill_line_distance_here /= 2;
                 }
                 
-                Infill infill_comp(infill_pattern, part.infill_area_per_combine_per_density[density_idx][combine_idx], 0, infill_line_width, infill_line_distance_here, infill_overlap, infill_angle, gcode_layer.z, infill_shift);
-                infill_comp.generate(infill_polygons, infill_lines, &mesh);
+                Infill infill_comp(infill_pattern, zig_zaggify_infill, part.infill_area_per_combine_per_density[density_idx][combine_idx], 0
+                    , infill_line_width, infill_line_distance_here, infill_overlap, infill_angle, gcode_layer.z, infill_shift
+                    , /*Polygons* perimeter_gaps =*/ nullptr
+                    , /*bool connected_zigzags =*/ false
+                    , /*bool use_endpieces =*/ false
+                    , /*bool skip_some_zags =*/ false
+                    , /*int zag_skip_count =*/ 0
+                    , mesh.getSettingBoolean("cross_infill_apply_pockets_alternatingly"), mesh.getSettingInMicrons("cross_infill_pocket_size"));
+                infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_pattern, &mesh);
             }
             if (infill_lines.size() > 0 || infill_polygons.size() > 0)
             {
@@ -1190,6 +1208,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     Polygons infill_lines;
 
     EFillMethod pattern = mesh.getSettingAsFillMethod("infill_pattern");
+    const bool zig_zaggify_infill = mesh.getSettingBoolean("zig_zaggify_infill");
     for (unsigned int density_idx = 0; density_idx < part.infill_area_per_combine_per_density.size(); density_idx++)
     {
         unsigned int density_factor = 2 << density_idx; // == pow(2, density_idx + 1)
@@ -1222,8 +1241,15 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 //     ^   highest density line dist
             infill_line_distance_here /= 2;
         }
-        Infill infill_comp(pattern, part.infill_area_per_combine_per_density[density_idx][0], 0, infill_line_width, infill_line_distance_here, infill_overlap, infill_angle, gcode_layer.z, infill_shift);
-        infill_comp.generate(infill_polygons, infill_lines, &mesh);
+        Infill infill_comp(pattern, zig_zaggify_infill, part.infill_area_per_combine_per_density[density_idx][0], 0
+            , infill_line_width, infill_line_distance_here, infill_overlap, infill_angle, gcode_layer.z, infill_shift
+            , /*Polygons* perimeter_gaps =*/ nullptr
+            , /*bool connected_zigzags =*/ false
+            , /*bool use_endpieces =*/ false
+            , /*bool skip_some_zags =*/ false
+            , /*int zag_skip_count =*/ 0
+            , mesh.getSettingBoolean("cross_infill_apply_pockets_alternatingly"), mesh.getSettingInMicrons("cross_infill_pocket_size"));
+        infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_pattern, &mesh);
     }
     if (infill_lines.size() > 0 || infill_polygons.size() > 0)
     {
@@ -1435,7 +1461,8 @@ void FffGcodeWriter::processOutlineGaps(const SliceDataStorage& storage, LayerPl
     int offset = 0;
     int extra_infill_shift = 0;
     constexpr coord_t outline_gap_overlap = 0;
-    Infill infill_comp(EFillMethod::LINES, part.outline_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, outline_gap_overlap, skin_angle, gcode_layer.z, extra_infill_shift);
+    constexpr bool zig_zaggify_infill = false;
+    Infill infill_comp(EFillMethod::LINES, zig_zaggify_infill, part.outline_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, outline_gap_overlap, skin_angle, gcode_layer.z, extra_infill_shift);
     infill_comp.generate(gap_polygons, gap_lines);
 
     if (gap_lines.size() > 0)
@@ -1617,7 +1644,8 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage, La
 
     constexpr int extra_infill_shift = 0;
     constexpr coord_t offset_from_inner_skin_infill = 0;
-    Infill infill_comp(pattern, area, offset_from_inner_skin_infill, config.getLineWidth(), config.getLineWidth(), skin_overlap, skin_angle, gcode_layer.z, extra_infill_shift, perimeter_gaps_output);
+    const bool zig_zaggify_infill = pattern == EFillMethod::ZIG_ZAG;
+    Infill infill_comp(pattern, zig_zaggify_infill, area, offset_from_inner_skin_infill, config.getLineWidth(), config.getLineWidth(), skin_overlap, skin_angle, gcode_layer.z, extra_infill_shift, perimeter_gaps_output);
     infill_comp.generate(skin_polygons, skin_lines);
 
     // add paths
@@ -1656,13 +1684,14 @@ void FffGcodeWriter::processPerimeterGaps(const SliceDataStorage& storage, Layer
     const coord_t perimeter_gaps_line_width = perimeter_gap_config.getLineWidth();
     
     assert(mesh.roofing_angles.size() > 0);
+    const bool zig_zaggify_infill = false;
     int perimeter_gaps_angle = mesh.roofing_angles[gcode_layer.getLayerNr() % mesh.roofing_angles.size()]; // use roofing angles for perimeter gaps
     Polygons gap_polygons; // will remain empty
     Polygons gap_lines;
     constexpr int offset = 0;
     constexpr int extra_infill_shift = 0;
     const coord_t skin_overlap = mesh.getSettingInMicrons("skin_overlap_mm");
-    Infill infill_comp(EFillMethod::LINES, perimeter_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, skin_overlap, perimeter_gaps_angle, gcode_layer.z, extra_infill_shift);
+    Infill infill_comp(EFillMethod::LINES, zig_zaggify_infill, perimeter_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, skin_overlap, perimeter_gaps_angle, gcode_layer.z, extra_infill_shift);
     infill_comp.generate(gap_polygons, gap_lines);
     if (gap_lines.size() > 0)
     {
@@ -1746,6 +1775,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
     {
         support_pattern = EFillMethod::GRID;
     }
+    const bool zig_zaggify_infill = support_pattern == EFillMethod::ZIG_ZAG || support_pattern == EFillMethod::CROSS || support_pattern == EFillMethod::CROSS_3D;
     const bool skip_some_zags = infill_extruder.getSettingBoolean("support_skip_some_zags");
     const int zag_skip_count = infill_extruder.getSettingAsCount("support_zag_skip_count");
 
@@ -1817,11 +1847,11 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
 
                 bool use_endpieces = true;
                 Polygons* perimeter_gaps = nullptr;
-                Infill infill_comp(support_pattern, support_area, offset_from_outline, support_line_width,
+                Infill infill_comp(support_pattern, zig_zaggify_infill, support_area, offset_from_outline, support_line_width,
                                    support_line_distance_here, current_support_infill_overlap, support_infill_angle, gcode_layer.z, support_shift,
                                    perimeter_gaps, infill_extruder.getSettingBoolean("support_connect_zigzags"), use_endpieces,
                                    skip_some_zags, zag_skip_count);
-                infill_comp.generate(support_polygons, support_lines);
+                infill_comp.generate(support_polygons, support_lines, storage.support.cross_fill_pattern);
             }
 
             if (support_lines.size() > 0 || support_polygons.size() > 0)
@@ -1856,6 +1886,7 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, Lay
 
     const EFillMethod pattern = roof_extr.getSettingAsFillMethod("support_roof_pattern");
     const double fill_angle = supportInterfaceFillAngle(storage, pattern, "support_roof_height", gcode_layer.getLayerNr());
+    const bool zig_zaggify_infill = pattern == EFillMethod::ZIG_ZAG;
     constexpr int support_roof_overlap = 0; // the roofs should never be expanded outwards
     constexpr int outline_offset =  0;
     constexpr int extra_infill_shift = 0;
@@ -1879,7 +1910,7 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, Lay
         infill_outline = wall.offset(-support_roof_line_width / 2);
     }
 
-    Infill roof_computation(pattern, infill_outline, outline_offset, gcode_layer.configs_storage.support_roof_config.getLineWidth(), support_roof_line_distance, support_roof_overlap, fill_angle, gcode_layer.z, extra_infill_shift, perimeter_gaps, connected_zigzags, use_endpieces);
+    Infill roof_computation(pattern, zig_zaggify_infill, infill_outline, outline_offset, gcode_layer.configs_storage.support_roof_config.getLineWidth(), support_roof_line_distance, support_roof_overlap, fill_angle, gcode_layer.z, extra_infill_shift, perimeter_gaps, connected_zigzags, use_endpieces);
     Polygons roof_polygons;
     Polygons roof_lines;
     roof_computation.generate(roof_polygons, roof_lines);
@@ -1914,6 +1945,7 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
 
     const EFillMethod pattern = bottom_extr.getSettingAsFillMethod("support_bottom_pattern");
     const double fill_angle = supportInterfaceFillAngle(storage, pattern, "support_bottom_height", gcode_layer.getLayerNr());
+    const bool zig_zaggify_infill = pattern == EFillMethod::ZIG_ZAG;
     constexpr int support_bottom_overlap = 0; // the bottoms should never be expanded outwards
     constexpr int outline_offset =  0;
     constexpr int extra_infill_shift = 0;
@@ -1922,7 +1954,7 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
     constexpr bool connected_zigzags = false;
 
     const coord_t support_bottom_line_distance = bottom_extr.getSettingInMicrons("support_bottom_line_distance"); // note: no need to apply initial line width factor; support bottoms cannot exist on the first layer
-    Infill bottom_computation(pattern, support_layer.support_bottom, outline_offset, gcode_layer.configs_storage.support_bottom_config.getLineWidth(), support_bottom_line_distance, support_bottom_overlap, fill_angle, gcode_layer.z, extra_infill_shift, perimeter_gaps, connected_zigzags, use_endpieces);
+    Infill bottom_computation(pattern, zig_zaggify_infill, support_layer.support_bottom, outline_offset, gcode_layer.configs_storage.support_bottom_config.getLineWidth(), support_bottom_line_distance, support_bottom_overlap, fill_angle, gcode_layer.z, extra_infill_shift, perimeter_gaps, connected_zigzags, use_endpieces);
     Polygons bottom_polygons;
     Polygons bottom_lines;
     bottom_computation.generate(bottom_polygons, bottom_lines);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1706,7 +1706,8 @@ bool FffGcodeWriter::processIroning(const SliceMeshStorage& mesh, const SliceLay
 {
     bool added_something = false;
     const bool ironing_enabled = mesh.getSettingBoolean("ironing_enabled");
-    if (ironing_enabled && layer.top_surface)
+    const bool ironing_only_highest_layer = mesh.getSettingBoolean("ironing_only_highest_layer");
+    if (ironing_enabled && (!ironing_only_highest_layer || mesh.layer_nr_max_filled_layer == gcode_layer.getLayerNr()) && layer.top_surface)
     {
         added_something |= layer.top_surface->ironing(mesh, line_config, gcode_layer);
     }

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -743,7 +743,7 @@ void FffPolygonGenerator::processSkinsAndInfill(const SliceDataStorage& storage,
     SkinInfillAreaComputation skin_infill_area_computation(layer_nr, storage, mesh, process_infill);
     skin_infill_area_computation.generateSkinsAndInfill();
 
-    if (mesh.getSettingBoolean("ironing_enabled") && (!mesh.getSettingBoolean("ironing_only_highest_layer") || mesh.layer_nr_max_filled_layer == layer_nr))
+    if (mesh.getSettingBoolean("ironing_enabled") && (!mesh.getSettingBoolean("ironing_only_highest_layer") || (unsigned int)mesh.layer_nr_max_filled_layer == layer_nr))
     {
         TopSurface* top_surface = new TopSurface(mesh, layer_nr); //Generate the top surface to iron over.
         mesh.layers[layer_nr].top_surface = top_surface;

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -24,6 +24,7 @@
 #include "SkirtBrim.h"
 #include "skin.h"
 #include "infill/SpaghettiInfill.h"
+#include "infill/SpaceFillingTreeFill.h"
 #include "infill.h"
 #include "raft.h"
 #include "progress/Progress.h"
@@ -591,9 +592,19 @@ void FffPolygonGenerator::processDerivedWallsSkinInfill(SliceMeshStorage& mesh)
         SkinInfillAreaComputation::generateGradualInfill(mesh, mesh.getSettingInMicrons("gradual_infill_step_height"), mesh.getSettingAsCount("gradual_infill_steps"));
 
         //SubDivCube Pre-compute Octree
-        if (mesh.getSettingAsFillMethod("infill_pattern") == EFillMethod::CUBICSUBDIV)
+        if (mesh.getSettingInMicrons("infill_line_distance") > 0
+            && mesh.getSettingAsFillMethod("infill_pattern") == EFillMethod::CUBICSUBDIV)
         {
             SubDivCube::precomputeOctree(mesh);
+        }
+
+        // Pre-compute Cross Fractal
+        if (mesh.getSettingInMicrons("infill_line_distance") > 0
+            && (mesh.getSettingAsFillMethod("infill_pattern") == EFillMethod::CROSS
+                || mesh.getSettingAsFillMethod("infill_pattern") == EFillMethod::CROSS_3D)
+        )
+        {
+            mesh.cross_fill_pattern = new SpaceFillingTreeFill(mesh.getSettingInMicrons("infill_line_distance"), mesh.bounding_box);
         }
 
         // combine infill

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -743,7 +743,7 @@ void FffPolygonGenerator::processSkinsAndInfill(const SliceDataStorage& storage,
     SkinInfillAreaComputation skin_infill_area_computation(layer_nr, storage, mesh, process_infill);
     skin_infill_area_computation.generateSkinsAndInfill();
 
-    if (mesh.getSettingBoolean("ironing_enabled"))
+    if (mesh.getSettingBoolean("ironing_enabled") && (!mesh.getSettingBoolean("ironing_only_highest_layer") || mesh.layer_nr_max_filled_layer == layer_nr))
     {
         TopSurface* top_surface = new TopSurface(mesh, layer_nr); //Generate the top surface to iron over.
         mesh.layers[layer_nr].top_surface = top_surface;

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -88,7 +88,8 @@ void PrimeTower::generatePaths_denseInfill(const SliceDataStorage& storage)
             int line_distance = line_width;
             double fill_angle = 45 + pattern_idx * 90;
             Polygons result_polygons; // should remain empty, since we generate lines pattern!
-            Infill infill_comp(EFillMethod::LINES, ground_poly, outline_offset, line_width, line_distance, infill_overlap, fill_angle, z, extra_infill_shift);
+            constexpr bool zig_zaggify_infill = false;
+            Infill infill_comp(EFillMethod::LINES, zig_zaggify_infill, ground_poly, outline_offset, line_width, line_distance, infill_overlap, fill_angle, z, extra_infill_shift);
             infill_comp.generate(result_polygons, result_lines);
         }
         int line_width_layer0 = line_width;
@@ -103,7 +104,8 @@ void PrimeTower::generatePaths_denseInfill(const SliceDataStorage& storage)
         int line_distance = line_width_layer0;
         double fill_angle = 45;
         Polygons result_polygons;
-        Infill infill_comp(EFillMethod::LINES, ground_poly, outline_offset, line_width_layer0, line_distance, infill_overlap, fill_angle, z, extra_infill_shift);
+        constexpr bool zig_zaggify_infill = false;
+        Infill infill_comp(EFillMethod::LINES, zig_zaggify_infill, ground_poly, outline_offset, line_width_layer0, line_distance, infill_overlap, fill_angle, z, extra_infill_shift);
         infill_comp.generate(result_polygons, pattern.lines);
     }
 }

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -33,6 +33,7 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
     }
     //Generate the lines to cover the surface.
     const EFillMethod pattern = mesh.getSettingAsFillMethod("ironing_pattern");
+    const bool zig_zaggify_infill = pattern == EFillMethod::ZIG_ZAG;
     const coord_t line_spacing = mesh.getSettingInMicrons("ironing_line_spacing");
     const coord_t outline_offset = -mesh.getSettingInMicrons("ironing_inset");
     const coord_t line_width = line_config.getLineWidth();
@@ -41,7 +42,7 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
     const double direction = top_most_skin_angles[layer.getLayerNr() % top_most_skin_angles.size()] + 90.0; //Always perpendicular to the skin lines.
     constexpr coord_t infill_overlap = 0;
     constexpr coord_t shift = 0;
-    Infill infill_generator(pattern, areas, outline_offset, line_width, line_spacing, infill_overlap, direction, layer.z - 10, shift);
+    Infill infill_generator(pattern, zig_zaggify_infill, areas, outline_offset, line_width, line_spacing, infill_overlap, direction, layer.z - 10, shift);
     Polygons ironing_polygons;
     Polygons ironing_lines;
     infill_generator.generate(ironing_polygons, ironing_lines);

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -838,7 +838,8 @@ void GCodeExport::writeZhopStart(int hop_height)
     if (hop_height > 0)
     {
         isZHopped = hop_height;
-        *output_stream << "G1 F" << PrecisionedDouble{1, current_max_z_feedrate * 60} << " Z" << MMtoStream{current_layer_z + isZHopped} << new_line;
+        currentSpeed = current_max_z_feedrate * 60;
+        *output_stream << "G1 F" << PrecisionedDouble{1, currentSpeed} << " Z" << MMtoStream{current_layer_z + isZHopped} << new_line;
         total_bounding_box.includeZ(current_layer_z + isZHopped);
         assert(current_max_z_feedrate > 0.0 && "Z feedrate should be positive");
     }
@@ -850,7 +851,8 @@ void GCodeExport::writeZhopEnd()
     {
         isZHopped = 0;
         currentPosition.z = current_layer_z;
-        *output_stream << "G1 F" << PrecisionedDouble{1, current_max_z_feedrate * 60} << " Z" << MMtoStream{current_layer_z} << new_line;
+        currentSpeed = current_max_z_feedrate * 60;
+        *output_stream << "G1 F" << PrecisionedDouble{1, currentSpeed} << " Z" << MMtoStream{current_layer_z} << new_line;
         assert(current_max_z_feedrate > 0.0 && "Z feedrate should be positive");
     }
 }

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -126,6 +126,7 @@ private:
     
     bool is_volumatric;
     bool firmware_retract; //!< whether retractions are done in the firmware, or hardcoded in E values.
+    bool relative_extrusion; //!< whether to use relative extrusion distances rather than absolute
 
     unsigned int layer_nr; //!< for sending travel data
 
@@ -245,6 +246,13 @@ public:
     
     void writeComment(std::string comment);
     void writeTypeComment(PrintFeatureType type);
+
+    /*!
+     * Write an M82 (absolute) or M83 (relative)
+     *
+     * \param set_relative_extrusion_mode If true, write an M83, otherwise write an M82
+     */
+    void writeExtrusionMode(bool set_relative_extrusion_mode);
 
     /*!
      * Write a comment saying what (estimated) time has passed up to this point

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -30,11 +30,10 @@ static inline int computeScanSegmentIdx(int x, int line_width)
 
 namespace cura {
 
-void Infill::generate(Polygons& result_polygons, Polygons& result_lines, const SliceMeshStorage* mesh)
+void Infill::generate(Polygons& result_polygons, Polygons& result_lines, const SpaceFillingTreeFill* cross_fill_pattern, const SliceMeshStorage* mesh)
 {
     if (in_outline.size() == 0) return;
     if (line_distance == 0) return;
-    Polygons outline_offsetted;
     switch(pattern)
     {
     case EFillMethod::GRID:
@@ -71,6 +70,15 @@ void Infill::generate(Polygons& result_polygons, Polygons& result_lines, const S
             break;
         }
         generateCubicSubDivInfill(result_lines, *mesh);
+        break;
+    case EFillMethod::CROSS:
+    case EFillMethod::CROSS_3D:
+        if (!cross_fill_pattern)
+        {
+            logError("Cannot generate Cross infill without a pregenerated cross fill pattern!\n");
+            break;
+        }
+        generateCrossInfill(*cross_fill_pattern, result_polygons, result_lines);
         break;
     default:
         logError("Fill pattern has unknown value.\n");
@@ -113,8 +121,8 @@ void Infill::generateConcentricInfill(Polygons& first_concentric_wall, Polygons&
 
 void Infill::generateConcentric3DInfill(Polygons& result)
 {
-    int period = line_distance * 2;
-    int shift = int64_t(one_over_sqrt_2 * z) % period;
+    coord_t period = line_distance * 2;
+    coord_t shift = int64_t(one_over_sqrt_2 * z) % period;
     shift = std::min(shift, period - shift); // symmetry due to the fact that we are applying the shift in both directions
     shift = std::min(shift, period / 2 - infill_line_width / 2); // don't put lines too close to each other
     shift = std::max(shift, infill_line_width / 2); // don't put lines too close to each other
@@ -154,8 +162,8 @@ void Infill::generateQuarterCubicInfill(Polygons& result)
 
 void Infill::generateHalfTetrahedralInfill(float pattern_z_shift, int angle_shift, Polygons& result)
 {
-    int period = line_distance * 2;
-    int shift = int64_t(one_over_sqrt_2 * (z + pattern_z_shift * period * 2)) % period;
+    coord_t period = line_distance * 2;
+    coord_t shift = int64_t(one_over_sqrt_2 * (z + pattern_z_shift * period * 2)) % period;
     shift = std::min(shift, period - shift); // symmetry due to the fact that we are applying the shift in both directions
     shift = std::min(shift, period / 2 - infill_line_width / 2); // don't put lines too close to each other
     shift = std::max(shift, infill_line_width / 2); // don't put lines too close to each other
@@ -175,6 +183,30 @@ void Infill::generateCubicSubDivInfill(Polygons& result, const SliceMeshStorage&
     Polygons uncropped;
     mesh.base_subdiv_cube->generateSubdivisionLines(z, uncropped);
     addLineSegmentsInfill(result, uncropped);
+}
+
+void Infill::generateCrossInfill(const SpaceFillingTreeFill& cross_fill_pattern, Polygons& result_polygons, Polygons& result_lines)
+{
+    if (zig_zaggify)
+    {
+        outline_offset += -infill_line_width / 2;
+    }
+    coord_t shift = line_distance / 2;
+    bool use_odd_in_junctions = false;
+    bool use_odd_out_junctions = false;
+    if (pattern == EFillMethod::CROSS_3D)
+    {
+        coord_t period = line_distance * 2;
+        shift = z % period;
+        shift = std::min(shift, period - shift); // symmetry due to the fact that we are applying the shift in both directions
+        shift = std::min(shift, period / 2 - infill_line_width / 2); // don't put lines too close to each other
+        shift = std::max(shift, infill_line_width / 2); // don't put lines too close to each other
+
+        use_odd_in_junctions = ((z + period / 2) / period) % 2 == 1; // change junction halfway in between each period when the in-junctions occur
+        use_odd_out_junctions = (z / period) % 2 == 1; // out junctions occur halfway at each periods
+    }
+    Polygons outline = in_outline.offset(outline_offset);
+    cross_fill_pattern.generate(outline, shift, zig_zaggify, fill_angle, apply_pockets_alternatingly, use_odd_in_junctions, use_odd_out_junctions, pocket_size, result_polygons, result_lines);
 }
 
 void Infill::addLineSegmentsInfill(Polygons& result, Polygons& input)

--- a/src/infill/SpaceFillingTreeFill.cpp
+++ b/src/infill/SpaceFillingTreeFill.cpp
@@ -1,0 +1,209 @@
+/** Copyright (C) 2017 Tim Kuipers - Released under terms of the AGPLv3 License */
+#include "SpaceFillingTreeFill.h"
+
+#include "../utils/linearAlg2D.h" // rotateAround
+
+namespace cura {
+
+SpaceFillingTreeFill::SpaceFillingTreeFill(coord_t line_distance, AABB3D model_aabb) : SpaceFillingTreeFill(line_distance, model_aabb, getTreeParams(line_distance, model_aabb))
+{
+}
+
+SpaceFillingTreeFill::SpaceFillingTreeFill(coord_t line_distance, AABB3D model_aabb, SpaceFillingTreeFill::TreeParams tree_params)
+: model_aabb(model_aabb)
+, line_distance(line_distance)
+, tree(tree_params.middle, tree_params.radius, tree_params.depth)
+{
+}
+
+void SpaceFillingTreeFill::generate(const Polygons& outlines, coord_t shift, bool zig_zaggify, double fill_angle, bool alternate, bool use_odd_in_junctions, bool use_odd_out_junctions, coord_t pocket_size, Polygons& result_polygons, Polygons& result_lines) const
+{
+    Point3 model_middle = model_aabb.getMiddle();
+    Point3Matrix transformation = LinearAlg2D::rotateAround(Point(model_middle.x, model_middle.y), fill_angle + 45);
+
+    Polygon infill_poly;
+    std::vector<const SpaceFillingTree::Node*> nodes;
+    generateTreePath(nodes);
+    offsetTreePath(nodes, shift, pocket_size, alternate, use_odd_in_junctions, use_odd_out_junctions, infill_poly);
+    infill_poly.applyMatrix(transformation); // apply rotation
+
+    if (zig_zaggify)
+    {
+        Polygons infill_pattern;
+        infill_pattern.add(infill_poly);
+        result_polygons = infill_pattern.intersection(outlines);
+    }
+    else
+    {
+        if (infill_poly.size() > 0)
+        {
+            infill_poly.add(infill_poly[0]);
+        }
+        Polygons infill_pattern;
+        infill_pattern.add(infill_poly);
+        Polygons poly_lines = outlines.intersectionPolyLines(infill_pattern);
+        for (PolygonRef poly_line : poly_lines)
+        {
+            for (unsigned int point_idx = 1; point_idx < poly_line.size(); point_idx++)
+            {
+                result_lines.addLine(poly_line[point_idx - 1], poly_line[point_idx]);
+            }
+        }
+    }
+}
+
+SpaceFillingTreeFill::TreeParams SpaceFillingTreeFill::getTreeParams(coord_t line_distance, AABB3D model_aabb)
+{
+    TreeParams ret;
+    AABB aabb(Point(model_aabb.min.x, model_aabb.min.y), Point(model_aabb.max.x, model_aabb.max.y));
+    const Point aabb_size = aabb.max - aabb.min;
+    coord_t minimal_radius = vSize(aabb_size) / 2; // to account for any possible infill angle
+
+    /*
+     * For the normal cross infill the width of the cross is equal to the width of the crosses which are left out.
+     * 
+     *  ▉  ▄    white cross left out          r/2
+     * ▀▉▀▀▉▀ ↙       by the black          ^^^^^^^^
+     * ▄▉▄   ▄▉▄                     +--------------+
+     *  ▉  ▄  ▉                      :              |
+     * ▀▉▀▀▉▀▀▉▀▀                    : --------+    |   quarter of the fractal with depth one
+     *                               :,.       |    | the fractal with depth one
+     *                              .:  '-.    |    |
+     *                            .' :  .' :'. |    |
+     *                          .'   :.'...:.,'.....+
+     *                        .'           :
+     *                         '-.       .':   :
+     *                          L  '-, .'  vvvvv
+     *                                       n
+     * minimum offset = 0
+     * maximum offset is such that n = r/2
+     * 2n^2 = L/2  ==>  n = 1/4 sqrt(2) L
+     * r = .5 sqrt(2) L
+     */
+    ret.middle = aabb.getMiddle();
+    ret.depth = -1;
+    ret.radius = line_distance * sqrt(2.0) * 0.5;
+    while (ret.radius <= minimal_radius)
+    {
+        ret.depth++;
+        ret.radius *= 2;
+    }
+    return ret;
+}
+
+void SpaceFillingTreeFill::generateTreePath(std::vector<const SpaceFillingTree::Node*>& nodes) const
+{
+    class Visitor : public SpaceFillingTree::LocationVisitor
+    {
+        std::vector<const SpaceFillingTree::Node*>& nodes;
+        bool is_first_point = true;
+    public:
+        Visitor(std::vector<const SpaceFillingTree::Node*>& nodes)
+        : nodes(nodes)
+        {}
+        void visit(const SpaceFillingTree::Node* node)
+        {
+            if (is_first_point)
+            { // skip first point because it is the same as the last
+                is_first_point = false;
+                return;
+            }
+            nodes.push_back(node);
+        }
+    };
+    Visitor visitor(nodes);
+    tree.walk(visitor);
+}
+
+void SpaceFillingTreeFill::offsetTreePath(std::vector<const SpaceFillingTree::Node*>& nodes, coord_t offset, coord_t pocket_size, bool alternating, bool use_odd_in_junctions, bool use_odd_out_junctions, PolygonRef infill) const
+{
+    coord_t corner_bevel = std::max(coord_t(0), pocket_size / 2 - offset) * std::sqrt(2);
+    coord_t point_bevel = std::max(coord_t(0), pocket_size / 2 - (line_distance - offset)) * std::sqrt(2);
+
+    coord_t corner_bevel_even = corner_bevel;
+    coord_t corner_bevel_odd = 0;
+    if (use_odd_in_junctions)
+    {
+        std::swap(corner_bevel_even, corner_bevel_odd);
+    }
+    coord_t point_bevel_even = point_bevel;
+    coord_t point_bevel_odd = 0;
+    if (use_odd_out_junctions)
+    {
+        std::swap(point_bevel_even, point_bevel_odd);
+    }
+    for (unsigned int point_idx = 0; point_idx < nodes.size(); point_idx++)
+    {
+        const SpaceFillingTree::Node* a_node = nodes[point_idx];
+        const SpaceFillingTree::Node* b_node = nodes[(point_idx + 1) % nodes.size()];
+        const SpaceFillingTree::Node* c_node = nodes[(point_idx + 2) % nodes.size()];
+
+        const Point a = a_node->middle;
+        const Point b = b_node->middle;
+        const Point c = c_node->middle;
+
+        const Point bc = c - b;
+        const Point bc_T = turn90CCW(bc);
+        const Point bc_offset = normal(bc_T, offset);
+
+        if (a == c)
+        { // pointy case
+            //       .                          .
+            //      / \                         .
+            //     /   \                        .
+            //    /  b  \                       .
+            //   |   :   |                      .
+            //   |   :   |                      .
+            //       :
+            // ......:......
+            //      a c
+            const Point left_point = b - bc_offset;
+            const Point pointy_point = b - normal(bc, offset);
+            const Point right_point = b + bc_offset;
+
+            infill.add(left_point);
+            const coord_t point_bevel_here = (alternating)?
+                                             ((b_node->parent && b_node->parent_to_here_direction == b_node->parent->parent_to_here_direction)? point_bevel_even : point_bevel_odd)
+                                             : point_bevel;
+            if (point_bevel_here)
+            {
+                infill.add(pointy_point - normal(pointy_point - left_point, point_bevel_here));
+                infill.add(pointy_point - normal(pointy_point - right_point, point_bevel_here));
+            }
+            else
+            {
+                infill.add(pointy_point);
+            }
+            infill.add(right_point);
+        }
+        else
+        { // corner case
+            //      a: |
+            //       : |
+            //       : L____
+            // ......:......
+            //      b:     c
+            //       :
+            //       :
+            const Point ab = b - a;
+            const Point ab_T = turn90CCW(ab);
+            const Point normal_corner = b + normal(ab_T, offset) + bc_offset; // WARNING: offset is not based on the directions of the two segments, rather than assuming 90 degree corners
+            const coord_t corner_bevel_here = (alternating)?
+                                              ((a_node->distance_depth % 2 == 1)? corner_bevel_even : corner_bevel_odd)
+                                              : corner_bevel;
+            if (corner_bevel_here)
+            {
+                infill.add(normal_corner - normal(ab, corner_bevel_here));
+                infill.add(normal_corner + normal(bc, corner_bevel_here));
+            }
+            else
+            {
+                infill.add(normal_corner);
+            }
+        }
+    }
+}
+
+
+
+}; // namespace cura

--- a/src/infill/SpaceFillingTreeFill.h
+++ b/src/infill/SpaceFillingTreeFill.h
@@ -1,0 +1,126 @@
+/** Copyright (C) 2017 Tim Kuipers - Released under terms of the AGPLv3 License */
+#ifndef INFILL_SPACE_FILLING_TREE_FILL_H
+#define INFILL_SPACE_FILLING_TREE_FILL_H
+
+#include "../utils/polygon.h"
+#include "../utils/AABB.h"
+#include "../utils/AABB3D.h"
+#include "../utils/SpaceFillingTree.h"
+
+#include "../utils/SVG.h"
+
+namespace cura
+{
+/*!
+ * A class for generating the Cross and Cross 3D infill patterns.
+ * 
+ * The generated line can be seen as an offset from a fractal cross,
+ * such that the offsetted line is in between the cross fractal and the square area which is the limit of the fractal.
+ * 
+ * This class is a generator for one model.
+ * It should be reused through multiple layers of the same \ref SliceMeshStorage
+ * 
+ * The pattern looks like this but 45degrees rotated:
+ *               ▄▉▄        white cross left out
+ *             ▄  ▉  ▄    ↙  by the black, a.k.a. anti-cross
+ *            ▀▉▀▀▉▀▀▉▀              ....................
+ *         ▄▉▄   ▄▉▄   ▄▉▄           :░░░░░░░░░░░░░░░░░░:
+ *       ▄  ▉  ▄  ▉  ▄  ▉  ▄         :░░░+-----+░░░+----:
+ *      ▀▉▀▀▉▀▀▉▀▀▉▀▀▉▀▀▉▀▀▉▀:       :░░░|     |░░░|    :
+ *         ▄▉▄   ▄▉▄   ▄▉▄   : ===>  :░░░+--.   'v'     :
+ *          ▀  ▄  ▉  ▄  ▀....:       :░░░░░░░>          :
+ *            ▀▉▀▀▉▀▀▉▀              :░░░+--'           :
+ *               ▄▉▄                 :...|..............:
+ *                ▀                   note how the anti-crosses have a diagonal straight part,
+ *                                    but end differently than the black crosses.
+ *                                    While the black crosses end in a point,
+ *                                    the anti-crosses end in a square.
+ */
+class SpaceFillingTreeFill
+{
+    /*!
+     * The parameters to pass to the constructor of the \ref SpaceFillingTreeFill::tree
+     */
+    struct TreeParams
+    {
+        Point middle; //!< The middle of where the grid should be centered
+        coord_t radius; //!< The distance from the middle to the side / top of the square which is filled with the pattern
+        int depth; //!< The recursion depth of the tree fractal
+    };
+public:
+    /*!
+     * Constructor for constructing an infill pattern generator.
+     * 
+     * \param line_distance The width of the crosses and the width of the anti-crosses.
+     * \param model_aabb The aabb to at aleast cover with the infill pattern
+     */
+    SpaceFillingTreeFill(coord_t line_distance, AABB3D model_aabb);
+
+    /*!
+     * Generate the polygons or line segments of the cross pattern.
+     * The pattern is cut of by the \p outlines.
+     * These outlines should be smaller when we are zig zaggifying the infill.
+     * 
+     * \param outlines The area by which to cut the infill pattern.
+     * \param shift The shift of the infill pattern from the cross fractal toward the square region
+     * \param zig_zaggify Whether to connect the cross lines via the \p outlines
+     * \param fill_angle The direction of the main crosses (modulo 90degrees)
+     * \param alternate Whether to apply the pockets only to half of the junctions.
+     * \param use_odd_in_junctions Whether to apply pockets on the odd vs even junctions which are formed at low \p shift values
+     * \param use_odd_out_junctions Whether to apply pockets on the odd vs even junctions which are formed at high \p shift values
+     * \param pocket_size The size of the pockets to leave open at junctions.
+     * \param[out] result_polygons The output when \p zig_zaggify
+     * \param[out] result_lines The output when not \p zig_zaggify
+     */
+    void generate(const Polygons& outlines, coord_t shift, bool zig_zaggify, double fill_angle, bool alternate, bool use_odd_in_junctions, bool use_odd_out_junctions, coord_t pocket_size, Polygons& result_polygons, Polygons& result_lines) const;
+private:
+    AABB3D model_aabb; //!< The AABB of the boundary to cover
+    coord_t line_distance; //!< The width of the crosses and of the straight part of the anti-crosses
+    SpaceFillingTree tree; //!< The space filling tree cross fractal
+
+    /*!
+     * \brief Delegating constructor with pre-generated tree parameters.
+     */
+    SpaceFillingTreeFill(coord_t line_distance, AABB3D model_aabb, TreeParams tree_params);
+
+    /*!
+     * Compute the parameters with which to construct the tree.
+     * 
+     * The is done in a separate function so that those parameters can be calculated during the construction of this object
+     * 
+     * \param line_distance The width of the crosses and of the straight parts of the anti-crosses
+     * \param model_aabb The aabb to at aleast cover with the infill pattern
+     * \return The parameters with which to construct the tree.
+     */
+    static TreeParams getTreeParams(coord_t line_distance, AABB3D model_aabb);
+
+    /*!
+     * Generate the pattern itself by doing a depth first walk over the fractal.
+     * The nodes itself are being recorded
+     * 
+     * The parent nodes are present in this path multiple times.
+     * 
+     * \param[out] nodes The nodes of the path to generate
+     */
+    void generateTreePath(std::vector<const SpaceFillingTree::Node*>& nodes) const;
+
+    /*!
+     * Generate the line in between the tree path and the circumscribed
+     * square of each stage in the fractal.
+     * 
+     * The pockets are applied on half the junctions when we are \p alternating.
+     * 
+     * \param nodes The nodes of the tree path which walks along the cross fractal tree
+     * \param offset The offset from the cross fractal on straight pieces for half of the segments.
+     * \param pocket_size The size of the pockets to leave open at junctions.
+     * \param alternating Whether to apply pockets only to half the junctions
+     * \param use_odd_in_junctions Whether to apply pockets on the odd vs even junctions which are formed at low \p shift values
+     * \param use_odd_out_junctions Whether to apply pockets on the odd vs even junctions which are formed at high \p shift values
+     * \param[out] infill The cross infill pattern which isn't bounded to the outlines yet
+     */
+    void offsetTreePath(std::vector<const SpaceFillingTree::Node*>& nodes, coord_t offset, coord_t pocket_size, bool alternating, bool use_odd_in_junctions, bool use_odd_out_junctions, PolygonRef infill) const;
+};
+} // namespace cura
+
+
+#endif // INFILL_SPACE_FILLING_TREE_FILL_H

--- a/src/infill/SpaghettiInfillPathGenerator.cpp
+++ b/src/infill/SpaghettiInfillPathGenerator.cpp
@@ -15,6 +15,7 @@ bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage
     bool added_something = false;
     const GCodePathConfig& config = mesh_config.infill_config[0];
     const EFillMethod pattern = mesh.getSettingAsFillMethod("infill_pattern");
+    const bool zig_zaggify_infill = mesh.getSettingBoolean("zig_zaggify_infill");
     const unsigned int infill_line_width = config.getLineWidth();
     const int64_t infill_shift = 0;
     const int64_t outline_offset = 0;
@@ -37,8 +38,10 @@ bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage
         Polygons* perimeter_gaps_output = nullptr;
         const bool connected_zigzags = true;
         const bool use_endpieces = false;
-        Infill infill_comp(pattern, area, outline_offset, infill_line_width, infill_line_distance, infill_overlap, infill_angle, gcode_layer.z, infill_shift, perimeter_gaps_output, connected_zigzags, use_endpieces);
-        infill_comp.generate(infill_polygons, infill_lines, &mesh);
+        Infill infill_comp(pattern, zig_zaggify_infill, area, outline_offset
+            , infill_line_width, infill_line_distance, infill_overlap, infill_angle, gcode_layer.z, infill_shift, perimeter_gaps_output, connected_zigzags, use_endpieces
+            , mesh.getSettingBoolean("cross_infill_apply_pockets_alternatingly"), mesh.getSettingInMicrons("cross_infill_pocket_size"));
+        infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_pattern, &mesh);
 
         // add paths to plan with a higher flow ratio in order to extrude the required amount.
         const coord_t total_length = infill_polygons.polygonLength() + infill_lines.polyLineLength();
@@ -56,13 +59,33 @@ bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage
                 added_something = true;
                 fff_gcode_writer.setExtruder_addPrime(storage, gcode_layer, extruder_nr);
                 gcode_layer.addPolygonsByOptimizer(infill_polygons, config, nullptr, ZSeamConfig(), 0, false, flow_ratio);
-                if (pattern == EFillMethod::GRID || pattern == EFillMethod::LINES || pattern == EFillMethod::TRIANGLES || pattern == EFillMethod::CUBIC || pattern == EFillMethod::TETRAHEDRAL || pattern == EFillMethod::QUARTER_CUBIC || pattern == EFillMethod::CUBICSUBDIV)
+                switch(pattern)
                 {
-                    gcode_layer.addLinesByOptimizer(infill_lines, config, SpaceFillType::Lines, mesh.getSettingInMicrons("infill_wipe_dist"), flow_ratio);
-                }
-                else
-                {
-                    gcode_layer.addLinesByOptimizer(infill_lines, config, (pattern == EFillMethod::ZIG_ZAG)? SpaceFillType::PolyLines : SpaceFillType::Lines, 0, flow_ratio);
+                    case EFillMethod::GRID:
+                    case EFillMethod::LINES:
+                    case EFillMethod::TRIANGLES:
+                    case EFillMethod::CUBIC:
+                    case EFillMethod::TETRAHEDRAL:
+                    case EFillMethod::QUARTER_CUBIC:
+                    case EFillMethod::CUBICSUBDIV:
+                        gcode_layer.addLinesByOptimizer(infill_lines, config, SpaceFillType::Lines, mesh.getSettingInMicrons("infill_wipe_dist"), flow_ratio);
+                        break;
+                    case EFillMethod::CROSS:
+                    case EFillMethod::CROSS_3D:
+                        if (mesh.getSettingBoolean("zig_zaggify_infill"))
+                        {
+                            gcode_layer.addLinesByOptimizer(infill_lines, config, SpaceFillType::PolyLines, 0, flow_ratio);
+                        }
+                        else
+                        {
+                            gcode_layer.addLinesByOptimizer(infill_lines, config, SpaceFillType::Lines, mesh.getSettingInMicrons("infill_wipe_dist"), flow_ratio);
+                        }
+                    case EFillMethod::ZIG_ZAG:
+                        gcode_layer.addLinesByOptimizer(infill_lines, config, SpaceFillType::PolyLines, 0, flow_ratio);
+                        break;
+                    default:
+                        gcode_layer.addLinesByOptimizer(infill_lines, config, SpaceFillType::Lines, 0, flow_ratio);
+                        break;
                 }
             }
         }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1,3 +1,6 @@
+//Copyright (c) 2017 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
 #include "mesh.h"
 #include "utils/logoutput.h"
 
@@ -189,7 +192,7 @@ int Mesh::getFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx, int notFaceVe
                     break;
         }
 
-        FPoint3 v1 = vertices[candidateVertex].p -vertices[idx0].p;
+        FPoint3 v1 = vertices[faces[candidateFace].vertex_index[candidateVertex]].p - vertices[idx0].p;
         FPoint3 n1 = v1.cross(v0);
 
         double dot = n0 * n1;

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -381,6 +381,10 @@ EFillMethod SettingsBaseVirtual::getSettingAsFillMethod(std::string key) const
         return EFillMethod::CONCENTRIC_3D;
     if (value == "zigzag")
         return EFillMethod::ZIG_ZAG;
+    if (value == "cross")
+        return EFillMethod::CROSS;
+    if (value == "cross_3d")
+        return EFillMethod::CROSS_3D;
     return EFillMethod::NONE;
 }
 

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -117,6 +117,8 @@ enum class EFillMethod
     CONCENTRIC,
     CONCENTRIC_3D,
     ZIG_ZAG,
+    CROSS,
+    CROSS_3D,
     NONE
 };
 

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -63,6 +63,8 @@ SkinInfillAreaComputation::SkinInfillAreaComputation(int layer_nr, const SliceDa
 , process_infill(process_infill)
 , top_reference_wall_expansion(mesh.getSettingInMicrons("top_skin_preshrink"))
 , bottom_reference_wall_expansion(mesh.getSettingInMicrons("bottom_skin_preshrink"))
+, top_skin_expand_distance(mesh.getSettingInMicrons("top_skin_expand_distance"))
+, bottom_skin_expand_distance(mesh.getSettingInMicrons("bottom_skin_expand_distance"))
 , top_reference_wall_idx(getReferenceWallIdx(top_reference_wall_expansion))
 , bottom_reference_wall_idx(getReferenceWallIdx(bottom_reference_wall_expansion))
 {
@@ -273,28 +275,41 @@ void SkinInfillAreaComputation::calculateTopSkin(const SliceLayerPart& part, int
  */
 void SkinInfillAreaComputation::applySkinExpansion(const Polygons& original_outline, Polygons& upskin, Polygons& downskin)
 {
-    coord_t expand_skins_expand_distance = mesh.getSettingInMicrons("expand_skins_expand_distance");
-    if (expand_skins_expand_distance <= 0)
+    // First we set the amount of distance we want to expand, as indicated in settings
+    coord_t top_outset = top_skin_expand_distance;
+    coord_t bottom_outset = bottom_skin_expand_distance;
+
+    coord_t top_min_width = mesh.getSettingInMicrons("min_skin_width_for_expansion") / 2;
+    coord_t bottom_min_width = top_min_width;
+
+    // Compensate for the pre-shrink applied because of the Skin Removal Width.
+    // The skin removal width is satisfied by applying a close operation and
+    // it's done in the calculateTopSkin and calculateBottomSkin, by expanding the infill.
+    // The inset of that close operation is applied in calculateTopSkin and calculateBottomSkin
+    // The outset of the close operation is applied at the same time as the skin expansion.
+    top_outset += top_reference_wall_expansion;
+    bottom_outset += bottom_reference_wall_expansion;
+
+    // Calculate the shrinkage needed to fulfill the minimum skin with for expansion
+    top_min_width = std::max(coord_t(0), top_min_width - top_reference_wall_expansion / 2); // if the min width is smaller than the pre-shrink then areas smaller than min_width will exist
+    bottom_min_width = std::max(coord_t(0), bottom_min_width - bottom_reference_wall_expansion / 2); // if the min width is smaller than the pre-shrink then areas smaller than min_width will exist
+
+    // skin areas are to be enlarged by skin_expand_distance but before they are expanded
+    // the skin areas are shrunk by min_width so that very narrow regions of skin
+    // (often caused by the model's surface having a steep incline) are not expanded
+
+    top_outset += top_min_width; // increase the expansion distance to compensate for the min_width shrinkage
+    bottom_outset += bottom_min_width; // increase the expansion distance to compensate for the min_width shrinkage
+
+    // Execute shrinkage and expansion in the same operation
+    if (top_outset)
     {
-        return;
+        upskin = upskin.offset(-top_min_width).offset(top_outset).unionPolygons(upskin).intersection(original_outline);
     }
 
-    coord_t pre_shrink = mesh.getSettingInMicrons("min_skin_width_for_expansion") / 2;
-
-    // skin areas are to be enlarged by expand_skins_expand_distance but before they are expanded
-    // the skin areas are shrunk by pre_shrink so that very narrow regions of skin
-    // (often caused by the model's surface having a steep incline) are removed first
-
-    expand_skins_expand_distance += pre_shrink; // increase the expansion distance to compensate for the shrinkage
-
-    if (mesh.getSettingBoolean("expand_upper_skins"))
+    if (bottom_outset)
     {
-        upskin = upskin.offset(-pre_shrink).offset(expand_skins_expand_distance).unionPolygons(upskin).intersection(original_outline);
-    }
-
-    if (mesh.getSettingBoolean("expand_lower_skins"))
-    {
-        downskin = downskin.offset(-pre_shrink).offset(expand_skins_expand_distance).unionPolygons(downskin).intersection(original_outline);
+        downskin = downskin.offset(-bottom_min_width).offset(bottom_outset).unionPolygons(downskin).intersection(original_outline);
     }
 }
 

--- a/src/skin.h
+++ b/src/skin.h
@@ -154,6 +154,8 @@ protected:
 
     coord_t top_reference_wall_expansion; //!< The horizontal expansion to apply to the top reference wall in order to shrink the top skin
     coord_t bottom_reference_wall_expansion; //!< The horizontal expansion to apply to the bottom reference wall in order to shrink the bottom skin
+    coord_t top_skin_expand_distance; //!< The distance by which the top skins should be larger than the original top skins.
+    coord_t bottom_skin_expand_distance; //!< The distance by which the bottom skins should be larger than the original bottom skins.
     const int top_reference_wall_idx; //!< The wall of the layer above to consider as inside. Lower index means more skin.
     const int bottom_reference_wall_idx; //!< The wall of the layer below to consider as inside. Lower index means more skin.
 private:

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -5,10 +5,20 @@
 
 #include "FffProcessor.h" //To create a mesh group with if none is provided.
 #include "infill/SubDivCube.h" // For the destructor
+#include "infill/SpaceFillingTreeFill.h" // for destructor
 
 
 namespace cura
 {
+
+SupportStorage::~SupportStorage()
+{
+    supportLayers.clear(); 
+    if (cross_fill_pattern)
+    {
+        delete cross_fill_pattern;
+    }
+}
 
 Polygons& SliceLayerPart::getOwnInfillArea()
 {
@@ -90,6 +100,10 @@ SliceMeshStorage::~SliceMeshStorage()
     if (base_subdiv_cube)
     {
         delete base_subdiv_cube;
+    }
+    if (cross_fill_pattern)
+    {
+        delete cross_fill_pattern;
     }
 }
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -211,6 +211,8 @@ public:
     void excludeAreasFromSupportInfillAreas(const Polygons& exclude_polygons, const AABB& exclude_polygons_boundary_box);
 };
 
+class SpaceFillingTreeFill; // forward declaration to prevent dependency loop
+
 class SupportStorage
 {
 public:
@@ -219,13 +221,15 @@ public:
     int layer_nr_max_filled_layer; //!< the layer number of the uppermost layer with content
 
     std::vector<SupportLayer> supportLayers;
+    SpaceFillingTreeFill* cross_fill_pattern; //!< the fractal pattern for the cross (3d) filling pattern
 
     SupportStorage()
     : generated(false)
     , layer_nr_max_filled_layer(-1)
+    , cross_fill_pattern(nullptr)
     {
     }
-    ~SupportStorage(){ supportLayers.clear(); }
+    ~SupportStorage();
 };
 /******************/
 
@@ -242,13 +246,16 @@ public:
     std::vector<int> roofing_angles; //!< a list of angle values (in degrees) which is cycled through to determine the roofing angle of each layer
     std::vector<int> skin_angles; //!< a list of angle values (in degrees) which is cycled through to determine the skin angle of each layer
     AABB3D bounding_box; //!< the mesh's bounding box
+
     SubDivCube* base_subdiv_cube;
+    SpaceFillingTreeFill* cross_fill_pattern; //!< the fractal pattern for the cross (3d) filling pattern
 
     SliceMeshStorage(Mesh* mesh, unsigned int slice_layer_count)
     : SettingsMessenger(mesh)
     , layer_nr_max_filled_layer(0)
     , bounding_box(mesh->getAABB())
     , base_subdiv_cube(nullptr)
+    , cross_fill_pattern(nullptr)
     {
         layers.resize(slice_layer_count);
     }

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -15,6 +15,7 @@
 
 #include "utils/math.h"
 #include "progress/Progress.h"
+#include "infill/SpaceFillingTreeFill.h"
 
 namespace cura 
 {
@@ -624,6 +625,37 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage, unsigned int l
 
     // split the global support areas into parts for later gradual support infill generation
     AreaSupport::splitGlobalSupportAreasIntoSupportInfillParts(storage, global_support_areas_per_layer, storage.print_layer_count);
+
+    // Pre-compute Cross Fractal
+    const ExtruderTrain& infill_extr = *storage.meshgroup->getExtruderTrain(storage.getSettingAsIndex("support_infill_extruder_nr"));
+    const EFillMethod support_pattern = infill_extr.getSettingAsFillMethod("support_pattern");
+    if (support_pattern == EFillMethod::CROSS || support_pattern == EFillMethod::CROSS_3D)
+    {
+        AABB3D aabb;
+        for (unsigned int mesh_idx = 0; mesh_idx < storage.meshes.size(); mesh_idx++)
+        {
+            const SliceMeshStorage& mesh = storage.meshes[mesh_idx];
+            if (mesh.getSettingBoolean("infill_mesh") || mesh.getSettingBoolean("anti_overhang_mesh"))
+            {
+                continue;
+            }
+            SettingsBaseVirtual* infill_settings = &storage.meshes[mesh_idx];
+            if (mesh.getSettingBoolean("support_mesh"))
+            {
+                // use extruder train settings rather than the per-object settings of the first support mesh encountered.
+                // because all support meshes are processed at the same time it doesn't make sense to use the per-object settings of the first support mesh encountered.
+                // instead we must use the support extruder settings, which is the settings base common to all support meshes.
+                int infill_extruder_nr = storage.getSettingAsIndex("support_infill_extruder_nr");
+                infill_settings = storage.meshgroup->getExtruderTrain(infill_extruder_nr);
+            }
+            const coord_t aabb_expansion = infill_settings->getSettingInMicrons("support_offset");
+            AABB3D aabb_here(mesh.bounding_box);
+            aabb_here.include(aabb_here.min - Point3(-aabb_expansion, -aabb_expansion, 0));
+            aabb_here.include(aabb_here.max + Point3(-aabb_expansion, -aabb_expansion, 0));
+            aabb.include(aabb_here);
+        }
+        storage.support.cross_fill_pattern = new SpaceFillingTreeFill(infill_extr.getSettingInMicrons("support_line_distance"), aabb);
+    }
 }
 
 /* 

--- a/src/utils/AABB.cpp
+++ b/src/utils/AABB.cpp
@@ -87,5 +87,15 @@ void AABB::expand(int dist)
     max.Y += dist;
 }
 
+Polygon AABB::toPolygon() const
+{
+    Polygon ret;
+    ret.add(min);
+    ret.add(Point(max.X, min.Y));
+    ret.add(max);
+    ret.add(Point(min.X, max.Y));
+    return ret;
+}
+
 }//namespace cura
 

--- a/src/utils/AABB.h
+++ b/src/utils/AABB.h
@@ -55,6 +55,12 @@ public:
      * \param dist The distance by which to expand the borders of the bounding box
      */
     void expand(int dist);
+
+    /*!
+     * Generate a square polygon which coincides with this aabb
+     * \return the polygon of this aabb
+     */
+    Polygon toPolygon() const;
 };
 
 }//namespace cura

--- a/src/utils/AABB3D.cpp
+++ b/src/utils/AABB3D.cpp
@@ -13,6 +13,12 @@ AABB3D::AABB3D()
 {
 }
 
+AABB3D::AABB3D(Point3 min, Point3 max) 
+: min(min)
+, max(max)
+{
+}
+
 Point3 AABB3D::getMiddle() const
 {
     return (min + max) / 2;
@@ -41,6 +47,12 @@ void AABB3D::include(Point3 p)
     max.x = std::max(max.x, p.x);
     max.y = std::max(max.y, p.y);
     max.z = std::max(max.z, p.z);   
+}
+
+void AABB3D::include(const AABB3D& aabb)
+{
+    include(aabb.min);
+    include(aabb.max);
 }
 
 void AABB3D::includeZ(int32_t z)

--- a/src/utils/AABB3D.h
+++ b/src/utils/AABB3D.h
@@ -23,6 +23,11 @@ struct AABB3D
     AABB3D();
 
     /*!
+     * Create an AABB3D with given limits
+     */
+    AABB3D(Point3 min, Point3 max);
+
+    /*!
      * Get the middle of the bounding box
      */
     Point3 getMiddle() const;
@@ -42,6 +47,12 @@ struct AABB3D
      * \param p The point to include with the bounding box.
      */
     void include(Point3 p);
+
+    /*!
+     * Expand the AABB3D to include the bounding box \p aabb.
+     * \param aabb The aabb to include with this bounding box.
+     */
+    void include(const AABB3D& aabb);
 
     /*!
      * Expand the AABB3D to include a z-coordinate.

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -51,7 +51,7 @@ private:
     const double scale;
 
 public:
-    SVG(const char* filename, AABB aabb, Point canvas_size = Point(1024 * 4, 1024 * 4))
+    SVG(const char* filename, AABB aabb, Point canvas_size = Point(1024, 1024))
     : aabb(aabb)
     , aabb_size(aabb.max - aabb.min)
     , border(200,100)
@@ -201,10 +201,10 @@ public:
     {
         fprintf(out, txt, args...);
     }
-    void writeText(Point p, std::string txt)
+    void writeText(Point p, std::string txt, Color color = Color::BLACK, coord_t font_size = 10)
     {
         Point pf = transform(p);
-        fprintf(out, "<text x=\"%lli\" y=\"%lli\" style=\"font-size: 10px;\" fill=\"black\">%s</text>\n",pf.X, pf.Y, txt.c_str());
+        fprintf(out, "<text x=\"%lli\" y=\"%lli\" style=\"font-size: %llipx;\" fill=\"%s\">%s</text>\n",pf.X, pf.Y, font_size, toString(color).c_str(), txt.c_str());
     }
     void writePolygons(const Polygons& polys, Color color = Color::BLACK)
     {
@@ -215,6 +215,10 @@ public:
     }
     void writePolygon(ConstPolygonRef poly, Color color = Color::BLACK)
     {
+        if (poly.size() == 0)
+        {
+            return;
+        }
         Point p0 = poly.back();
         for (Point p1 : poly)
         {

--- a/src/utils/SpaceFillingTree.cpp
+++ b/src/utils/SpaceFillingTree.cpp
@@ -1,0 +1,274 @@
+/** Copyright (C) 2017 Tim Kuipers - Released under terms of the AGPLv3 License */
+#include "SpaceFillingTree.h"
+
+namespace cura {
+
+
+SpaceFillingTree::SpaceFillingTree(
+    Point middle,
+    coord_t radius,
+    unsigned int depth)
+: root(nullptr)
+, depth(depth)
+{
+    unsigned int root_depth = 0;
+    root = new Node(nullptr
+    , root_depth
+    , middle
+    , Direction::DIRECTION_COUNT // The root has no parent to child direction, so DIRECTION_COUNT is used as exception value
+    , depth
+    );
+
+    // total width = radius becase 1 + .5 + .25 + ... = 2
+    // therefore the initial width = .5 * radius
+    coord_t first_offset = radius / 2; // horizontal/vertical distance from the middle to the end of the first line segment
+    // construct 1st order children
+    root->construct(first_offset);
+    root->prune();
+    root->distance_depth = 0;
+    root->setDistanceDepth();
+}
+
+
+SpaceFillingTree::SpaceFillingTree(SpaceFillingTree&& other)
+: aabb(other.aabb)
+, root(other.root)
+{ // move constructor
+    other.root = nullptr;
+}
+
+SpaceFillingTree::~SpaceFillingTree()
+{
+    if (root)
+    {
+        delete root;
+    }
+}
+
+void SpaceFillingTree::walk(SpaceFillingTree::LocationVisitor& visitor) const
+{
+    root->walk(visitor);
+}
+
+void SpaceFillingTree::debugOutput(SVG& out, bool output_dfs_order) const
+{
+    out.writePolygon(aabb.toPolygon());
+    int root_order = 0;
+    root->debugOutput(out, root->middle, output_dfs_order, root_order); // root will draw line from its middle to the same middle
+}
+
+bool SpaceFillingTree::debugCheck() const
+{
+    return root->debugCheck();
+}
+
+SpaceFillingTree::Node::Node(SpaceFillingTree::Node* parent, unsigned int recursion_depth, Point middle, Direction parent_to_here_direction, unsigned int total_depth)
+: parent(parent)
+, recursion_depth(recursion_depth)
+, total_depth(total_depth)
+, middle(middle)
+, parent_to_here_direction(parent_to_here_direction)
+{
+    for (Node*& child_place : children)
+    {
+        child_place = nullptr;
+    }
+}
+
+SpaceFillingTree::Node::~Node()
+{
+    for (Node* child : children)
+    {
+        if (child)
+        {
+            delete child;
+        }
+    }
+}
+
+void SpaceFillingTree::Node::construct(coord_t child_offset)
+{
+    for (Direction child_dir = static_cast<Direction>(0); child_dir < Direction::DIRECTION_COUNT; child_dir = static_cast<Direction>(child_dir + 1))
+    {
+        constructNode(child_dir, child_offset);
+    }
+}
+
+void SpaceFillingTree::Node::constructNode(Direction direction, coord_t child_offset)
+{
+    Point child_middle_offset = Point(child_offset, child_offset);
+    if (direction == Direction::LD || direction == Direction::RD)
+    { // if down
+        child_middle_offset.Y *= -1;
+    }
+    if (direction == Direction::LD || direction == Direction::LU)
+    { // if left
+        child_middle_offset.X *= -1;
+    }
+    const Point child_middle = middle + child_middle_offset;
+    Node* new_node;
+    if (parent && direction == (parent_to_here_direction + 2) % Direction::DIRECTION_COUNT)
+    {
+        /*
+         * reorder:
+         *   make
+         * parent-->new_node-->this
+         *   rather than
+         * parent------------->this
+         *         new_node<---'
+         */
+        new_node = new Node(parent, recursion_depth + 1, child_middle, parent_to_here_direction, total_depth);
+        parent->children[parent_to_here_direction] = new_node;
+        new_node->children[parent_to_here_direction] = this;
+        parent = new_node;
+    }
+    else
+    {
+        new_node = new Node(this, recursion_depth + 1, child_middle, direction, total_depth);
+        if (children[direction])
+        {
+            /*!
+             * reorder
+             *  from
+             * this------------->child
+             *   make
+             * this-->new_node-->child
+             */
+            new_node->children[direction] = this->children[direction];
+            new_node->children[direction]->parent = new_node;
+        }
+        this->children[direction] = new_node;
+    }
+#ifdef DEBUG
+    if (parent)
+    {
+        parent->debugCheck();
+    }
+    else
+    {
+        debugCheck();
+    }
+#endif // DEBUG
+
+    assert(new_node->parent == this || new_node == parent);
+    if (recursion_depth >= total_depth)
+    {
+        return;
+    }
+    new_node->construct(child_offset / 2);
+}
+
+void SpaceFillingTree::Node::prune()
+{
+    for (int child_dir = 0; child_dir < Direction::DIRECTION_COUNT; child_dir++)
+    {
+        Node*& child = children[child_dir];
+        if (!child)
+        {
+            continue;
+        }
+        Node* right = child->children[(child_dir + 1) % Direction::DIRECTION_COUNT];
+        Node* front = child->children[child_dir];
+        Node* left = child->children[(child_dir + 3) % Direction::DIRECTION_COUNT];
+        if (front && !left && !right)
+        {
+            Node* original_child = child;
+            child = front; // move grandchild to children
+            child->parent = this;
+            original_child->children[child_dir] = nullptr; // so that it won't be deleted
+            assert(!original_child->children[0]);
+            assert(!original_child->children[1]);
+            assert(!original_child->children[2]);
+            assert(!original_child->children[3]);
+            delete original_child;
+            child_dir--; // make the next iteration of this loop handle this new child again
+#ifdef DEBUG
+            debugCheck();
+#endif // DEBUG
+        }
+        child->prune(); // prune new or existing child recursively
+        assert(child->parent == this);
+    }
+}
+
+void SpaceFillingTree::Node::setDistanceDepth()
+{
+    for (int child_dir = 0; child_dir < Direction::DIRECTION_COUNT; child_dir++)
+    {
+        Node*& child = children[child_dir];
+        if (!child)
+        {
+            continue;
+        }
+        child->distance_depth = distance_depth + 1;
+        child->setDistanceDepth();
+    }
+}
+
+void SpaceFillingTree::Node::walk(SpaceFillingTree::LocationVisitor& visitor) const
+{
+    visitor.visit(this);
+    for (int dir_offset = 0; dir_offset < Direction::DIRECTION_COUNT; dir_offset++)
+    {
+        int direction = (parent_to_here_direction + dir_offset + 2) % Direction::DIRECTION_COUNT;
+        Node* child = children[direction];
+        if (child)
+        {
+            assert(child->parent == this);
+            child->walk(visitor);
+            visitor.visit(this);
+        }
+    }
+}
+
+void SpaceFillingTree::Node::debugOutput(SVG& out, Point parent_middle, bool output_dfs_order, int& order_nr, bool output_directions, bool output_distance_depth) const
+{
+    out.writeLine(parent_middle, middle);
+    if (output_dfs_order)
+    {
+        out.writeText(middle, std::to_string(order_nr));
+    }
+    if (output_distance_depth)
+    {
+        out.writeText(middle, std::to_string(distance_depth));
+    }
+    for (int dir_offset = 0; dir_offset < Direction::DIRECTION_COUNT; dir_offset++)
+    {
+        int direction = (parent_to_here_direction + dir_offset + 2) % Direction::DIRECTION_COUNT;
+        Node* child = children[direction];
+        if (child)
+        {
+            order_nr++;
+            if (output_directions)
+            {
+                out.writeText((middle + child->middle) / 2, std::to_string(direction), SVG::Color::BLUE);
+            }
+            child->debugOutput(out, middle, output_dfs_order, order_nr, output_directions, output_distance_depth);
+        }
+    }
+}
+
+bool SpaceFillingTree::Node::debugCheck() const
+{
+    bool fail = false;
+    for (int child_dir = 0; child_dir < Direction::DIRECTION_COUNT; child_dir++)
+    {
+        Node* child = children[child_dir];
+        if (child)
+        {
+#ifdef DEBUG
+            assert(child->children[(child_dir + 2) % Direction::DIRECTION_COUNT] == nullptr);
+            assert(child->parent == this);
+            assert(child->parent_to_here_direction == static_cast<Direction>(child_dir));
+#endif // DEBUG
+            fail |= child->children[(child_dir + 2) % Direction::DIRECTION_COUNT] != nullptr;
+            fail |= child->parent != this;
+            fail |= child->parent_to_here_direction != static_cast<Direction>(child_dir);
+            fail |= child->debugCheck();
+            assert(!fail);
+        }
+    }
+    return fail;
+}
+
+}; // namespace cura

--- a/src/utils/SpaceFillingTree.h
+++ b/src/utils/SpaceFillingTree.h
@@ -1,0 +1,226 @@
+/** Copyright (C) 2017 Tim Kuipers - Released under terms of the AGPLv3 License */
+#ifndef UTILS_SPACE_FILLING_TREE_H
+#define UTILS_SPACE_FILLING_TREE_H
+
+#include "../utils/polygon.h"
+#include "../utils/AABB.h"
+#include "../utils/intpoint.h"
+#include "../utils/optional.h"
+
+#include "../utils/SVG.h"
+
+namespace cura
+{
+
+class SpaceFillingTreeFill;
+/*!
+ *                 |
+ *               --+--
+ *            |    |    |                              ▄▉▄
+ *          --+----+----+--                          ▄  ▉  ▄
+ *       |    |    |    |                           ▀▉▀▀▉▀▀▉▀
+ *     --+--     --+--     --+--                 ▄▉▄   ▄▉▄   ▄▉▄
+ *  |    |    |    |    |    |    |            ▄  ▉  ▄  ▉  ▄  ▉  ▄
+ *--+----+----+----+----+----+----+--         ▀▉▀▀▉▀▀▉▀▀▉▀▀▉▀▀▉▀▀▉▀
+ *  |    |    |    |    |    |    |              ▄▉▄   ▄▉▄   ▄▉▄
+ *     --+--     --+--     --+--                  ▀  ▄  ▉  ▄  ▀
+ *       |    |    |    |                           ▀▉▀▀▉▀▀▉▀
+ *          --+----+----+--                            ▄▉▄
+ *            |    |    |                               ▀
+ *               --+--
+ *                 |
+ *
+ * Class for generating a space filling tree which consists of a cros fractal.
+ * The limit of the fractal sovers the area of a square.
+ * 
+ * The initial line segments have half the width of the full square;
+ * The next iteration adds line segments of half that width to the end;
+ * because 1+.5+.25+... = 2 this eventually fills the square
+ * 
+ * The root of the tree is the middle.
+ * 
+ * The connected distance from a point to the root determines it's parent-child relation;
+ * no child is along the edge from a node to it's parent.
+ */
+class SpaceFillingTree
+{
+public:
+    class Node;
+    /*!
+     * pure virtual class to implement by an external class
+     * which is used to process nodes when doing a DFS walk.
+     */
+    class LocationVisitor
+    {
+    public:
+        /*!
+         * Register a location being crossed during the walk.
+         * \param node The node visited
+         */
+        virtual void visit(const Node* node) = 0;
+    };
+
+    /*!
+     * Construct a tree
+     * \param middle The location of the root
+     * \param radius The distance from the root to the side (or the top etc.)
+     * \param depth The recursion depth of the fractal
+     */
+    SpaceFillingTree(
+        Point middle,
+        coord_t radius,
+        unsigned int depth);
+
+    /*!
+     * Move constructor
+     */
+    SpaceFillingTree(SpaceFillingTree&& other);
+
+    /*!
+     * Destructor, which recursively deletes all nodes in the tree.
+     */
+    ~SpaceFillingTree();
+
+    /*!
+     * Do a depth first walk along the tree.
+     * This is a pre-order, in-order AND post-order DFS.
+     * A node is visited.
+     * Then it's child.
+     * Then the node again.
+     * Then the next child.
+     *    ...
+     * Then the node again.
+     * Then its parent.
+     * etc.
+     * \param visitor The external handler of each location of a node.
+     */
+    void walk(LocationVisitor& visitor) const;
+
+    /*!
+     * Create a nice picture of the cross fractal with optional numbers of a pre-order DFS.
+     * This DFS is not the same as the order from \ref SpaceFillingTree::walk
+     * 
+     * \param[out] out the canvas in which to draw
+     * \param output_dfs_order Whether to output the numbers of a pre-order DFS
+     */
+    void debugOutput(SVG& out, bool output_dfs_order = false) const;
+
+    /*!
+     * Check whether the tree is correct.
+     * 
+     * Only handled in debug mode.
+     * 
+     * Works by way of assertions in DEBUG mode.
+     * \return Whether problems have been found
+     */
+    bool debugCheck() const;
+
+    /*!
+     * Direction of a line segment.
+     * 
+     * Combinations of (left|right) and (up|down)
+     * in circular order.
+     */
+    enum Direction : unsigned char
+    {
+        LU = 0,
+        RU = 1,
+        RD = 2,
+        LD = 3,
+        DIRECTION_COUNT = 4
+    };
+
+    /*!
+     * A node in the space filling tree
+     */
+    class  Node
+    {
+    public:
+        Node* parent; //!< Parent node. Optional because of root
+        unsigned int recursion_depth; //!< The recursion distance from root.
+        unsigned int distance_depth; //!< The node distance from root.
+        unsigned int total_depth; //!< The total depth the tree should have
+        Point middle; //!< The location of the middle of this node. This is the middle of the square which is to be covered by the subtree of this node.
+        Direction parent_to_here_direction; //!< The direction from the parent middle to this nodes middle.
+        Node* children[4]; //!< connected junction points ordered on absolute direction
+
+        /*!
+         * Create a node with given parameters and no children.
+         * 
+         * \param parent Parent node. Optional because of root
+         * \param depth The number of generations BELOW this node. Not the distance from root.
+         * \param middle The location of the middle of this node. This is the middle of the square which is to be covered by the subtree of this node.
+         * \param parent_to_here_direction The direction from the parent middle to this nodes middle.
+         * \param total_depth The total depth the tree should have
+         */
+        Node(Node* parent, unsigned int depth, Point middle, Direction parent_to_here_direction, unsigned int total_depth);
+
+        /*!
+         * Destruct node and all it's children recursively
+         */
+        ~Node();
+
+        /*!
+         * Construct the sub-tree of this node recursively.
+         * 
+         * \param child_offset The horizontal and vertical offset from this middle to create a child
+         */
+        void construct(coord_t child_offset);
+
+        /*!
+         * Construct the child and its sub-tree of a given direction.
+         * 
+         * \param direction The direction in which to construct a child
+         * \param child_offset The horizontal and vertical offset from this middle to create a child
+         */
+        void constructNode(Direction direction, coord_t child_offset);
+
+        /*!
+         * Remove points along straight edges in the sub-tree of this node, recursively.
+         */
+        void prune();
+
+        /*!
+         * Walk through this subtree and set the distance_depth of each child lower than my own.
+         */
+        void setDistanceDepth();
+
+        /*!
+         * Do a pre-order, in-order and post-order walk of the subtree of this node.
+         * \param visitor The external handler of each location of a node.
+         */
+        void walk(LocationVisitor& visitor) const;
+
+        /*!
+         * Create a nice picture of the cubtree of this node with optional numbers of a pre-order DFS.
+         * This DFS is not the same as the order from \ref SpaceFillingTree::walk
+         * 
+         * \param[out] out the canvas in which to draw
+         * \param parent_middle The location of the middle of the parent node
+         * \param output_dfs_order Whether to output the numbers of a pre-order DFS
+         * \param[in,out] order_nr The dfs order
+         * \param output_directions Include numbers along each edge of th direction of that edge. This is handy to verify that all edges are pointing away from the root, rather than toward.
+         * \param output_distance_depth Whether to output the distance depth of each node
+         */
+        void debugOutput(SVG& out, Point parent_middle, bool output_dfs_order, int& order_nr, bool output_directions = false, bool output_distance_depth = true) const;
+
+        /*!
+         * Check whether node is correct and recurse for all children.
+         * 
+         * Only processed in DEBUG mode.
+         * 
+         * Works by way of assertions in DEBUG mode.
+         * \return Whether problems have been found
+         */
+        bool debugCheck() const;
+    };
+
+protected:
+    AABB aabb; //!< The aabb of the pattern to be generated. This is the area which is covered by the limit of the fractal.
+    Node* root; //!< The root node of the tree. The middle of the fractal.
+    unsigned int depth; //!< The depth of this tree.
+};
+} // namespace cura
+
+
+#endif // UTILS_SPACE_FILLING_TREE_H

--- a/src/utils/intpoint.h
+++ b/src/utils/intpoint.h
@@ -327,6 +327,23 @@ public:
                     , p.x * matrix[6] + p.y * matrix[7] + p.z * matrix[8]);
     }
 
+    /*!
+     * Apply matrix to vector as homogeneous coordinates.
+     */
+    Point apply(const Point p) const
+    {
+        Point3 result = apply(Point3(p.X, p.Y, 1));
+        return Point(result.x / result.z, result.y / result.z);
+    }
+
+    static Point3Matrix translate(const Point p)
+    {
+        Point3Matrix ret; // uniform matrix
+        ret.matrix[2] = p.X;
+        ret.matrix[5] = p.Y;
+        return ret;
+    }
+
     Point3Matrix compose(const Point3Matrix& b)
     {
         Point3Matrix ret;

--- a/src/utils/linearAlg2D.h
+++ b/src/utils/linearAlg2D.h
@@ -321,6 +321,15 @@ public:
         return dot(ba, bc);
     }
 
+    /*!
+     * Get the rotation matrix for rotating around a specific point in place.
+     */
+    static Point3Matrix rotateAround(Point middle, double rotation)
+    {
+        PointMatrix rotation_matrix(rotation);
+        Point3Matrix rotation_matrix_homogeneous(rotation_matrix);
+        return Point3Matrix::translate(middle).compose(rotation_matrix_homogeneous).compose(Point3Matrix::translate(-middle));
+    }
 };
 
 

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -208,6 +208,18 @@ unsigned int Polygons::findInside(Point p, bool border_result)
     return ret;
 }
 
+Polygons Polygons::intersectionPolyLines(const Polygons& polylines) const
+{
+    ClipperLib::PolyTree result;
+    ClipperLib::Clipper clipper(clipper_init);
+    clipper.AddPaths(polylines.paths, ClipperLib::ptSubject, false);
+    clipper.AddPaths(paths, ClipperLib::ptClip, true);
+    clipper.Execute(ClipperLib::ctIntersection, result);
+    Polygons ret;
+    ret.addPolyTreeNodeRecursive(result);
+    return ret;
+}
+
 coord_t Polygons::polyLineLength() const
 {
     coord_t length = 0;
@@ -499,6 +511,21 @@ void PolygonRef::simplify(int smallest_line_segment_squared, int allowed_error_d
     ListPolyIt::convertListPolygonToPolygon(result_list_poly, *this);
 }
 
+void PolygonRef::applyMatrix(const PointMatrix& matrix)
+{
+    for (unsigned int path_idx = 0; path_idx < path->size(); path_idx++)
+    {
+        (*path)[path_idx] = matrix.apply((*path)[path_idx]);
+    }
+}
+void PolygonRef::applyMatrix(const Point3Matrix& matrix)
+{
+    for (unsigned int path_idx = 0; path_idx < path->size(); path_idx++)
+    {
+        (*path)[path_idx] = matrix.apply((*path)[path_idx]);
+    }
+}
+
 Polygons Polygons::getOutsidePolygons() const
 {
     Polygons ret;
@@ -562,6 +589,25 @@ void Polygons::removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& 
                 removeEmptyHoles_processPolyTreeNode(hole_node, remove_holes, ret);
             }
         }
+    }
+}
+
+
+Polygons Polygons::toPolygons(ClipperLib::PolyTree& poly_tree)
+{
+    Polygons ret;
+    ret.addPolyTreeNodeRecursive(poly_tree);
+    return ret;
+}
+
+
+void Polygons::addPolyTreeNodeRecursive(const ClipperLib::PolyNode& node)
+{
+    for (int outer_poly_idx = 0; outer_poly_idx < node.ChildCount(); outer_poly_idx++)
+    {
+        ClipperLib::PolyNode* child = node.Childs[outer_poly_idx];
+        this->paths.push_back(child->Contour);
+        addPolyTreeNodeRecursive(*child);
     }
 }
 

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -43,6 +43,11 @@ const static int clipper_init = (0);
 
 class ConstPolygonPointer;
 
+/*!
+ * Outer polygons should be counter-clockwise,
+ * inner hole polygons should be clockwise.
+ * (When negative X is to the left and negative Y is downward.)
+ */
 class ConstPolygonRef
 {
     friend class Polygons;
@@ -435,6 +440,12 @@ public:
     { 
         path->pop_back();
     }
+
+    /*!
+     * Apply a matrix to each vertex in this polygon
+     */
+    void applyMatrix(const PointMatrix& matrix);
+    void applyMatrix(const Point3Matrix& matrix);
 };
 
 class ConstPolygonPointer
@@ -661,6 +672,12 @@ public:
 
     bool operator==(const Polygons& other) const =delete;
 
+    /*!
+     * Convert ClipperLib::PolyTree to a Polygons object,
+     * which uses ClipperLib::Paths instead of ClipperLib::PolyTree
+     */
+    static Polygons toPolygons(ClipperLib::PolyTree& poly_tree);
+
     Polygons difference(const Polygons& other) const
     {
         Polygons ret;
@@ -695,6 +712,12 @@ public:
         clipper.Execute(ClipperLib::ctIntersection, ret.paths);
         return ret;
     }
+
+    /*!
+     * Intersect polylines with this area Polygons object.
+     */
+    Polygons intersectionPolyLines(const Polygons& polylines) const;
+
     /*!
      * Clips input line segments by this Polygons.
      * \param other Input line segments to be cropped
@@ -882,6 +905,12 @@ private:
      */
     void removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, const bool remove_holes, Polygons& ret) const;
     void splitIntoParts_processPolyTreeNode(ClipperLib::PolyNode* node, std::vector<PolygonsPart>& ret) const;
+
+    /*!
+     * Convert a node from a ClipperLib::PolyTree and add it to a Polygons object,
+     * which uses ClipperLib::Paths instead of ClipperLib::PolyTree
+     */
+    void addPolyTreeNodeRecursive(const ClipperLib::PolyNode& node);
 public:
     /*!
      * Split up the polygons into groups according to the even-odd rule.

--- a/tests/infill/SpaceFillingTreeFillTest.cpp
+++ b/tests/infill/SpaceFillingTreeFillTest.cpp
@@ -1,0 +1,52 @@
+//Copyright (c) 2017 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include "SpaceFillingTreeFillTest.h"
+
+namespace cura
+{
+CPPUNIT_TEST_SUITE_REGISTRATION(SpaceFillingTreeFillTest);
+
+void SpaceFillingTreeFillTest::setUp()
+{
+    // no dothing
+}
+
+void SpaceFillingTreeFillTest::tearDown()
+{
+    // no dothing
+}
+
+void SpaceFillingTreeFillTest::debugCheck()
+{
+    bool fail = tree.debugCheck();
+    CPPUNIT_ASSERT_MESSAGE("Space filling tree incorrect!", !fail);
+}
+
+void SpaceFillingTreeFillTest::boundsCheck()
+{
+    struct Visitor : public SpaceFillingTree::LocationVisitor
+    {
+        AABB aabb;
+        Visitor()
+        {}
+        /*!
+         * Register a location being crossed during the walk.
+         * \param node The node visited
+         */
+        void visit(const SpaceFillingTree::Node* node)
+        {
+            aabb.include(node->middle);
+        }
+    };
+    Visitor v;
+    tree.walk(v);
+    const coord_t expected_tree_width = 2 * radius * (1.0 - pow(0.5, (double)depth)); // fractal depth determines the covered square of the fractal
+    std::stringstream ss;
+    ss << "Tree is not spanning expected square " << expected_tree_width << "; actual width: " << (v.aabb.max.X - v.aabb.min.X);
+    CPPUNIT_ASSERT_MESSAGE(ss.str(), std::abs((v.aabb.max.X - v.aabb.min.X) - expected_tree_width) <= allowed_error);
+    CPPUNIT_ASSERT_MESSAGE(ss.str(), std::abs((v.aabb.max.Y - v.aabb.min.Y) - expected_tree_width) <= allowed_error);
+    CPPUNIT_ASSERT_MESSAGE("Tree middle is not the given middle", vSize(v.aabb.getMiddle() - middle) <= allowed_error);
+}
+
+}

--- a/tests/infill/SpaceFillingTreeFillTest.h
+++ b/tests/infill/SpaceFillingTreeFillTest.h
@@ -1,0 +1,52 @@
+//Copyright (c) 2017 Tim Kuipers
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef SPACE_FILLING_TREE_FILL_TEST_H
+#define SPACE_FILLING_TREE_FILL_TEST_H
+
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <../src/infill/SpaceFillingTreeFill.h>
+
+namespace cura
+{
+
+class SpaceFillingTreeFillTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(SpaceFillingTreeFillTest);
+    CPPUNIT_TEST(debugCheck);
+    CPPUNIT_TEST(boundsCheck);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    /*!
+     * \brief Sets up the test suite to prepare for testing.
+     */
+    void setUp();
+
+    /*!
+     * \brief Tears down the test suite when testing is done.
+     */
+    void tearDown();
+
+    /*!
+     * debugCheck of the tree
+     */
+    void debugCheck();
+
+    /*!
+     * checking whether all falls within the original square
+     */
+    void boundsCheck();
+private:
+    coord_t allowed_error = 10;
+    Point middle = Point(0, 0);
+    coord_t radius = 123;
+    int depth = 4;
+    SpaceFillingTree tree = SpaceFillingTree(middle, radius, depth);
+};
+
+}
+
+#endif //SPACE_FILLING_TREE_FILL_TEST_H
+

--- a/tests/utils/IntPointTest.cpp
+++ b/tests/utils/IntPointTest.cpp
@@ -1,0 +1,38 @@
+//Copyright (c) 2017 Tim Kuipers
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include "IntPointTest.h"
+
+#include <../src/utils/intpoint.h>
+
+namespace cura
+{
+    CPPUNIT_TEST_SUITE_REGISTRATION(IntPointTest);
+
+void IntPointTest::setUp()
+{
+    //Do nothing.
+}
+
+void IntPointTest::tearDown()
+{
+    //Do nothing.
+}
+
+void IntPointTest::testRotationMatrix()
+{
+    PointMatrix rot2d(90);
+    Point3Matrix rot_homogeneous(rot2d);
+    Point a(20, 10);
+    Point b(30, 20);
+    Point translated = Point3Matrix::translate(-a).apply(b);
+    Point rotated = rot_homogeneous.apply(translated);
+    Point rotated_in_place = Point3Matrix::translate(a).apply(rotated);
+
+    Point3Matrix all_in_one = Point3Matrix::translate(a).compose(rot_homogeneous).compose(Point3Matrix::translate(-a));
+    Point rotated_in_place_2 = all_in_one.apply(b);
+
+    CPPUNIT_ASSERT_MESSAGE(std::string("Matrix composition with translate and rotate failed"), rotated_in_place == rotated_in_place_2);
+}
+
+}

--- a/tests/utils/IntPointTest.h
+++ b/tests/utils/IntPointTest.h
@@ -1,0 +1,46 @@
+//Copyright (c) 2017 Tim Kuipers
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef INT_POINT_TEST_H
+#define LINEARALG2DTEST_H
+
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <../src/utils/intpoint.h>
+
+namespace cura
+{
+
+class IntPointTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(IntPointTest);
+    CPPUNIT_TEST(testRotationMatrix);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    /*!
+     * \brief Sets up the test suite to prepare for testing.
+     * 
+     * Since <em>IntPointTest</em> only has static functions, no instance
+     * needs to be created here.
+     */
+    void setUp();
+
+    /*!
+     * \brief Tears down the test suite when testing is done.
+     * 
+     * Since <em>IntPointTest</em> only has static functions, no instance
+     * exists that needs to be destroyed.
+     */
+    void tearDown();
+
+    //These are the actual test cases. The name of the function sort of describes what it tests but I refuse to document all of these, sorry.
+    void testRotationMatrix();
+
+private:
+};
+
+}
+
+#endif //LINEARALG2DTEST_H
+

--- a/tests/utils/LinearAlg2DTest.cpp
+++ b/tests/utils/LinearAlg2DTest.cpp
@@ -1,9 +1,11 @@
-//Copyright (c) 2015 Ultimaker B.V.
+//Copyright (c) 2017 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "LinearAlg2DTest.h"
 
 #include <../src/utils/linearAlg2D.h>
+
+#define FUZZ_DISTANCE 2 //Error that is allowed to be introduced by rounding.
 
 namespace cura
 {
@@ -363,5 +365,33 @@ void LinearAlg2DTest::getPointOnLineWithDistAssert(const Point p, const Point a,
     CPPUNIT_ASSERT_MESSAGE(ss.str(), (!actual_returned && !supposed_returned) || (actual_returned && vSize2(actual_result - supposed_result) < 10 * 10 && std::abs(returned_dist - dist) < 10));
 }
 
+void LinearAlg2DTest::rotateAround90()
+{
+    rotateAroundAssert(Point(25, 30), Point(10, 17), 90, Point(-3, 32));
+}
+
+void LinearAlg2DTest::rotateAroundNegative90()
+{
+    rotateAroundAssert(Point(25, 30), Point(10, 17), -90, Point(23, 2));
+}
+
+void LinearAlg2DTest::rotateAround0()
+{
+    rotateAroundAssert(Point(-67, 14), Point(50, 50), 0, Point(-67, 14));
+}
+
+void LinearAlg2DTest::rotateAround12()
+{
+    rotateAroundAssert(Point(-67, 14), Point(50, 50), 12, Point(-57, -9)); //Actually [-57, -9.5]!
+}
+
+void LinearAlg2DTest::rotateAroundAssert(const Point point, const Point origin, const double angle, const Point expected_result)
+{
+    Point3Matrix mat = LinearAlg2D::rotateAround(origin, angle);
+    Point result = mat.apply(point);
+    std::stringstream ss;
+    ss << "LinearAlg2D::rotateAround failed: Rotating " << point << " around " << origin << " for " << angle << " degrees resulted in " << result << " instead of expected " << expected_result << ".";
+    CPPUNIT_ASSERT_MESSAGE(ss.str(), vSize(result - expected_result) < FUZZ_DISTANCE);
+}
 
 }

--- a/tests/utils/LinearAlg2DTest.h
+++ b/tests/utils/LinearAlg2DTest.h
@@ -62,6 +62,11 @@ class LinearAlg2DTest : public CppUnit::TestFixture
     CPPUNIT_TEST(getPointOnLineWithDistTest5);
     CPPUNIT_TEST(getPointOnLineWithDistTest6);
     CPPUNIT_TEST(getPointOnLineWithDistTest7);
+
+    CPPUNIT_TEST(rotateAround90);
+    CPPUNIT_TEST(rotateAroundNegative90);
+    CPPUNIT_TEST(rotateAround0);
+    CPPUNIT_TEST(rotateAround12);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -131,6 +136,11 @@ public:
     void getPointOnLineWithDistTest6();
     void getPointOnLineWithDistTest7();
 
+    void rotateAround90();
+    void rotateAroundNegative90();
+    void rotateAround0();
+    void rotateAround12();
+
 private:
     /*!
      * \brief The maximum allowed error in distance measurements.
@@ -168,6 +178,16 @@ private:
     void getAngleAssert(Point a, Point b, Point c, float actual_angle_in_half_rounds);
 
     void getPointOnLineWithDistAssert(const Point p, const Point a, const Point b, int64_t dist, Point actual_result, bool actual_returned);
+
+    /*!
+     * \brief Tests rotating a point with rotateAround.
+     *
+     * \param point The original location of the point.
+     * \param origin The point to rotate around.
+     * \param angle The angle to rotate the point under.
+     * \param expected_result The new location of the point, after rotating.
+     */
+    void rotateAroundAssert(const Point point, const Point origin, const double angle, const Point expected_result);
 };
 
 }

--- a/tests/utils/PolygonTest.h
+++ b/tests/utils/PolygonTest.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2015 Ultimaker B.V.
+//Copyright (c) 2017 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef POLYGON_TEST_H
@@ -22,6 +22,9 @@ class PolygonTest : public CppUnit::TestFixture
     CPPUNIT_TEST(polygonOffsetBugTest);
     CPPUNIT_TEST(isOutsideTest);
     CPPUNIT_TEST(isInsideTest);
+    CPPUNIT_TEST(splitIntoPartsWithHoleTest);
+    CPPUNIT_TEST(differenceContainsOriginalPointTest);
+    CPPUNIT_TEST(differenceClockwiseTest);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -46,6 +49,9 @@ public:
     void polygonOffsetBugTest();
     void isOutsideTest();
     void isInsideTest();
+    void splitIntoPartsWithHoleTest();
+    void differenceContainsOriginalPointTest();
+    void differenceClockwiseTest();
 
 
 private:
@@ -53,11 +59,15 @@ private:
      * \brief The maximum allowed error in distance measurements.
      */
     static const int64_t maximum_error = 10;
-    
+
+    //Some fixtures.
     Polygon test_square;
     Polygon pointy_square;
     Polygon triangle;
     Polygon clipper_bug;
+    Polygon clockwise_large;
+    Polygon clockwise_small;
+    Polygons clockwise_donut;
 };
 
 }


### PR DESCRIPTION
This can save some time if only the highest layer needs to be smooth.

The ironing is only performed on the highest layer of the current mesh. If there are multiple meshes, it will iron on the highest layers of each mesh. I thought that was the behaviour that would be most desired in that case.