### PR TITLE
Start polygon at closest point when SHARPEST_CORNER and Z_SEAM_CORNER_PREF_NONE both specified.

### DIFF
--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -91,7 +91,7 @@ int PathOrderOptimizer::getClosestPointInPolygon(Point prev_point, int poly_idx)
         const Point& p1 = poly[point_idx];
         const Point& p2 = poly[(point_idx + 1) % poly.size()];
         // when type is SHARPEST_CORNER, actual distance is ignored, we use a fixed distance and decision is based on curvature only
-        int64_t dist_score = (config.type == EZSeamType::SHARPEST_CORNER)? 100 : vSize2(p1 - prev_point);
+        int64_t dist_score = (config.type == EZSeamType::SHARPEST_CORNER && config.corner_pref != EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE)? 100 : vSize2(p1 - prev_point);
         const float corner_angle = LinearAlg2D::getAngleLeft(p0, p1, p2) / M_PI; // 0 -> 2
         int64_t corner_shift;
         if (config.type == EZSeamType::SHORTEST)


### PR DESCRIPTION
The UI should not allow this combination as it doesn't make sense but it does. Before this
change, with this combination of settings, the first point in the polygon would be chosen
but I think it's better to use the closest point (to the current position) instead.