### PR TITLE
Most line based infill patterns are now positioned relative to the centre of the model.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1127,25 +1127,21 @@ bool FffGcodeWriter::processInfill(const SliceDataStorage& storage, LayerPlan& g
     {
         return false;
     }
+    const Point3 mesh_middle = mesh.bounding_box.getMiddle();
+    const Point infill_origin(mesh_middle.x + mesh.getSettingInMicrons("infill_offset_x"), mesh_middle.y + mesh.getSettingInMicrons("infill_offset_y"));
     if (mesh.getSettingBoolean("spaghetti_infill_enabled"))
     {
-        return SpaghettiInfillPathGenerator::processSpaghettiInfill(storage, *this, gcode_layer, mesh, extruder_nr, mesh_config, part, infill_line_distance, infill_overlap, infill_angle);
+        return SpaghettiInfillPathGenerator::processSpaghettiInfill(storage, *this, gcode_layer, mesh, extruder_nr, mesh_config, part, infill_line_distance, infill_overlap, infill_angle, infill_origin);
     }
     else
     {
-        bool added_something = processMultiLayerInfill(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, infill_line_distance, infill_overlap, infill_angle);
-        added_something = added_something | processSingleLayerInfill(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, infill_line_distance, infill_overlap, infill_angle);
+        bool added_something = processMultiLayerInfill(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, infill_line_distance, infill_overlap, infill_angle, infill_origin);
+        added_something = added_something | processSingleLayerInfill(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, infill_line_distance, infill_overlap, infill_angle, infill_origin);
         return added_something;
     }
 }
 
-static Point getInfillOrigin(const SliceMeshStorage& mesh)
-{
-    Point3 mesh_middle = mesh.bounding_box.getMiddle();
-    return Point(mesh_middle.x + mesh.getSettingInMicrons("infill_offset_x"), mesh_middle.y + mesh.getSettingInMicrons("infill_offset_y"));
-}
-
-bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int infill_angle) const
+bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int infill_angle, const Point& infill_origin) const
 {
     if (extruder_nr != mesh.getSettingAsExtruderNr("infill_extruder_nr"))
     {
@@ -1167,7 +1163,6 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                 unsigned int density_factor = 2 << density_idx; // == pow(2, density_idx + 1)
                 int infill_line_distance_here = infill_line_distance * density_factor; // the highest density infill combines with the next to create a grid with density_factor 1
                 int infill_shift = infill_line_distance_here / 2;
-                const Point infill_origin = getInfillOrigin(mesh);
                 if (density_idx == part.infill_area_per_combine_per_density.size() - 1)
                 {
                     infill_line_distance_here /= 2;
@@ -1196,7 +1191,7 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
     return added_something;
 }
 
-bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int infill_angle) const
+bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int infill_angle, const Point& infill_origin) const
 {
     if (extruder_nr != mesh.getSettingAsExtruderNr("infill_extruder_nr"))
     {
@@ -1220,7 +1215,6 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         unsigned int density_factor = 2 << density_idx; // == pow(2, density_idx + 1)
         int infill_line_distance_here = infill_line_distance * density_factor; // the highest density infill combines with the next to create a grid with density_factor 1
         int infill_shift = infill_line_distance_here / 2;
-        const Point infill_origin = getInfillOrigin(mesh);
         // infill shift explanation: [>]=shift ["]=line_dist
 // :       |       :       |       :       |       :       |         > furthest from top
 // :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |     > further from top

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -384,9 +384,10 @@ private:
      * \param infill_line_distance The distance between the infill lines
      * \param infill_overlap The distance by which the infill overlaps with the wall insets.
      * \param fillAngle The angle in the XY plane at which the infill is generated.
+     * \param infill_origin The origin of the infill pattern.
      * \return Whether this function added anything to the layer plan
      */
-    bool processMultiLayerInfill(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int fillAngle) const;
+    bool processMultiLayerInfill(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int fillAngle, const Point& infill_origin) const;
     
     /*!
      * Add normal sparse infill for a given part in a layer.
@@ -398,9 +399,10 @@ private:
      * \param infill_line_distance The distance between the infill lines
      * \param infill_overlap The distance by which the infill overlaps with the wall insets.
      * \param fillAngle The angle in the XY plane at which the infill is generated.
+     * \param infill_origin The origin of the infill pattern.
      * \return Whether this function added anything to the layer plan
      */
-    bool processSingleLayerInfill(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int fillAngle) const;
+    bool processSingleLayerInfill(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int fillAngle, const Point& infill_origin) const;
     
     /*!
      * Generate the insets for the walls of a given layer part.

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -259,6 +259,11 @@ void Infill::addLineInfill(Polygons& result, const PointMatrix& rotation_matrix,
 
 void Infill::generateLineInfill(Polygons& result, int line_distance, const double& fill_angle, int64_t shift)
 {
+    if (infill_origin.X != 0 || infill_origin.Y != 0)
+    {
+        const double fill_angle_rads = fill_angle * M_PI / 180;
+        shift += infill_origin.X * std::cos(fill_angle_rads) - infill_origin.Y * std::sin(fill_angle_rads);
+    }
     PointMatrix rotation_matrix(fill_angle);
     NoZigZagConnectorProcessor lines_processor(rotation_matrix, result);
     bool connected_zigzags = false;
@@ -268,9 +273,15 @@ void Infill::generateLineInfill(Polygons& result, int line_distance, const doubl
 
 void Infill::generateZigZagInfill(Polygons& result, const int line_distance, const double& fill_angle)
 {
+    int64_t shift = 0;
+    if (infill_origin.X != 0 || infill_origin.Y != 0)
+    {
+        const double fill_angle_rads = fill_angle * M_PI / 180;
+        shift += infill_origin.X * std::cos(fill_angle_rads) - infill_origin.Y * std::sin(fill_angle_rads);
+    }
     PointMatrix rotation_matrix(fill_angle);
     ZigzagConnectorProcessor zigzag_processor(rotation_matrix, result, use_endpieces, connected_zigzags, skip_some_zags, zag_skip_count);
-    generateLinearBasedInfill(outline_offset - infill_line_width / 2, result, line_distance, rotation_matrix, zigzag_processor, connected_zigzags, 0);
+    generateLinearBasedInfill(outline_offset - infill_line_width / 2, result, line_distance, rotation_matrix, zigzag_processor, connected_zigzags, shift);
 }
 
 /* 

--- a/src/infill.h
+++ b/src/infill.h
@@ -207,10 +207,10 @@ private:
      * 
      * \param[out] result (output) The resulting lines
      * \param line_distance The distance between two lines which are in the same direction
-     * \param fill_angle The angle of the generated lines
-     * \param extra_shift extra shift of the scanlines in the direction perpendicular to the fill_angle
+     * \param infill_rotation The angle of the generated lines
+     * \param extra_shift extra shift of the scanlines in the direction perpendicular to the infill_rotation
      */
-    void generateLineInfill(Polygons& result, int line_distance, const double& fill_angle, int64_t extra_shift);
+    void generateLineInfill(Polygons& result, int line_distance, const double& infill_rotation, int64_t extra_shift);
     
     /*!
      * Function for creating linear based infill types (Lines, ZigZag).
@@ -275,9 +275,18 @@ private:
      * 
      * \param[out] result (output) The resulting lines
      * \param line_distance The distance between two lines which are in the same direction
-     * \param fill_angle The angle of the generated lines
+     * \param infill_rotation The angle of the generated lines
      */
-    void generateZigZagInfill(Polygons& result, const int line_distance, const double& fill_angle);
+    void generateZigZagInfill(Polygons& result, const int line_distance, const double& infill_rotation);
+
+    /*!
+     * determine how far the infill pattern should be shifted based on the values of infill_origin and \p infill_rotation
+     *
+     * \param[in] infill_rotation the angle the infill pattern is rotated through
+     *
+     * \return the distance the infill pattern should be shifted
+     */
+    int64_t getShiftOffsetFromInfillOriginAndRotation(const double& infill_rotation);
 };
 
 }//namespace cura

--- a/src/infill.h
+++ b/src/infill.h
@@ -31,6 +31,7 @@ class Infill
     double fill_angle; //!< for linear infill types: the angle of the infill lines (or the angle of the grid)
     coord_t z; //!< height of the layer for which we generate infill
     coord_t shift; //!< shift of the scanlines in the direction perpendicular to the fill_angle
+    const Point infill_origin; //!< origin of the infill pattern
     Polygons* perimeter_gaps; //!< (optional output) The areas in between consecutive insets when Concentric infill is used.
     bool connected_zigzags; //!< (ZigZag) Whether endpieces of zigzag infill should be connected to the nearest infill line on both sides of the zigzag connector
     bool use_endpieces; //!< (ZigZag) Whether to include endpieces: zigzag connector segments from one infill line to itself
@@ -59,6 +60,7 @@ public:
         , double fill_angle
         , int64_t z
         , int64_t shift
+        , const Point& infill_origin = Point()
         , Polygons* perimeter_gaps = nullptr
         , bool connected_zigzags = false
         , bool use_endpieces = false
@@ -77,6 +79,7 @@ public:
     , fill_angle(fill_angle)
     , z(z)
     , shift(shift)
+    , infill_origin(infill_origin)
     , perimeter_gaps(perimeter_gaps)
     , connected_zigzags(connected_zigzags)
     , use_endpieces(use_endpieces)

--- a/src/infill/SpaghettiInfillPathGenerator.cpp
+++ b/src/infill/SpaghettiInfillPathGenerator.cpp
@@ -38,8 +38,9 @@ bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage
         Polygons* perimeter_gaps_output = nullptr;
         const bool connected_zigzags = true;
         const bool use_endpieces = false;
+        const Point infill_origin;
         Infill infill_comp(pattern, zig_zaggify_infill, area, outline_offset
-            , infill_line_width, infill_line_distance, infill_overlap, infill_angle, gcode_layer.z, infill_shift, perimeter_gaps_output, connected_zigzags, use_endpieces
+            , infill_line_width, infill_line_distance, infill_overlap, infill_angle, gcode_layer.z, infill_shift, infill_origin, perimeter_gaps_output, connected_zigzags, use_endpieces
             , mesh.getSettingBoolean("cross_infill_apply_pockets_alternatingly"), mesh.getSettingInMicrons("cross_infill_pocket_size"));
         infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_pattern, &mesh);
 

--- a/src/infill/SpaghettiInfillPathGenerator.cpp
+++ b/src/infill/SpaghettiInfillPathGenerator.cpp
@@ -6,7 +6,7 @@
 namespace cura {
 
 
-bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage& storage, const FffGcodeWriter& fff_gcode_writer, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int infill_angle)
+bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage& storage, const FffGcodeWriter& fff_gcode_writer, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int infill_angle, const Point& infill_origin)
 {
     if (extruder_nr != mesh.getSettingAsExtruderNr("infill_extruder_nr"))
     {
@@ -38,7 +38,6 @@ bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage
         Polygons* perimeter_gaps_output = nullptr;
         const bool connected_zigzags = true;
         const bool use_endpieces = false;
-        const Point infill_origin;
         Infill infill_comp(pattern, zig_zaggify_infill, area, outline_offset
             , infill_line_width, infill_line_distance, infill_overlap, infill_angle, gcode_layer.z, infill_shift, infill_origin, perimeter_gaps_output, connected_zigzags, use_endpieces
             , mesh.getSettingBoolean("cross_infill_apply_pockets_alternatingly"), mesh.getSettingInMicrons("cross_infill_pocket_size"));

--- a/src/infill/SpaghettiInfillPathGenerator.h
+++ b/src/infill/SpaghettiInfillPathGenerator.h
@@ -47,9 +47,10 @@ public:
      * \param infill_line_distance The distance between the infill lines
      * \param infill_overlap The distance by which the infill overlaps with the wall insets.
      * \param fillAngle The angle in the XY plane at which the infill is generated.
+     * \param infill_origin The origin of the infill pattern.
      * \return Whether this function added anything to the layer plan
      */
-    static bool processSpaghettiInfill(const SliceDataStorage& storage, const FffGcodeWriter& fff_gcode_writer, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int fillAngle);
+    static bool processSpaghettiInfill(const SliceDataStorage& storage, const FffGcodeWriter& fff_gcode_writer, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, int infill_line_distance, int infill_overlap, int fillAngle, const Point& infill_origin);
 
 };
 


### PR DESCRIPTION

This makes the infill immune to the position of the model on the build plate.

New settings infill_offset_x and infill_offset_y shift the infill pattern relative to the
model centre.

See https://github.com/Ultimaker/Cura/issues/2412.