### PR TITLE
Travel move added at start of new layer now obeys travel_retract_before_outer_wall.

### DIFF
--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -99,7 +99,8 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
     if (!prev_layer->last_planned_position || *prev_layer->last_planned_position != first_location_new_layer)
     {
         prev_layer->setIsInside(new_layer_destination_state->second);
-        prev_layer->addTravel(first_location_new_layer);
+        const bool force_retract = prev_layer->storage.getSettingBoolean("travel_retract_before_outer_wall") && prev_layer->storage.getSettingBoolean("outer_inset_first");
+        prev_layer->addTravel(first_location_new_layer, force_retract);
     }
 }
 


### PR DESCRIPTION

This got left out which meant that it could insert a long travel with no retraction which
would arrive at the outer wall with the extruder emptier than it should have been.

Should fix https://ultimaker.com/en/community/51226-rectract-before-outer-wall-not-working-zscar-issues