### PR TITLE
Fixes SEGV when infill/support pattern is anything other than a cross fractal

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -609,6 +609,11 @@ void FffPolygonGenerator::processDerivedWallsSkinInfill(SliceMeshStorage& mesh)
                 mesh.cross_fill_patterns.push_back(new SpaceFillingTreeFill(mesh.getSettingInMicrons("infill_line_distance") << gradual_step, mesh.bounding_box));
             }
         }
+        else
+        {
+            // cross_fill_patterns must not be empty even when the infill pattern is not a cross fractal
+            mesh.cross_fill_patterns.push_back(nullptr);
+        }
 
         // combine infill
         unsigned int combined_infill_layers = std::max(1U, round_divide(mesh.getSettingInMicrons("infill_sparse_thickness"), std::max(getSettingInMicrons("layer_height"), (coord_t)1))); //How many infill layers to combine to obtain the requested sparse thickness.

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -655,6 +655,11 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage, unsigned int l
         }
         storage.support.cross_fill_patterns.push_back(new SpaceFillingTreeFill(infill_extr.getSettingInMicrons("support_line_distance"), aabb));
     }
+    else
+    {
+        // cross_fill_patterns must not be empty even when the support pattern is not a cross fractal
+        storage.support.cross_fill_patterns.push_back(nullptr);
+    }
 }
 
 /* 


### PR DESCRIPTION
This PR fixes recently committed breakage whereby empty array objects were accessed causing a SEGV. You may not care for this solution but it's simple and effective.