### PR TITLE
Only index into cross_fill_patterns[] when it contains elements!

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1175,7 +1175,8 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                     , /*bool skip_some_zags =*/ false
                     , /*int zag_skip_count =*/ 0
                     , mesh.getSettingBoolean("cross_infill_apply_pockets_alternatingly"), mesh.getSettingInMicrons("cross_infill_pocket_size"));
-                infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_patterns[density_idx], &mesh);
+                SpaceFillingTreeFill* cross_fill_pattern = (infill_pattern == EFillMethod::CROSS || infill_pattern == EFillMethod::CROSS_3D) ? mesh.cross_fill_patterns[density_idx] : nullptr;
+                infill_comp.generate(infill_polygons, infill_lines, cross_fill_pattern, &mesh);
             }
             if (infill_lines.size() > 0 || infill_polygons.size() > 0)
             {
@@ -1249,7 +1250,8 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             , /*bool skip_some_zags =*/ false
             , /*int zag_skip_count =*/ 0
             , mesh.getSettingBoolean("cross_infill_apply_pockets_alternatingly"), mesh.getSettingInMicrons("cross_infill_pocket_size"));
-        infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_patterns[density_idx], &mesh);
+        SpaceFillingTreeFill* cross_fill_pattern = (pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D) ? mesh.cross_fill_patterns[density_idx] : nullptr;
+        infill_comp.generate(infill_polygons, infill_lines, cross_fill_pattern, &mesh);
     }
     if (infill_lines.size() > 0 || infill_polygons.size() > 0)
     {
@@ -1852,7 +1854,8 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                                    support_line_distance_here, current_support_infill_overlap, support_infill_angle, gcode_layer.z, support_shift,
                                    perimeter_gaps, infill_extruder.getSettingBoolean("support_connect_zigzags"), use_endpieces,
                                    skip_some_zags, zag_skip_count);
-                infill_comp.generate(support_polygons, support_lines, storage.support.cross_fill_patterns[density_idx]);
+                SpaceFillingTreeFill* cross_fill_pattern = (support_pattern == EFillMethod::CROSS || support_pattern == EFillMethod::CROSS_3D) ? storage.support.cross_fill_patterns[density_idx] : nullptr;
+                infill_comp.generate(support_polygons, support_lines, cross_fill_pattern);
             }
 
             if (support_lines.size() > 0 || support_polygons.size() > 0)


### PR DESCRIPTION
Fix recently introduced crash caused by accessing arrays that contain no elements.