### PR TITLE
Make the LineOrderOptimizer prefer to start at ends of a sequence of connected lines.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -465,7 +465,7 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathCon
     {
         orderOptimizer.addPolygon(polygons[line_idx]);
     }
-    orderOptimizer.optimize();
+    orderOptimizer.optimize(&comb_boundary_inside);
     for (int poly_idx : orderOptimizer.polyOrder)
     {
         ConstPolygonRef polygon = polygons[poly_idx];

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -460,12 +460,12 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
 }
 void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location)
 {
-    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()));
+    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()), &comb_boundary_inside);
     for (unsigned int line_idx = 0; line_idx < polygons.size(); line_idx++)
     {
         orderOptimizer.addPolygon(polygons[line_idx]);
     }
-    orderOptimizer.optimize(&comb_boundary_inside);
+    orderOptimizer.optimize();
     for (int poly_idx : orderOptimizer.polyOrder)
     {
         ConstPolygonRef polygon = polygons[poly_idx];

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -336,14 +336,14 @@ inline float LineOrderOptimizer::travelDistance(const Point& p0, const Point& p1
     CombPath comb_path;
     if (LinePolygonsCrossings::comb(*combing_boundary, *loc_to_line, p0, p1, comb_path, -40, 0, true))
     {
-        float dist2 = 0;
+        float dist = 0;
         Point last_point = p0;
         for (const Point& comb_point : comb_path)
         {
-            dist2 += vSize2f(comb_point - last_point);
+            dist += vSize(comb_point - last_point);
             last_point = comb_point;
         }
-        return dist2;
+        return dist * dist;
     }
     // fall back to direct distance
     return vSize2f(p0 - p1);

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -222,7 +222,15 @@ void LineOrderOptimizer::optimize()
             }
         }
 
-        // if no line ends close to last_point have been found, see if we can find a point on a line that could be the start of a chain of lines
+        if (have_chains && best_line_idx != -1 && !pointsAreCoincident(prev_point, (*polygons[best_line_idx])[polyStart[best_line_idx]]))
+        {
+            // we found a point close to prev_point but it's not close enough for the points to be considered coincident so we would
+            // probably be better off by ditching this point and finding an end of a chain instead (let's hope it's not too far away!)
+            best_line_idx = -1;
+            best_score = std::numeric_limits<float>::infinity();
+        }
+
+        // if no line ends close to prev_point, see if we can find a point on a line that could be the start of a chain of lines
         if (best_line_idx == -1 && have_chains)
         {
             have_chains = false; // now assume that we don't have any chains and change back to true below if we find any joined line segments

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -334,7 +334,7 @@ inline float LineOrderOptimizer::travelDistance(const Point& p0, const Point& p1
         return vSize2f(p0 - p1);
     }
     CombPath comb_path;
-    if (LinePolygonsCrossings::comb(*combing_boundary, *loc_to_line, p0, p1, comb_path, -40, 0, true))
+    if (LinePolygonsCrossings::comb(*combing_boundary, *loc_to_line, p0, p1, comb_path, -40, 0, false))
     {
         float dist = 0;
         Point last_point = p0;

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -212,12 +212,12 @@ void LineOrderOptimizer::optimize(const Polygons* combing_boundary)
         int best_line_idx = -1;
         float best_score = std::numeric_limits<float>::infinity(); // distance score for the best next line
 
-        if (order_idx == 1 && combing_boundary != nullptr && have_chains)
+        if (order_idx == 1 && combing_boundary != nullptr && combing_boundary->size() > 0 && have_chains)
         {
             // we now know that we have chains and the combing boundary has been provided so do the initialisation
             // required to be able to calculate realistic travel distances to the start of new paths
             const int travel_avoid_distance = 1000; // assume 1mm - not really critical for our purposes
-            this->loc_to_line = PolygonUtils::createLocToLineGrid(*combing_boundary, travel_avoid_distance);
+            loc_to_line = PolygonUtils::createLocToLineGrid(*combing_boundary, travel_avoid_distance);
         }
 
         // for the first line we would prefer a line that is at the end of a sequence of connected lines (think zigzag) and

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -160,6 +160,11 @@ int PathOrderOptimizer::getRandomPointInPolygon(int poly_idx)
     return rand() % polygons[poly_idx]->size();
 }
 
+static inline bool pointsAreCoincident(const Point& a, const Point& b)
+{
+    return vSize2(a - b) < 25; // points are closer than 5uM, consider them coincident
+}
+
 /**
 *
 */
@@ -229,16 +234,16 @@ void LineOrderOptimizer::optimize()
                 }
                 assert(polygons[poly_idx]->size() == 2);
 
-                // does this line either end in thin air (doesn't join another line) or exactly join another line that has already been picked?
+                // does this line either end in thin air (doesn't join another line) or join another line that has already been picked?
                 // check both of its ends and see if it's a possible candidate to be used to start the next sequence
                 for (unsigned point_idx = 0; point_idx < 2; ++point_idx)
                 {
                     int num_joined_lines = 0;
                     const Point& p = (*polygons[poly_idx])[point_idx];
-                    // look at each of the lines that finish close to this line to see if either of its vertices exactly match this vertex
+                    // look at each of the lines that finish close to this line to see if either of its vertices are coincident this vertex
                     for (unsigned int close_line_idx : line_bucket_grid.getNearbyVals(p, gridSize))
                     {
-                        if (close_line_idx != poly_idx && (p == (*polygons[close_line_idx])[0] || p == (*polygons[close_line_idx])[1]))
+                        if (close_line_idx != poly_idx && (pointsAreCoincident(p, (*polygons[close_line_idx])[0]) || pointsAreCoincident(p, (*polygons[close_line_idx])[1])))
                         {
                             have_chains = true; // we have found a joint between line segments so we have chains
 

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -343,7 +343,6 @@ inline float LineOrderOptimizer::travelDistance(const Point& p0, const Point& p1
             dist2 += vSize2f(comb_point - last_point);
             last_point = comb_point;
         }
-        std::cerr << " direct distance = " << vSize2(p0 - p1) << ", combed distance = " << dist2 << "\n";
         return dist2;
     }
     // fall back to direct distance

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -170,15 +170,13 @@ static inline bool pointsAreCoincident(const Point& a, const Point& b)
 /**
 *
 */
-void LineOrderOptimizer::optimize(const Polygons* combing_boundary)
+void LineOrderOptimizer::optimize()
 {
     int gridSize = 5000; // the size of the cells in the hash grid. TODO
     SparsePointGridInclusive<unsigned int> line_bucket_grid(gridSize);
     bool picked[polygons.size()];
     memset(picked, false, sizeof(bool) * polygons.size());/// initialized as falses
     loc_to_line = nullptr;
-    this->combing_boundary = combing_boundary;
-
     
     for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++) /// find closest point to initial starting point within each polygon +initialize picked
     {

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "utils/polygon.h"
+#include "utils/polygonUtils.h"
 #include "settings/settings.h"
 
 namespace cura {
@@ -89,6 +90,8 @@ public:
     std::vector<ConstPolygonPointer> polygons; //!< the parts of the layer (in arbitrary order)
     std::vector<int> polyStart; //!< polygons[i][polyStart[i]] = point of polygon i which is to be the starting point in printing the polygon
     std::vector<int> polyOrder; //!< the optimized order as indices in #polygons
+    LocToLineGrid* loc_to_line;
+    const Polygons* combing_boundary;
 
     LineOrderOptimizer(Point startPoint)
     {
@@ -111,7 +114,7 @@ public:
             this->polygons.push_back(polygons[i]);
     }
 
-    void optimize(); //!< sets #polyStart and #polyOrder
+    void optimize(const Polygons* combing_boundary = nullptr); //!< sets #polyStart and #polyOrder
 
 private:
     /*!
@@ -144,6 +147,16 @@ private:
      * 
      */
     static float getAngleScore(Point incoming_perpundicular_normal, Point from, Point to);
+
+    /*!
+     * Calculate the distance covered when traveling between two points.
+     *
+     * \param[in] p0 One end of the travel path.
+     * \param[in] p1 The other end of the travel path.
+     * \param[in] travel_direct If true, assume that the shortest path can be used.
+     * \return The distance covered to go from \p p0 to \p p1.
+     */
+    float travelDistance(const Point& p0, const Point& p1, const bool travel_direct);
 };
 
 }//namespace cura

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -93,9 +93,10 @@ public:
     LocToLineGrid* loc_to_line;
     const Polygons* combing_boundary;
 
-    LineOrderOptimizer(Point startPoint)
+    LineOrderOptimizer(Point startPoint, const Polygons* combing_boundary = nullptr)
     {
         this->startPoint = startPoint;
+        this->combing_boundary = combing_boundary;
     }
 
     void addPolygon(PolygonRef polygon)
@@ -114,7 +115,7 @@ public:
             this->polygons.push_back(polygons[i]);
     }
 
-    void optimize(const Polygons* combing_boundary = nullptr); //!< sets #polyStart and #polyOrder
+    void optimize(); //!< sets #polyStart and #polyOrder
 
 private:
     /*!

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -128,8 +128,9 @@ private:
      * \param best_score[in, out] The distance score for the current best line
      * \param prev_point[in] The previous point from which to find the next best line
      * \param incoming_perpundicular_normal[in] The direction of movement when the print head arrived at \p prev_point, turned 90 degrees CCW
+     * \param just_point[in] If not -1, only look at the line vertex with this index
      */
-    void updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal);
+    void updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal, int just_point = -1);
 
     /*!
      * Get a score to modify the distance score for measuring how good two lines follow each other.

--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -19,7 +19,7 @@ bool LinePolygonsCrossings::calcScanlineCrossings(bool fail_on_unavoidable_obsta
     for(unsigned int poly_idx = 0; poly_idx < boundary.size(); poly_idx++)
     {
         PolyCrossings minMax(poly_idx); 
-        PolygonRef poly = boundary[poly_idx];
+        ConstPolygonRef poly = boundary[poly_idx];
         Point p0 = transformation_matrix.apply(poly[poly.size() - 1]);
         for(unsigned int point_idx = 0; point_idx < poly.size(); point_idx++)
         {
@@ -79,7 +79,7 @@ bool LinePolygonsCrossings::lineSegmentCollidesWithBoundary()
     transformed_startPoint = transformation_matrix.apply(startPoint);
     transformed_endPoint = transformation_matrix.apply(endPoint);
 
-    for(PolygonRef poly : boundary)
+    for(ConstPolygonRef poly : boundary)
     {
         Point p0 = transformation_matrix.apply(poly.back());
         for(Point p1_ : poly)
@@ -144,7 +144,7 @@ void LinePolygonsCrossings::getBasicCombingPath(CombPath& combPath)
 
 void LinePolygonsCrossings::getBasicCombingPath(PolyCrossings& polyCrossings, CombPath& combPath) 
 {
-    PolygonRef poly = boundary[polyCrossings.poly_idx];
+    ConstPolygonRef poly = boundary[polyCrossings.poly_idx];
     combPath.push_back(transformation_matrix.unapply(Point(polyCrossings.min.x - std::abs(dist_to_move_boundary_point_outside), transformed_startPoint.Y)));
     if ( ( polyCrossings.max.point_idx - polyCrossings.min.point_idx + poly.size() ) % poly.size() 
         < poly.size() / 2 )

--- a/src/pathPlanning/LinePolygonsCrossings.h
+++ b/src/pathPlanning/LinePolygonsCrossings.h
@@ -81,7 +81,7 @@ private:
     unsigned int min_crossing_idx; //!< The index into LinePolygonsCrossings::crossings to the crossing with the minimal PolyCrossings::min crossing of all PolyCrossings's.
     unsigned int max_crossing_idx; //!< The index into LinePolygonsCrossings::crossings to the crossing with the maximal PolyCrossings::max crossing of all PolyCrossings's.
     
-    Polygons& boundary; //!< The boundary not to cross during combing.
+    const Polygons& boundary; //!< The boundary not to cross during combing.
     LocToLineGrid& loc_to_line_grid; //!< Mapping from locations to line segments of \ref LinePolygonsCrossings::boundary
     Point startPoint; //!< The start point of the scanline.
     Point endPoint; //!< The end point of the scanline.
@@ -166,7 +166,7 @@ private:
      * \param end the end point
      * \param dist_to_move_boundary_point_outside Distance used to move a point from a boundary so that it doesn't intersect with it anymore. (Precision issue)
      */
-    LinePolygonsCrossings(Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point& start, Point& end, int64_t dist_to_move_boundary_point_outside)
+    LinePolygonsCrossings(const Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point& start, Point& end, int64_t dist_to_move_boundary_point_outside)
     : boundary(boundary)
     , loc_to_line_grid(loc_to_line_grid)
     , startPoint(start)
@@ -187,7 +187,7 @@ public:
      * \param fail_on_unavoidable_obstacles When moving over other parts is inavoidable, stop calculation early and return false.
      * \return Whether combing succeeded, i.e. we didn't cross any gaps/other parts
      */
-    static bool comb(Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point startPoint, Point endPoint, CombPath& combPath, int64_t dist_to_move_boundary_point_outside, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles)
+    static bool comb(const Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point startPoint, Point endPoint, CombPath& combPath, int64_t dist_to_move_boundary_point_outside, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles)
     {
         LinePolygonsCrossings linePolygonsCrossings(boundary, loc_to_line_grid, startPoint, endPoint, dist_to_move_boundary_point_outside);
         return linePolygonsCrossings.getCombingPath(combPath, max_comb_distance_ignored, fail_on_unavoidable_obstacles);


### PR DESCRIPTION

Previously, when processing zigzag patterns of lines, it was possible for the lines to be
output as disconnected pairs of lines (a zig and a zag together). This commit adds code that
determines the vertices that are at the end of a sequence of lines and it selects the end
vertex that is closest to the current point as the next to be output.

This still doesn't guarantee that the lines are output optimally but it does at least appear
to stop the disconnected line pairs problem.

See https://ultimaker.com/en/community/51264-cura-27-toolpath?page=last#lastreply for a discussion
about the problem this PR targeted at.

**This one is going to require quite a lot of testing as it is used for infill, skin, (pretty much everything).**