### PR TITLE
In addLine(), also test the vector length and reject zags < 5 uM long.

### DIFF
--- a/src/infill/ZigzagConnectorProcessor.h
+++ b/src/infill/ZigzagConnectorProcessor.h
@@ -201,8 +201,9 @@ inline void ZigzagConnectorProcessor::reset()
 
 inline void ZigzagConnectorProcessor::addLine(Point from, Point to)
 {
-    if (from == to)
+    if (from == to || vSize2(from - to) < 25)
     {
+        // don't add lines less than 5uM long
         return;
     }
     result.addLine(rotation_matrix.unapply(from), rotation_matrix.unapply(to));


### PR DESCRIPTION
Or are they zigs? Anyway, the point equality test is OK as far as it goes but lines of
lengths < 5uM were still being generated which would subsequently cause wacky travels to
far flung regions to print what are essentially, zero length extrusions. This change stops
those useless travels.