### PR TITLE
Some simple tweaks to improve the combing path

### DIFF
--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -215,6 +215,40 @@ bool LinePolygonsCrossings::optimizePath(CombPath& comb_path, CombPath& optimize
                 }
             }
             optimized_comb_path.push_back(comb_path[point_idx - 1]);
+
+            if (point_idx == 1)
+            {
+                // we have just inserted the first point in the path that touches the boundary
+                // and as the first line in the comb is pointing from the start point towards the
+                // end point, we can maybe save some travel by replacing this first point with another
+                // that also lies on the second path of the comb, like this:
+                //
+                //         1
+                //        /|
+                //       / |
+                //      /  |           ===>  ----1
+                //     S   |                 S   |
+                //         |                     |
+                //         2----3 ...            2----3 ...
+                //
+
+                Point p = optimized_comb_path.back();
+                for (float frac : { 0.9, 0.9, 0.7, 0.5 })
+                {
+                    // slide p towards the second point in the comb path
+                    p = comb_path[1] + (p - comb_path[1]) * frac;
+                    if (!PolygonUtils::polygonCollidesWithLineSegment(startPoint, p, loc_to_line_grid))
+                    {
+                        // using the new corner doesn't cause a conflict
+                        optimized_comb_path.back() = p;
+                    }
+                    else
+                    {
+                        // quit loop and keep what we know to be good
+                        break;
+                    }
+                }
+            }
         }
         else 
         {
@@ -234,6 +268,36 @@ bool LinePolygonsCrossings::optimizePath(CombPath& comb_path, CombPath& optimize
             }
         }
     }
+
+    if (optimized_comb_path.size() > 1)
+    {
+        const unsigned n = optimized_comb_path.size();
+        // the penultimate corner may be deleted if the resulting path doesn't conflict with the boundary
+        if (!PolygonUtils::polygonCollidesWithLineSegment(optimized_comb_path[n - 2], comb_path.back(), loc_to_line_grid))
+        {
+            optimized_comb_path.pop_back();
+        }
+        else {
+            // that wasn't possible so try and move the penultimate corner without conficting with the boundary
+            // in exactly the same way as we did at the start of the path
+            for (float frac : { 0.9, 0.9, 0.7, 0.5 })
+            {
+                // make a new point between the penultimate corner and the corner before that
+                Point p = optimized_comb_path[n - 2] + (optimized_comb_path[n - 1] - optimized_comb_path[n - 2]) * frac;
+                if (!PolygonUtils::polygonCollidesWithLineSegment(p, comb_path.back(), loc_to_line_grid))
+                {
+                    // using the new corner doesn't cause a conflict
+                    optimized_comb_path[n - 1] = p;
+                }
+                else
+                {
+                    // quit loop and keep what we know to be good
+                    break;
+                }
+            }
+        }
+    }
+
     optimized_comb_path.push_back(comb_path.back());
     return true;
 }

--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -200,6 +200,20 @@ bool LinePolygonsCrossings::optimizePath(CombPath& comb_path, CombPath& optimize
             {
                 comb_path.cross_boundary = true;
             }
+            // before we add this point, can we discard some of the previous points and still avoid clashing with the combing boundary?
+            const int max_short_circuit_len = 1 << 3; // test distances of 8, 4, 2, 1
+            for (unsigned n = std::min(max_short_circuit_len, (int)optimized_comb_path.size()); n > 0; n >>= 1)
+            {
+                if (optimized_comb_path.size() > n && !PolygonUtils::polygonCollidesWithLineSegment(optimized_comb_path[optimized_comb_path.size() - n - 1], comb_path[point_idx - 1], loc_to_line_grid))
+                {
+                    // we can remove n points from the path without it clashing with the combing boundary
+                    for (unsigned i = 0; i < n; ++i)
+                    {
+                        optimized_comb_path.pop_back();
+                    }
+                    break;
+                }
+            }
             optimized_comb_path.push_back(comb_path[point_idx - 1]);
         }
         else 


### PR DESCRIPTION

Sometimes, the combing algorithm will produce a maximal length path that hugs the part
boundary when it could, in fact, be shorter and still be inside the part. For example,
Imagine a part shaped like the outline of a hand. The combing algorithm is quite happy to
create a path that goes up and down the fingers when travelling from one side of the palm
to the other when, perhaps, it could cut across the base of each finger.

A real optimizer would detect the excess travel and trim it to the minimum required by
"pulling tight" the path. This commit tries to achieve a similar result but with no claims
to being optimal. It's relatively cheap (computationally) and cheerful (can produce good
results).

What it does is look back at the sequence of points that have been inserted into the comb
path and see if they can be removed ("short-circuited") without causing the path to cross
the comb boundary. So paths that hug a concave boundary will be shortened. They can even be
shortened when they go around holes but that is not guaranteed to occur.