### PR TITLE
slicing mode

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -89,8 +89,7 @@ bool FffPolygonGenerator::sliceModel(MeshGroup* meshgroup, TimeKeeper& timeKeepe
         logError("Layer height %i is disallowed.\n", layer_thickness);
         return false;
     }
-    int initial_slice_z = initial_layer_thickness - layer_thickness / 2;
-    int slice_layer_count = (storage.model_max.z - initial_slice_z) / layer_thickness + 1;
+    int slice_layer_count = (storage.model_max.z - initial_layer_thickness) / layer_thickness + 2;
     if (slice_layer_count <= 0) //Model is shallower than layer_height_0, so not even the first layer is sliced. Return an empty model then.
     {
         return true; //This is NOT an error state!
@@ -100,7 +99,7 @@ bool FffPolygonGenerator::sliceModel(MeshGroup* meshgroup, TimeKeeper& timeKeepe
     for(unsigned int mesh_idx = 0; mesh_idx < meshgroup->meshes.size(); mesh_idx++)
     {
         Mesh& mesh = meshgroup->meshes[mesh_idx];
-        Slicer* slicer = new Slicer(&mesh, initial_slice_z, layer_thickness, slice_layer_count, mesh.getSettingBoolean("meshfix_keep_open_polygons"), mesh.getSettingBoolean("meshfix_extensive_stitching"));
+        Slicer* slicer = new Slicer(&mesh, initial_layer_thickness, layer_thickness, slice_layer_count, mesh.getSettingBoolean("meshfix_keep_open_polygons"), mesh.getSettingBoolean("meshfix_extensive_stitching"));
         slicerList.push_back(slicer);
         /*
         for(SlicerLayer& layer : slicer->layers)
@@ -172,9 +171,9 @@ bool FffPolygonGenerator::sliceModel(MeshGroup* meshgroup, TimeKeeper& timeKeepe
         for (unsigned int layer_nr = 0; layer_nr < meshStorage.layers.size(); layer_nr++)
         {
             SliceLayer& layer = meshStorage.layers[layer_nr];
-            meshStorage.layers[layer_nr].printZ += 
+            meshStorage.layers[layer_nr].printZ =
                 getSettingInMicrons("layer_height_0")
-                - initial_slice_z;
+                + layer_nr * layer_thickness;
             if (has_raft)
             {
                 ExtruderTrain* train = storage.meshgroup->getExtruderTrain(getSettingAsIndex("adhesion_extruder_nr"));

--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -51,8 +51,6 @@ void createLayerParts(SliceMeshStorage& mesh, Slicer* slicer, bool union_layers,
     {
         SliceLayer& layer_storage = mesh.layers[layer_nr];
         SlicerLayer& slice_layer = slicer->layers[layer_nr];
-        layer_storage.sliceZ = slice_layer.z;
-        layer_storage.printZ = slice_layer.z;
         createLayerWithParts(layer_storage, &slice_layer, union_layers, union_all_remove_holes);
     }
 

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -497,6 +497,20 @@ SupportDistPriority SettingsBaseVirtual::getSettingAsSupportDistPriority(std::st
     return SupportDistPriority::XY_OVERRIDES_Z;
 }
 
+SlicingMode SettingsBaseVirtual::getSettingAsSlicingMode(std::string key) const
+{
+    const std::string& value = getSettingString(key);
+    if (value == "inclusive")
+    {
+        return SlicingMode::INCLUSIVE;
+    }
+    if (value == "exclusive")
+    {
+        return SlicingMode::EXCLUSIVE;
+    }
+    return SlicingMode::MIDDLE;
+}
+
 std::vector<int> SettingsBaseVirtual::getSettingAsIntegerList(std::string key) const
 {
     std::vector<int> result;

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -497,18 +497,18 @@ SupportDistPriority SettingsBaseVirtual::getSettingAsSupportDistPriority(std::st
     return SupportDistPriority::XY_OVERRIDES_Z;
 }
 
-SlicingMode SettingsBaseVirtual::getSettingAsSlicingMode(std::string key) const
+SlicingTolerance SettingsBaseVirtual::getSettingAsSlicingTolerance(std::string key) const
 {
     const std::string& value = getSettingString(key);
     if (value == "inclusive")
     {
-        return SlicingMode::INCLUSIVE;
+        return SlicingTolerance::INCLUSIVE;
     }
     if (value == "exclusive")
     {
-        return SlicingMode::EXCLUSIVE;
+        return SlicingTolerance::EXCLUSIVE;
     }
-    return SlicingMode::MIDDLE;
+    return SlicingTolerance::MIDDLE;
 }
 
 std::vector<int> SettingsBaseVirtual::getSettingAsIntegerList(std::string key) const

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -194,6 +194,13 @@ enum class SupportDistPriority
     Z_OVERRIDES_XY
 };
 
+enum class SlicingMode
+{
+    MIDDLE,
+    INCLUSIVE,
+    EXCLUSIVE
+};
+
 #define MAX_EXTRUDERS 16
 
 //Maximum number of infill layers that can be combined into a single infill extrusion area.
@@ -277,6 +284,7 @@ public:
     FillPerimeterGapMode getSettingAsFillPerimeterGapMode(std::string key) const;
     CombingMode getSettingAsCombingMode(std::string key) const;
     SupportDistPriority getSettingAsSupportDistPriority(std::string key) const;
+    SlicingMode getSettingAsSlicingMode(std::string key) const;
     std::vector<int> getSettingAsIntegerList(std::string key) const;
 };
 

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -194,7 +194,7 @@ enum class SupportDistPriority
     Z_OVERRIDES_XY
 };
 
-enum class SlicingMode
+enum class SlicingTolerance
 {
     MIDDLE,
     INCLUSIVE,
@@ -284,7 +284,7 @@ public:
     FillPerimeterGapMode getSettingAsFillPerimeterGapMode(std::string key) const;
     CombingMode getSettingAsCombingMode(std::string key) const;
     SupportDistPriority getSettingAsSupportDistPriority(std::string key) const;
-    SlicingMode getSettingAsSlicingMode(std::string key) const;
+    SlicingTolerance getSettingAsSlicingTolerance(std::string key) const;
     std::vector<int> getSettingAsIntegerList(std::string key) const;
 };
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -140,8 +140,6 @@ public:
 class SliceLayer
 {
 public:
-    int sliceZ;     //!< The height at which the 3D model was cut. 
-    // TODO: remove this /\ unused member!
     int printZ;     //!< The height at which this layer needs to be printed. Can differ from sliceZ due to the raft.
     std::vector<SliceLayerPart> parts;  //!< An array of LayerParts which contain the actual data. The parts are printed one at a time to minimize travel outside of the 3D model.
     Polygons openPolyLines; //!< A list of lines which were never hooked up into a 2D polygon. (Currently unused in normal operation)

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -922,7 +922,7 @@ Slicer::Slicer(Mesh* mesh, int initial_layer_thickness, int thickness, int slice
         {
             layers[layer_nr].polygons = layers[layer_nr].polygons.intersection(layers[layer_nr + 1].polygons);
         }
-        layers.pop_back();
+        layers.back().polygons.clear();
         break;
     case SlicingTolerance::MIDDLE:
     default:

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -794,15 +794,22 @@ void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool ext
 }
 
 
-Slicer::Slicer(Mesh* mesh, int initial, int thickness, int slice_layer_count, bool keep_none_closed, bool extensive_stitching)
+Slicer::Slicer(Mesh* mesh, int initial_layer_thickness, int thickness, int slice_layer_count, bool keep_none_closed, bool extensive_stitching)
 : mesh(mesh)
 {
+    SlicingMode slicing_mode = mesh->getSettingAsSlicingMode("slicing_mode");
+
     assert(slice_layer_count > 0);
 
     TimeKeeper slice_timer;
 
     layers.resize(slice_layer_count);
 
+    int initial = initial_layer_thickness - thickness; // slice height of initial slice layer
+    if (slicing_mode == SlicingMode::MIDDLE)
+    {
+        initial += thickness / 2;
+    }
 
     for(int32_t layer_nr = 0; layer_nr < slice_layer_count; layer_nr++)
     {
@@ -900,6 +907,27 @@ Slicer::Slicer(Mesh* mesh, int initial, int thickness, int slice_layer_count, bo
     for(unsigned int layer_nr=0; layer_nr<layers_ref.size(); layer_nr++)
     {
         layers_ref[layer_nr].makePolygons(mesh, keep_none_closed, extensive_stitching, layer_nr == 0);
+    }
+
+    switch(slicing_mode)
+    {
+    case SlicingMode::INCLUSIVE:
+        for (unsigned int layer_nr = 0; layer_nr + 1 < layers_ref.size(); layer_nr++)
+        {
+            layers[layer_nr].polygons = layers[layer_nr].polygons.unionPolygons(layers[layer_nr + 1].polygons);
+        }
+        break;
+    case SlicingMode::EXCLUSIVE:
+        for (unsigned int layer_nr = 0; layer_nr + 1 < layers_ref.size(); layer_nr++)
+        {
+            layers[layer_nr].polygons = layers[layer_nr].polygons.intersection(layers[layer_nr + 1].polygons);
+        }
+        layers.pop_back();
+        break;
+    case SlicingMode::MIDDLE:
+    default:
+        // do nothing
+        ;
     }
 
     mesh->expandXY(mesh->getSettingInMicrons("xy_offset"));

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -797,7 +797,7 @@ void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool ext
 Slicer::Slicer(Mesh* mesh, int initial_layer_thickness, int thickness, int slice_layer_count, bool keep_none_closed, bool extensive_stitching)
 : mesh(mesh)
 {
-    SlicingMode slicing_mode = mesh->getSettingAsSlicingMode("slicing_mode");
+    SlicingTolerance slicing_tolerance = mesh->getSettingAsSlicingTolerance("slicing_tolerance");
 
     assert(slice_layer_count > 0);
 
@@ -806,7 +806,7 @@ Slicer::Slicer(Mesh* mesh, int initial_layer_thickness, int thickness, int slice
     layers.resize(slice_layer_count);
 
     int initial = initial_layer_thickness - thickness; // slice height of initial slice layer
-    if (slicing_mode == SlicingMode::MIDDLE)
+    if (slicing_tolerance == SlicingTolerance::MIDDLE)
     {
         initial += thickness / 2;
     }
@@ -909,22 +909,22 @@ Slicer::Slicer(Mesh* mesh, int initial_layer_thickness, int thickness, int slice
         layers_ref[layer_nr].makePolygons(mesh, keep_none_closed, extensive_stitching, layer_nr == 0);
     }
 
-    switch(slicing_mode)
+    switch(slicing_tolerance)
     {
-    case SlicingMode::INCLUSIVE:
+    case SlicingTolerance::INCLUSIVE:
         for (unsigned int layer_nr = 0; layer_nr + 1 < layers_ref.size(); layer_nr++)
         {
             layers[layer_nr].polygons = layers[layer_nr].polygons.unionPolygons(layers[layer_nr + 1].polygons);
         }
         break;
-    case SlicingMode::EXCLUSIVE:
+    case SlicingTolerance::EXCLUSIVE:
         for (unsigned int layer_nr = 0; layer_nr + 1 < layers_ref.size(); layer_nr++)
         {
             layers[layer_nr].polygons = layers[layer_nr].polygons.intersection(layers[layer_nr + 1].polygons);
         }
         layers.pop_back();
         break;
-    case SlicingMode::MIDDLE:
+    case SlicingTolerance::MIDDLE:
     default:
         // do nothing
         ;

--- a/src/slicer.h
+++ b/src/slicer.h
@@ -487,7 +487,7 @@ public:
 
     const Mesh* mesh = nullptr; //!< The sliced mesh
 
-    Slicer(Mesh* mesh, int initial, int thickness, int slice_layer_count, bool keepNoneClosed, bool extensiveStitching);
+    Slicer(Mesh* mesh, int initial_layer_thickness, int thickness, int slice_layer_count, bool keepNoneClosed, bool extensiveStitching);
 
     /*!
      * Linear interpolation


### PR DESCRIPTION
Options to determine how to slice a layer.

One of the reasons printed parts don't fit is because currently the middle of a layer is taken for the area of that layer, while that could mean half of the layer is sticking out of the model.

Exclusive:
[UM3N_cone_to_cylinder.3mf.txt](https://github.com/Ultimaker/CuraEngine/files/1364572/UM3N_cone_to_cylinder.3mf.txt)
![image](https://user-images.githubusercontent.com/8895761/31307627-7ffe2d66-ab68-11e7-833a-7f75379dae25.png)


Inclusive:
![image](https://user-images.githubusercontent.com/8895761/31307722-0f45049e-ab6a-11e7-9cde-f69b2324a23f.png)
