### PR TITLE
In generateInsets(), if the last inset disappears try again using 99% of the line width.

### DIFF
--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -36,10 +36,23 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
             part->insets[0] = part->outline.offset(-line_width_0 / 2 - wall_0_inset);
         } else if (i == 1)
         {
-            part->insets[1] = part->insets[0].offset(-line_width_0 / 2 + wall_0_inset - line_width_x / 2);
+            const int offset = -line_width_0 / 2 + wall_0_inset - line_width_x / 2;
+            part->insets[1] = part->insets[0].offset(offset);
+            if (part->insets[1].size() == 0)
+            {
+                // if a slightly thinner line would fit, allow it as the overlap is so small
+                // this helps when you have parts such as tubes whose walls are an exact number of line widths wide
+                // e.g. when the tube wall is 1.5mm wide and the line widths are 0.5mm
+                part->insets[1] = part->insets[0].offset(offset * 0.99f);
+            }
         } else
         {
             part->insets[i] = part->insets[i-1].offset(-line_width_x);
+            if (part->insets[i].size() == 0)
+            {
+                // if a slightly thinner line would fit, allow it as the overlap is so small
+                part->insets[i] = part->insets[i-1].offset(-line_width_x * 0.99f);
+            }
         }
 
         //Finally optimize all the polygons. Every point removed saves time in the long run.

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -21,6 +21,7 @@ WallsComputation::WallsComputation(int wall_0_inset, int line_width_0, int line_
  */
 void WallsComputation::generateInsets(SliceLayerPart* part)
 {
+    const float undersize_factor = 0.95f; // allow innermost inset to be this much narrower than normal
     if (insetCount == 0)
     {
         part->insets.push_back(part->outline);
@@ -43,7 +44,7 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
                 // if a slightly thinner line would fit, allow it as the overlap is so small
                 // this helps when you have parts such as tubes whose walls are an exact number of line widths wide
                 // e.g. when the tube wall is 1.5mm wide and the line widths are 0.5mm
-                part->insets[1] = part->insets[0].offset(offset * 0.99f);
+                part->insets[1] = part->insets[0].offset(offset * undersize_factor);
             }
         } else
         {
@@ -51,7 +52,7 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
             if (part->insets[i].size() == 0)
             {
                 // if a slightly thinner line would fit, allow it as the overlap is so small
-                part->insets[i] = part->insets[i-1].offset(-line_width_x * 0.99f);
+                part->insets[i] = part->insets[i-1].offset(-line_width_x * undersize_factor);
             }
         }
 


### PR DESCRIPTION
This makes it more likely that walls whose width is exactly the sum of the constituent wall
widths - e.g. a wall 1.5mm wide with line widths of 0.5mm will have all the walls
generated rather than the middle one getting missed out which often happened before.