### PR TITLE
Fix start extruder heatup

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -413,15 +413,21 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
 
         if (getSettingBoolean("material_bed_temp_prepend"))
         {
-            if (getSettingBoolean("machine_heated_bed") && getSettingInDegreeCelsius("material_bed_temperature_layer_0") != 0)
+            if (getSettingBoolean("machine_heated_bed"))
             {
-                gcode.writeBedTemperatureCommand(getSettingInDegreeCelsius("material_bed_temperature_layer_0"), getSettingBoolean("material_bed_temp_wait"));
+                double bed_temp = getSettingInDegreeCelsius("material_bed_temperature_layer_0");
+                if (bed_temp != 0)
+                {
+                    gcode.writeBedTemperatureCommand(bed_temp, getSettingBoolean("material_bed_temp_wait"));
+                }
             }
         }
 
         if (getSettingBoolean("material_print_temp_prepend"))
         {
-            for (int extruder_nr = 0; extruder_nr < storage.getSettingAsCount("machine_extruder_count"); extruder_nr++)
+            const unsigned num_extruders = storage.getSettingAsCount("machine_extruder_count");
+
+            for (unsigned extruder_nr = 0; extruder_nr < num_extruders; extruder_nr++)
             {
                 if (extruder_is_used[extruder_nr])
                 {
@@ -441,7 +447,7 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
             }
             if (getSettingBoolean("material_print_temp_wait"))
             {
-                for (int extruder_nr = 0; extruder_nr < storage.getSettingAsCount("machine_extruder_count"); extruder_nr++)
+                for (unsigned extruder_nr = 0; extruder_nr < num_extruders; extruder_nr++)
                 {
                     if (extruder_is_used[extruder_nr])
                     {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -392,6 +392,7 @@ void FffGcodeWriter::setInfillAndSkinAngles(SliceMeshStorage& mesh)
 void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const unsigned int start_extruder_nr)
 {
     std::vector<bool> extruder_is_used = storage.getExtrudersUsed();
+    const unsigned num_extruders = storage.getSettingAsCount("machine_extruder_count");
     if (!CommandSocket::isInstantiated())
     {
         std::string prefix = gcode.getFileHeader(extruder_is_used);
@@ -407,9 +408,12 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
 
     if (gcode.getFlavor() != EGCodeFlavor::ULTIGCODE && gcode.getFlavor() != EGCodeFlavor::GRIFFIN)
     {
-        std::ostringstream tmp;
-        tmp << "T" << start_extruder_nr;
-        gcode.writeLine(tmp.str().c_str());
+        if (num_extruders > 1)
+        {
+            std::ostringstream tmp;
+            tmp << "T" << start_extruder_nr;
+            gcode.writeLine(tmp.str().c_str());
+        }
 
         if (getSettingBoolean("material_bed_temp_prepend"))
         {
@@ -425,8 +429,6 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
 
         if (getSettingBoolean("material_print_temp_prepend"))
         {
-            const unsigned num_extruders = storage.getSettingAsCount("machine_extruder_count");
-
             for (unsigned extruder_nr = 0; extruder_nr < num_extruders; extruder_nr++)
             {
                 if (extruder_is_used[extruder_nr])


### PR DESCRIPTION
This PR changes the temperature commands inserted before the start gcode if the start gcode does not contain heatup commands. For multiextrusion machines, it inserts a T command to activate the first used extruder. Only the first used extruder is heated up to printing temperatures, the other extruders used in the print are heated up to the standby temperature. Unused extruders are no longer heated up.

Griffin-based printers (such as the UM3) are not affected.

This PR fixes https://github.com/Ultimaker/Cura/issues/1819

I have tested the PR using a Custom FDM Printer with 4 extruders by slicing multiple objects printed with either of these extruders, with and without buildplate adhesion. All seems to behave correctly.