### PR TITLE
Speedup the line order optimizer

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -460,7 +460,7 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
 }
 void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location)
 {
-    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()), &comb_boundary_inside);
+    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()));
     for (unsigned int line_idx = 0; line_idx < polygons.size(); line_idx++)
     {
         orderOptimizer.addPolygon(polygons[line_idx]);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -460,7 +460,7 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
 }
 void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location)
 {
-    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()));
+    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()), &comb_boundary_inside);
     for (unsigned int line_idx = 0; line_idx < polygons.size(); line_idx++)
     {
         orderOptimizer.addPolygon(polygons[line_idx]);

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -363,7 +363,12 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
 
     if (just_point != 1)
     { /// check distance to first point on line (0)
-        float score = travelDistance(p0, prev_point, just_point == -1) + dot_score; // prefer 90 degree corners
+        float score = travelDistance(prev_point, p0, true) + dot_score; // prefer 90 degree corners
+        if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p0, prev_point))
+        {
+            // this could be a candidate but as the combing distance can be computed, use that instead of the direct distance
+            score = travelDistance(prev_point, p0, false) + dot_score;
+        }
         if (score < best_score)
         {
             best = poly_idx;
@@ -373,7 +378,12 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
     }
     if (just_point != 0)
     { /// check distance to second point on line (1)
-        float score = travelDistance(p1, prev_point, just_point == -1) + dot_score; // prefer 90 degree corners
+        float score = travelDistance(prev_point, p1, true) + dot_score; // prefer 90 degree corners
+        if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p1, prev_point))
+        {
+            // this could be a candidate but as the combing distance can be computed, use that instead of the direct distance
+            score = travelDistance(prev_point, p1, false) + dot_score;
+        }
         if (score < best_score)
         {
             best = poly_idx;

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -349,13 +349,13 @@ inline float LineOrderOptimizer::travelDistance(const Point& p0, const Point& p1
 
 inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal, int just_point)
 {
+    // when looking for chains, just_point will be either 0 or 1 depending on which vertex we are currently interested in testing
+    // if just_point is -1, it means that we are not looking for chains and we will test both vertices to see if either is best
+
     const Point& p0 = (*polygons[poly_idx])[0];
     const Point& p1 = (*polygons[poly_idx])[1];
     float dot_score = (just_point >= 0) ? 0 : getAngleScore(incoming_perpundicular_normal, p0, p1);
-    // if just_point is -1, it means that we are not looking for chains and we are going to use the direct travel
-    // distance rather than going to the effort of combing
-    // when looking for chains, just_point will be either 0 or 1 depending on which vertex we are currently interested in and
-    // if possible we shall be using combing to calculate the travel distance
+
     if (just_point != 1)
     { /// check distance to first point on line (0)
         float score = travelDistance(p0, prev_point, just_point == -1) + dot_score; // prefer 90 degree corners

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -331,11 +331,17 @@ inline float LineOrderOptimizer::travelDistance(const Point& p0, const Point& p1
     {
         return vSize2f(p0 - p1);
     }
+    // because infill lines can actually extend outside of the combing boundary (infill_overlap)
+    // we need to move the points inside before calculating the combed distance
+    Point p0_inside = p0;
+    Point p1_inside = p1;
+    PolygonUtils::moveInside(*combing_boundary, p0_inside, 10);
+    PolygonUtils::moveInside(*combing_boundary, p1_inside, 10);
     CombPath comb_path;
-    if (LinePolygonsCrossings::comb(*combing_boundary, *loc_to_line, p0, p1, comb_path, -40, 0, false))
+    if (LinePolygonsCrossings::comb(*combing_boundary, *loc_to_line, p0_inside, p1_inside, comb_path, -40, 0, false))
     {
         float dist = 0;
-        Point last_point = p0;
+        Point last_point = p0_inside;
         for (const Point& comb_point : comb_path)
         {
             dist += vSize(comb_point - last_point);

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -201,6 +201,13 @@ void LineOrderOptimizer::optimize()
 
     }
 
+    if (combing_boundary != nullptr && combing_boundary->size() > 0)
+    {
+        // the combing boundary has been provided so do the initialisation
+        // required to be able to calculate realistic travel distances to the start of new paths
+        const int travel_avoid_distance = 1000; // assume 1mm - not really critical for our purposes
+        loc_to_line = PolygonUtils::createLocToLineGrid(*combing_boundary, travel_avoid_distance);
+    }
 
     Point incoming_perpundicular_normal(0, 0);
     Point prev_point = startPoint;
@@ -209,14 +216,6 @@ void LineOrderOptimizer::optimize()
     {
         int best_line_idx = -1;
         float best_score = std::numeric_limits<float>::infinity(); // distance score for the best next line
-
-        if (order_idx == 1 && combing_boundary != nullptr && combing_boundary->size() > 0 && have_chains)
-        {
-            // we now know that we have chains and the combing boundary has been provided so do the initialisation
-            // required to be able to calculate realistic travel distances to the start of new paths
-            const int travel_avoid_distance = 1000; // assume 1mm - not really critical for our purposes
-            loc_to_line = PolygonUtils::createLocToLineGrid(*combing_boundary, travel_avoid_distance);
-        }
 
         // for the first line we would prefer a line that is at the end of a sequence of connected lines (think zigzag) and
         // so we only consider the closest line when looking for the second line onwards

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -232,12 +232,26 @@ void LineOrderOptimizer::optimize()
             }
         }
 
-        if (have_chains && best_line_idx != -1 && !pointsAreCoincident(prev_point, (*polygons[best_line_idx])[polyStart[best_line_idx]]))
+        if (best_line_idx != -1)
         {
-            // we found a point close to prev_point but it's not close enough for the points to be considered coincident so we would
-            // probably be better off by ditching this point and finding an end of a chain instead (let's hope it's not too far away!)
-            best_line_idx = -1;
-            best_score = std::numeric_limits<float>::infinity();
+            const Point& best_point = (*polygons[best_line_idx])[polyStart[best_line_idx]];
+            if (!pointsAreCoincident(prev_point, best_point))
+            {
+                if (loc_to_line != nullptr && travelDistance(prev_point, best_point, true) < best_score / 2)
+                {
+                    // we have found a point whose as-the-crow-flies distance is close to prev_point but the winning score is based on the combed distance
+                    // so we forget this point and rely on the loop below that finds the nearest unpicked line
+                    best_line_idx = -1;
+                    best_score = std::numeric_limits<float>::infinity();
+                }
+                else if (have_chains)
+                {
+                    // we found a point close to prev_point but it's not close enough for the points to be considered coincident so we would
+                    // probably be better off by ditching this point and finding an end of a chain instead (let's hope it's not too far away!)
+                    best_line_idx = -1;
+                    best_score = std::numeric_limits<float>::infinity();
+                }
+            }
         }
 
         // if no line ends close to prev_point, see if we can find a point on a line that could be the start of a chain of lines

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -338,34 +338,6 @@ void LineOrderOptimizer::optimize()
         delete loc_to_line;
 }
 
-inline float LineOrderOptimizer::travelDistance(const Point& p0, const Point& p1, const bool travel_direct)
-{
-    if (travel_direct || loc_to_line == nullptr)
-    {
-        return vSize2f(p0 - p1);
-    }
-    // because infill lines can actually extend outside of the combing boundary (infill_overlap)
-    // we need to move the points inside before calculating the combed distance
-    Point p0_inside = p0;
-    Point p1_inside = p1;
-    PolygonUtils::moveInside(*combing_boundary, p0_inside, 10);
-    PolygonUtils::moveInside(*combing_boundary, p1_inside, 10);
-    CombPath comb_path;
-    if (LinePolygonsCrossings::comb(*combing_boundary, *loc_to_line, p0_inside, p1_inside, comb_path, -40, 0, false))
-    {
-        float dist = 0;
-        Point last_point = p0_inside;
-        for (const Point& comb_point : comb_path)
-        {
-            dist += vSize(comb_point - last_point);
-            last_point = comb_point;
-        }
-        return dist * dist;
-    }
-    // fall back to direct distance
-    return vSize2f(p0 - p1);
-}
-
 inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal, int just_point)
 {
     // when looking for chains, just_point will be either 0 or 1 depending on which vertex we are currently interested in testing
@@ -377,7 +349,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
 
     if (just_point != 1)
     { /// check distance to first point on line (0)
-        float score = travelDistance(prev_point, p0, true) + dot_score; // prefer 90 degree corners
+        float score = vSize2f(p0 - prev_point) + dot_score; // prefer 90 degree corners
         if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p0, prev_point))
         {
             // this could be a candidate but as the combing distance can be computed, use that instead of the direct distance
@@ -392,7 +364,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
     }
     if (just_point != 0)
     { /// check distance to second point on line (1)
-        float score = travelDistance(prev_point, p1, true) + dot_score; // prefer 90 degree corners
+        float score = vSize2f(p1 - prev_point) + dot_score; // prefer 90 degree corners
         if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p1, prev_point))
         {
             // this could be a candidate but as the combing distance can be computed, use that instead of the direct distance

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -148,16 +148,6 @@ private:
      * 
      */
     static float getAngleScore(Point incoming_perpundicular_normal, Point from, Point to);
-
-    /*!
-     * Calculate the distance covered when traveling between two points.
-     *
-     * \param[in] p0 One end of the travel path.
-     * \param[in] p1 The other end of the travel path.
-     * \param[in] travel_direct If true, assume that the shortest path can be used.
-     * \return The distance covered to go from \p p0 to \p p1.
-     */
-    float travelDistance(const Point& p0, const Point& p1, const bool travel_direct);
 };
 
 }//namespace cura


### PR DESCRIPTION
This PR requires that 82417aa45029871ac6aaf8b8c297d9aa161e7b3f is reverted so that the code that this PR modifies is back in place. Why did you just remove it without giving me a chance to come up with a solution? That was really very unfriendly.
