### PR TITLE
Improve the order that lines are output to minimize travel.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -460,7 +460,26 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
 }
 void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location)
 {
-    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()), &comb_boundary_inside);
+    Polygons boundary;
+    if (comb_boundary_inside.size() > 0)
+    {
+        int dist = 0;
+        if (layer_nr >= 0)
+        {
+            // determine how much the skin/infill lines overlap the combing boundary
+            for (const SliceMeshStorage& mesh : storage.meshes)
+            {
+                int overlap = std::max(mesh.getSettingInMicrons("skin_overlap_mm"), mesh.getSettingInMicrons("infill_overlap_mm"));
+                if (overlap > dist)
+                {
+                    dist = overlap;
+                }
+            }
+            dist += 10; // ensure boundary is slightly outside all skin/infill lines
+        }
+        boundary.add(comb_boundary_inside.offset(dist));
+    }
+    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()), &boundary);
     for (unsigned int line_idx = 0; line_idx < polygons.size(); line_idx++)
     {
         orderOptimizer.addPolygon(polygons[line_idx]);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -460,7 +460,7 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
 }
 void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location)
 {
-    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()));
+    LineOrderOptimizer orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()), &comb_boundary_inside);
     for (unsigned int line_idx = 0; line_idx < polygons.size(); line_idx++)
     {
         orderOptimizer.addPolygon(polygons[line_idx]);

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -232,16 +232,12 @@ void LineOrderOptimizer::optimize()
             }
         }
 
-        if (best_line_idx != -1)
+        if (best_line_idx != -1 && have_chains && !pointsAreCoincident(prev_point, (*polygons[best_line_idx])[polyStart[best_line_idx]]))
         {
-            const Point& best_point = (*polygons[best_line_idx])[polyStart[best_line_idx]];
-            if (have_chains && !pointsAreCoincident(prev_point, best_point))
-            {
-                // we found a point close to prev_point but it's not close enough for the points to be considered coincident so we would
-                // probably be better off by ditching this point and finding an end of a chain instead (let's hope it's not too far away!)
-                best_line_idx = -1;
-                best_score = std::numeric_limits<float>::infinity();
-            }
+            // we found a point close to prev_point but it's not close enough for the points to be considered coincident so we would
+            // probably be better off by ditching this point and finding an end of a chain instead (let's hope it's not too far away!)
+            best_line_idx = -1;
+            best_score = std::numeric_limits<float>::infinity();
         }
 
         // if no line ends close to prev_point, see if we can find a point on a line that could be the start of a chain of lines

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -335,7 +335,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
     const Point& p1 = (*polygons[poly_idx])[1];
     float dot_score = (just_point >= 0) ? 0 : getAngleScore(incoming_perpundicular_normal, p0, p1);
     const int move_inside_distance = 100; // how far to move points inside part boundary
-    const int non_trivial_move_penalty_factor = 1000; // if a travel move is not a single straight line, multiply the score by this factor
+    const int non_trivial_move_penalty_factor = 10000; // if a travel move is not a single straight line, multiply the score by this factor
 
     if (just_point != 1)
     { /// check distance to first point on line (0)

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -207,6 +207,7 @@ void LineOrderOptimizer::optimize()
         // to decide whether a direct travel path between two points crosses the part boundary
         const int travel_avoid_distance = 1000; // assume 1mm - not really critical for our purposes
         loc_to_line = PolygonUtils::createLocToLineGrid(*combing_boundary, travel_avoid_distance);
+        inside_points = new std::unordered_map<Point, Point>();
     }
 
     Point incoming_perpundicular_normal(0, 0);
@@ -321,7 +322,10 @@ void LineOrderOptimizer::optimize()
     }
 
     if (loc_to_line != nullptr)
+    {
         delete loc_to_line;
+        delete inside_points;
+    }
 }
 
 inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal, int just_point)
@@ -339,9 +343,27 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
         if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p0, prev_point))
         {
             Point p0_inside = p0;
+            auto search = inside_points->find(p0);
+            if (search != inside_points->end())
+            {
+                p0_inside = search->second;
+            }
+            else
+            {
+                PolygonUtils::moveInside(*combing_boundary, p0_inside, 100);
+                inside_points->emplace(p0, p0_inside);
+            }
             Point prev_inside = prev_point;
-            PolygonUtils::moveInside(*combing_boundary, p0_inside, 100);
-            PolygonUtils::moveInside(*combing_boundary, prev_inside, 100);
+            search = inside_points->find(prev_point);
+            if (search != inside_points->end())
+            {
+                prev_inside = search->second;
+            }
+            else
+            {
+                PolygonUtils::moveInside(*combing_boundary, prev_inside, 100);
+                inside_points->emplace(prev_point, prev_inside);
+            }
             if (PolygonUtils::polygonCollidesWithLineSegment(p0_inside, prev_inside, *loc_to_line))
             {
                 // severely penalise this score because the travel requires combing or a retract
@@ -361,9 +383,27 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
         if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p1, prev_point))
         {
             Point p1_inside = p1;
+            auto search = inside_points->find(p1);
+            if (search != inside_points->end())
+            {
+                p1_inside = search->second;
+            }
+            else
+            {
+                PolygonUtils::moveInside(*combing_boundary, p1_inside, 100);
+                inside_points->emplace(p1, p1_inside);
+            }
             Point prev_inside = prev_point;
-            PolygonUtils::moveInside(*combing_boundary, p1_inside, 100);
-            PolygonUtils::moveInside(*combing_boundary, prev_inside, 100);
+            search = inside_points->find(prev_point);
+            if (search != inside_points->end())
+            {
+                prev_inside = search->second;
+            }
+            else
+            {
+                PolygonUtils::moveInside(*combing_boundary, prev_inside, 100);
+                inside_points->emplace(prev_point, prev_inside);
+            }
             if (PolygonUtils::polygonCollidesWithLineSegment(p1_inside, prev_inside, *loc_to_line))
             {
                 // severely penalise this score because the travel requires combing or a retract

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -336,6 +336,8 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
     const Point& p0 = (*polygons[poly_idx])[0];
     const Point& p1 = (*polygons[poly_idx])[1];
     float dot_score = (just_point >= 0) ? 0 : getAngleScore(incoming_perpundicular_normal, p0, p1);
+    const int move_inside_distance = 100; // how far to move points inside part boundary
+    const int non_trivial_move_penalty_factor = 1000; // if a travel move is not a single straight line, multiply the score by this factor
 
     if (just_point != 1)
     { /// check distance to first point on line (0)
@@ -350,7 +352,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             }
             else
             {
-                PolygonUtils::moveInside(*combing_boundary, p0_inside, 100);
+                PolygonUtils::moveInside(*combing_boundary, p0_inside, move_inside_distance);
                 inside_points->emplace(p0, p0_inside);
             }
             Point prev_inside = prev_point;
@@ -361,13 +363,13 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             }
             else
             {
-                PolygonUtils::moveInside(*combing_boundary, prev_inside, 100);
+                PolygonUtils::moveInside(*combing_boundary, prev_inside, move_inside_distance);
                 inside_points->emplace(prev_point, prev_inside);
             }
             if (PolygonUtils::polygonCollidesWithLineSegment(p0_inside, prev_inside, *loc_to_line))
             {
                 // severely penalise this score because the travel requires combing or a retract
-                score *= 1000;
+                score *= non_trivial_move_penalty_factor;
             }
         }
         if (score < best_score)
@@ -390,7 +392,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             }
             else
             {
-                PolygonUtils::moveInside(*combing_boundary, p1_inside, 100);
+                PolygonUtils::moveInside(*combing_boundary, p1_inside, move_inside_distance);
                 inside_points->emplace(p1, p1_inside);
             }
             Point prev_inside = prev_point;
@@ -401,13 +403,13 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             }
             else
             {
-                PolygonUtils::moveInside(*combing_boundary, prev_inside, 100);
+                PolygonUtils::moveInside(*combing_boundary, prev_inside, move_inside_distance);
                 inside_points->emplace(prev_point, prev_inside);
             }
             if (PolygonUtils::polygonCollidesWithLineSegment(p1_inside, prev_inside, *loc_to_line))
             {
                 // severely penalise this score because the travel requires combing or a retract
-                score *= 1000;
+                score *= non_trivial_move_penalty_factor;
             }
         }
         if (score < best_score)

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -342,7 +342,8 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
     const Point& p0 = (*polygons[poly_idx])[0];
     const Point& p1 = (*polygons[poly_idx])[1];
     float dot_score = (just_point >= 0) ? 0 : getAngleScore(incoming_perpundicular_normal, p0, p1);
-    const int move_inside_distance = 100; // how far to move points inside part boundary
+    const int move_inside_distance = 100; // how far to move points inside combing boundary
+    const int64_t max_move_inside_distance2 = 1000 * 1000; // (1mm) don't move points further than this when moving them inside the combing boundary
     const int non_trivial_move_penalty_factor = 10000; // if a travel move is not a single straight line, multiply the score by this factor
 
     if (just_point != 1)
@@ -358,7 +359,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             }
             else
             {
-                PolygonUtils::moveInside(*combing_boundary, p0_inside, move_inside_distance);
+                PolygonUtils::moveInside(*combing_boundary, p0_inside, move_inside_distance, max_move_inside_distance2);
                 inside_points->emplace(p0, p0_inside);
             }
             Point prev_inside = prev_point;
@@ -369,7 +370,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             }
             else
             {
-                PolygonUtils::moveInside(*combing_boundary, prev_inside, move_inside_distance);
+                PolygonUtils::moveInside(*combing_boundary, prev_inside, move_inside_distance, max_move_inside_distance2);
                 inside_points->emplace(prev_point, prev_inside);
             }
             if (PolygonUtils::polygonCollidesWithLineSegment(*combing_boundary, p0_inside, prev_inside))
@@ -398,7 +399,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             }
             else
             {
-                PolygonUtils::moveInside(*combing_boundary, p1_inside, move_inside_distance);
+                PolygonUtils::moveInside(*combing_boundary, p1_inside, move_inside_distance, max_move_inside_distance2);
                 inside_points->emplace(p1, p1_inside);
             }
             Point prev_inside = prev_point;
@@ -409,7 +410,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             }
             else
             {
-                PolygonUtils::moveInside(*combing_boundary, prev_inside, move_inside_distance);
+                PolygonUtils::moveInside(*combing_boundary, prev_inside, move_inside_distance, max_move_inside_distance2);
                 inside_points->emplace(prev_point, prev_inside);
             }
             if (PolygonUtils::polygonCollidesWithLineSegment(*combing_boundary, p1_inside, prev_inside))

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -232,7 +232,7 @@ void LineOrderOptimizer::optimize()
             }
         }
 
-        if (best_line_idx != -1 && best_score > 4e8)
+        if (best_line_idx != -1 && best_score > (2 * gridSize * gridSize))
         {
             // we found a point that is close to prev_point as the crow flies but the score is high so it must have been
             // penalised due to the part boundary clashing with the straight line path so let's forget it and find something closer

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -232,6 +232,14 @@ void LineOrderOptimizer::optimize()
             }
         }
 
+        if (best_line_idx != -1 && best_score > 4e8)
+        {
+            // we found a point that is close to prev_point as the crow flies but the score is high so it must have been
+            // penalised due to the part boundary clashing with the straight line path so let's forget it and find something closer
+            best_line_idx = -1;
+            best_score = std::numeric_limits<float>::infinity();
+        }
+
         if (best_line_idx != -1 && have_chains && !pointsAreCoincident(prev_point, (*polygons[best_line_idx])[polyStart[best_line_idx]]))
         {
             // we found a point close to prev_point but it's not close enough for the points to be considered coincident so we would

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -3,6 +3,8 @@
 #include "utils/logoutput.h"
 #include "utils/SparsePointGridInclusive.h"
 #include "utils/linearAlg2D.h"
+#include "pathPlanning/LinePolygonsCrossings.h"
+#include "pathPlanning/CombPath.h"
 
 #define INLINE static inline
 
@@ -160,6 +162,11 @@ int PathOrderOptimizer::getRandomPointInPolygon(int poly_idx)
     return rand() % polygons[poly_idx]->size();
 }
 
+static inline bool pointsAreCoincident(const Point& a, const Point& b)
+{
+    return vSize2(a - b) < 25; // points are closer than 5uM, consider them coincident
+}
+
 /**
 *
 */
@@ -169,6 +176,7 @@ void LineOrderOptimizer::optimize()
     SparsePointGridInclusive<unsigned int> line_bucket_grid(gridSize);
     bool picked[polygons.size()];
     memset(picked, false, sizeof(bool) * polygons.size());/// initialized as falses
+    loc_to_line = nullptr;
     
     for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++) /// find closest point to initial starting point within each polygon +initialize picked
     {
@@ -193,26 +201,93 @@ void LineOrderOptimizer::optimize()
 
     }
 
+    if (combing_boundary != nullptr && combing_boundary->size() > 0)
+    {
+        // the combing boundary has been provided so create a LocToLineGrid that will be used
+        // to decide whether a direct travel path between two points crosses the part boundary
+        const int travel_avoid_distance = 1000; // assume 1mm - not really critical for our purposes
+        loc_to_line = PolygonUtils::createLocToLineGrid(*combing_boundary, travel_avoid_distance);
+    }
 
     Point incoming_perpundicular_normal(0, 0);
     Point prev_point = startPoint;
+    bool have_chains = true; // start by assuming that line segments are chained together (i.e. zigzags) and set to false later if no chains exist
     for (unsigned int order_idx = 0; order_idx < polygons.size(); order_idx++) /// actual path order optimizer
     {
         int best_line_idx = -1;
         float best_score = std::numeric_limits<float>::infinity(); // distance score for the best next line
 
-        /// check if single-line-polygon is close to last point
-        for(unsigned int close_line_idx :
-                line_bucket_grid.getNearbyVals(prev_point, gridSize))
+        // for the first line we would prefer a line that is at the end of a sequence of connected lines (think zigzag) and
+        // so we only consider the closest line when looking for the second line onwards
+        if (order_idx > 0)
         {
-            if (picked[close_line_idx] || polygons[close_line_idx]->size() < 1)
+            /// check if single-line-polygon is close to last point
+            for(unsigned int close_line_idx : line_bucket_grid.getNearbyVals(prev_point, gridSize))
             {
-                continue;
+                if (picked[close_line_idx] || polygons[close_line_idx]->size() < 1)
+                {
+                    continue;
+                }
+                updateBestLine(close_line_idx, best_line_idx, best_score, prev_point, incoming_perpundicular_normal);
             }
-
-            updateBestLine(close_line_idx, best_line_idx, best_score, prev_point, incoming_perpundicular_normal);
         }
 
+        if (best_line_idx != -1)
+        {
+            const Point& best_point = (*polygons[best_line_idx])[polyStart[best_line_idx]];
+            if (have_chains && !pointsAreCoincident(prev_point, best_point))
+            {
+                // we found a point close to prev_point but it's not close enough for the points to be considered coincident so we would
+                // probably be better off by ditching this point and finding an end of a chain instead (let's hope it's not too far away!)
+                best_line_idx = -1;
+                best_score = std::numeric_limits<float>::infinity();
+            }
+        }
+
+        // if no line ends close to prev_point, see if we can find a point on a line that could be the start of a chain of lines
+        if (best_line_idx == -1 && have_chains)
+        {
+            have_chains = false; // now assume that we don't have any chains and change back to true below if we find any joined line segments
+            for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++)
+            {
+                if (picked[poly_idx] || polygons[poly_idx]->size() < 1) /// skip single-point-polygons
+                {
+                    continue;
+                }
+                assert(polygons[poly_idx]->size() == 2);
+
+                // does this line either end in thin air (doesn't join another line) or join another line that has already been picked?
+                // check both of its ends and see if it's a possible candidate to be used to start the next sequence
+                for (unsigned point_idx = 0; point_idx < 2; ++point_idx)
+                {
+                    int num_joined_lines = 0;
+                    const Point& p = (*polygons[poly_idx])[point_idx];
+                    // look at each of the lines that finish close to this line to see if either of its vertices are coincident this vertex
+                    for (unsigned int close_line_idx : line_bucket_grid.getNearbyVals(p, gridSize))
+                    {
+                        if (close_line_idx != poly_idx && (pointsAreCoincident(p, (*polygons[close_line_idx])[0]) || pointsAreCoincident(p, (*polygons[close_line_idx])[1])))
+                        {
+                            have_chains = true; // we have found a joint between line segments so we have chains
+
+                            ++num_joined_lines;
+
+                            if (picked[close_line_idx])
+                            {
+                                // candidate line exactly meets a line that has already been picked so consider this vertex as a start point
+                                updateBestLine(poly_idx, best_line_idx, best_score, prev_point, incoming_perpundicular_normal, point_idx);
+                            }
+                        }
+                    }
+                    if (num_joined_lines == 0)
+                    {
+                        // candidate line ends in thin air so this vertex could possibly be located at the end of a sequence of lines
+                        updateBestLine(poly_idx, best_line_idx, best_score, prev_point, incoming_perpundicular_normal, point_idx);
+                    }
+                }
+            }
+        }
+
+        // fallback to using the nearest unpicked line
         if (best_line_idx == -1) /// if single-line-polygon hasn't been found yet
         {
             for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++)
@@ -248,15 +323,35 @@ void LineOrderOptimizer::optimize()
             logError("Failed to find next closest line.\n");
         }
     }
+
+    if (loc_to_line != nullptr)
+        delete loc_to_line;
 }
 
-inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal)
+inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal, int just_point)
 {
+    // when looking for chains, just_point will be either 0 or 1 depending on which vertex we are currently interested in testing
+    // if just_point is -1, it means that we are not looking for chains and we will test both vertices to see if either is best
+
     const Point& p0 = (*polygons[poly_idx])[0];
     const Point& p1 = (*polygons[poly_idx])[1];
-    float dot_score = getAngleScore(incoming_perpundicular_normal, p0, p1);
+    float dot_score = (just_point >= 0) ? 0 : getAngleScore(incoming_perpundicular_normal, p0, p1);
+
+    if (just_point != 1)
     { /// check distance to first point on line (0)
         float score = vSize2f(p0 - prev_point) + dot_score; // prefer 90 degree corners
+        if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p0, prev_point))
+        {
+            Point p0_inside = p0;
+            Point prev_inside = prev_point;
+            PolygonUtils::moveInside(*combing_boundary, p0_inside, 100);
+            PolygonUtils::moveInside(*combing_boundary, prev_inside, 100);
+            if (PolygonUtils::polygonCollidesWithLineSegment(p0_inside, prev_inside, *loc_to_line))
+            {
+                // severely penalise this score because the travel requires combing or a retract
+                score *= 1000;
+            }
+        }
         if (score < best_score)
         {
             best = poly_idx;
@@ -264,8 +359,21 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
             polyStart[poly_idx] = 0;
         }
     }
+    if (just_point != 0)
     { /// check distance to second point on line (1)
         float score = vSize2f(p1 - prev_point) + dot_score; // prefer 90 degree corners
+        if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p1, prev_point))
+        {
+            Point p1_inside = p1;
+            Point prev_inside = prev_point;
+            PolygonUtils::moveInside(*combing_boundary, p1_inside, 100);
+            PolygonUtils::moveInside(*combing_boundary, prev_inside, 100);
+            if (PolygonUtils::polygonCollidesWithLineSegment(p1_inside, prev_inside, *loc_to_line))
+            {
+                // severely penalise this score because the travel requires combing or a retract
+                score *= 1000;
+            }
+        }
         if (score < best_score)
         {
             best = poly_idx;

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -176,8 +176,8 @@ void LineOrderOptimizer::optimize()
     SparsePointGridInclusive<unsigned int> line_bucket_grid(gridSize);
     bool picked[polygons.size()];
     memset(picked, false, sizeof(bool) * polygons.size());/// initialized as falses
-    loc_to_line = nullptr;
-    
+    inside_points = nullptr;
+
     for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++) /// find closest point to initial starting point within each polygon +initialize picked
     {
         int best_point_idx = -1;
@@ -203,10 +203,9 @@ void LineOrderOptimizer::optimize()
 
     if (combing_boundary != nullptr && combing_boundary->size() > 0)
     {
-        // the combing boundary has been provided so create a LocToLineGrid that will be used
-        // to decide whether a direct travel path between two points crosses the part boundary
-        const int travel_avoid_distance = 1000; // assume 1mm - not really critical for our purposes
-        loc_to_line = PolygonUtils::createLocToLineGrid(*combing_boundary, travel_avoid_distance);
+        // the combing boundary has been provided so create a map that will be used to hold for each line end point
+        // a new point that is the result of moving the end point inside the boundary
+
         inside_points = new std::unordered_map<Point, Point>();
     }
 
@@ -321,9 +320,8 @@ void LineOrderOptimizer::optimize()
         }
     }
 
-    if (loc_to_line != nullptr)
+    if (inside_points != nullptr)
     {
-        delete loc_to_line;
         delete inside_points;
     }
 }
@@ -342,7 +340,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
     if (just_point != 1)
     { /// check distance to first point on line (0)
         float score = vSize2f(p0 - prev_point) + dot_score; // prefer 90 degree corners
-        if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p0, prev_point))
+        if (score < best_score && inside_points != nullptr && !pointsAreCoincident(p0, prev_point))
         {
             Point p0_inside = p0;
             auto search = inside_points->find(p0);
@@ -366,7 +364,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
                 PolygonUtils::moveInside(*combing_boundary, prev_inside, move_inside_distance);
                 inside_points->emplace(prev_point, prev_inside);
             }
-            if (PolygonUtils::polygonCollidesWithLineSegment(p0_inside, prev_inside, *loc_to_line))
+            if (PolygonUtils::polygonCollidesWithLineSegment(*combing_boundary, p0_inside, prev_inside))
             {
                 // severely penalise this score because the travel requires combing or a retract
                 score *= non_trivial_move_penalty_factor;
@@ -382,7 +380,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
     if (just_point != 0)
     { /// check distance to second point on line (1)
         float score = vSize2f(p1 - prev_point) + dot_score; // prefer 90 degree corners
-        if (score < best_score && loc_to_line != nullptr && !pointsAreCoincident(p1, prev_point))
+        if (score < best_score && inside_points != nullptr && !pointsAreCoincident(p1, prev_point))
         {
             Point p1_inside = p1;
             auto search = inside_points->find(p1);
@@ -406,7 +404,7 @@ inline void LineOrderOptimizer::updateBestLine(unsigned int poly_idx, int& best,
                 PolygonUtils::moveInside(*combing_boundary, prev_inside, move_inside_distance);
                 inside_points->emplace(prev_point, prev_inside);
             }
-            if (PolygonUtils::polygonCollidesWithLineSegment(p1_inside, prev_inside, *loc_to_line))
+            if (PolygonUtils::polygonCollidesWithLineSegment(*combing_boundary, p1_inside, prev_inside))
             {
                 // severely penalise this score because the travel requires combing or a retract
                 score *= non_trivial_move_penalty_factor;

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "utils/polygon.h"
+#include "utils/polygonUtils.h"
 #include "settings/settings.h"
 
 namespace cura {
@@ -89,10 +90,13 @@ public:
     std::vector<ConstPolygonPointer> polygons; //!< the parts of the layer (in arbitrary order)
     std::vector<int> polyStart; //!< polygons[i][polyStart[i]] = point of polygon i which is to be the starting point in printing the polygon
     std::vector<int> polyOrder; //!< the optimized order as indices in #polygons
+    LocToLineGrid* loc_to_line;
+    const Polygons* combing_boundary;
 
-    LineOrderOptimizer(Point startPoint)
+    LineOrderOptimizer(Point startPoint, const Polygons* combing_boundary = nullptr)
     {
         this->startPoint = startPoint;
+        this->combing_boundary = combing_boundary;
     }
 
     void addPolygon(PolygonRef polygon)
@@ -128,8 +132,9 @@ private:
      * \param best_score[in, out] The distance score for the current best line
      * \param prev_point[in] The previous point from which to find the next best line
      * \param incoming_perpundicular_normal[in] The direction of movement when the print head arrived at \p prev_point, turned 90 degrees CCW
+     * \param just_point[in] If not -1, only look at the line vertex with this index
      */
-    void updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal);
+    void updateBestLine(unsigned int poly_idx, int& best, float& best_score, Point prev_point, Point incoming_perpundicular_normal, int just_point = -1);
 
     /*!
      * Get a score to modify the distance score for measuring how good two lines follow each other.

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -90,7 +90,6 @@ public:
     std::vector<ConstPolygonPointer> polygons; //!< the parts of the layer (in arbitrary order)
     std::vector<int> polyStart; //!< polygons[i][polyStart[i]] = point of polygon i which is to be the starting point in printing the polygon
     std::vector<int> polyOrder; //!< the optimized order as indices in #polygons
-    LocToLineGrid* loc_to_line;
     const Polygons* combing_boundary;
     std::unordered_map<Point, Point>* inside_points;
 

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -92,6 +92,7 @@ public:
     std::vector<int> polyOrder; //!< the optimized order as indices in #polygons
     LocToLineGrid* loc_to_line;
     const Polygons* combing_boundary;
+    std::unordered_map<Point, Point>* inside_points;
 
     LineOrderOptimizer(Point startPoint, const Polygons* combing_boundary = nullptr)
     {

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -90,13 +90,12 @@ public:
     std::vector<ConstPolygonPointer> polygons; //!< the parts of the layer (in arbitrary order)
     std::vector<int> polyStart; //!< polygons[i][polyStart[i]] = point of polygon i which is to be the starting point in printing the polygon
     std::vector<int> polyOrder; //!< the optimized order as indices in #polygons
-    const Polygons* combing_boundary;
-    std::unordered_map<Point, Point>* inside_points;
+    const Polygons* combing_boundary; //!< travel moves that cross this boundary are penalised so they are less likely to be chosen
 
     LineOrderOptimizer(Point startPoint, const Polygons* combing_boundary = nullptr)
     {
         this->startPoint = startPoint;
-        this->combing_boundary = combing_boundary;
+        this->combing_boundary = (combing_boundary != nullptr && combing_boundary->size() > 0) ? combing_boundary : nullptr;
     }
 
     void addPolygon(PolygonRef polygon)

--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -19,7 +19,7 @@ bool LinePolygonsCrossings::calcScanlineCrossings(bool fail_on_unavoidable_obsta
     for(unsigned int poly_idx = 0; poly_idx < boundary.size(); poly_idx++)
     {
         PolyCrossings minMax(poly_idx); 
-        PolygonRef poly = boundary[poly_idx];
+        ConstPolygonRef poly = boundary[poly_idx];
         Point p0 = transformation_matrix.apply(poly[poly.size() - 1]);
         for(unsigned int point_idx = 0; point_idx < poly.size(); point_idx++)
         {
@@ -79,7 +79,7 @@ bool LinePolygonsCrossings::lineSegmentCollidesWithBoundary()
     transformed_startPoint = transformation_matrix.apply(startPoint);
     transformed_endPoint = transformation_matrix.apply(endPoint);
 
-    for(PolygonRef poly : boundary)
+    for(ConstPolygonRef poly : boundary)
     {
         Point p0 = transformation_matrix.apply(poly.back());
         for(Point p1_ : poly)
@@ -144,7 +144,7 @@ void LinePolygonsCrossings::getBasicCombingPath(CombPath& combPath)
 
 void LinePolygonsCrossings::getBasicCombingPath(PolyCrossings& polyCrossings, CombPath& combPath) 
 {
-    PolygonRef poly = boundary[polyCrossings.poly_idx];
+    ConstPolygonRef poly = boundary[polyCrossings.poly_idx];
     combPath.push_back(transformation_matrix.unapply(Point(polyCrossings.min.x - std::abs(dist_to_move_boundary_point_outside), transformed_startPoint.Y)));
     if ( ( polyCrossings.max.point_idx - polyCrossings.min.point_idx + poly.size() ) % poly.size() 
         < poly.size() / 2 )

--- a/src/pathPlanning/LinePolygonsCrossings.h
+++ b/src/pathPlanning/LinePolygonsCrossings.h
@@ -81,7 +81,7 @@ private:
     unsigned int min_crossing_idx; //!< The index into LinePolygonsCrossings::crossings to the crossing with the minimal PolyCrossings::min crossing of all PolyCrossings's.
     unsigned int max_crossing_idx; //!< The index into LinePolygonsCrossings::crossings to the crossing with the maximal PolyCrossings::max crossing of all PolyCrossings's.
     
-    Polygons& boundary; //!< The boundary not to cross during combing.
+    const Polygons& boundary; //!< The boundary not to cross during combing.
     LocToLineGrid& loc_to_line_grid; //!< Mapping from locations to line segments of \ref LinePolygonsCrossings::boundary
     Point startPoint; //!< The start point of the scanline.
     Point endPoint; //!< The end point of the scanline.
@@ -166,7 +166,7 @@ private:
      * \param end the end point
      * \param dist_to_move_boundary_point_outside Distance used to move a point from a boundary so that it doesn't intersect with it anymore. (Precision issue)
      */
-    LinePolygonsCrossings(Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point& start, Point& end, int64_t dist_to_move_boundary_point_outside)
+    LinePolygonsCrossings(const Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point& start, Point& end, int64_t dist_to_move_boundary_point_outside)
     : boundary(boundary)
     , loc_to_line_grid(loc_to_line_grid)
     , startPoint(start)
@@ -187,7 +187,7 @@ public:
      * \param fail_on_unavoidable_obstacles When moving over other parts is inavoidable, stop calculation early and return false.
      * \return Whether combing succeeded, i.e. we didn't cross any gaps/other parts
      */
-    static bool comb(Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point startPoint, Point endPoint, CombPath& combPath, int64_t dist_to_move_boundary_point_outside, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles)
+    static bool comb(const Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point startPoint, Point endPoint, CombPath& combPath, int64_t dist_to_move_boundary_point_outside, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles)
     {
         LinePolygonsCrossings linePolygonsCrossings(boundary, loc_to_line_grid, startPoint, endPoint, dist_to_move_boundary_point_outside);
         return linePolygonsCrossings.getCombingPath(combPath, max_comb_distance_ignored, fail_on_unavoidable_obstacles);


### PR DESCRIPTION
Two strategies are involved:

1 - detect chains of lines (i.e. zigzag infill) and start chains at an end.

2 - detect when a travel move would cross the part boundary and penalise such moves.