### PR TITLE
Now ensureInsideOrOutside() returns same value whether DEBUG is defined or not

### DIFF
--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -433,10 +433,10 @@ ClosestPolygonPoint PolygonUtils::ensureInsideOrOutside(const Polygons& polygons
                 // Perform an offset on all polygons instead.
                 Polygons all_insetted = polygons.offset(-preferred_dist_inside);
                 ClosestPolygonPoint overall_inside = findClosest(from, all_insetted, penalty_function);
-#ifdef DEBUG
                 bool overall_is_inside = polygons.inside(overall_inside.location);
                 if (overall_is_inside != (preferred_dist_inside > 0))
                 {
+#ifdef DEBUG
                     try
                     {
                         int offset_performed = offset / 2;
@@ -474,9 +474,9 @@ ClosestPolygonPoint PolygonUtils::ensureInsideOrOutside(const Polygons& polygons
                     {
                     }
                     logError("Clipper::offset failed. See generated debug.html!\n\tBlack is original\n\tBlue is offsetted polygon\n");
+#endif
                     return ClosestPolygonPoint();
                 }
-#endif
                 inside = overall_inside;
             }
             from = inside.location;


### PR DESCRIPTION

Before, when DEBUG was defined, after outputting some diagnostics it returned a default
constructed ClosestPolygonPoint() and if DEBUG was not defined it went on to do some other
processing.

By always returning ClosestPolygonPoint() irrespective of whether DEBUG is defined, the
function is more consistent.

This fixes the issue reported in https://github.com/Ultimaker/Cura/issues/2704.