### PR TITLE
Add line thickness and feedrates to the data sent to Cura

### DIFF
--- a/Cura.proto
+++ b/Cura.proto
@@ -61,6 +61,8 @@ message Polygon {
     Type type = 1; // Type of move
     bytes points = 2; // The points of the polygon, or two points if only a line segment (Currently only line segments are used)
     float line_width = 3; // The width of the line being laid down
+    float line_thickness = 4; // The thickness of the line being laid down
+    float line_feedrate = 5; // The feedrate of the line being laid down
 }
 
 message LayerOptimized {
@@ -82,6 +84,8 @@ message PathSegment {
     bytes points = 3; // The points defining the line segments, bytes of float[2/3] array of length N+1
     bytes line_type = 4; // Type of line segment as an unsigned char array of length 1 or N, where N is the number of line segments in this path
     bytes line_width = 5; // The widths of the line segments as bytes of a float array of length 1 or N
+    bytes line_thickness = 6; // The thickness of the line segments as bytes of a float array of length 1 or N
+    bytes line_feedrate = 7; // The feedrate of the line segments as bytes of a float array of length 1 or N
 }
 
 

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -900,7 +900,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         && shorterThen(paths[path_idx+2].points.back() - paths[path_idx+1].points.back(), 2 * nozzle_size) // consecutive extrusion is close by
                     )
                     {
-                        sendLineTo(paths[path_idx+2].config->type, paths[path_idx+2].points.back(), paths[path_idx+2].getLineWidthForLayerView());
+                        sendLineTo(paths[path_idx+2].config->type, paths[path_idx+2].points.back(), paths[path_idx+2].getLineWidthForLayerView(), paths[path_idx+2].config->getLayerThickness(), speed);
                         gcode.writeExtrusion(paths[path_idx+2].points.back(), speed, paths[path_idx+1].getExtrusionMM3perMM(), paths[path_idx+2].config->type);
                         path_idx += 2;
                     }
@@ -908,7 +908,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                     {
                         for(unsigned int point_idx = 0; point_idx < path.points.size(); point_idx++)
                         {
-                            sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
+                            sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView(), path.config->getLayerThickness(), speed);
                             gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), path.config->type);
                         }
                     }
@@ -942,7 +942,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         length += vSizeMM(p0 - p1);
                         p0 = p1;
                         gcode.setZ(z + layer_thickness * length / totalLength);
-                        sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
+                        sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView(), path.config->getLayerThickness(), speed);
                         gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), path.config->type);
                     }
                     // for layer display only - the loop finished at the seam vertex but as we started from
@@ -954,7 +954,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                     // vertex would not be shifted (as it's the last vertex in the sequence). The smoother the model,
                     // the less the vertices are shifted and the less obvious is the ridge. If the layer display
                     // really displayed a spiral rather than slices of a spiral, this would not be required.
-                    sendLineTo(path.config->type, path.points[0], path.getLineWidthForLayerView());
+                    sendLineTo(path.config->type, path.points[0], path.getLineWidthForLayerView(), path.config->getLayerThickness(), speed);
                 }
                 path_idx--; // the last path_idx didnt spiralize, so it's not part of the current spiralize path
             }
@@ -1120,10 +1120,10 @@ bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, unsigned int extruder_
     { // write normal extrude path:
         for(unsigned int point_idx = 0; point_idx <= point_idx_before_start; point_idx++)
         {
-            sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
+            sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView(), path.config->getLayerThickness(), extrude_speed);
             gcode.writeExtrusion(path.points[point_idx], extrude_speed, path.getExtrusionMM3perMM(), path.config->type);
         }
-        sendLineTo(path.config->type, start, path.getLineWidthForLayerView());
+        sendLineTo(path.config->type, start, path.getLineWidthForLayerView(), path.config->getLayerThickness(), extrude_speed);
         gcode.writeExtrusion(start, extrude_speed, path.getExtrusionMM3perMM(), path.config->type);
     }
 

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -377,9 +377,9 @@ public:
     /*!
      * send a line segment through the command socket from the previous point to the given point \p to
      */
-    void sendLineTo(PrintFeatureType print_feature_type, Point to, int line_width) const
+    void sendLineTo(PrintFeatureType print_feature_type, Point to, int line_width, int line_thickness, int line_feedrate) const
     {
-        CommandSocket::sendLineTo(print_feature_type, to, line_width);
+        CommandSocket::sendLineTo(print_feature_type, to, line_width, line_thickness, line_feedrate);
     }
 
     /*!

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -18,7 +18,7 @@ void MergeInfillLines::writeCompensatedMove(Point& to, double speed, GCodePath& 
         double speed_mod = old_line_width / new_line_width_mm;
         new_speed = std::min(speed * speed_mod, speed_equalize_flow_max);
     }
-    sendLineTo(last_path.config->type, to, last_path.getLineWidthForLayerView());
+    sendLineTo(last_path.config->type, to, last_path.getLineWidthForLayerView(), last_path.config->getLayerThickness(), new_speed);
     gcode.writeExtrusion(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod, last_path.config->type);
 }
     

--- a/src/MergeInfillLines.h
+++ b/src/MergeInfillLines.h
@@ -90,9 +90,9 @@ public:
     /*!
      * send a line segment through the command socket from the previous point to the given point \p to
      */
-    void sendLineTo(PrintFeatureType print_feature_type, Point to, int line_width)
+    void sendLineTo(PrintFeatureType print_feature_type, Point to, int line_width, int line_thickness, int line_feedrate)
     {
-        CommandSocket::sendLineTo(print_feature_type, to, line_width);
+        CommandSocket::sendLineTo(print_feature_type, to, line_width, line_thickness, line_feedrate);
     }
 };
 

--- a/src/Weaver.cpp
+++ b/src/Weaver.cpp
@@ -53,7 +53,7 @@ void Weaver::weave(MeshGroup* meshgroup)
         for (cura::Slicer* slicer : slicerList)
             wireFrame.bottom_outline.add(slicer->layers[starting_layer_idx].polygons);
         
-        CommandSocket::sendPolygons(PrintFeatureType::OuterWall, /*0,*/ wireFrame.bottom_outline, 1);
+        CommandSocket::sendPolygons(PrintFeatureType::OuterWall, /*0,*/ wireFrame.bottom_outline, 1, 1, 1);
         
         if (slicerList.empty()) //Wait, there is nothing to slice.
         {
@@ -84,7 +84,7 @@ void Weaver::weave(MeshGroup* meshgroup)
 
             chainify_polygons(parts1, starting_point_in_layer, chainified);
             
-            CommandSocket::sendPolygons(PrintFeatureType::OuterWall, /*layer_idx - starting_layer_idx,*/ chainified, 1);
+            CommandSocket::sendPolygons(PrintFeatureType::OuterWall, /*layer_idx - starting_layer_idx,*/ chainified, 1, 1, 1);
 
             if (chainified.size() > 0)
             {

--- a/src/commandSocket.h
+++ b/src/commandSocket.h
@@ -59,17 +59,17 @@ public:
     /*! 
      * Send a polygon to the front-end. This is used for the layerview in the GUI
      */
-    static void sendPolygons(cura::PrintFeatureType type, const cura::Polygons& polygons, int line_width);
+    static void sendPolygons(cura::PrintFeatureType type, const cura::Polygons& polygons, int line_width, int line_thickness, int line_feedrate);
 
     /*! 
      * Send a polygon to the front-end. This is used for the layerview in the GUI
      */
-    static void sendPolygon(cura::PrintFeatureType type, ConstPolygonRef polygon, int line_width);
+    static void sendPolygon(cura::PrintFeatureType type, ConstPolygonRef polygon, int line_width, int line_thickness, int line_feedrate);
 
     /*!
      * Send a line to the front-end. This is used for the layerview in the GUI
      */
-    static void sendLineTo(cura::PrintFeatureType type, Point to, int line_width);
+    static void sendLineTo(cura::PrintFeatureType type, Point to, int line_width, int line_thickness, int line_feedrate);
 
     /*!
      * Set the current position of the path compiler to \p position. This is used for the layerview in the GUI

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -627,7 +627,7 @@ void GCodeExport::writeTravel(int x, int y, int z, double speed)
 
     const PrintFeatureType travel_move_type = extruder_attr[current_extruder].retraction_e_amount_current ? PrintFeatureType::MoveRetraction : PrintFeatureType::MoveCombing;
     const int display_width = extruder_attr[current_extruder].retraction_e_amount_current ? MM2INT(0.2) : MM2INT(0.1);
-    CommandSocket::sendLineTo(travel_move_type, Point(x, y), display_width);
+    CommandSocket::sendLineTo(travel_move_type, Point(x, y), display_width, layer_height, speed);
 
     *output_stream << "G0";
     writeFXYZE(speed, x, y, z, current_e_value, PrintFeatureType::MoveCombing);


### PR DESCRIPTION
These changes add more information sent from the Engine to Cura, such as line thicknesses of each segment (in the future maybe we can use it for having different layer thickness for the infill and the walls) and feedrates (aka. speed)