### PR TITLE
Maximum mesh resolution

### DIFF
--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -777,7 +777,8 @@ void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool ext
     polygons.erase(it, polygons.end());
 
     //Finally optimize all the polygons. Every point removed saves time in the long run.
-    polygons.simplify();
+    const coord_t line_segment_resolution = mesh->getSettingInMicrons("meshfix_maximum_resolution");
+    polygons.simplify(line_segment_resolution, line_segment_resolution / 2); //Maximum error is half of the resolution so it's only a limit when removing really sharp corners.
 
     polygons.removeDegenerateVerts(); // remove verts connected to overlapping line segments
 

--- a/tests/utils/StringTest.cpp
+++ b/tests/utils/StringTest.cpp
@@ -76,7 +76,7 @@ void StringTest::writeInt2mmTestMax()
 }
 
 
-void StringTest::writeInt2mmAssert(int64_t in)
+void StringTest::writeInt2mmAssert(int in)
 {
     std::ostringstream ss;
     writeInt2mm(in, ss);
@@ -89,7 +89,7 @@ void StringTest::writeInt2mmAssert(int64_t in)
         sprintf(buffer, "The integer %d was printed as '%s' which was a bad string!", in, str.c_str());
         CPPUNIT_ASSERT_MESSAGE(std::string(buffer), false);
     }
-    int64_t out = MM2INT(strtod(str.c_str(), nullptr));
+    int out = MM2INT(strtod(str.c_str(), nullptr));
 
     char buffer[200];
     sprintf(buffer, "The integer %d was printed as '%s' which was interpreted as %d rather than %d!", in, str.c_str(), out, in);

--- a/tests/utils/StringTest.h
+++ b/tests/utils/StringTest.h
@@ -106,7 +106,7 @@ private:
      * 
      * \param in the integer to check
      */
-    void writeInt2mmAssert(int64_t in);
+    void writeInt2mmAssert(int in);
 
     /*!
      * \brief Performs the actual assertion for the getDist2FromLineSegmentTest.


### PR DESCRIPTION
A mesh fix setting that reduces the resolution of mesh polygons. This is already happening by default to a resolution of 10 micrometres, but now it's a setting that can be edited.

Implements CURA-4590.

See also https://github.com/Ultimaker/Cura/pull/2814 for the actual implementation.