### PR TITLE
CURA-4104 Flow rate compensated extruder offset

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -909,7 +909,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                     )
                     {
                         sendLineTo(paths[path_idx+2].config->type, paths[path_idx+2].points.back(), paths[path_idx+2].getLineWidthForLayerView());
-                        gcode.writeExtrusion(paths[path_idx+2].points.back(), speed, paths[path_idx+1].getExtrusionMM3perMM(), update_extrusion_offset, paths[path_idx+2].config->type);
+                        gcode.writeExtrusion(paths[path_idx+2].points.back(), speed, paths[path_idx+1].getExtrusionMM3perMM(), paths[path_idx+2].config->type, update_extrusion_offset);
                         path_idx += 2;
                     }
                     else 
@@ -917,7 +917,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         for(unsigned int point_idx = 0; point_idx < path.points.size(); point_idx++)
                         {
                             sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
-                            gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), update_extrusion_offset, path.config->type);
+                            gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), path.config->type, update_extrusion_offset);
                         }
                     }
                 }
@@ -951,7 +951,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         p0 = p1;
                         gcode.setZ(z + layer_thickness * length / totalLength);
                         sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
-                        gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), update_extrusion_offset, path.config->type);
+                        gcode.writeExtrusion(path.points[point_idx], speed, path.getExtrusionMM3perMM(), path.config->type, update_extrusion_offset);
                     }
                     // for layer display only - the loop finished at the seam vertex but as we started from
                     // the location of the previous layer's seam vertex the loop may have a gap if this layer's
@@ -1035,7 +1035,6 @@ bool LayerPlan::makeRetractSwitchRetract(unsigned int extruder_plan_idx, unsigne
     
 bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, unsigned int extruder_plan_idx, unsigned int path_idx, int64_t layerThickness, double coasting_volume, double coasting_speed, double coasting_min_volume)
 {
-    bool update_extrusion_offset = false;
     if (coasting_volume <= 0)
     { 
         return false; 
@@ -1130,10 +1129,10 @@ bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, unsigned int extruder_
         for(unsigned int point_idx = 0; point_idx <= point_idx_before_start; point_idx++)
         {
             sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView());
-            gcode.writeExtrusion(path.points[point_idx], extrude_speed, path.getExtrusionMM3perMM(), update_extrusion_offset, path.config->type);
+            gcode.writeExtrusion(path.points[point_idx], extrude_speed, path.getExtrusionMM3perMM(), path.config->type);
         }
         sendLineTo(path.config->type, start, path.getLineWidthForLayerView());
-        gcode.writeExtrusion(start, extrude_speed, path.getExtrusionMM3perMM(), update_extrusion_offset, path.config->type);
+        gcode.writeExtrusion(start, extrude_speed, path.getExtrusionMM3perMM(), path.config->type);
     }
 
     // write coasting path

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -13,13 +13,14 @@ void MergeInfillLines::writeCompensatedMove(Point& to, double speed, GCodePath& 
     double new_line_width_mm = INT2MM(new_line_width);
     double extrusion_mod = new_line_width_mm / old_line_width;
     double new_speed = speed;
+    bool update_extrusion_offset = false;
     if (speed_equalize_flow_enabled)
     {
         double speed_mod = old_line_width / new_line_width_mm;
         new_speed = std::min(speed * speed_mod, speed_equalize_flow_max);
     }
     sendLineTo(last_path.config->type, to, last_path.getLineWidthForLayerView());
-    gcode.writeExtrusion(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod, last_path.config->type);
+    gcode.writeExtrusion(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod, update_extrusion_offset, last_path.config->type);
 }
     
 bool MergeInfillLines::mergeInfillLines(unsigned int& path_idx)

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -13,14 +13,13 @@ void MergeInfillLines::writeCompensatedMove(Point& to, double speed, GCodePath& 
     double new_line_width_mm = INT2MM(new_line_width);
     double extrusion_mod = new_line_width_mm / old_line_width;
     double new_speed = speed;
-    bool update_extrusion_offset = false;
     if (speed_equalize_flow_enabled)
     {
         double speed_mod = old_line_width / new_line_width_mm;
         new_speed = std::min(speed * speed_mod, speed_equalize_flow_max);
     }
     sendLineTo(last_path.config->type, to, last_path.getLineWidthForLayerView());
-    gcode.writeExtrusion(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod, update_extrusion_offset, last_path.config->type);
+    gcode.writeExtrusion(to, new_speed, last_path.getExtrusionMM3perMM() * extrusion_mod, last_path.config->type);
 }
     
 bool MergeInfillLines::mergeInfillLines(unsigned int& path_idx)

--- a/src/Wireframe2gcode.cpp
+++ b/src/Wireframe2gcode.cpp
@@ -51,7 +51,7 @@ void Wireframe2gcode::writeGCode()
         writeMoveWithRetract(bottom_part[bottom_part.size()-1]);
         for (Point& segment_to : bottom_part)
         {
-            gcode.writeExtrusion(segment_to, speedBottom, extrusion_mm3_per_mm_flat, update_extrusion_offset, PrintFeatureType::Skin);
+            gcode.writeExtrusion(segment_to, speedBottom, extrusion_mm3_per_mm_flat, PrintFeatureType::Skin);
         }
     }
     
@@ -67,7 +67,7 @@ void Wireframe2gcode::writeGCode()
                         writeMoveWithRetract(segment.to); 
                     } else 
                     {
-                        gcode.writeExtrusion(segment.to, speedBottom, extrusion_mm3_per_mm_connection, update_extrusion_offset, PrintFeatureType::Skin);
+                        gcode.writeExtrusion(segment.to, speedBottom, extrusion_mm3_per_mm_connection, PrintFeatureType::Skin);
                     }
                 }   
             , 
@@ -77,7 +77,7 @@ void Wireframe2gcode::writeGCode()
                     else if (segment.segmentType == WeaveSegmentType::DOWN_AND_FLAT)
                         return; // do nothing
                     else 
-                        gcode.writeExtrusion(segment.to, speedBottom, extrusion_mm3_per_mm_flat, update_extrusion_offset, PrintFeatureType::Skin);
+                        gcode.writeExtrusion(segment.to, speedBottom, extrusion_mm3_per_mm_flat, PrintFeatureType::Skin);
                 }
             );
     Progress::messageProgressStage(Progress::Stage::EXPORT, nullptr);
@@ -127,7 +127,7 @@ void Wireframe2gcode::writeGCode()
                         writeMoveWithRetract(segment.to);
                     } else 
                     {
-                        gcode.writeExtrusion(segment.to, speedFlat, extrusion_mm3_per_mm_flat, update_extrusion_offset, PrintFeatureType::OuterWall);
+                        gcode.writeExtrusion(segment.to, speedFlat, extrusion_mm3_per_mm_flat, PrintFeatureType::OuterWall);
                         gcode.writeDelay(flat_delay);
                     }
                 }
@@ -149,7 +149,7 @@ void Wireframe2gcode::writeGCode()
                         // do nothing
                     } else 
                     {   
-                        gcode.writeExtrusion(segment.to, speedFlat, extrusion_mm3_per_mm_flat, update_extrusion_offset, PrintFeatureType::Skin);
+                        gcode.writeExtrusion(segment.to, speedFlat, extrusion_mm3_per_mm_flat, PrintFeatureType::Skin);
                         gcode.writeDelay(flat_delay);
                     }
                 });
@@ -175,14 +175,13 @@ void Wireframe2gcode::writeGCode()
     
 void Wireframe2gcode::go_down(WeaveConnectionPart& part, unsigned int segment_idx)
 {
-    bool update_extrusion_offset = false;
     WeaveConnectionSegment& segment = part.connection.segments[segment_idx];
     Point3 from = (segment_idx == 0)? part.connection.from : part.connection.segments[segment_idx - 1].to;
     if (go_back_to_last_top)
         gcode.writeTravel(from, speedDown);
     if (straight_first_when_going_down <= 0)
     {
-        gcode.writeExtrusion(segment.to, speedDown, extrusion_mm3_per_mm_connection, update_extrusion_offset, PrintFeatureType::OuterWall);
+        gcode.writeExtrusion(segment.to, speedDown, extrusion_mm3_per_mm_connection, PrintFeatureType::OuterWall);
     } else 
     {
         Point3& to = segment.to;
@@ -194,14 +193,14 @@ void Wireframe2gcode::go_down(WeaveConnectionPart& part, unsigned int segment_id
         int64_t new_length = (up - from).vSize() + (to - up).vSize() + 5;
         int64_t orr_length = vec.vSize();
         double enlargement = new_length / orr_length;
-        gcode.writeExtrusion(up, speedDown*enlargement, extrusion_mm3_per_mm_connection / enlargement, update_extrusion_offset, PrintFeatureType::OuterWall);
-        gcode.writeExtrusion(to, speedDown*enlargement, extrusion_mm3_per_mm_connection / enlargement, update_extrusion_offset, PrintFeatureType::OuterWall);
+        gcode.writeExtrusion(up, speedDown*enlargement, extrusion_mm3_per_mm_connection / enlargement, PrintFeatureType::OuterWall);
+        gcode.writeExtrusion(to, speedDown*enlargement, extrusion_mm3_per_mm_connection / enlargement, PrintFeatureType::OuterWall);
     }
     gcode.writeDelay(bottom_delay);
     if (up_dist_half_speed > 0)
     {
         
-        gcode.writeExtrusion(Point3(0,0,up_dist_half_speed) + gcode.getPosition(), speedUp / 2, extrusion_mm3_per_mm_connection * 2, update_extrusion_offset, PrintFeatureType::OuterWall);
+        gcode.writeExtrusion(Point3(0,0,up_dist_half_speed) + gcode.getPosition(), speedUp / 2, extrusion_mm3_per_mm_connection * 2, PrintFeatureType::OuterWall);
     }
 }
 
@@ -209,9 +208,8 @@ void Wireframe2gcode::go_down(WeaveConnectionPart& part, unsigned int segment_id
     
 void Wireframe2gcode::strategy_knot(WeaveConnectionPart& part, unsigned int segment_idx)
 {
-    bool update_extrusion_offset = false;
     WeaveConnectionSegment& segment = part.connection.segments[segment_idx];
-    gcode.writeExtrusion(segment.to, speedUp, extrusion_mm3_per_mm_connection, update_extrusion_offset, PrintFeatureType::OuterWall);
+    gcode.writeExtrusion(segment.to, speedUp, extrusion_mm3_per_mm_connection, PrintFeatureType::OuterWall);
     Point3 next_vector;
     if (segment_idx + 1 < part.connection.segments.size())
     {
@@ -253,8 +251,6 @@ void Wireframe2gcode::strategy_retract(WeaveConnectionPart& part, unsigned int s
     bool after_retract_hop = false;
     //bool go_horizontal_first = true;
     bool lower_retract_start = true;
-    bool update_extrusion_offset = false;
-
     
     Point3& to = segment.to;
     if (lower_retract_start)
@@ -262,7 +258,7 @@ void Wireframe2gcode::strategy_retract(WeaveConnectionPart& part, unsigned int s
         Point3 vec = to - from;
         Point3 lowering = vec * retract_hop_dist / 2 / vec.vSize();
         Point3 lower = to - lowering;
-        gcode.writeExtrusion(lower, speedUp, extrusion_mm3_per_mm_connection, update_extrusion_offset, PrintFeatureType::OuterWall);
+        gcode.writeExtrusion(lower, speedUp, extrusion_mm3_per_mm_connection, PrintFeatureType::OuterWall);
         gcode.writeRetraction(retraction_config);
         gcode.writeTravel(to + lowering, speedUp);
         gcode.writeDelay(top_retract_pause);
@@ -271,7 +267,7 @@ void Wireframe2gcode::strategy_retract(WeaveConnectionPart& part, unsigned int s
         
     } else 
     {
-        gcode.writeExtrusion(to, speedUp, extrusion_mm3_per_mm_connection, update_extrusion_offset, PrintFeatureType::OuterWall);
+        gcode.writeExtrusion(to, speedUp, extrusion_mm3_per_mm_connection, PrintFeatureType::OuterWall);
         gcode.writeRetraction(retraction_config);
         gcode.writeTravel(to + Point3(0, 0, retract_hop_dist), speedFlat);
         gcode.writeDelay(top_retract_pause);
@@ -287,7 +283,6 @@ void Wireframe2gcode::strategy_compensate(WeaveConnectionPart& part, unsigned in
     Point3 to = segment.to + Point3(0, 0, fall_down*(segment.to - from).vSize() / connectionHeight);
     Point3 vector = segment.to - from;
     Point3 dir = vector * drag_along / vector.vSize();
-    bool update_extrusion_offset = false;
     
     Point3 next_point;
     if (segment_idx + 1 < part.connection.segments.size())
@@ -310,7 +305,7 @@ void Wireframe2gcode::strategy_compensate(WeaveConnectionPart& part, unsigned in
     int64_t orrLength = (segment.to - from).vSize() + next_vector.vSize() + 1; // + 1 in order to avoid division by zero
     int64_t newLength = (newTop - from).vSize() + (next_point - newTop).vSize() + 1; // + 1 in order to avoid division by zero
     
-    gcode.writeExtrusion(newTop, speedUp * newLength / orrLength, extrusion_mm3_per_mm_connection * orrLength / newLength, update_extrusion_offset, PrintFeatureType::OuterWall);
+    gcode.writeExtrusion(newTop, speedUp * newLength / orrLength, extrusion_mm3_per_mm_connection * orrLength / newLength, PrintFeatureType::OuterWall);
 }
 void Wireframe2gcode::handle_segment(WeaveConnectionPart& part, unsigned int segment_idx)
 {
@@ -389,12 +384,12 @@ void Wireframe2gcode::handle_roof_segment(WeaveConnectionPart& part, unsigned in
                     detoured -= next_dir;
                 }
                 
-                gcode.writeExtrusion(detoured, speedUp, extrusion_mm3_per_mm_connection, update_extrusion_offset, PrintFeatureType::Skin);
+                gcode.writeExtrusion(detoured, speedUp, extrusion_mm3_per_mm_connection, PrintFeatureType::Skin);
 
             }
             break;
         case WeaveSegmentType::DOWN:
-            gcode.writeExtrusion(segment.to, speedDown, extrusion_mm3_per_mm_connection, update_extrusion_offset, PrintFeatureType::Skin);
+            gcode.writeExtrusion(segment.to, speedDown, extrusion_mm3_per_mm_connection, PrintFeatureType::Skin);
             gcode.writeDelay(roof_outer_delay);
             break;
         case WeaveSegmentType::FLAT:
@@ -620,7 +615,6 @@ void Wireframe2gcode::processStartingCode()
 
 void Wireframe2gcode::processSkirt()
 {
-    bool update_extrusion_offset = false;
     if (wireFrame.bottom_outline.size() == 0) //If we have no layers, don't create a skirt either.
     {
         return;
@@ -638,7 +632,7 @@ void Wireframe2gcode::processSkirt()
         for (unsigned int point_idx = 0; point_idx < poly.size(); point_idx++)
         {
             Point& p = poly[(point_idx + order.polyStart[poly_idx] + 1) % poly.size()];
-            gcode.writeExtrusion(p, getSettingInMillimetersPerSecond("skirt_brim_speed"), getSettingInMillimeters("skirt_brim_line_width") * getSettingAsRatio("initial_layer_line_width_factor") * INT2MM(initial_layer_thickness), update_extrusion_offset, PrintFeatureType::SkirtBrim);
+            gcode.writeExtrusion(p, getSettingInMillimetersPerSecond("skirt_brim_speed"), getSettingInMillimeters("skirt_brim_line_width") * getSettingAsRatio("initial_layer_line_width_factor") * INT2MM(initial_layer_thickness), PrintFeatureType::SkirtBrim);
         }
     }
 }

--- a/src/Wireframe2gcode.h
+++ b/src/Wireframe2gcode.h
@@ -36,6 +36,7 @@ private:
     double flowFlat; 
     double extrusion_mm3_per_mm_connection;
     double extrusion_mm3_per_mm_flat;
+    bool update_extrusion_offset;
     int nozzle_outer_diameter;
     int nozzle_head_distance;
     double nozzle_expansion_angle;

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -530,9 +530,9 @@ void GCodeExport::writeTravel(Point p, double speed)
 {
     writeTravel(Point3(p.X, p.Y, current_layer_z), speed);
 }
-void GCodeExport::writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature)
+void GCodeExport::writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature, bool update_extrusion_offset)
 {
-    writeExtrusion(Point3(p.X, p.Y, current_layer_z), speed, extrusion_mm3_per_mm, update_extrusion_offset, feature);
+    writeExtrusion(Point3(p.X, p.Y, current_layer_z), speed, extrusion_mm3_per_mm, feature, update_extrusion_offset);
 }
 
 void GCodeExport::writeTravel(Point3 p, double speed)
@@ -545,14 +545,14 @@ void GCodeExport::writeTravel(Point3 p, double speed)
     writeTravel(p.x, p.y, p.z + isZHopped, speed);
 }
 
-void GCodeExport::writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature)
+void GCodeExport::writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature, bool update_extrusion_offset)
 {
     if (flavor == EGCodeFlavor::BFB)
     {
         writeMoveBFB(p.x, p.y, p.z, speed, extrusion_mm3_per_mm, feature);
         return;
     }
-    writeExtrusion(p.x, p.y, p.z, speed, extrusion_mm3_per_mm, update_extrusion_offset, feature);
+    writeExtrusion(p.x, p.y, p.z, speed, extrusion_mm3_per_mm, feature, update_extrusion_offset);
 }
 
 void GCodeExport::writeMoveBFB(int x, int y, int z, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature)
@@ -639,7 +639,7 @@ void GCodeExport::writeTravel(int x, int y, int z, double speed)
     writeFXYZE(speed, x, y, z, current_e_value, PrintFeatureType::MoveCombing);
 }
 
-void GCodeExport::writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature)
+void GCodeExport::writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature, bool update_extrusion_offset)
 {
     if (currentPosition.x == x && currentPosition.y == y && currentPosition.z == z)
         return;

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -285,6 +285,12 @@ void GCodeExport::setZ(int z)
     this->current_layer_z = z;
 }
 
+void GCodeExport::setFlowRateExtrusionSettings(double max_extrusion_offset, double extrusion_offset_factor)
+{
+    this->max_extrusion_offset = max_extrusion_offset;
+    this->extrusion_offset_factor = extrusion_offset_factor;
+}
+
 Point3 GCodeExport::getPosition() const
 {
     return currentPosition;
@@ -524,9 +530,9 @@ void GCodeExport::writeTravel(Point p, double speed)
 {
     writeTravel(Point3(p.X, p.Y, current_layer_z), speed);
 }
-void GCodeExport::writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature)
+void GCodeExport::writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature)
 {
-    writeExtrusion(Point3(p.X, p.Y, current_layer_z), speed, extrusion_mm3_per_mm, feature);
+    writeExtrusion(Point3(p.X, p.Y, current_layer_z), speed, extrusion_mm3_per_mm, update_extrusion_offset, feature);
 }
 
 void GCodeExport::writeTravel(Point3 p, double speed)
@@ -539,14 +545,14 @@ void GCodeExport::writeTravel(Point3 p, double speed)
     writeTravel(p.x, p.y, p.z + isZHopped, speed);
 }
 
-void GCodeExport::writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature)
+void GCodeExport::writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature)
 {
     if (flavor == EGCodeFlavor::BFB)
     {
         writeMoveBFB(p.x, p.y, p.z, speed, extrusion_mm3_per_mm, feature);
         return;
     }
-    writeExtrusion(p.x, p.y, p.z, speed, extrusion_mm3_per_mm, feature);
+    writeExtrusion(p.x, p.y, p.z, speed, extrusion_mm3_per_mm, update_extrusion_offset, feature);
 }
 
 void GCodeExport::writeMoveBFB(int x, int y, int z, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature)
@@ -633,7 +639,7 @@ void GCodeExport::writeTravel(int x, int y, int z, double speed)
     writeFXYZE(speed, x, y, z, current_e_value, PrintFeatureType::MoveCombing);
 }
 
-void GCodeExport::writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature)
+void GCodeExport::writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature)
 {
     if (currentPosition.x == x && currentPosition.y == y && currentPosition.z == z)
         return;
@@ -676,6 +682,20 @@ void GCodeExport::writeExtrusion(int x, int y, int z, double speed, double extru
 
     writeUnretractionAndPrime();
 
+    //flow rate compensation
+    double extrusion_offset = 0;
+    if (diff.vSizeMM()) {
+        extrusion_offset = speed * extrusion_mm3_per_mm * extrusion_offset_factor;
+        if (extrusion_offset > max_extrusion_offset) {
+            extrusion_offset = max_extrusion_offset;
+        }
+    }
+    // write new value of extrusion_offset, which will be remembered.
+    if ((update_extrusion_offset) && (extrusion_offset != current_e_offset)) {
+        current_e_offset = extrusion_offset;
+        *output_stream << ";FLOW_RATE_COMPENSATED_OFFSET = " << current_e_offset << new_line;
+    }
+
     double new_e_value = current_e_value + extrusion_per_mm * diff.vSizeMM();
 
     *output_stream << "G1";
@@ -698,9 +718,9 @@ void GCodeExport::writeFXYZE(double speed, int x, int y, int z, double e, PrintF
     {
         *output_stream << " Z" << MMtoStream{z};
     }
-    if (e != current_e_value)
+    if (e + current_e_offset != current_e_value)
     {
-        const double output_e = (relative_extrusion)? e - current_e_value : e;
+        const double output_e = (relative_extrusion)? e + current_e_offset - current_e_value : e + current_e_offset;
         *output_stream << " " << extruder_attr[current_extruder].extruderCharacter << PrecisionedDouble{5, output_e};
     }
     *output_stream << new_line;

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -295,10 +295,10 @@ public:
      * 
      * \param p location to go to
      * \param speed movement speed
-     * \param update_extrusion_offset update the extrusion offset to match the current flow rate
      * \param feature the feature that's currently printing
+     * \param update_extrusion_offset whether to update the extrusion offset to match the current flow rate
      */
-    void writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature);
+    void writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature, bool update_extrusion_offset = false);
 
     /*!
      * Go to a X/Y location with the z-hopped Z value
@@ -318,10 +318,10 @@ public:
      * 
      * \param p location to go to
      * \param speed movement speed
-     * \param update_extrusion_offset update the extrusion offset to match the current flow rate
      * \param feature the feature that's currently printing
+     * \param update_extrusion_offset whether to update the extrusion offset to match the current flow rate
      */
-    void writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature);
+    void writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature, bool update_extrusion_offset = false);
 private:
     /*!
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
@@ -344,10 +344,10 @@ private:
      * \param z build plate z
      * \param speed movement speed
      * \param extrusion_mm3_per_mm flow
-     * \param update_extrusion_offset update the extrusion offset to match the current flow rate
      * \param feature the print feature that's currently printing
+     * \param update_extrusion_offset whether to update the extrusion offset to match the current flow rate
      */
-    void writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature);
+    void writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature, bool update_extrusion_offset = false);
 
     /*!
      * Write the F, X, Y, Z and E value (if they are not different from the last)

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -98,6 +98,12 @@ private:
     std::string new_line;
 
     double current_e_value; //!< The last E value written to gcode (in mm or mm^3)
+
+    // flow-rate compensation
+    double current_e_offset; //!< Offset to compensate for flow rate (mm or mm^3)
+    double max_extrusion_offset; //!< 0 to turn it off, normally 4
+    double extrusion_offset_factor; //!< default 1
+
     Point3 currentPosition; //!< The last build plate coordinates written to gcode (which might be different from actually written gcode coordinates when the extruder offset is encoded in the gcode)
     double currentSpeed; //!< The current speed (F values / 60) in mm/s
     double current_print_acceleration; //!< The current acceleration (in mm/s^2) used for print moves (and also for travel moves if the gcode flavor doesn't have separate travel acceleration)
@@ -201,7 +207,9 @@ public:
     EGCodeFlavor getFlavor() const;
     
     void setZ(int z);
-    
+
+    void setFlowRateExtrusionSettings(double max_extrusion_offset, double extrusion_offset_factor);
+
     void addLastCoastedVolume(double last_coasted_volume) 
     {
         extruder_attr[current_extruder].prime_volume += last_coasted_volume; 
@@ -287,9 +295,10 @@ public:
      * 
      * \param p location to go to
      * \param speed movement speed
+     * \param update_extrusion_offset update the extrusion offset to match the current flow rate
      * \param feature the feature that's currently printing
      */
-    void writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
+    void writeExtrusion(Point p, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature);
 
     /*!
      * Go to a X/Y location with the z-hopped Z value
@@ -309,9 +318,10 @@ public:
      * 
      * \param p location to go to
      * \param speed movement speed
+     * \param update_extrusion_offset update the extrusion offset to match the current flow rate
      * \param feature the feature that's currently printing
      */
-    void writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
+    void writeExtrusion(Point3 p, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature);
 private:
     /*!
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
@@ -334,9 +344,10 @@ private:
      * \param z build plate z
      * \param speed movement speed
      * \param extrusion_mm3_per_mm flow
+     * \param update_extrusion_offset update the extrusion offset to match the current flow rate
      * \param feature the print feature that's currently printing
      */
-    void writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
+    void writeExtrusion(int x, int y, int z, double speed, double extrusion_mm3_per_mm, bool update_extrusion_offset, PrintFeatureType feature);
 
     /*!
      * Write the F, X, Y, Z and E value (if they are not different from the last)


### PR DESCRIPTION
**Description from the JIRA issue**

At the moment, the Bowden system has the drawback that a change in flowrate will result in either dumping excess material or print too little material at a certain spot.

Experiments have shown that a speed dependant offset on the extrusion rate can compensate between 80-90% of this problem.

By creating this open loop feedforward, the materials team has more possibilities to select different speeds for the infill and different walls, which could result in higher printing speeds and or better quality output.

The desired compensation is driven by the expected flowrate within Cura, as accurate as possible (based on the speed that is used to calculate the printing time?)
THE COMPENSATION NEEDS TESTING, DO NOT RELEASE IMMEDIATELY!!!

**Done in this PR**

Add a feed rate dependent offset to the existing extrusion, called extrusion_offset. This offset is always added to the extrusion and is 0 by default, so you get the behaviour without modifications. If the extrusion_offset becomes smaller, it may mean that the printer retracts.

The extrusion_offset is linearly dependent of the flow rate. Its maximum value can be controlled by flow_rate_max_extrusion_offset and its slope is controlled by flow_rate_extrusion_offset_factor.

flow_rate_max_extrusion_offset. Try a value of 4 for some nice results. 0 to turn the compensation off.
flow_rate_extrusion_offset_factor. Normally leave this as 100(%).
