### PR TITLE
If retraction is enabled, do a retract between start gcode and first planned travel.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -501,11 +501,11 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
     }
     if (gcode.getFlavor() != EGCodeFlavor::GRIFFIN)
     {
-        // ensure extruder is zeroed
-        gcode.resetExtrusionValue();
-
         if (getSettingBoolean("retraction_enable"))
         {
+            // ensure extruder is zeroed
+            gcode.resetExtrusionValue();
+
             // retract before first travel move
             gcode.writeRetraction(storage.retraction_config_per_extruder[start_extruder_nr]);
         }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -499,6 +499,17 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
     {
         gcode.writeExtrusionMode(true);
     }
+    if (gcode.getFlavor() != EGCodeFlavor::GRIFFIN)
+    {
+        // ensure extruder is zeroed
+        gcode.resetExtrusionValue();
+
+        if (getSettingBoolean("retraction_enable"))
+        {
+            // retract before first travel move
+            gcode.writeRetraction(storage.retraction_config_per_extruder[start_extruder_nr]);
+        }
+    }
 }
 
 void FffGcodeWriter::processNextMeshGroupCode(const SliceDataStorage& storage)


### PR DESCRIPTION

Fix for https://github.com/Ultimaker/Cura/issues/2945.

BTW I added a call to resetExtrusionValue() because I noticed that when absolute extrusion is being used, I wasn't getting any G92 output at all which seems pretty dodgy as that would assume that the extruder was zeroed. Not a problem for me as I use relative extrusion.