### PR TITLE
Fix recent regression (2ccda764d272) that removed T0 for RepRap flavour gcode.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -408,7 +408,7 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
 
     if (gcode.getFlavor() != EGCodeFlavor::ULTIGCODE && gcode.getFlavor() != EGCodeFlavor::GRIFFIN)
     {
-        if (num_extruders > 1)
+        if (num_extruders > 1 || gcode.getFlavor() == EGCodeFlavor::REPRAP)
         {
             std::ostringstream tmp;
             tmp << "T" << start_extruder_nr;


### PR DESCRIPTION

The RepRap people want this before any temperature setting commands.