### PR TITLE
Only pass combing boundary to LineOrderOptimizer when lines are infilll (not skin, support, etc.)

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -461,9 +461,9 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
 void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location)
 {
     Polygons boundary;
-    if (comb_boundary_inside.size() > 0)
+    if (config.type == PrintFeatureType::Infill && comb_boundary_inside.size() > 0)
     {
-        // use the combing boundary inflated so that all skin/infill lines are inside the boundary
+        // use the combing boundary inflated so that all infill lines are inside the boundary
         int dist = 0;
         if (layer_nr >= 0)
         {


### PR DESCRIPTION

The potential reduction in travel time achieved by passing the combing boundary for
non-infill lines is relatively small but the slicing time can increase greatly (e.g. when
processing the skin created when filling gaps between walls) so only pass the combing boundary
for infill lines where the travel time reduction can be well worth the extra slicing time.

Hi @jackha, this is a good fix because it now only does the expensive computation required to determine the correct travel distance for infill lines where it can make a big difference to the print time. For skin, there's little benefit in doing the extra computation and as we have seen with your example it can really increase the slicing time a lot.