### PR TITLE
Made gcode comment style consistent

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -486,11 +486,11 @@ void GCodeExport::writeExtrusionMode(bool set_relative_extrusion_mode)
 {
     if (set_relative_extrusion_mode)
     {
-        *output_stream << "M83 ; relative extrusion mode" << new_line;
+        *output_stream << "M83 ;relative extrusion mode" << new_line;
     }
     else
     {
-        *output_stream << "M82 ; absolute extrusion mode" << new_line;
+        *output_stream << "M82 ;absolute extrusion mode" << new_line;
     }
 }
 


### PR DESCRIPTION
The gcode comments generated in gcodeExport.cpp were not all consistent: "; relative extrusion mode" and "; absolute extrusion mode" have spaces between the semicolon and text, while the rest do not. I've changed those two lines remove that space so that they match the rest of the comments.

I know this is kinda trivial, but I was reading through the gcode to learn and that was bugging me. It's also a chance for me to get more involved with contributing to these sorts of projects, which is good. 