### PR TITLE
Ignore retract_at_layer_change if what follows is spiralized.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -818,16 +818,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         else if (extruder_plan_idx == 0 && layer_nr != 0 && storage.meshgroup->getExtruderTrain(extruder)->getSettingBoolean("retract_at_layer_change"))
         {
             // only do the retract if the paths are not spiralized
-            bool do_retract_on_layer_change = true;
-            for(GCodePath& path : extruder_plan.paths)
-            {
-                if(!path.isTravelPath())
-                {
-                    do_retract_on_layer_change = !path.spiralize;
-                    break;
-                }
-            }
-            if (do_retract_on_layer_change)
+            if (!storage.getSettingBoolean("magic_spiralize"))
             {
                 gcode.writeRetraction(retraction_config);
             }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -817,7 +817,20 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         }
         else if (extruder_plan_idx == 0 && layer_nr != 0 && storage.meshgroup->getExtruderTrain(extruder)->getSettingBoolean("retract_at_layer_change"))
         {
-            gcode.writeRetraction(retraction_config);
+            // only do the retract if the paths are not spiralized
+            bool do_retract_on_layer_change = true;
+            for(GCodePath& path : extruder_plan.paths)
+            {
+                if(!path.isTravelPath())
+                {
+                    do_retract_on_layer_change = !path.spiralize;
+                    break;
+                }
+            }
+            if (do_retract_on_layer_change)
+            {
+                gcode.writeRetraction(retraction_config);
+            }
         }
         gcode.writeFanCommand(extruder_plan.getFanSpeed());
         std::vector<GCodePath>& paths = extruder_plan.paths;


### PR DESCRIPTION
Otherwise, if retract_at_layer_change is true, the z-seam because visible due to the
unneeded retract/prime.

Possibly, this buglet is causing the report in https://community.ultimaker.com/topic/21213-cura-32-beta-spiralize-outer-contour-issues/ but even if not, it's worth stopping the retract/primes between spiralized layers.