### PR TITLE
Bug fix for broken overlap compensation when optimizing walls and number of walls > 2

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -462,7 +462,8 @@ bool InsetOrderOptimizer::processInsetsWithOptimizedOrdering()
         {
             wall_x_polys.add(part.insets[inset_level]);
         }
-        wall_overlapper_x = new WallOverlapComputation(wall_x_polys, mesh_config.insetX_config.getLineWidth());
+        // use a slightly reduced line width so that compensation only occurs between insets at the same level (and not between insets in adjacent levels)
+        wall_overlapper_x = new WallOverlapComputation(wall_x_polys, mesh_config.insetX_config.getLineWidth() - 1);
     }
 
     // create a vector of vectors containing all the inset polys


### PR DESCRIPTION
Pass inner inset wall overlap computer a very slightly reduced line width.

Because the same overlap computer is used for all of the inner insets, we need to reduce
the line width to stop the computer from flow reducing adjacent insets that are not at
the same level but while still allowing overlapping insets that are at the same level
to be flow reduced.

Fixes https://github.com/Ultimaker/Cura/issues/3197.