### PR TITLE
Now pointsAreCoincident() allows points to be up to 10um apart.

### DIFF
--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -199,7 +199,7 @@ int PathOrderOptimizer::getRandomPointInPolygon(int poly_idx)
 
 static inline bool pointsAreCoincident(const Point& a, const Point& b)
 {
-    return vSize2(a - b) < 25; // points are closer than 5uM, consider them coincident
+    return vSize2(a - b) < 100; // points are closer than 10uM, consider them coincident
 }
 
 /**


### PR DESCRIPTION
Zigzag infill is still being produced with the odd gap here and there between line end points.
This most often occurs when the boundary of the skin/infill is curved. By allowing the line
end points to be a little further apart, chains are continued which would otherwise be
terminated at the gap.