### PR TITLE
Don't bother to optimize the wall print order when there are no holes in the part.

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -553,12 +553,12 @@ bool InsetOrderOptimizer::optimizingInsetsIsWorthwhile(const SliceMeshStorage& m
         // optimization disabled
         return false;
     }
-    if (part.insets.size() < 2 && part.insets[0].size() < 2)
+    if (part.insets.size() < 2 || part.insets[0].size() < 2)
     {
-        // only a single outline and no holes, definitely not worth optimizing
+        // only a single outline or no holes, not worth optimizing as the original inset processing code now aligns the z-seams of the outside walls
         return false;
     }
-    // the default is to optimize as it will make the inner insets start near to the z seam location
+    // optimize all other combinations of walls and holes
     return true;
 }
 


### PR DESCRIPTION
The original wall printing code now aligns the z-seams of the inner walls with the outer
wall so using the optimizing code is no longer beneficial.

Also, this change fixes a feature of the optimizing code that would cause the z-seams not
to be aligned in the specific situation where infill was being printed before walls, the
inner walls were printed before the outer and the part had no holes!

Fixes https://github.com/Ultimaker/Cura/issues/3335.
