### PR TITLE
setting to disable omitting retractions in support

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -314,7 +314,8 @@ GCodePath& LayerPlan::addTravel(Point p, bool force_comb_retract)
                 if (combPaths.size() == 1)
                 {
                     CombPath comb_path = combPaths[0];
-                    if (combPaths.throughAir && !comb_path.cross_boundary && comb_path.size() == 2 && comb_path[0] == *last_planned_position && comb_path[1] == p)
+                    if (extr->getSettingBoolean("limit_support_retractions") &&
+                        combPaths.throughAir && !comb_path.cross_boundary && comb_path.size() == 2 && comb_path[0] == *last_planned_position && comb_path[1] == p)
                     { // limit the retractions from support to support, which didn't cross anything
                         retract = false;
                     }


### PR DESCRIPTION
Some users report that omitting the retractions causes print failures.
It might be machine/material dependant, so we need a user setting for this.

Omitting retractions was implemented somewhere in 2.5 or something, but it was never a setting.
We've since gotten some critique on this.