### PR TITLE
Feature: limit infill to where needed

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -520,7 +520,6 @@ void FffPolygonGenerator::processPerimeterGaps(SliceDataStorage& storage)
             const ExtruderTrain& train_wall_x = *storage.meshgroup->getExtruderTrain(mesh.getSettingAsExtruderNr("wall_x_extruder_nr"));
             bool fill_gaps_between_inner_wall_and_skin_or_infill =
                 mesh.getSettingInMicrons("infill_line_distance") > 0
-                && !mesh.getSettingBoolean("infill_hollow")
                 && mesh.getSettingInMicrons("infill_overlap_mm") >= 0
                 && !(mesh.getSettingAsFillMethod("infill_pattern") == EFillMethod::CONCENTRIC
                     && (mesh.getSettingBoolean("alternate_extra_perimeter") || (layer_nr == 0 && train_wall_x.getSettingInPercentage("initial_layer_line_width_factor") > 100))

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -673,6 +673,11 @@ void FffPolygonGenerator::processDerivedWallsSkinInfill(SliceMeshStorage& mesh)
     }
     else
     {
+        if (mesh.getSettingBoolean("infill_support_enabled"))
+        {// create gradual infill areas
+            SkinInfillAreaComputation::generateInfillSupport(mesh);
+        }
+
         // create gradual infill areas
         SkinInfillAreaComputation::generateGradualInfill(mesh, mesh.getSettingInMicrons("gradual_infill_step_height"), mesh.getSettingAsCount("gradual_infill_steps"));
 

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -437,16 +437,7 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
     infill = infill.difference(skin);
     infill.removeSmallAreas(MIN_AREA_SIZE);
 
-    Polygons final_infill = infill.offset(infill_skin_overlap);
-
-    if (mesh.getSettingBoolean("infill_hollow"))
-    {
-        part.print_outline = part.print_outline.difference(final_infill);
-    }
-    else
-    {
-        part.infill_area = final_infill;
-    }
+    part.infill_area = infill.offset(infill_skin_overlap);
 }
 
 /*

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -446,7 +446,6 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
     else
     {
         part.infill_area = final_infill;
-        part.infill_area = final_infill;
     }
 }
 

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -526,7 +526,7 @@ void SkinInfillAreaComputation::generateInfillSupport(SliceMeshStorage& mesh)
 
             const Polygons unsupported = infill_area.offset(-max_dist_from_lower_layer);
             const Polygons basic_overhang = unsupported.difference(inside_above);
-            const Polygons overhang_extented = basic_overhang.offset(max_dist_from_lower_layer + 50); // +100 for easier joining with support from layer above
+            const Polygons overhang_extented = basic_overhang.offset(max_dist_from_lower_layer + 50); // +50 for easier joining with support from layer above
             const Polygons full_overhang = overhang_extented.difference(inside_above);
             const Polygons infill_support = infill_above.unionPolygons(full_overhang);
 

--- a/src/skin.h
+++ b/src/skin.h
@@ -54,6 +54,15 @@ public:
      */
     static void generateGradualInfill(SliceMeshStorage& mesh, unsigned int gradual_infill_step_height, unsigned int max_infill_steps);
 
+    /*!
+     * Limit the infill areas to places where they support internal overhangs.
+     * 
+     * This function uses the part.infill_area and part.infill_area_own
+     * and computes a new part.infill_area_own
+     * 
+     * \param mesh The mesh for which to recalculate the infill areas
+     */
+    static void generateInfillSupport(SliceMeshStorage& mesh);
 protected:
     /*!
      * Generate the skin areas (outlines) and the infill areas


### PR DESCRIPTION
This awesome feature is like a specialized support generation algorithm, but for the internal support structures ak infill.

With this enabled only infill will be generated where it's needed.

Doesn't work optimally with Infill meshes, but it works for 97% of infill mesh cases in combination with infill support.

![image](https://user-images.githubusercontent.com/8895761/36796656-542b856c-1ca6-11e8-992f-cd01d6e01ee2.png)
