### PR TITLE
Take support into consideration when evaluating a skin region to see if it is a bridge.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1845,6 +1845,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
 
     // if support is enabled, consider the support outlines so we don't generate bridges over support
 
+    int support_layer_nr = -1;
     const SupportLayer* support_layer = nullptr;
 
     if (storage.getSettingBoolean("support_enable") || storage.getSettingBoolean("support_tree_enable"))
@@ -1852,16 +1853,16 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
         const coord_t layer_height = mesh_config.inset0_config.getLayerThickness();
         const coord_t z_distance_top = mesh.getSettingInMicrons("support_top_distance");
         const size_t z_distance_top_layers = std::max(0U, round_up_divide(z_distance_top, layer_height)) + 1;
-        const int support_layer_nr = layer_nr - z_distance_top_layers;
-        if (support_layer_nr >= 0)
-        {
-            support_layer = &storage.support.supportLayers[support_layer_nr];
-        }
+        support_layer_nr = layer_nr - z_distance_top_layers;
     }
 
     // calculate bridging angle
     if (layer_nr > 0)
     {
+        if (support_layer_nr >= 0)
+        {
+            support_layer = &storage.support.supportLayers[support_layer_nr];
+        }
         bridge = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 1], support_layer, supportedSkinPartRegions);
     }
     if (bridge > -1)
@@ -1886,6 +1887,10 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
         {
             // if this is the second bridge layer use bridge_skin_config2
             Polygons supportedSkinPartRegions2;
+            if (support_layer_nr >= 1)
+            {
+                support_layer = &storage.support.supportLayers[support_layer_nr - 1];
+            }
             int bridge2 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 2], support_layer, supportedSkinPartRegions2);
             if (bridge2 > -1 || (supportedSkinPartRegions2.area() / (skin_part.outline.area() + 1) < mesh.getSettingInPercentage("bridge_skin_support_threshold") / 100))
             {
@@ -1903,6 +1908,10 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
             {
                 // if this is the third bridge layer, use the same skin_angle as the first
                 Polygons supportedSkinPartRegions3;
+                if (support_layer_nr >= 2)
+                {
+                    support_layer = &storage.support.supportLayers[support_layer_nr - 2];
+                }
                 int bridge3 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 3], support_layer, supportedSkinPartRegions3);
                 if (bridge3 > -1)
                 {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1843,10 +1843,26 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
     coord_t skin_overlap = mesh.getSettingInMicrons("skin_overlap_mm");
     Polygons supportedSkinPartRegions;
 
+    // if support is enabled, consider the support outlines so we don't generate bridges over support
+
+    const SupportLayer* support_layer = nullptr;
+
+    if (storage.getSettingBoolean("support_enable") || storage.getSettingBoolean("support_tree_enable"))
+    {
+        const coord_t layer_height = mesh_config.inset0_config.getLayerThickness();
+        const coord_t z_distance_top = mesh.getSettingInMicrons("support_top_distance");
+        const size_t z_distance_top_layers = std::max(0U, round_up_divide(z_distance_top, layer_height)) + 1;
+        const int support_layer_nr = layer_nr - z_distance_top_layers;
+        if (support_layer_nr >= 0)
+        {
+            support_layer = &storage.support.supportLayers[support_layer_nr];
+        }
+    }
+
     // calculate bridging angle
     if (layer_nr > 0)
     {
-        bridge = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 1], supportedSkinPartRegions);
+        bridge = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 1], support_layer, supportedSkinPartRegions);
     }
     if (bridge > -1)
     {
@@ -1870,7 +1886,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
         {
             // if this is the second bridge layer use bridge_skin_config2
             Polygons supportedSkinPartRegions2;
-            int bridge2 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 2], supportedSkinPartRegions2);
+            int bridge2 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 2], support_layer, supportedSkinPartRegions2);
             if (bridge2 > -1 || (supportedSkinPartRegions2.area() / (skin_part.outline.area() + 1) < mesh.getSettingInPercentage("bridge_skin_support_threshold") / 100))
             {
                 if (bridge2 > -1)
@@ -1887,7 +1903,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
             {
                 // if this is the third bridge layer, use the same skin_angle as the first
                 Polygons supportedSkinPartRegions3;
-                int bridge3 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 3], supportedSkinPartRegions3);
+                int bridge3 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 3], support_layer, supportedSkinPartRegions3);
                 if (bridge3 > -1)
                 {
                     skin_angle = bridge3;

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -2,11 +2,13 @@
 #ifndef BRIDGE_H
 #define BRIDGE_H
 
+#include "sliceDataStorage.h"
+
 namespace cura {
     class Polygons;
     class SliceLayer;
 
-int bridgeAngle(Polygons outline, const SliceLayer* prevLayer, Polygons& supportedRegions);
+int bridgeAngle(Polygons outline, const SliceLayer* prevLayer, const SupportLayer* supportLayer, Polygons& supportedRegions);
 
 }//namespace cura
 


### PR DESCRIPTION
Otherwise, an area of skin that is supported by a combination of model and support
could be considered a bridge region when it really shouldn't.

This is a bit of a grey area because some combinations of model+support could leave skin
regions that really should be printed using bridge settings. More work required sometime.

Please consider this for inclusion in 3.3 as it should be beta tested along with the main bridging PR that has already been merged. Thanks.