### PR TITLE
Wall line segments that have a flow < wall_min_flow are converted into travel moves.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -646,9 +646,6 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
         }
     }
 
-    Point p0 = wall[start_idx];
-    addTravel(p0, always_retract);
-
     float non_bridge_line_volume = 0; // zero before first non-bridge line is output
     double speed_factor = 1.0; // start first line at normal speed
     double distance_to_bridge_start = 0; // will be updated before each line is processed
@@ -741,7 +738,11 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
         }
     };
 
-    bool travel_required = false; // true when a wall has been omitted due to its flow being less than the minimum required
+    bool travel_required = true; // true at the start of the line and when a wall has been omitted due to its flow being less than the minimum required
+
+    bool first_line = true;
+
+    Point p0 = wall[start_idx];
 
     for (unsigned int point_idx = 1; point_idx < wall.size(); point_idx++)
     {
@@ -763,7 +764,8 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
         {
             if (travel_required)
             {
-                addTravel(p0, wall_min_flow_retract);
+                addTravel(p0, (first_line) ? always_retract : wall_min_flow_retract);
+                first_line = false;
                 travel_required = false;
             }
             addWallLine(p0, p1, non_bridge_config, bridge_config, flow, non_bridge_line_volume, speed_factor, distance_to_bridge_start);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -819,10 +819,6 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
                 forceNewPathStart();
             }
         }
-        else
-        {
-            addTravel(p1, wall_min_flow_retract);
-        }
     }
     else
     {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -754,13 +754,7 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
             computeDistanceToBridgeStart((start_idx + point_idx - 1) % wall.size());
         }
 
-        // HACK ALERT
-        // the overlap compensation is not perfect, it can produce short non-flow reduced line segments within a sequence of flow reduced
-        // line segments and so to try and avoid printing the spurious fat line segments we require that their lengths are above a threshold
-
-        const coord_t max_spurious_fat_segment_length2 = 2500; // 50 microns
-
-        if (flow >= wall_min_flow && (first_line || !travel_required || vSize2f(p0 - p1) > max_spurious_fat_segment_length2))
+        if (flow >= wall_min_flow)
         {
             if (first_line || travel_required)
             {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -652,7 +652,7 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
 
     const SettingsBaseVirtual* extr = getLastPlannedExtruderTrainSettings();
     const double min_bridge_line_len = extr->getSettingInMicrons("bridge_wall_min_length");
-    const double wall_min_flow = extr->getSettingInPercentage("wall_min_flow") / 100;
+    const double wall_min_flow = extr->getSettingAsRatio("wall_min_flow");
     const bool wall_min_flow_retract = extr->getSettingBoolean("wall_min_flow_retract");
 
     // helper function to calculate the distance from the start of the current wall line to the first bridge segment

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -758,7 +758,7 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
         // the overlap compensation is not perfect, it can produce short non-flow reduced line segments within a sequence of flow reduced
         // line segments and so to try and avoid printing the spurious fat line segments we require that their lengths are above a threshold
 
-        const int64_t max_spurious_fat_segment_length = 50; // microns
+        const coord_t max_spurious_fat_segment_length = 50; // microns
 
         if (flow >= wall_min_flow && (first_line || !travel_required || vSize(p0 - p1) > max_spurious_fat_segment_length))
         {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -738,7 +738,7 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
         }
     };
 
-    bool travel_required = true; // true at the start of the line and when a wall has been omitted due to its flow being less than the minimum required
+    bool travel_required = false; // true when a wall has been omitted due to its flow being less than the minimum required
 
     bool first_line = true;
 
@@ -760,9 +760,9 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
 
         const int64_t max_spurious_fat_segment_length = 50; // microns
 
-        if (flow >= wall_min_flow && (!travel_required || vSize(p0 - p1) > max_spurious_fat_segment_length))
+        if (flow >= wall_min_flow && (first_line || !travel_required || vSize(p0 - p1) > max_spurious_fat_segment_length))
         {
-            if (travel_required)
+            if (first_line || travel_required)
             {
                 addTravel(p0, (first_line) ? always_retract : wall_min_flow_retract);
                 first_line = false;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -758,9 +758,9 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const GCodePathConf
         // the overlap compensation is not perfect, it can produce short non-flow reduced line segments within a sequence of flow reduced
         // line segments and so to try and avoid printing the spurious fat line segments we require that their lengths are above a threshold
 
-        const coord_t max_spurious_fat_segment_length = 50; // microns
+        const coord_t max_spurious_fat_segment_length2 = 2500; // 50 microns
 
-        if (flow >= wall_min_flow && (first_line || !travel_required || vSize(p0 - p1) > max_spurious_fat_segment_length))
+        if (flow >= wall_min_flow && (first_line || !travel_required || vSize2f(p0 - p1) > max_spurious_fat_segment_length2))
         {
             if (first_line || travel_required)
             {


### PR DESCRIPTION

Companion to https://github.com/Ultimaker/Cura/pull/3479.