### PR TITLE
More Svg improvements

### DIFF
--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -72,7 +72,7 @@ void SVG::writeComment(std::string comment)
     fprintf(out, "<!-- %s -->\n", comment.c_str());
 }
 
-void SVG::writeAreas(const Polygons& polygons, Color color, Color outline_color, coord_t stroke_width) 
+void SVG::writeAreas(const Polygons& polygons, Color color, Color outline_color, float stroke_width) 
 {
     for(PolygonsPart& parts : polygons.splitIntoParts())
     {
@@ -85,16 +85,16 @@ void SVG::writeAreas(const Polygons& polygons, Color color, Color outline_color,
                 fprintf(out, "%lli,%lli ", fp.X, fp.Y);
             }
             if (j == 0)
-                fprintf(out, "\" style=\"fill:%s;stroke:%s;stroke-width:%lli\" />\n", toString(color).c_str(), toString(outline_color).c_str(), stroke_width);
+                fprintf(out, "\" style=\"fill:%s;stroke:%s;stroke-width:%f\" />\n", toString(color).c_str(), toString(outline_color).c_str(), stroke_width);
             else
-                fprintf(out, "\" style=\"fill:white;stroke:%s;stroke-width:%lli\" />\n", toString(outline_color).c_str(), stroke_width);
+                fprintf(out, "\" style=\"fill:white;stroke:%s;stroke-width:%f\" />\n", toString(outline_color).c_str(), stroke_width);
         }
     }
 }
 
-void SVG::writeAreas(ConstPolygonRef polygon, Color color, Color outline_color, coord_t stroke_width)
+void SVG::writeAreas(ConstPolygonRef polygon, Color color, Color outline_color, float stroke_width)
 {
-    fprintf(out,"<polygon fill=\"%s\" stroke=\"%s\" stroke-width=\"%lli\" points=\"",toString(color).c_str(),toString(outline_color).c_str(), stroke_width); //The beginning of the polygon tag.
+    fprintf(out,"<polygon fill=\"%s\" stroke=\"%s\" stroke-width=\"%f\" points=\"",toString(color).c_str(),toString(outline_color).c_str(), stroke_width); //The beginning of the polygon tag.
     for (const Point& point : polygon) //Add every point to the list of points.
     {
         Point transformed = transform(point);
@@ -154,11 +154,11 @@ void SVG::writeLine(const Point& a, const Point& b, Color color, float stroke_wi
     fprintf(out, "<line x1=\"%lli\" y1=\"%lli\" x2=\"%lli\" y2=\"%lli\" style=\"stroke:%s;stroke-width:%f\" />\n", fa.X, fa.Y, fb.X, fb.Y, toString(color).c_str(), stroke_width);
 }
 
-void SVG::writeLineRGB(const Point& from, const Point& to, int r, int g, int b, int stroke_width)
+void SVG::writeLineRGB(const Point& from, const Point& to, int r, int g, int b, float stroke_width)
 {
     Point fa = transform(from);
     Point fb = transform(to);
-    fprintf(out, "<line x1=\"%lli\" y1=\"%lli\" x2=\"%lli\" y2=\"%lli\" style=\"stroke:rgb(%i,%i,%i);stroke-width:%i\" />\n", fa.X, fa.Y, fb.X, fb.Y, r, g, b, stroke_width);
+    fprintf(out, "<line x1=\"%lli\" y1=\"%lli\" x2=\"%lli\" y2=\"%lli\" style=\"stroke:rgb(%i,%i,%i);stroke-width:%f\" />\n", fa.X, fa.Y, fb.X, fb.Y, r, g, b, stroke_width);
 }
 
 void SVG::writeDashedLine(const Point& a, const Point& b, Color color)
@@ -173,7 +173,7 @@ void SVG::writeText(Point p, std::string txt, Color color, coord_t font_size)
     Point pf = transform(p);
     fprintf(out, "<text x=\"%lli\" y=\"%lli\" style=\"font-size: %llipx;\" fill=\"%s\">%s</text>\n",pf.X, pf.Y, font_size, toString(color).c_str(), txt.c_str());
 }
-void SVG::writePolygons(const Polygons& polys, Color color, int stroke_width)
+void SVG::writePolygons(const Polygons& polys, Color color, float stroke_width)
 {
     for (ConstPolygonRef poly : polys)
     {
@@ -181,7 +181,7 @@ void SVG::writePolygons(const Polygons& polys, Color color, int stroke_width)
     }
 }
 
-void SVG::writePolygon(ConstPolygonRef poly, Color color, int stroke_width)
+void SVG::writePolygon(ConstPolygonRef poly, Color color, float stroke_width)
 {
     if (poly.size() == 0)
     {

--- a/src/utils/SVG.cpp.orig
+++ b/src/utils/SVG.cpp.orig
@@ -1,3 +1,4 @@
+<<<<<<< facc8c844a67c3be60ce27867a41d7e54a53104d
 /** Copyright (C) 2017 Tim Kuipers - Released under terms of the AGPLv3 License */
 #include "SVG.h"
 
@@ -55,11 +56,6 @@ SVG::~SVG()
         fprintf(out, "</body></html>");
     }
     fclose(out);
-}
-
-double SVG::getScale() const
-{
-    return scale;
 }
 
 Point SVG::transform(const Point& p) 
@@ -147,11 +143,11 @@ void SVG::writeLines(std::vector<Point> polyline, Color color)
     fprintf(out,"\" />\n"); //Write the end of the tag.
 }
 
-void SVG::writeLine(const Point& a, const Point& b, Color color, float stroke_width)
+void SVG::writeLine(const Point& a, const Point& b, Color color, int stroke_width)
 {
     Point fa = transform(a);
     Point fb = transform(b);
-    fprintf(out, "<line x1=\"%lli\" y1=\"%lli\" x2=\"%lli\" y2=\"%lli\" style=\"stroke:%s;stroke-width:%f\" />\n", fa.X, fa.Y, fb.X, fb.Y, toString(color).c_str(), stroke_width);
+    fprintf(out, "<line x1=\"%lli\" y1=\"%lli\" x2=\"%lli\" y2=\"%lli\" style=\"stroke:%s;stroke-width:%i\" />\n", fa.X, fa.Y, fb.X, fb.Y, toString(color).c_str(), stroke_width);
 }
 
 void SVG::writeLineRGB(const Point& from, const Point& to, int r, int g, int b, int stroke_width)
@@ -210,3 +206,48 @@ void SVG::writePolygon(ConstPolygonRef poly, Color color, int stroke_width)
 }
 
 } // namespace cura 
+||||||| merged common ancestors
+=======
+/** Copyright (C) 2017 Tim Kuipers - Released under terms of the AGPLv3 License */
+#include "SVG.h"
+
+
+namespace cura {
+
+void SVG::writeLineRGB(const Point& from, const Point& to, int r, int g, int b, int stroke_width)
+{
+    Point fa = transform(from);
+    Point fb = transform(to);
+    fprintf(out, "<line x1=\"%lli\" y1=\"%lli\" x2=\"%lli\" y2=\"%lli\" style=\"stroke:rgb(%i,%i,%i);stroke-width:%i\" />\n", fa.X, fa.Y, fb.X, fb.Y, r, g, b, stroke_width);
+}
+
+void SVG::writePolygon(ConstPolygonRef poly, Color color, int stroke_width)
+{
+    if (poly.size() == 0)
+    {
+        return;
+    }
+    int size = poly.size();
+    Point p0 = poly.back();
+    int i = 0;
+    for (Point p1 : poly)
+    {
+        if (color == Color::RAINBOW)
+        {
+            int g = (i * 255 * 11 / size) % (255 * 2);
+            if (g > 255) g = 255 * 2 - g;
+            int b = (i * 255 * 5 / size) % (255 * 2);
+            if (b > 255) b = 255 * 2 - b;
+            writeLineRGB(p0, p1, i * 255 / size, g, b, stroke_width);
+        }
+        else
+        {
+            writeLine(p0, p1, color, stroke_width);
+        }
+        p0 = p1;
+        i++;
+    }
+}
+
+} // namespace cura 
+>>>>>>> rainbow SVG coloring

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -5,6 +5,7 @@
 
 #include "polygon.h"
 #include "intpoint.h"
+#include "floatpoint.h"
 #include "AABB.h"
 #include "logoutput.h"
 #include "NoCopy.h"
@@ -52,6 +53,11 @@ public:
      * transform a point in real space to canvas space
      */
     Point transform(const Point& p);
+
+    /*!
+     * transform a point in real space to canvas space with more precision
+     */
+    FPoint3 transformF(const Point& p);
 
     void writeComment(std::string comment);
 

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -55,9 +55,9 @@ public:
 
     void writeComment(std::string comment);
 
-    void writeAreas(const Polygons& polygons, Color color = Color::GRAY, Color outline_color = Color::BLACK, coord_t stroke_width = 1);
+    void writeAreas(const Polygons& polygons, Color color = Color::GRAY, Color outline_color = Color::BLACK, float stroke_width = 1);
 
-    void writeAreas(ConstPolygonRef polygon, Color color = Color::GRAY, Color outline_color = Color::BLACK, coord_t stroke_width = 1);
+    void writeAreas(ConstPolygonRef polygon, Color color = Color::GRAY, Color outline_color = Color::BLACK, float stroke_width = 1);
 
     void writePoint(const Point& p, bool write_coords=false, int size = 5, Color color = Color::BLACK);
 
@@ -80,7 +80,7 @@ public:
 
     void writeLine(const Point& a, const Point& b, Color color = Color::BLACK, float stroke_width = 1);
 
-    void writeLineRGB(const Point& from, const Point& to, int r = 0, int g = 0, int b = 0, int stroke_width = 1);
+    void writeLineRGB(const Point& from, const Point& to, int r = 0, int g = 0, int b = 0, float stroke_width = 1);
 
     /*!
      * \brief Draws a dashed line on the canvas from point A to point B.
@@ -98,9 +98,9 @@ public:
 
     void writeText(Point p, std::string txt, Color color = Color::BLACK, coord_t font_size = 10);
 
-    void writePolygons(const Polygons& polys, Color color = Color::BLACK, int stroke_width = 1);
+    void writePolygons(const Polygons& polys, Color color = Color::BLACK, float stroke_width = 1);
 
-    void writePolygon(ConstPolygonRef poly, Color color = Color::BLACK, int stroke_width = 1);
+    void writePolygon(ConstPolygonRef poly, Color color = Color::BLACK, float stroke_width = 1);
 
 };
 

--- a/src/utils/SVG.h.orig
+++ b/src/utils/SVG.h.orig
@@ -44,18 +44,55 @@ public:
     ~SVG();
 
     /*!
-     * get the scaling factor applied to convert real space to canvas space
-     */
-    double getScale() const;
-    
-    /*!
      * transform a point in real space to canvas space
      */
     Point transform(const Point& p);
 
     void writeComment(std::string comment);
 
+<<<<<<< 6990ae6903474b27cc52dd03321b12abd68a6ebf
     void writeAreas(const Polygons& polygons, Color color = Color::GRAY, Color outline_color = Color::BLACK, coord_t stroke_width = 1);
+||||||| merged common ancestors
+    void writeAreas(const Polygons& polygons, Color color = Color::GRAY, Color outline_color = Color::BLACK) 
+    {
+        for(PolygonsPart& parts : polygons.splitIntoParts())
+        {
+            for(unsigned int j=0;j<parts.size();j++)
+            {
+                fprintf(out, "<polygon points=\"");
+                for (Point& p : parts[j])
+                {
+                    Point fp = transform(p);
+                    fprintf(out, "%lli,%lli ", fp.X, fp.Y);
+                }
+                if (j == 0)
+                    fprintf(out, "\" style=\"fill:%s;stroke:%s;stroke-width:1\" />\n", toString(color).c_str(), toString(outline_color).c_str());
+                else
+                    fprintf(out, "\" style=\"fill:white;stroke:%s;stroke-width:1\" />\n", toString(outline_color).c_str());
+            }
+        }
+    }
+=======
+    void writeAreas(const Polygons& polygons, Color color = Color::GRAY, Color outline_color = Color::BLACK, coord_t stroke_width = 1)
+    {
+        for(PolygonsPart& parts : polygons.splitIntoParts())
+        {
+            for(unsigned int j=0;j<parts.size();j++)
+            {
+                fprintf(out, "<polygon points=\"");
+                for (Point& p : parts[j])
+                {
+                    Point fp = transform(p);
+                    fprintf(out, "%lli,%lli ", fp.X, fp.Y);
+                }
+                if (j == 0)
+                    fprintf(out, "\" style=\"fill:%s;stroke:%s;stroke-width:1\" />\n", toString(color).c_str(), toString(outline_color).c_str());
+                else
+                    fprintf(out, "\" style=\"fill:white;stroke:%s;stroke-width:1\" />\n", toString(outline_color).c_str());
+            }
+        }
+    }
+>>>>>>> fixed sierpinski simultaneous subdivision and consecutivity constraint
 
     void writeAreas(ConstPolygonRef polygon, Color color = Color::GRAY, Color outline_color = Color::BLACK, coord_t stroke_width = 1);
 
@@ -78,7 +115,7 @@ public:
      */
     void writeLines(std::vector<Point> polyline, Color color = Color::BLACK);
 
-    void writeLine(const Point& a, const Point& b, Color color = Color::BLACK, float stroke_width = 1);
+    void writeLine(const Point& a, const Point& b, Color color = Color::BLACK, int stroke_width = 1);
 
     void writeLineRGB(const Point& from, const Point& to, int r = 0, int g = 0, int b = 0, int stroke_width = 1);
 


### PR DESCRIPTION
I was having a lot of rounding errors, which produces visual problems which people have asked me about on several occasions.

In this PR the internal format the SVG class uses is FPoint3 (floating 3d) instead of Point (integer 2D)
(3d because there is no class in cura for a 2D float point and I didn't want to introduce one just for a debugging class).