### PR TITLE
Do not call handleInitialLayerSpeedup() for raft layers.

### DIFF
--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -242,7 +242,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, int layer_
     }
 
     const int initial_speedup_layer_count = storage.getSettingAsCount("speed_slowdown_layers");
-    if (layer_nr < initial_speedup_layer_count)
+    if (layer_nr >= 0 && layer_nr < initial_speedup_layer_count)
     {
         handleInitialLayerSpeedup(storage, layer_nr, initial_speedup_layer_count);
     }


### PR DESCRIPTION
This was calculating a bad speed when initial_speedup_layer_count is zero but I have my
doubts that it should be called at all for rafts given that rafts have their own speed
settings.

I think this should fix https://github.com/Ultimaker/Cura/issues/3555.