### PR TITLE
fix: escape newlines in settings

### DIFF
--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -8,6 +8,7 @@
 #include <sstream>
 
 #include "../utils/floatpoint.h"
+#include "../utils/string.h"
 
 #include "../FlowTempGraph.h"
 
@@ -327,7 +328,7 @@ public:
         {
             if (!pair.second.empty())
             {
-                sstream << " -s " << pair.first << "=\"" << pair.second << "\"";
+                sstream << " -s " << pair.first << "=\"" << Escaped{pair.second.c_str()} << '\"';
             }
         }
         return sstream.str();

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -176,6 +176,39 @@ struct PrecisionedDouble
     }
 };
 
+/*!
+ * Struct for writing a string to a stream in an escaped form
+ */
+struct Escaped
+{
+    const char* str;
+    
+    /*!
+     * Streaming function which replaces escape sequences with extra slashes
+     */
+    friend inline std::ostream& operator<<(std::ostream& os, const Escaped& e)
+    {
+        for (const char* char_p = e.str; *char_p != '\0'; char_p++)
+        {
+            switch (*char_p)
+            {
+                case '\a':  os << "\\a"; break;
+                case '\b':  os << "\\b"; break;
+                case '\f':  os << "\\f"; break;
+                case '\n':  os << "\\n"; break;
+                case '\r':  os << "\\r"; break;
+                case '\t':  os << "\\t"; break;
+                case '\v':  os << "\\v"; break;
+                case '\\':  os << "\\\\"; break;
+                case '\'':  os << "\\'"; break;
+                case '\"':  os << "\\\""; break;
+                case '\?':  os << "\\\?"; break;
+                default: os << *char_p;
+            }
+        }
+        return os;
+    }
+};
 
 }//namespace cura
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8895761/37935836-4f8e2c78-3153-11e8-82db-1129788782c3.png)

:(

After:
![image](https://user-images.githubusercontent.com/8895761/37935863-66db9a8c-3153-11e8-92bf-ed522275eea8.png)

:)