### PR TITLE
potential improvements to overlap compensation

### DIFF
--- a/src/utils/PolygonProximityLinker.cpp
+++ b/src/utils/PolygonProximityLinker.cpp
@@ -369,6 +369,7 @@ void PolygonProximityLinker::addProximityEnding(const ProximityPointLink& link, 
     {
 //         addProximityLink(link.a, link.b, proximity_distance);
         // won't be inserted any way, because there already is such a link!
+        link.setDist(proximity_distance);
     }
 }
 

--- a/src/utils/ProximityPointLink.cpp
+++ b/src/utils/ProximityPointLink.cpp
@@ -17,4 +17,10 @@ bool ProximityPointLink::operator==(const ProximityPointLink& other) const
     return (a == other.a && b == other.b) || (a == other.b && b == other.a);
 }
 
+void ProximityPointLink::setDist(coord_t distance) const
+{
+    ProximityPointLink& thiss = *const_cast<ProximityPointLink*>(this);
+    thiss.dist = distance;
+}
+
 }//namespace cura 

--- a/src/utils/ProximityPointLink.h
+++ b/src/utils/ProximityPointLink.h
@@ -39,8 +39,9 @@ struct ProximityPointLink
 {
     const ListPolyIt a; //!< the one point (invalidated after list_polygons have been cleared!)
     const ListPolyIt b; //!< the other point (invalidated after list_polygons have been cleared!)
-    const int dist; //!< The distance between the two points
+    coord_t dist; //!< The distance between the two points
     const ProximityPointLinkType type; //!< The type of link; why/how it was created
+    void setDist(coord_t dist) const; //!< Set the distance. This disregards cosntness, which is only relevant for the equality check and hash operation.
     ProximityPointLink(const ListPolyIt a, const ListPolyIt b, int dist, const ProximityPointLinkType type);
     bool operator==(const ProximityPointLink& other) const;
 };

--- a/src/wallOverlap.cpp
+++ b/src/wallOverlap.cpp
@@ -72,7 +72,7 @@ float WallOverlapComputation::getFlow(const Point& from, const Point& to)
         //   to other
         if (!are_in_same_general_direction)
         {
-            overlap_area += handlePotentialOverlap(to_it, to_it, to_link, to_other_next_it, to_other_it);
+            overlap_area = std::max(overlap_area, handlePotentialOverlap(to_it, to_it, to_link, to_other_next_it, to_other_it));
         }
 
         // handle multiple points  linked to [to_other]
@@ -83,7 +83,7 @@ float WallOverlapComputation::getFlow(const Point& from, const Point& to)
         bool all_are_in_same_general_direction = are_in_same_general_direction && dot(from - to, to_other_it.prev().p() - to_other_it.p()) > 0;
         if (!all_are_in_same_general_direction)
         {
-            overlap_area += handlePotentialOverlap(from_it, to_it, to_link, to_other_it, to_other_it);
+            overlap_area = std::max(overlap_area, handlePotentialOverlap(from_it, to_it, to_link, to_other_it, to_other_it));
         }
 
         // handle normal case where the segment from-to overlaps with another segment
@@ -96,7 +96,7 @@ float WallOverlapComputation::getFlow(const Point& from, const Point& to)
         //       to other
         if (!are_in_same_general_direction)
         {
-            overlap_area += handlePotentialOverlap(from_it, to_it, to_link, to_other_next_it, to_other_it);
+            overlap_area = std::max(overlap_area, handlePotentialOverlap(from_it, to_it, to_link, to_other_next_it, to_other_it));
         }
     }
 


### PR DESCRIPTION
- When a link cannot be introduced because the distance is zero, change the existing link instead, rather than doing nothing.

- When there are multiple links use the one with the most overlap. That means: only compensate for the overlap between a line segment and the most overlapping line segment. I'm not sure whether this is smart, because this means the amount of overlap being compensated depends on the processing order and thus on the Z seam.

I haven't checked if this fixes anything. The bugs I am encountering occur even though overlap compensation is off, so there is something weird going on here.

Anyway I thought I would post this here for other people to check whether this improves the horrid overlap compensation situation ;)

Maybe this is something @smartavionics would like to look at?