### PR TITLE
Improve handling of bridge skin areas

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1868,14 +1868,13 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
     }
 
     // generate skin_polygons and skin_lines (and concentric_perimeter_gaps if needed)
-    int bridge = -1;
     const GCodePathConfig* skin_config = &mesh_config.skin_config;
     double skin_density = 1.0;
     coord_t skin_overlap = mesh.getSettingInMicrons("skin_overlap_mm");
     const coord_t more_skin_overlap = std::max(skin_overlap, (coord_t)(mesh_config.insetX_config.getLineWidth() / 2)); // force a minimum amount of skin_overlap
-    Polygons supported_skin_part_regions;
     const bool bridge_settings_enabled = mesh.getSettingBoolean("bridge_settings_enabled");
-    const double support_threshold = bridge_settings_enabled ? mesh.getSettingInPercentage("bridge_skin_support_threshold") / 100 : 0;
+    const double support_threshold = bridge_settings_enabled ? mesh.getSettingAsRatio("bridge_skin_support_threshold") : 0;
+    const int bottom_layers = mesh.getSettingAsCount("bottom_layers");
 
     // if support is enabled, consider the support outlines so we don't generate bridges over support
 
@@ -1890,116 +1889,95 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
         support_layer_nr = layer_nr - z_distance_top_layers;
     }
 
-    // calculate bridging angle
-    if (layer_nr > 0)
-    {
-        if (support_layer_nr >= 0)
-        {
-            support_layer = &storage.support.supportLayers[support_layer_nr];
-        }
-        bridge = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 1], support_layer, supported_skin_part_regions, support_threshold);
-    }
-    if (bridge > -1)
-    {
-        pattern = EFillMethod::LINES; // force lines pattern when bridging
-        skin_angle = bridge;
-        if (bridge_settings_enabled)
-        {
-            skin_config = &mesh_config.bridge_skin_config;
-            skin_overlap = more_skin_overlap;
-            skin_density = mesh.getSettingInPercentage("bridge_skin_density")  / 100;
-        }
-    }
-    else if (layer_nr > 0 && bridge_settings_enabled)
-    {
-        const int bottom_layers = mesh.getSettingAsCount("bottom_layers");
-        // if the fraction of the skin that is supported is less than the required threshold, print using bridge skin settings
-        if ((supported_skin_part_regions.area() / (skin_part.outline.area() + 1) < support_threshold))
-        {
-            pattern = EFillMethod::LINES; // force lines pattern when bridging
-            skin_config = &mesh_config.bridge_skin_config;
-            skin_overlap = more_skin_overlap;
-            skin_density = mesh.getSettingInPercentage("bridge_skin_density")  / 100;
-        }
-        else if (layer_nr > 1 && bottom_layers > 1 && mesh.getSettingBoolean("bridge_enable_more_layers"))
-        {
-            // if this is the second bridge layer use bridge_skin_config2
-            Polygons supported_skin_part_regions2;
-            if (support_layer_nr >= 1)
-            {
-                support_layer = &storage.support.supportLayers[support_layer_nr - 1];
-            }
-            // outline used is union of current skin part and those skin parts from the 1st bridge layer that overlap the curent skin part
+    // helper function that detects skin regions that have no support and modifies their print settings (config, line angle, density, etc.)
 
-            // this is done because if we only use skin_part.outline for this layer and that outline is different (i.e. smaller) than
-            // the skin outline used to compute the bridge angle for the first skin, the angle computed for this (second) skin could
-            // be different and we would prefer it to be the same as computed for the first bridge layer
-            Polygons skin2_outline(skin_part.outline);
-            for (auto layer_part : mesh.layers[layer_nr - 1].parts)
+    auto handle_bridge_skin = [&](const int bridge_layer, const GCodePathConfig* config, const float density) // bridge_layer = 1, 2 or 3
+    {
+        if (support_layer_nr >= (bridge_layer - 1))
+        {
+            support_layer = &storage.support.supportLayers[support_layer_nr - (bridge_layer - 1)];
+        }
+
+        // for upper bridge skins, outline used is union of current skin part and those skin parts from the 1st bridge layer that overlap the curent skin part
+
+        // this is done because if we only use skin_part.outline for this layer and that outline is different (i.e. smaller) than
+        // the skin outline used to compute the bridge angle for the first skin, the angle computed for this (second) skin could
+        // be different and we would prefer it to be the same as computed for the first bridge layer
+        Polygons skin_outline(skin_part.outline);
+
+        if (bridge_layer > 1)
+        {
+            for (auto layer_part : mesh.layers[layer_nr - (bridge_layer - 1)].parts)
             {
                 for (auto other_skin_part : layer_part.skin_parts)
                 {
                     if (PolygonUtils::polygonsIntersect(skin_part.outline.outerPolygon(), other_skin_part.outline.outerPolygon()))
                     {
-                        skin2_outline = skin2_outline.unionPolygons(other_skin_part.outline);
+                        skin_outline = skin_outline.unionPolygons(other_skin_part.outline);
                     }
                 }
             }
-            int bridge2 = bridgeAngle(skin2_outline, &mesh.layers[layer_nr - 2], support_layer, supported_skin_part_regions2, support_threshold);
-            if (bridge2 > -1 || (supported_skin_part_regions2.area() / (skin2_outline.area() + 1) < support_threshold))
+        }
+
+        Polygons supported_skin_part_regions;
+
+        int angle = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - bridge_layer], support_layer, supported_skin_part_regions, support_threshold);
+
+        if (angle > -1 || (supported_skin_part_regions.area() / (skin_part.outline.area() + 1) < support_threshold))
+        {
+            if (angle > -1)
             {
-                if (bridge2 > -1)
+                switch (bridge_layer)
                 {
-                    if (bottom_layers > 2)
-                    {
-                        // orientate second bridge skin at +45 deg to first
-                        skin_angle = (bridge2 + 45) % 360;
-                    }
-                    else
-                    {
-                        // orientate second bridge skin at 90 deg to first
-                        skin_angle = (bridge2 + 90) % 360;
-                    }
-                }
-                pattern = EFillMethod::LINES; // force lines pattern on upper bridge skins
-                skin_overlap = more_skin_overlap;
-                skin_density = mesh.getSettingInPercentage("bridge_skin_density_2") / 100;
-                skin_config = &mesh_config.bridge_skin_config2;
-            }
-            else if (layer_nr > 2 && bottom_layers > 2)
-            {
-                // if this is the third bridge layer use bridge_skin_config3
-                Polygons supported_skin_part_regions3;
-                if (support_layer_nr >= 2)
-                {
-                    support_layer = &storage.support.supportLayers[support_layer_nr - 2];
-                }
-                // outline used is union of current skin part and those skin parts from the 1st bridge layer that overlap the curent skin part
-                Polygons skin3_outline(skin_part.outline);
-                for (auto layer_part : mesh.layers[layer_nr - 2].parts)
-                {
-                    for (auto other_skin_part : layer_part.skin_parts)
-                    {
-                        if (PolygonUtils::polygonsIntersect(skin_part.outline.outerPolygon(), other_skin_part.outline.outerPolygon()))
+                    default:
+                    case 1:
+                        skin_angle = angle;
+                        break;
+
+                    case 2:
+                        if (bottom_layers > 2)
                         {
-                            skin3_outline = skin3_outline.unionPolygons(other_skin_part.outline);
+                            // orientate second bridge skin at +45 deg to first
+                            skin_angle = (angle + 45) % 360;
                         }
-                    }
-                }
-                int bridge3 = bridgeAngle(skin3_outline, &mesh.layers[layer_nr - 3], support_layer, supported_skin_part_regions3, support_threshold);
-                if (bridge3 > -1 || (supported_skin_part_regions3.area() / (skin3_outline.area() + 1) < support_threshold))
-                {
-                    if (bridge3 > -1)
-                    {
+                        else
+                        {
+                            // orientate second bridge skin at 90 deg to first
+                            skin_angle = (angle + 90) % 360;
+                        }
+                        break;
+
+                    case 3:
                         // orientate third bridge skin at 135 (same result as -45) deg to first
-                        skin_angle = (bridge3 + 135) % 360;
-                    }
-                    pattern = EFillMethod::LINES; // force lines pattern on upper bridge skins
-                    skin_overlap = more_skin_overlap;
-                    skin_density = mesh.getSettingInPercentage("bridge_skin_density_3") / 100;
-                    skin_config = &mesh_config.bridge_skin_config3;
+                        skin_angle = (angle + 135) % 360;
+                        break;
                 }
             }
+            pattern = EFillMethod::LINES; // force lines pattern when bridging
+            if (bridge_settings_enabled)
+            {
+                skin_config = config;
+                skin_overlap = more_skin_overlap;
+                skin_density = density;
+            }
+            return true;
+        }
+
+        return false;
+    };
+
+    bool is_bridge_skin = false;
+    if (layer_nr > 0)
+    {
+        is_bridge_skin = handle_bridge_skin(1, &mesh_config.bridge_skin_config, mesh.getSettingAsRatio("bridge_skin_density"));
+    }
+    if (bridge_settings_enabled && !is_bridge_skin && layer_nr > 1 && bottom_layers > 1)
+    {
+        is_bridge_skin = handle_bridge_skin(2, &mesh_config.bridge_skin_config2, mesh.getSettingAsRatio("bridge_skin_density_2"));
+
+        if (!is_bridge_skin && layer_nr > 2 && bottom_layers > 2)
+        {
+            is_bridge_skin = handle_bridge_skin(3, &mesh_config.bridge_skin_config3, mesh.getSettingAsRatio("bridge_skin_density_3"));
         }
     }
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1806,7 +1806,7 @@ void FffGcodeWriter::processSkinInsets(const SliceDataStorage& storage, LayerPla
                 added_something = true;
                 setExtruder_addPrime(storage, gcode_layer, extruder_nr);
                 gcode_layer.setIsInside(true); // going to print stuff inside print object
-                gcode_layer.addPolygonsByOptimizer(skin_perimeter, mesh_config.skin_config); // add polygons to gcode in inward order
+                gcode_layer.addWalls(skin_perimeter, mesh_config.skin_config, mesh_config.bridge_skin_config, nullptr); // add polygons to gcode in inward order
             }
         }
     }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1881,6 +1881,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
     }
     else if (layer_nr > 0 && bridge_settings_enabled)
     {
+        const int bottom_layers = mesh.getSettingAsCount("bottom_layers");
         // if the fraction of the skin that is supported is less than the required threshold, print using bridge skin settings
         if ((supported_skin_part_regions.area() / (skin_part.outline.area() + 1) < support_threshold))
         {
@@ -1889,7 +1890,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
             skin_overlap = more_skin_overlap;
             skin_density = mesh.getSettingInPercentage("bridge_skin_density")  / 100;
         }
-        else if (layer_nr > 1 && mesh.getSettingBoolean("bridge_enable_more_layers"))
+        else if (layer_nr > 1 && bottom_layers > 1 && mesh.getSettingBoolean("bridge_enable_more_layers"))
         {
             // if this is the second bridge layer use bridge_skin_config2
             Polygons supported_skin_part_regions2;
@@ -1902,26 +1903,38 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
             {
                 if (bridge2 > -1)
                 {
-                    // orientate second bridge skin at 90 deg to first
-                    skin_angle = (bridge2 + 90) % 360;
+                    if (bottom_layers > 2)
+                    {
+                        // orientate second bridge skin at +45 deg to first
+                        skin_angle = (bridge2 + 45) % 360;
+                    }
+                    else
+                    {
+                        // orientate second bridge skin at 90 deg to first
+                        skin_angle = (bridge2 + 90) % 360;
+                    }
                 }
-                use_bridge_config2 = true;
                 pattern = EFillMethod::LINES; // force lines pattern on upper bridge skins
                 skin_overlap = more_skin_overlap;
                 skin_density = mesh.getSettingInPercentage("bridge_skin_density_2") / 100;
+                use_bridge_config2 = true;
             }
-            else if (layer_nr > 2)
+            else if (layer_nr > 2 && bottom_layers > 2)
             {
-                // if this is the third bridge layer, use the same skin_angle as the first
+                // if this is the third bridge layer use bridge_skin_config3
                 Polygons supported_skin_part_regions3;
                 if (support_layer_nr >= 2)
                 {
                     support_layer = &storage.support.supportLayers[support_layer_nr - 2];
                 }
                 int bridge3 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 3], support_layer, supported_skin_part_regions3, support_threshold);
-                if (bridge3 > -1)
+                if (bridge3 > -1 || (supported_skin_part_regions3.area() / (skin_part.outline.area() + 1) < support_threshold))
                 {
-                    skin_angle = bridge3;
+                    if (bridge3 > -1)
+                    {
+                        // orientate third bridge skin at 135 (same result as -45) deg to first
+                        skin_angle = (bridge3 + 135) % 360;
+                    }
                     pattern = EFillMethod::LINES; // force lines pattern on upper bridge skins
                     skin_overlap = more_skin_overlap;
                     skin_density = mesh.getSettingInPercentage("bridge_skin_density_3") / 100;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1841,7 +1841,9 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
     bool use_bridge_config3 = false;
     double skin_density = 1.0;
     coord_t skin_overlap = mesh.getSettingInMicrons("skin_overlap_mm");
-    Polygons supportedSkinPartRegions;
+    Polygons supported_skin_part_regions;
+    const bool bridge_settings_enabled = mesh.getSettingBoolean("bridge_settings_enabled");
+    const double support_threshold = bridge_settings_enabled ? mesh.getSettingInPercentage("bridge_skin_support_threshold") / 100 : 0;
 
     // if support is enabled, consider the support outlines so we don't generate bridges over support
 
@@ -1862,32 +1864,33 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
     // calculate bridging angle
     if (layer_nr > 0)
     {
-        bridge = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 1], support_layer, supportedSkinPartRegions);
+        bridge = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 1], support_layer, supported_skin_part_regions, support_threshold);
     }
     if (bridge > -1)
     {
         pattern = EFillMethod::LINES; // force lines pattern when bridging
         skin_angle = bridge;
-        use_bridge_config = mesh.getSettingBoolean("bridge_settings_enabled");
+        use_bridge_config = bridge_settings_enabled;
         if (use_bridge_config)
         {
             skin_density = mesh.getSettingInPercentage("bridge_skin_density")  / 100;
         }
     }
-    else if (layer_nr > 0 && mesh.getSettingBoolean("bridge_settings_enabled"))
+    else if (layer_nr > 0 && bridge_settings_enabled)
     {
         // if the fraction of the skin that is supported is less than the required threshold, print using bridge skin settings
-        if ((supportedSkinPartRegions.area() / (skin_part.outline.area() + 1) < mesh.getSettingInPercentage("bridge_skin_support_threshold") / 100))
+        if ((supported_skin_part_regions.area() / (skin_part.outline.area() + 1) < support_threshold))
         {
             pattern = EFillMethod::LINES; // force lines pattern when bridging
             use_bridge_config = true;
+            skin_density = mesh.getSettingInPercentage("bridge_skin_density")  / 100;
         }
         else if (layer_nr > 1 && mesh.getSettingBoolean("bridge_enable_more_layers"))
         {
             // if this is the second bridge layer use bridge_skin_config2
-            Polygons supportedSkinPartRegions2;
-            int bridge2 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 2], support_layer, supportedSkinPartRegions2);
-            if (bridge2 > -1 || (supportedSkinPartRegions2.area() / (skin_part.outline.area() + 1) < mesh.getSettingInPercentage("bridge_skin_support_threshold") / 100))
+            Polygons supported_skin_part_regions2;
+            int bridge2 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 2], support_layer, supported_skin_part_regions2, support_threshold);
+            if (bridge2 > -1 || (supported_skin_part_regions2.area() / (skin_part.outline.area() + 1) < support_threshold))
             {
                 if (bridge2 > -1)
                 {
@@ -1902,8 +1905,8 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
             else if (layer_nr > 2)
             {
                 // if this is the third bridge layer, use the same skin_angle as the first
-                Polygons supportedSkinPartRegions3;
-                int bridge3 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 3], support_layer, supportedSkinPartRegions3);
+                Polygons supported_skin_part_regions3;
+                int bridge3 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 3], support_layer, supported_skin_part_regions3, support_threshold);
                 if (bridge3 > -1)
                 {
                     skin_angle = bridge3;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1841,6 +1841,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
     bool use_bridge_config3 = false;
     double skin_density = 1.0;
     coord_t skin_overlap = mesh.getSettingInMicrons("skin_overlap_mm");
+    const coord_t more_skin_overlap = std::max(skin_overlap, (coord_t)(mesh_config.insetX_config.getLineWidth() / 2)); // force a minimum amount of skin_overlap
     Polygons supported_skin_part_regions;
     const bool bridge_settings_enabled = mesh.getSettingBoolean("bridge_settings_enabled");
     const double support_threshold = bridge_settings_enabled ? mesh.getSettingInPercentage("bridge_skin_support_threshold") / 100 : 0;
@@ -1874,6 +1875,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
         use_bridge_config = bridge_settings_enabled;
         if (use_bridge_config)
         {
+            skin_overlap = more_skin_overlap;
             skin_density = mesh.getSettingInPercentage("bridge_skin_density")  / 100;
         }
     }
@@ -1884,6 +1886,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
         {
             pattern = EFillMethod::LINES; // force lines pattern when bridging
             use_bridge_config = true;
+            skin_overlap = more_skin_overlap;
             skin_density = mesh.getSettingInPercentage("bridge_skin_density")  / 100;
         }
         else if (layer_nr > 1 && mesh.getSettingBoolean("bridge_enable_more_layers"))
@@ -1904,7 +1907,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
                 }
                 use_bridge_config2 = true;
                 pattern = EFillMethod::LINES; // force lines pattern on upper bridge skins
-                skin_overlap = std::max(skin_overlap, (coord_t)(mesh_config.insetX_config.getLineWidth() / 2)); // force a minimum amount of skin_overlap
+                skin_overlap = more_skin_overlap;
                 skin_density = mesh.getSettingInPercentage("bridge_skin_density_2") / 100;
             }
             else if (layer_nr > 2)
@@ -1920,6 +1923,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
                 {
                     skin_angle = bridge3;
                     pattern = EFillMethod::LINES; // force lines pattern on upper bridge skins
+                    skin_overlap = more_skin_overlap;
                     skin_density = mesh.getSettingInPercentage("bridge_skin_density_3") / 100;
                     use_bridge_config3 = true;
                 }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1490,11 +1490,14 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
 
             Polygons outlines_below;
             AABB boundaryBox(part.outline);
-            for(auto prevLayerPart : mesh.layers[gcode_layer.getLayerNr() - 1].parts)
+            for (auto m : storage.meshes)
             {
-                if (boundaryBox.hit(prevLayerPart.boundaryBox))
+                for (auto prevLayerPart : m.layers[gcode_layer.getLayerNr() - 1].parts)
                 {
-                    outlines_below.add(prevLayerPart.outline);
+                    if (boundaryBox.hit(prevLayerPart.boundaryBox))
+                    {
+                        outlines_below.add(prevLayerPart.outline);
+                    }
                 }
             }
 
@@ -1921,7 +1924,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
 
         Polygons supported_skin_part_regions;
 
-        int angle = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - bridge_layer], support_layer, supported_skin_part_regions, support_threshold);
+        int angle = bridgeAngle(skin_part.outline, storage, layer_nr - bridge_layer, support_layer, supported_skin_part_regions, support_threshold);
 
         if (angle > -1 || (supported_skin_part_regions.area() / (skin_part.outline.area() + 1) < support_threshold))
         {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1843,10 +1843,26 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
     coord_t skin_overlap = mesh.getSettingInMicrons("skin_overlap_mm");
     Polygons supportedSkinPartRegions;
 
+    // if support is enabled, consider the support outlines so we don't generate bridges over support
+
+    const SupportLayer* support_layer = nullptr;
+
+    if (storage.getSettingBoolean("support_enable") || storage.getSettingBoolean("support_tree_enable"))
+    {
+        const coord_t layer_height = mesh_config.inset0_config.getLayerThickness();
+        const coord_t z_distance_top = mesh.getSettingInMicrons("support_top_distance");
+        const size_t z_distance_top_layers = std::max(0U, round_up_divide(z_distance_top, layer_height)) + 1;
+        const int support_layer_nr = layer_nr - z_distance_top_layers;
+        if (support_layer_nr >= 0)
+        {
+            support_layer = &storage.support.supportLayers[support_layer_nr];
+        }
+    }
+
     // calculate bridging angle
     if (layer_nr > 0)
     {
-        bridge = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 1], supportedSkinPartRegions);
+        bridge = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 1], support_layer, supportedSkinPartRegions);
     }
     if (bridge > -1)
     {
@@ -1870,7 +1886,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
         {
             // if this is the second bridge layer use bridge_skin_config2
             Polygons supportedSkinPartRegions2;
-            int bridge2 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 2], supportedSkinPartRegions2);
+            int bridge2 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 2], support_layer, supportedSkinPartRegions2);
             if (bridge2 > -1 || (supportedSkinPartRegions2.area() / (skin_part.outline.area() + 1) < mesh.getSettingInPercentage("bridge_skin_support_threshold") / 100))
             {
                 if (bridge2 > -1)
@@ -1887,7 +1903,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
             {
                 // if this is the third bridge layer, use the same skin_angle as the first
                 Polygons supportedSkinPartRegions3;
-                int bridge3 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 3], supportedSkinPartRegions3);
+                int bridge3 = bridgeAngle(skin_part.outline, &mesh.layers[layer_nr - 3], support_layer, supportedSkinPartRegions3);
                 if (bridge3 > -1)
                 {
                     skin_angle = bridge3;

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -3,7 +3,7 @@
 
 namespace cura {
 
-int bridgeAngle(const Polygons& skin_outline, const SliceLayer* prev_layer, const SupportLayer* support_layer, Polygons& supported_regions, const double support_threshold)
+int bridgeAngle(const Polygons& skin_outline, const SliceDataStorage& storage, const unsigned layer_nr, const SupportLayer* support_layer, Polygons& supported_regions, const double support_threshold)
 {
     AABB boundary_box(skin_outline);
 
@@ -13,14 +13,18 @@ int bridgeAngle(const Polygons& skin_outline, const SliceLayer* prev_layer, cons
 
     Polygons prev_layer_outline; // we also want the complete outline of the previous layer
 
-    for(auto prev_layer_part : prev_layer->parts)
+    // include parts from all meshes
+    for (auto mesh : storage.meshes)
     {
-        prev_layer_outline.add(prev_layer_part.outline); // not intersected with skin
+        for (auto prev_layer_part : mesh.layers[layer_nr].parts)
+        {
+            prev_layer_outline.add(prev_layer_part.outline); // not intersected with skin
 
-        if (!boundary_box.hit(prev_layer_part.boundaryBox))
-            continue;
-        
-        islands.add(skin_outline.intersection(prev_layer_part.outline));
+            if (!boundary_box.hit(prev_layer_part.boundaryBox))
+                continue;
+
+            islands.add(skin_outline.intersection(prev_layer_part.outline));
+        }
     }
     supported_regions = islands;
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -121,6 +121,13 @@ int bridgeAngle(const Polygons& skinOutline, const SliceLayer* prevLayer, const 
         }
     }
 
+    // if the proportion of the skin region that is supported is >= supportThreshold, it's not considered to be a bridge
+
+    if (supportThreshold > 0 && (supportedRegions.area() / (skinOutline.area() + 1)) >= supportThreshold)
+    {
+        return -1;
+    }
+
     if (islands.size() > 5 || islands.size() < 1)
         return -1;
     

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -3,18 +3,24 @@
 
 namespace cura {
 
-int bridgeAngle(Polygons outline, const SliceLayer* prevLayer, const SupportLayer* supportLayer, Polygons& supportedRegions)
+int bridgeAngle(const Polygons& skinOutline, const SliceLayer* prevLayer, const SupportLayer* supportLayer, Polygons& supportedRegions, const double supportThreshold)
 {
-    AABB boundaryBox(outline);
+    AABB boundaryBox(skinOutline);
+
     //To detect if we have a bridge, first calculate the intersection of the current layer with the previous layer.
     // This gives us the islands that the layer rests on.
     Polygons islands;
+
+    Polygons prevLayerOutline; // we also want the complete outline of the previous layer
+
     for(auto prevLayerPart : prevLayer->parts)
     {
+        prevLayerOutline.add(prevLayerPart.outline); // not intersected with skin
+
         if (!boundaryBox.hit(prevLayerPart.boundaryBox))
             continue;
         
-        islands.add(outline.intersection(prevLayerPart.outline));
+        islands.add(skinOutline.intersection(prevLayerPart.outline));
     }
     supportedRegions = islands;
 
@@ -31,7 +37,9 @@ int bridgeAngle(Polygons outline, const SliceLayer* prevLayer, const SupportLaye
             AABB support_roof_bb(supportLayer->support_roof);
             if (boundaryBox.hit(support_roof_bb))
             {
-                Polygons supported_skin(outline.intersection(supportLayer->support_roof));
+                prevLayerOutline.add(supportLayer->support_roof); // not intersected with skin
+
+                Polygons supported_skin(skinOutline.intersection(supportLayer->support_roof));
                 if (!supported_skin.empty())
                 {
                     supportedRegions.add(supported_skin);
@@ -45,13 +53,71 @@ int bridgeAngle(Polygons outline, const SliceLayer* prevLayer, const SupportLaye
                 AABB support_part_bb(support_part.getInfillArea());
                 if (boundaryBox.hit(support_part_bb))
                 {
-                    Polygons supported_skin(outline.intersection(support_part.getInfillArea()));
+                    prevLayerOutline.add(support_part.getInfillArea()); // not intersected with skin
+
+                    Polygons supported_skin(skinOutline.intersection(support_part.getInfillArea()));
                     if (!supported_skin.empty())
                     {
                         supportedRegions.add(supported_skin);
                     }
                 }
             }
+        }
+    }
+
+    // if the proportion of the skin region that is supported is less than supportThreshold, it's considered a bridge and we
+    // determine the best angle for the skin lines - the current heuristic is that the skin lines should be parallel to the
+    // direction of the skin area's longest unsupported edge - if the skin has no unsupported edges, we fall through to the
+    // original code
+
+    if (supportThreshold > 0 && (supportedRegions.area() / (skinOutline.area() + 1)) < supportThreshold)
+    {
+        Polygons bbPoly;
+        bbPoly.add(boundaryBox.toPolygon());
+
+        // airBelow is the region below the skin that is not supported, it extends well past the boundary of the skin.
+        // It needs to be shrunk slightly so that the vertices of the skin polygon that would otherwise fall exactly on
+        // the air boundary do appear to be supported
+
+        const int bbMaxDim = std::max(boundaryBox.max.X - boundaryBox.min.X, boundaryBox.max.Y - boundaryBox.min.Y);
+        const Polygons airBelow(bbPoly.offset(bbMaxDim).difference(prevLayerOutline).offset(-10));
+
+        Polygons skinPerimeterLines;
+        for (ConstPolygonRef poly : skinOutline)
+        {
+            Point p0 = poly[0];
+            for (unsigned i = 1; i < poly.size(); ++i)
+            {
+                Point p1 = poly[i];
+                skinPerimeterLines.addLine(p0, p1);
+                p0 = p1;
+            }
+            skinPerimeterLines.addLine(p0, poly[0]);
+        }
+
+        Polygons skinPerimeterLinesOverAir(airBelow.intersectionPolyLines(skinPerimeterLines));
+
+        if (skinPerimeterLinesOverAir.size())
+        {
+            // one or more edges of the skin region are unsupported, determine the longest
+            double maxDist2 = 0;
+            double lineAngle = -1;
+            for (PolygonRef airLine : skinPerimeterLinesOverAir)
+            {
+                Point p0 = airLine[0];
+                for (unsigned i = 1; i < airLine.size(); ++i)
+                {
+                    const Point& p1(airLine[i]);
+                    double dist2 = vSize2(p0 - p1);
+                    if (dist2 > maxDist2)
+                    {
+                        maxDist2 = dist2;
+                        lineAngle = angle(p0 - p1);
+                    }
+                    p0 = p1;
+                }
+            }
+            return lineAngle;
         }
     }
 

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -8,7 +8,7 @@ namespace cura {
     class Polygons;
     class SliceLayer;
 
-int bridgeAngle(Polygons outline, const SliceLayer* prevLayer, const SupportLayer* supportLayer, Polygons& supportedRegions);
+int bridgeAngle(const Polygons& skinOutline, const SliceLayer* prevLayer, const SupportLayer* supportLayer, Polygons& supportedRegions, const double supportThreshold);
 
 }//namespace cura
 

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -8,7 +8,7 @@ namespace cura {
     class Polygons;
     class SliceLayer;
 
-int bridgeAngle(const Polygons& skinOutline, const SliceLayer* prevLayer, const SupportLayer* supportLayer, Polygons& supportedRegions, const double supportThreshold);
+int bridgeAngle(const Polygons& skin_outline, const SliceLayer* prev_layer, const SupportLayer* support_layer, Polygons& supported_regions, const double support_threshold);
 
 }//namespace cura
 

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -8,7 +8,7 @@ namespace cura {
     class Polygons;
     class SliceLayer;
 
-int bridgeAngle(const Polygons& skin_outline, const SliceLayer* prev_layer, const SupportLayer* support_layer, Polygons& supported_regions, const double support_threshold);
+int bridgeAngle(const Polygons& skin_outline, const SliceDataStorage& storage, const unsigned layer_nr, const SupportLayer* support_layer, Polygons& supported_regions, const double support_threshold);
 
 }//namespace cura
 

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -2,11 +2,13 @@
 #ifndef BRIDGE_H
 #define BRIDGE_H
 
+#include "sliceDataStorage.h"
+
 namespace cura {
     class Polygons;
     class SliceLayer;
 
-int bridgeAngle(Polygons outline, const SliceLayer* prevLayer, Polygons& supportedRegions);
+int bridgeAngle(Polygons outline, const SliceLayer* prevLayer, const SupportLayer* supportLayer, Polygons& supportedRegions);
 
 }//namespace cura
 


### PR DESCRIPTION
This PR incorporates a few improvements to the handling  of bridge skin layers. It doesn't replace the
original code that determines the orientation of the bridge skin layers from the position of the support "islands" but augments it so that it can determine a bridge skin angle in further situations. e.g. when you have a bridge region that is supported on, say, 3 sides but not on the 4th.  Here's an example, the stair tread is supported on 2 sides but not the 3rd. The original bridge code doesn't work in this situation but the code in this PR detects the unsupported edge and orientates the skin lines so that they are parallel to the unsupported edge.

Original bridge skin code:

![screenshot_2018-04-03_08-08-43](https://user-images.githubusercontent.com/585618/38234716-98df5b36-3716-11e8-9d6d-01fd8861e8ab.png)

This PR code:

![screenshot_2018-04-03_08-09-22](https://user-images.githubusercontent.com/585618/38234738-a442de30-3716-11e8-89b4-74d07df5450e.png)

Other changes in this PR are that it expands all of the bridge skin layers by half the width of the inner wall lines so to ensure that the skins have a good chance of attaching to the walls. This can help avoid the situation where the first bridge layer skin lines don't attach to the wall and they curl back.

Also, the orientation of the 2nd and 3rd bridge skins are now +/- 45 degrees to the first skin if there are 3 bridge skins and +90 deg if there's only 2 bridge skins.

Finally, it detects support so that it won't consider a skin that is over support to be a bridge.
