### PR TITLE
Try multiple line widths if that may produce a nicer continuous wall

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -743,7 +743,8 @@ void FffPolygonGenerator::processInsets(const SliceDataStorage& storage, SliceMe
         }
         bool recompute_outline_based_on_outer_wall = (mesh.getSettingBoolean("support_enable") || mesh.getSettingBoolean("support_tree_enable")) && !mesh.getSettingBoolean("fill_outline_gaps");
         bool remove_parts_with_no_insets = !mesh.getSettingBoolean("fill_outline_gaps");
-        WallsComputation walls_computation(mesh.getSettingInMicrons("wall_0_inset"), line_width_0, line_width_x, inset_count, recompute_outline_based_on_outer_wall, remove_parts_with_no_insets);
+        const bool try_line_thickness = mesh.getSettingBoolean("wall_try_line_thickness");
+        WallsComputation walls_computation(mesh.getSettingInMicrons("wall_0_inset"), line_width_0, line_width_x, inset_count, recompute_outline_based_on_outer_wall, remove_parts_with_no_insets, try_line_thickness);
         walls_computation.generateInsets(layer);
     }
     else

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -1,15 +1,18 @@
-/** Copyright (C) 2013 Ultimaker - Released under terms of the AGPLv3 License */
+//Copyright (c) 2018 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
 #include "WallsComputation.h"
 #include "utils/polygonUtils.h"
 namespace cura {
 
-WallsComputation::WallsComputation(int wall_0_inset, int line_width_0, int line_width_x, int insetCount, bool recompute_outline_based_on_outer_wall, bool remove_parts_with_no_insets)
+WallsComputation::WallsComputation(int wall_0_inset, int line_width_0, int line_width_x, int insetCount, bool recompute_outline_based_on_outer_wall, bool remove_parts_with_no_insets, const bool try_line_thickness)
 : wall_0_inset(wall_0_inset)
 , line_width_0(line_width_0)
 , line_width_x(line_width_x)
 , insetCount(insetCount)
 , recompute_outline_based_on_outer_wall(recompute_outline_based_on_outer_wall)
 , remove_parts_with_no_insets(remove_parts_with_no_insets)
+, try_line_thickness(try_line_thickness)
 {
 }
 
@@ -34,12 +37,41 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
         if (i == 0)
         {
             part->insets[0] = part->outline.offset(-line_width_0 / 2 - wall_0_inset);
-        } else if (i == 1)
+        }
+        else if (i == 1)
         {
             part->insets[1] = part->insets[0].offset(-line_width_0 / 2 + wall_0_inset - line_width_x / 2);
-        } else
+        }
+        else
         {
-            part->insets[i] = part->insets[i-1].offset(-line_width_x);
+            part->insets[i] = part->insets[i - 1].offset(-line_width_x);
+        }
+
+        const size_t inset_part_count = part->insets[i].size();
+        constexpr size_t minimum_part_saving = 3; //Only try if the part has more pieces than the previous inset and saves at least this many parts.
+        constexpr coord_t try_smaller = 10; //How many micrometres to inset with the try with a smaller inset.
+        if (try_line_thickness && inset_part_count > minimum_part_saving + 1 && (i == 0 || (i > 0 && inset_part_count > part->insets[i - 1].size() + minimum_part_saving)))
+        {
+            //Try a different line thickness and see if this fits better, based on these criteria:
+            // - There are fewer parts to the polygon (fits better in slim areas).
+            // - The polygon area is largely unaffected.
+            Polygons alternative_inset;
+            if (i == 0)
+            {
+                alternative_inset = part->outline.offset(-(line_width_0 - try_smaller) / 2 - wall_0_inset);
+            }
+            else if (i == 1)
+            {
+                alternative_inset = part->outline.offset(-(line_width_0 - try_smaller) / 2 + wall_0_inset - line_width_x / 2);
+            }
+            else
+            {
+                alternative_inset = part->insets[i - 1].offset(-(line_width_x - try_smaller));
+            }
+            if (alternative_inset.size() < inset_part_count - minimum_part_saving) //Significantly fewer parts (saves more than 3 parts).
+            {
+                part->insets[i] = alternative_inset;
+            }
         }
 
         //Finally optimize all the polygons. Every point removed saves time in the long run.

--- a/src/WallsComputation.h
+++ b/src/WallsComputation.h
@@ -1,4 +1,6 @@
-/** Copyright (C) 2013 Ultimaker - Released under terms of the AGPLv3 License */
+//Copyright (c) 2018 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
 #ifndef WALLS_COMPUTATION_H
 #define WALLS_COMPUTATION_H
 
@@ -33,26 +35,42 @@ public:
      * Whether to compute a more accurate poly representation of the printed outlines, based on the outer wall
      */
     bool recompute_outline_based_on_outer_wall;
-    bool remove_parts_with_no_insets; // Whether to remove parts which have no insets.
 
     /*!
-     * Basic constructor initializing the parameters with which to perform the walls computation
-     * 
-     * \param wall_0_inset The offset applied to the outer wall
-     * \param line_width_0 line width of the outer wall
-     * \param line_width_x line width of other walls
-     * \param insetCount The number of insets to to generate
-     * \param recompute_outline_based_on_outer_wall Whether to compute a more accurate poly representation of the printed outlines, based on the outer wall
-     * \param remove_parts_with_no_insets Whether to remove parts if they get no single inset
+     * Whether to remove parts which have no insets.
      */
-    WallsComputation(int wall_0_inset, int line_width_0, int line_width_x, int insetCount, bool recompute_outline_based_on_outer_wall, bool remove_parts_with_no_insets);
+    bool remove_parts_with_no_insets;
+
+    /*!
+     * Whether or not to try multiple line widths to get a better fit of the
+     * line in the allotted space.
+     */
+    bool try_line_thickness;
+
+    /*!
+     * Basic constructor initializing the parameters with which to perform the
+     * walls computation.
+     * 
+     * \param wall_0_inset The offset applied to the outer wall.
+     * \param line_width_0 Line width of the outer wall.
+     * \param line_width_x Line width of other walls.
+     * \param insetCount The number of insets to to generate.
+     * \param recompute_outline_based_on_outer_wall Whether to compute a more
+     * accurate poly representation of the printed outlines, based on the outer
+     * wall.
+     * \param remove_parts_with_no_insets Whether to remove parts if they get no
+     * single inset.
+     * \param try_line_thickness Whether to try reducing line thickness if that
+     * would make a line fit better in the space.
+     */
+    WallsComputation(int wall_0_inset, int line_width_0, int line_width_x, int insetCount, bool recompute_outline_based_on_outer_wall, bool remove_parts_with_no_insets, bool try_line_thickness);
 
     /*!
      * Generates the insets / perimeters for all parts in a layer.
      * 
      * Note that the second inset gets offsetted by WallsComputation::line_width_0 instead of the first, 
      * which leads to better results for a smaller WallsComputation::line_width_0 than WallsComputation::line_width_x and when printing the outer wall last.
-     * 
+     *
      * \param layer The layer for which to generate the insets.
      */ 
     void generateInsets(SliceLayer* layer);
@@ -60,7 +78,7 @@ public:
 private:
     /*!
      * Generates the insets / perimeters for a single layer part.
-     * 
+     *
      * \param part The part for which to generate the insets.
      */
     void generateInsets(SliceLayerPart* part);


### PR DESCRIPTION
Walls may get fractured in some cases. This is supposed to fix it by also trying a 0.01mm slimmer wall. It only tries though if the wall has 3 parts more than the previous (surrounding) wall or if it's the outer wall and it has 3 parts. If so, it will try a different line width.

This currently introduces a setting to allow us to test safely. If this works well, we'll remove the setting. If this doesn't work well because of performance impact, we'll remove the setting and the implementation.

Implements CURA-5189.