### PR TITLE
Fix z-seam quality regression caused by recent commit.

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -54,6 +54,14 @@ void InsetOrderOptimizer::moveInside()
 
 void InsetOrderOptimizer::processHoleInsets()
 {
+    if (inset_polys[0].size() < 2)
+    {
+        // part has no holes - the code below has a problem in that it causes the z-seams not
+        // to be aligned in the specific situation where infill was being printed before walls, the
+        // inner walls were printed before the outer and the part has no holes!
+        return;
+    }
+
     const coord_t wall_line_width_0 = mesh_config.inset0_config.getLineWidth();
     const coord_t wall_line_width_x = mesh_config.insetX_config.getLineWidth();
     const coord_t max_gap = std::max(wall_line_width_0, wall_line_width_x) * 1.1f; // if polys are closer than this, they are considered adjacent
@@ -552,9 +560,9 @@ bool InsetOrderOptimizer::optimizingInsetsIsWorthwhile(const SliceMeshStorage& m
         // optimization disabled
         return false;
     }
-    if (part.insets.size() < 2 || part.insets[0].size() < 2)
+    if (part.insets.size() < 2 && part.insets[0].size() < 2)
     {
-        // only a single outline or no holes, not worth optimizing as the original inset processing code now aligns the z-seams of the outside walls
+        // only a single outline and no holes, definitely not worth optimizing
         return false;
     }
     // optimize all other combinations of walls and holes


### PR DESCRIPTION
Commit 7502d9908 fixed a problem that the optimizer would not align the z-seams correctly
in the specific situation where infill is printed before walls, the inner walls are
printed before the outer and the part has no holes.

That commit simply avoided using the optimizer when the part had no holes. Unfortunately,
that leads to more visible z-seams as the non-optimizing wall printing code doesn't try
to avoid retracting on the outer wall which the optimizer does. Therefore, this commit
reinstates using the optimizer when the part has no holes so the z-seam will be better
hidden again but it also avoids the previous problem by not executing the code that
fails when there are no holes.