### PR TITLE
Fix recent regression in getLayerOutlines().

### DIFF
--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -365,7 +365,7 @@ Polygons SliceDataStorage::getLayerOutlines(int layer_nr, bool include_helper_pa
                 total.add(primeTower.inner_poly);
             }
         }
-        total.simplify(maximum_resolution * maximum_resolution, maximum_resolution * maximum_resolution);
+        total.simplify(maximum_resolution, maximum_resolution);
         return total;
     }
 }


### PR DESCRIPTION
Commit 246ed65c3733dc709 passed squared values to Polygons.simplify() but the args should not
have been squared.

Hi @Ghostkeeper , I realise you are very busy so I fixed your bug for you!