### PR TITLE
CURA-5182 Feature better combing

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -564,7 +564,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             fan_speed_layer_time_settings.cool_fan_speed_0 = regular_fan_speed; // ignore initial layer fan speed stuff
         }
 
-        LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_height, extruder_nr, fan_speed_layer_time_settings_per_extruder_raft_base, combing_mode, comb_offset, train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
+        LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_height, extruder_nr, fan_speed_layer_time_settings_per_extruder_raft_base, combing_mode, comb_offset, train->getSettingInMicrons("line_width"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
         gcode_layer.setIsInside(true);
 
         gcode_layer.setExtruder(extruder_nr);
@@ -625,7 +625,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             fan_speed_layer_time_settings.cool_fan_speed_0 = regular_fan_speed; // ignore initial layer fan speed stuff
         }
 
-        LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_height, current_extruder_nr, fan_speed_layer_time_settings_per_extruder_raft_interface, combing_mode, comb_offset, train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
+        LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_height, current_extruder_nr, fan_speed_layer_time_settings_per_extruder_raft_interface, combing_mode, comb_offset, train->getSettingInMicrons("line_width"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
         gcode_layer.setIsInside(true);
 
         gcode_layer.setExtruder(extruder_nr); // reset to extruder number, because we might have primed in the last layer
@@ -680,7 +680,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             fan_speed_layer_time_settings.cool_fan_speed_0 = regular_fan_speed; // ignore initial layer fan speed stuff
         }
 
-        LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_height, extruder_nr, fan_speed_layer_time_settings_per_extruder_raft_surface, combing_mode, comb_offset, train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
+        LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_height, extruder_nr, fan_speed_layer_time_settings_per_extruder_raft_surface, combing_mode, comb_offset, train->getSettingInMicrons("line_width"), train->getSettingBoolean("travel_avoid_other_parts"), train->getSettingInMicrons("travel_avoid_distance"));
         gcode_layer.setIsInside(true);
 
         // make sure that we are using the correct extruder to print raft
@@ -773,6 +773,7 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, int lay
 
     bool avoid_other_parts = false;
     coord_t avoid_distance = 0; // minimal avoid distance is zero
+    coord_t line_width = 0;
     const std::vector<bool> extruder_is_used = storage.getExtrudersUsed();
     for (int extr_nr = 0; extr_nr < storage.meshgroup->getExtruderCount(); extr_nr++)
     {
@@ -785,6 +786,7 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, int lay
                 avoid_other_parts = true;
                 avoid_distance = std::max(avoid_distance, extr->getSettingInMicrons("travel_avoid_distance"));
             }
+            line_width = extr->getSettingInMicrons("line_width");
         }
     }
 
@@ -807,7 +809,7 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, int lay
         :
         extruder_order_per_layer[layer_nr];
 
-    LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_thickness, extruder_order.front(), fan_speed_layer_time_settings_per_extruder, getSettingAsCombingMode("retraction_combing"), comb_offset_from_outlines, avoid_other_parts, avoid_distance);
+    LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_thickness, extruder_order.front(), fan_speed_layer_time_settings_per_extruder, getSettingAsCombingMode("retraction_combing"), comb_offset_from_outlines, line_width, avoid_other_parts, avoid_distance);
 
     if (include_helper_parts && layer_nr == 0)
     { // process the skirt or the brim of the starting extruder.

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -72,7 +72,7 @@ void LayerPlan::forceNewPathStart()
         paths[paths.size()-1].done = true;
 }
 
-LayerPlan::LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int layer_thickness, unsigned int start_extruder, const std::vector<FanSpeedLayerTimeSettings>& fan_speed_layer_time_settings_per_extruder, CombingMode combing_mode, int64_t comb_boundary_offset, bool travel_avoid_other_parts, int64_t travel_avoid_distance)
+LayerPlan::LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int layer_thickness, unsigned int start_extruder, const std::vector<FanSpeedLayerTimeSettings>& fan_speed_layer_time_settings_per_extruder, CombingMode combing_mode, int64_t comb_boundary_offset, coord_t comb_move_inside_distance, bool travel_avoid_other_parts, int64_t travel_avoid_distance)
 : storage(storage)
 , configs_storage(storage, layer_nr, layer_thickness)
 , z(z)
@@ -86,6 +86,7 @@ LayerPlan::LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int l
 , first_travel_destination_is_inside(false) // set properly when addTravel is called for the first time (otherwise not set properly)
 , comb_boundary_inside1(computeCombBoundaryInside(combing_mode, 1))
 , comb_boundary_inside2(computeCombBoundaryInside(combing_mode, 2))
+, comb_move_inside_distance(comb_move_inside_distance)
 , fan_speed_layer_time_settings_per_extruder(fan_speed_layer_time_settings_per_extruder)
 {
     int current_extruder = start_extruder;
@@ -94,7 +95,7 @@ LayerPlan::LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int l
     is_inside = false; // assumes the next move will not be to inside a layer part (overwritten just before going into a layer part)
     if (combing_mode != CombingMode::OFF)
     {
-        comb = new Comb(storage, layer_nr, comb_boundary_inside1, comb_boundary_inside2, comb_boundary_offset, travel_avoid_other_parts, travel_avoid_distance);
+        comb = new Comb(storage, layer_nr, comb_boundary_inside1, comb_boundary_inside2, comb_boundary_offset, travel_avoid_other_parts, travel_avoid_distance, comb_move_inside_distance);
     }
     else
     {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -84,7 +84,8 @@ LayerPlan::LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int l
 , last_extruder_previous_layer(start_extruder)
 , last_planned_extruder_setting_base(storage.meshgroup->getExtruderTrain(start_extruder))
 , first_travel_destination_is_inside(false) // set properly when addTravel is called for the first time (otherwise not set properly)
-, comb_boundary_inside(computeCombBoundaryInside(combing_mode))
+, comb_boundary_inside1(computeCombBoundaryInside(combing_mode, 1))
+, comb_boundary_inside2(computeCombBoundaryInside(combing_mode, 2))
 , fan_speed_layer_time_settings_per_extruder(fan_speed_layer_time_settings_per_extruder)
 {
     int current_extruder = start_extruder;
@@ -93,7 +94,7 @@ LayerPlan::LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int l
     is_inside = false; // assumes the next move will not be to inside a layer part (overwritten just before going into a layer part)
     if (combing_mode != CombingMode::OFF)
     {
-        comb = new Comb(storage, layer_nr, comb_boundary_inside, comb_boundary_offset, travel_avoid_other_parts, travel_avoid_distance);
+        comb = new Comb(storage, layer_nr, comb_boundary_inside1, comb_boundary_inside2, comb_boundary_offset, travel_avoid_other_parts, travel_avoid_distance);
     }
     else
     {
@@ -125,7 +126,7 @@ SettingsBaseVirtual* LayerPlan::getLastPlannedExtruderTrainSettings()
 }
 
 
-Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode)
+Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode, int max_inset)
 {
     if (combing_mode == CombingMode::OFF)
     {
@@ -160,7 +161,7 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode)
             }
             else
             {
-                layer.getSecondOrInnermostWalls(comb_boundary);
+                layer.getInnermostWalls(comb_boundary, max_inset);
             }
         }
         return comb_boundary;
@@ -230,11 +231,11 @@ void LayerPlan::moveInsideCombBoundary(int distance)
     int max_dist2 = MM2INT(2.0) * MM2INT(2.0); // if we are further than this distance, we conclude we are not inside even though we thought we were.
     // this function is to be used to move from the boudary of a part to inside the part
     Point p = getLastPlannedPositionOrStartingPosition(); // copy, since we are going to move p
-    if (PolygonUtils::moveInside(comb_boundary_inside, p, distance, max_dist2) != NO_INDEX)
+    if (PolygonUtils::moveInside(comb_boundary_inside2, p, distance, max_dist2) != NO_INDEX)
     {
         //Move inside again, so we move out of tight 90deg corners
-        PolygonUtils::moveInside(comb_boundary_inside, p, distance, max_dist2);
-        if (comb_boundary_inside.inside(p))
+        PolygonUtils::moveInside(comb_boundary_inside2, p, distance, max_dist2);
+        if (comb_boundary_inside2.inside(p))
         {
             addTravel_simple(p);
             //Make sure the that any retraction happens after this move, not before it by starting a new move path.
@@ -815,7 +816,7 @@ void LayerPlan::addWalls(const Polygons& walls, const GCodePathConfig& non_bridg
 void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location)
 {
     Polygons boundary;
-    if (enable_travel_optimization && comb_boundary_inside.size() > 0)
+    if (enable_travel_optimization && comb_boundary_inside2.size() > 0)
     {
         // use the combing boundary inflated so that all infill lines are inside the boundary
         int dist = 0;
@@ -832,7 +833,7 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathCon
             }
             dist += 100; // ensure boundary is slightly outside all skin/infill lines
         }
-        boundary.add(comb_boundary_inside.offset(dist));
+        boundary.add(comb_boundary_inside2.offset(dist));
         // simplify boundary to cut down processing time
         boundary.simplify(100, 100);
     }

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -263,7 +263,8 @@ private:
     bool first_travel_destination_is_inside; //!< Whether the destination of the first planned travel move is inside a layer part
     bool was_inside; //!< Whether the last planned (extrusion) move was inside a layer part
     bool is_inside; //!< Whether the destination of the next planned travel move is inside a layer part
-    Polygons comb_boundary_inside; //!< The boundary within which to comb, or to move into when performing a retraction.
+    Polygons comb_boundary_inside1; //!< The minimum boundary within which to comb, or to move into when performing a retraction.
+    Polygons comb_boundary_inside2; //!< The boundary preferably within which to comb, or to move into when performing a retraction.
     Comb* comb;
     Polygons bridge_wall_mask; //!< The regions of a layer part that are not supported, used for bridging
 
@@ -317,7 +318,7 @@ public:
 
     const Polygons* getCombBoundaryInside() const
     {
-        return &comb_boundary_inside;
+        return &comb_boundary_inside2;
     }
 
 private:
@@ -326,7 +327,7 @@ private:
      * \param combing_mode Whether combing is enabled and full or within infill only.
      * \return the comb_boundary_inside
      */
-    Polygons computeCombBoundaryInside(CombingMode combing_mode);
+    Polygons computeCombBoundaryInside(CombingMode combing_mode, int max_inset);
 
 public:
     int getLayerNr() const

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -266,10 +266,11 @@ private:
     Polygons comb_boundary_inside1; //!< The minimum boundary within which to comb, or to move into when performing a retraction.
     Polygons comb_boundary_inside2; //!< The boundary preferably within which to comb, or to move into when performing a retraction.
     Comb* comb;
+    coord_t comb_move_inside_distance;  //!< Whenever using the minimum boundary for combing it tries to move the coordinates inside by this distance after calculating the combing.
     Polygons bridge_wall_mask; //!< The regions of a layer part that are not supported, used for bridging
 
     const std::vector<FanSpeedLayerTimeSettings> fan_speed_layer_time_settings_per_extruder;
-    
+
 private:
     /*!
      * Either create a new path with the given config or return the last path if it already had that config.
@@ -306,7 +307,7 @@ public:
      * \param last_position The position of the head at the start of this gcode layer
      * \param combing_mode Whether combing is enabled and full or within infill only.
      */
-    LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int layer_height, unsigned int start_extruder, const std::vector<FanSpeedLayerTimeSettings>& fan_speed_layer_time_settings_per_extruder, CombingMode combing_mode, int64_t comb_boundary_offset, bool travel_avoid_other_parts, int64_t travel_avoid_distance);
+    LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int layer_height, unsigned int start_extruder, const std::vector<FanSpeedLayerTimeSettings>& fan_speed_layer_time_settings_per_extruder, CombingMode combing_mode, int64_t comb_boundary_offset, coord_t comb_move_inside_distance, bool travel_avoid_other_parts, int64_t travel_avoid_distance);
     ~LayerPlan();
 
     void overrideFanSpeeds(double speed);

--- a/src/infill/SubDivCube.cpp
+++ b/src/infill/SubDivCube.cpp
@@ -227,7 +227,7 @@ int SubDivCube::distanceFromPointToMesh(SliceMeshStorage& mesh, int layer_nr, Po
         *distance2 = 0;
     }
     Polygons collide;
-    mesh.layers[layer_nr].getSecondOrInnermostWalls(collide);
+    mesh.layers[layer_nr].getInnermostWalls(collide, 2);
     Point centerpoint = location;
     bool inside = collide.inside(centerpoint);
     ClosestPolygonPoint border_point = PolygonUtils::moveInside2(collide, centerpoint);

--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -74,24 +74,24 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool _st
         return true;
     }
 
-    //Move start and end point inside the comb boundary
+    //Move start and end point inside the optimal comb boundary
     unsigned int start_inside_poly = NO_INDEX;
-    const bool startInside = moveInside(boundary_inside_optimal, _startInside, startPoint, start_inside_poly, inside_loc_to_line_optimal);
+    const bool startInside = moveInside(boundary_inside_optimal, _startInside, inside_loc_to_line_optimal, startPoint, start_inside_poly);
 
     unsigned int end_inside_poly = NO_INDEX;
-    const bool endInside = moveInside(boundary_inside_optimal, _endInside, endPoint, end_inside_poly, inside_loc_to_line_optimal);
+    const bool endInside = moveInside(boundary_inside_optimal, _endInside, inside_loc_to_line_optimal, endPoint, end_inside_poly);
 
     unsigned int start_part_boundary_poly_idx;
     unsigned int end_part_boundary_poly_idx;
     unsigned int start_part_idx =   (start_inside_poly == NO_INDEX)?    NO_INDEX : partsView_inside_optimal.getPartContaining(start_inside_poly, &start_part_boundary_poly_idx);
     unsigned int end_part_idx =     (end_inside_poly == NO_INDEX)?      NO_INDEX : partsView_inside_optimal.getPartContaining(end_inside_poly, &end_part_boundary_poly_idx);
 
-    //Move start and end point inside the comb boundary
+    //Move start and end point inside the minimum comb boundary
     unsigned int start_inside_poly_min = NO_INDEX;
-    const bool startInsideMin = moveInside(boundary_inside_minimum, _startInside, startPoint, start_inside_poly_min, inside_loc_to_line_minimum);
+    const bool startInsideMin = moveInside(boundary_inside_minimum, _startInside, inside_loc_to_line_minimum, startPoint, start_inside_poly_min);
 
     unsigned int end_inside_poly_min = NO_INDEX;
-    const bool endInsideMin = moveInside(boundary_inside_minimum, _endInside, endPoint, end_inside_poly_min, inside_loc_to_line_minimum);
+    const bool endInsideMin = moveInside(boundary_inside_minimum, _endInside, inside_loc_to_line_minimum, endPoint, end_inside_poly_min);
 
     unsigned int start_part_boundary_poly_idx_min;
     unsigned int end_part_boundary_poly_idx_min;
@@ -105,7 +105,7 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool _st
         return LinePolygonsCrossings::comb(part, *inside_loc_to_line_optimal, startPoint, endPoint, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
     }
     else if (startInsideMin && endInsideMin && start_part_idx_min == end_part_idx_min)
-    { // normal combing within part
+    { // normal combing within part using minimum comb boundary
         PolygonsPart part = partsView_inside_minimum.assemblePart(start_part_idx_min);
         combPaths.emplace_back();
         return LinePolygonsCrossings::comb(part, *inside_loc_to_line_minimum, startPoint, endPoint, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
@@ -243,7 +243,7 @@ Comb::Crossing::Crossing(const Point& dest_point, const bool dest_is_inside, con
     }
 }
 
-bool Comb::moveInside(Polygons& boundary_inside, bool is_inside, Point& dest_point, unsigned int& inside_poly, LocToLineGrid* inside_loc_to_line)
+bool Comb::moveInside(Polygons& boundary_inside, bool is_inside, LocToLineGrid* inside_loc_to_line, Point& dest_point, unsigned int& inside_poly)
 {
     if (is_inside)
     {

--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -23,7 +23,7 @@ Polygons& Comb::getBoundaryOutside()
     return *boundary_outside;
 }
   
-Comb::Comb(const SliceDataStorage& storage, int layer_nr, const Polygons& comb_boundary_inside_minimum, const Polygons& comb_boundary_inside_optimal, coord_t comb_boundary_offset, bool travel_avoid_other_parts, coord_t travel_avoid_distance)
+Comb::Comb(const SliceDataStorage& storage, int layer_nr, const Polygons& comb_boundary_inside_minimum, const Polygons& comb_boundary_inside_optimal, coord_t comb_boundary_offset, bool travel_avoid_other_parts, coord_t travel_avoid_distance, coord_t move_inside_distance)
 : storage(storage)
 , layer_nr(layer_nr)
 , offset_from_outlines(comb_boundary_offset) // between second wall and infill / other walls
@@ -52,6 +52,7 @@ Comb::Comb(const SliceDataStorage& storage, int layer_nr, const Polygons& comb_b
         , this
         , offset_from_inside_to_outside
     )
+, move_inside_distance(move_inside_distance)
 {
 }
 
@@ -113,7 +114,6 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool _st
         combPaths.emplace_back();
         CombPath path;
         bool result;
-        //LinePolygonsCrossings::comb(part, *inside_loc_to_line_minimum, startPoint, endPoint, combPaths.back(), -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
         result = LinePolygonsCrossings::comb(part, *inside_loc_to_line_minimum, startPoint, endPoint, path, -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
         Comb::moveCombPathInside(boundary_inside_minimum, boundary_inside_optimal, inside_loc_to_line_minimum, path, combPaths.back());
         return result;
@@ -239,7 +239,7 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool _st
 
 void Comb::moveCombPathInside(Polygons& boundary_inside, Polygons& boundary_inside_optimal, LocToLineGrid* inside_loc_to_line, CombPath& comb_path_input, CombPath& comb_path_output)
 {
-    int dist = MM2INT(0.5);
+    int dist = move_inside_distance;
     int dist2 = dist * dist;
 
     if (comb_path_input.size() == 0)

--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -107,16 +107,18 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool _st
     unsigned int start_part_idx_min =   (start_inside_poly_min == NO_INDEX)?    NO_INDEX : partsView_inside_minimum.getPartContaining(start_inside_poly_min, &start_part_boundary_poly_idx_min);
     unsigned int end_part_idx_min =     (end_inside_poly_min == NO_INDEX)?      NO_INDEX : partsView_inside_minimum.getPartContaining(end_inside_poly_min, &end_part_boundary_poly_idx_min);
 
+    CombPath result_path;
+    bool comb_result;
+
     // normal combing within part using minimum comb boundary
     if (startInsideMin && endInsideMin && start_part_idx_min == end_part_idx_min)
     {
         PolygonsPart part = partsView_inside_minimum.assemblePart(start_part_idx_min);
         combPaths.emplace_back();
-        CombPath path;
-        bool result;
-        result = LinePolygonsCrossings::comb(part, *inside_loc_to_line_minimum, startPoint, endPoint, path, -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
-        Comb::moveCombPathInside(boundary_inside_minimum, boundary_inside_optimal, inside_loc_to_line_minimum, path, combPaths.back());
-        return result;
+
+        comb_result = LinePolygonsCrossings::comb(part, *inside_loc_to_line_minimum, startPoint, endPoint, result_path, -offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
+        Comb::moveCombPathInside(boundary_inside_minimum, boundary_inside_optimal, inside_loc_to_line_minimum, result_path, combPaths.back());  // add altered result_path to combPaths.back()
+        return comb_result;
     }
 
     // comb inside part to edge (if needed) >> move through air avoiding other parts >> comb inside end part upto the endpoint (if needed)
@@ -237,6 +239,7 @@ bool Comb::calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool _st
     return true;
 }
 
+//  Try to move comb_path_input points inside by the amount of `move_inside_distance` and see if the points are still in boundary_inside_optimal, add result in comp_path_output
 void Comb::moveCombPathInside(Polygons& boundary_inside, Polygons& boundary_inside_optimal, LocToLineGrid* inside_loc_to_line, CombPath& comb_path_input, CombPath& comb_path_output)
 {
     int dist = move_inside_distance;

--- a/src/pathPlanning/Comb.h
+++ b/src/pathPlanning/Comb.h
@@ -115,8 +115,8 @@ private:
 
     const bool avoid_other_parts; //!< Whether to perform inverse combing a.k.a. avoid parts.
     
-    Polygons boundary_inside_minimum; //!< The boundary within which to comb. (Will be reordered by the partsView_inside)
-    Polygons boundary_inside_optimal; //!< The boundary within which to comb. (Will be reordered by the partsView_inside)
+    Polygons boundary_inside_minimum; //!< The boundary within which to comb. (Will be reordered by the partsView_inside_minimum)
+    Polygons boundary_inside_optimal; //!< The boundary within which to comb. (Will be reordered by the partsView_inside_optimal)
     const PartsView partsView_inside_minimum; //!< Structured indices onto boundary_inside_minimum which shows which polygons belong to which part.
     const PartsView partsView_inside_optimal; //!< Structured indices onto boundary_inside_optimal which shows which polygons belong to which part.
     LocToLineGrid* inside_loc_to_line_minimum; //!< The SparsePointGridInclusive mapping locations to line segments of the inner boundary.
@@ -143,6 +143,8 @@ private:
      * \return Whether we have moved the point inside
      */
     bool moveInside(Polygons& boundary_inside, bool is_inside, LocToLineGrid* inside_loc_to_line, Point& dest_point, unsigned int& start_inside_poly);
+
+    void moveCombPathInside(Polygons& boundary_inside, Polygons& boundary_inside_optimal, LocToLineGrid* inside_loc_to_line, CombPath& comb_path_input, CombPath& comb_path_output);
 
 public:
     /*!

--- a/src/pathPlanning/Comb.h
+++ b/src/pathPlanning/Comb.h
@@ -115,9 +115,12 @@ private:
 
     const bool avoid_other_parts; //!< Whether to perform inverse combing a.k.a. avoid parts.
     
-    Polygons boundary_inside; //!< The boundary within which to comb. (Will be reordered by the partsView_inside)
-    const PartsView partsView_inside; //!< Structured indices onto boundary_inside which shows which polygons belong to which part. 
-    LocToLineGrid* inside_loc_to_line; //!< The SparsePointGridInclusive mapping locations to line segments of the inner boundary.
+    Polygons boundary_inside_minimum; //!< The boundary within which to comb. (Will be reordered by the partsView_inside)
+    Polygons boundary_inside_optimal; //!< The boundary within which to comb. (Will be reordered by the partsView_inside)
+    const PartsView partsView_inside_minimum; //!< Structured indices onto boundary_inside_minimum which shows which polygons belong to which part.
+    const PartsView partsView_inside_optimal; //!< Structured indices onto boundary_inside_optimal which shows which polygons belong to which part.
+    LocToLineGrid* inside_loc_to_line_minimum; //!< The SparsePointGridInclusive mapping locations to line segments of the inner boundary.
+    LocToLineGrid* inside_loc_to_line_optimal; //!< The SparsePointGridInclusive mapping locations to line segments of the inner boundary.
     LazyInitialization<Polygons> boundary_outside; //!< The boundary outside of which to stay to avoid collision with other layer parts. This is a pointer cause we only compute it when we move outside the boundary (so not when there is only a single part in the layer)
     LazyInitialization<LocToLineGrid, Comb*, const int64_t> outside_loc_to_line; //!< The SparsePointGridInclusive mapping locations to line segments of the outside boundary.
 
@@ -138,7 +141,7 @@ private:
      * \param start_inside_poly[out] The polygon in which the point has been moved
      * \return Whether we have moved the point inside
      */
-    bool moveInside(bool is_inside, Point& dest_point, unsigned int& start_inside_poly);
+    bool moveInside(Polygons& boundary_inside, bool is_inside, Point& dest_point, unsigned int& start_inside_poly, LocToLineGrid* inside_loc_to_line);
 
 public:
     /*!
@@ -148,12 +151,13 @@ public:
      * 
      * \param storage Where the layer polygon data is stored
      * \param layer_nr The number of the layer for which to generate the combing areas.
-     * \param comb_boundary_inside The comb boundary within which to comb within layer parts.
+     * \param comb_boundary_inside_optimal The better comb boundary within which to comb within layer parts.
+     * \param comb_boundary_inside_fallback The minimum comb boundary within which to comb within layer parts.
      * \param offset_from_outlines The offset from the outline polygon, to create the combing boundary in case there is no second wall.
      * \param travel_avoid_other_parts Whether to avoid other layer parts when traveling through air.
      * \param travel_avoid_distance The distance by which to avoid other layer parts when traveling through air.
      */
-    Comb(const SliceDataStorage& storage, int layer_nr, const Polygons& comb_boundary_inside, int64_t offset_from_outlines, bool travel_avoid_other_parts, int64_t travel_avoid_distance);
+    Comb(const SliceDataStorage& storage, int layer_nr, const Polygons& comb_boundary_inside_minimum, const Polygons& comb_boundary_inside_optimal, coord_t offset_from_outlines, bool travel_avoid_other_parts, coord_t travel_avoid_distance);
 
     ~Comb();
 
@@ -171,7 +175,7 @@ public:
      * \param fail_on_unavoidable_obstacles When moving over other parts is inavoidable, stop calculation early and return false.
      * \return Whether combing has succeeded; otherwise a retraction is needed.
      */
-    bool calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool startInside, bool endInside, int64_t max_comb_distance_ignored, bool via_outside_makes_combing_fail, bool fail_on_unavoidable_obstacles);
+    bool calc(Point startPoint, Point endPoint, CombPaths& combPaths, bool startInside, bool endInside, coord_t max_comb_distance_ignored, bool via_outside_makes_combing_fail, bool fail_on_unavoidable_obstacles);
 };
 
 }//namespace cura

--- a/src/pathPlanning/Comb.h
+++ b/src/pathPlanning/Comb.h
@@ -137,11 +137,12 @@ private:
     /*!
      * Move the startPoint or endPoint inside when it should be inside
      * \param is_inside[in] Whether the \p dest_point should be inside
+     * \param inside_loc_to_line[in] A SparseGrid mapping locations to line segments of \p polygons
      * \param dest_point[in,out] The point to move
      * \param start_inside_poly[out] The polygon in which the point has been moved
      * \return Whether we have moved the point inside
      */
-    bool moveInside(Polygons& boundary_inside, bool is_inside, Point& dest_point, unsigned int& start_inside_poly, LocToLineGrid* inside_loc_to_line);
+    bool moveInside(Polygons& boundary_inside, bool is_inside, LocToLineGrid* inside_loc_to_line, Point& dest_point, unsigned int& start_inside_poly);
 
 public:
     /*!

--- a/src/pathPlanning/Comb.h
+++ b/src/pathPlanning/Comb.h
@@ -123,6 +123,7 @@ private:
     LocToLineGrid* inside_loc_to_line_optimal; //!< The SparsePointGridInclusive mapping locations to line segments of the inner boundary.
     LazyInitialization<Polygons> boundary_outside; //!< The boundary outside of which to stay to avoid collision with other layer parts. This is a pointer cause we only compute it when we move outside the boundary (so not when there is only a single part in the layer)
     LazyInitialization<LocToLineGrid, Comb*, const int64_t> outside_loc_to_line; //!< The SparsePointGridInclusive mapping locations to line segments of the outside boundary.
+    coord_t move_inside_distance; //!< When using comb_boundary_inside_minimum for combing it tries to move points inside by this amount after calculating the path to move it from the border a bit.
 
     /*!
      * Get the SparsePointGridInclusive mapping locations to line segments of the outside boundary. Calculate it when it hasn't been calculated yet.
@@ -155,12 +156,13 @@ public:
      * \param storage Where the layer polygon data is stored
      * \param layer_nr The number of the layer for which to generate the combing areas.
      * \param comb_boundary_inside_optimal The better comb boundary within which to comb within layer parts.
-     * \param comb_boundary_inside_fallback The minimum comb boundary within which to comb within layer parts.
+     * \param comb_boundary_inside_minimum The minimum comb boundary within which to comb within layer parts.
      * \param offset_from_outlines The offset from the outline polygon, to create the combing boundary in case there is no second wall.
      * \param travel_avoid_other_parts Whether to avoid other layer parts when traveling through air.
      * \param travel_avoid_distance The distance by which to avoid other layer parts when traveling through air.
+     * \param move_inside_distance When using comb_boundary_inside_minimum for combing it tries to move points inside by this amount after calculating the path to move it from the border a bit.
      */
-    Comb(const SliceDataStorage& storage, int layer_nr, const Polygons& comb_boundary_inside_minimum, const Polygons& comb_boundary_inside_optimal, coord_t offset_from_outlines, bool travel_avoid_other_parts, coord_t travel_avoid_distance);
+    Comb(const SliceDataStorage& storage, int layer_nr, const Polygons& comb_boundary_inside_minimum, const Polygons& comb_boundary_inside_optimal, coord_t offset_from_outlines, bool travel_avoid_other_parts, coord_t travel_avoid_distance, coord_t move_inside_distance);
 
     ~Comb();
 

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -71,18 +71,11 @@ void SliceLayer::getOutlines(Polygons& result, bool external_polys_only) const
     }
 }
 
-Polygons SliceLayer::getSecondOrInnermostWalls() const
-{
-    Polygons ret;
-    getInnermostWalls(ret, 2);
-    return ret;
-}
-
-void SliceLayer::getInnermostWalls(Polygons& layer_walls, int max_inset_size) const
+void SliceLayer::getInnermostWalls(Polygons& layer_walls, int max_inset) const
 {
     for (const SliceLayerPart& part : parts)
     {
-        switch (max_inset_size) {
+        switch (max_inset) {
             case 1:
                 // take the inner wall
                 if (part.insets.size() >= 1) {

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -74,23 +74,34 @@ void SliceLayer::getOutlines(Polygons& result, bool external_polys_only) const
 Polygons SliceLayer::getSecondOrInnermostWalls() const
 {
     Polygons ret;
-    getSecondOrInnermostWalls(ret);
+    getInnermostWalls(ret, 2);
     return ret;
 }
 
-void SliceLayer::getSecondOrInnermostWalls(Polygons& layer_walls) const
+void SliceLayer::getInnermostWalls(Polygons& layer_walls, int max_inset_size) const
 {
     for (const SliceLayerPart& part : parts)
     {
-        // we want the 2nd inner walls
-        if (part.insets.size() >= 2) {
-            layer_walls.add(part.insets[1]);
-            continue;
-        }
-        // but we'll also take the inner wall if the 2nd doesn't exist
-        if (part.insets.size() == 1) {
-            layer_walls.add(part.insets[0]);
-            continue;
+        switch (max_inset_size) {
+            case 1:
+                // take the inner wall
+                if (part.insets.size() >= 1) {
+                    layer_walls.add(part.insets[0]);
+                    continue;
+                }
+                break;
+            case 2:
+            default:
+                // we want the 2nd inner walls
+                if (part.insets.size() >= 2) {
+                    layer_walls.add(part.insets[1]);
+                    continue;
+                }
+                // but we'll also take the inner wall if the 2nd doesn't exist
+                if (part.insets.size() == 1) {
+                    layer_walls.add(part.insets[0]);
+                    continue;
+                }
         }
         // offset_from_outlines was so large that it completely destroyed our isle,
         // so we'll just use the regular outline
@@ -391,7 +402,7 @@ Polygons SliceDataStorage::getLayerSecondOrInnermostWalls(int layer_nr, bool inc
             for (const SliceMeshStorage& mesh : meshes)
             {
                 const SliceLayer& layer = mesh.layers[layer_nr];
-                layer.getSecondOrInnermostWalls(total);
+                layer.getInnermostWalls(total, 2);
                 if (mesh.getSettingAsSurfaceMode("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
                 {
                     total = total.unionPolygons(layer.openPolyLines.offsetPolyLine(100));

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -181,7 +181,7 @@ public:
      * Add those polygons to @p result.
      * \param result The result: the collection of all polygons thus obtained
      */
-    void getSecondOrInnermostWalls(Polygons& result) const;
+    void getInnermostWalls(Polygons& result, int max_inset_size) const;
 
     ~SliceLayer();
 };

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -172,16 +172,10 @@ public:
 
     /*!
      * Collects the second wall of every part, or the outer wall if it has no second, or the outline, if it has no outer wall.
-     * \return The collection of all polygons thus obtained
-     */
-    Polygons getSecondOrInnermostWalls() const;
-
-    /*!
-     * Collects the second wall of every part, or the outer wall if it has no second, or the outline, if it has no outer wall.
      * Add those polygons to @p result.
      * \param result The result: the collection of all polygons thus obtained
      */
-    void getInnermostWalls(Polygons& result, int max_inset_size) const;
+    void getInnermostWalls(Polygons& result, int max_inset) const;
 
     ~SliceLayer();
 };


### PR DESCRIPTION
Text from @Ghostkeeper :

The issue here is that the bits between the main clip body and the tips are very narrow. So narrow that it thinks it won't fit when moving there, and that travelling there will influence the shape of the outer wall. This is probably true, but travelling through this narrow bit is probably still better than what it's doing now, i.e. moving outside, combing outside to somewhere near its destination, and then moving inside again. I'd like to propose this solution that adjusts which walls it needs to avoid when combing:

Currently combing avoids the outer walls completely and does some other trickery with different numbers of walls. We should simplify this to:
- If there is a direct path to the destination that avoids all walls, take that. Otherwise...
- If there is a direct path to the destination that avoids the actual centre path of the outer wall, take that. 
- Otherwise... Move outside, comb there to a location close to the destination, move inside there and try again.


Extra:

The PR here implements a refined version of what @Ghostkeeper suggested:

- It first tries the old way, which is combing 2 lines inwards whenever possible
- If that's not possible, comb through outer wall. All points in the results are moved inwards whenever possible to reduce the ugliness as possible
- If it's just separate parts (or some other reason), comb through outside.