### PR TITLE
Improve outline accuracy  and reduce z-seam wobble by not discarding so many points

### DIFF
--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -74,8 +74,8 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
             }
         }
 
-        //Finally optimize all the polygons. Every point removed saves time in the long run.
-        part->insets[i].simplify();
+        //Previously, simplify() was called here with the default params but as the polygons have already been simplified using meshfix_maximum_resolution
+        //it's better to not simplify again as it can introduce z-seam wobble
         part->insets[i].removeDegenerateVerts();
         if (i == 0)
         {

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -779,7 +779,8 @@ void SlicerLayer::makePolygons(const Mesh* mesh, bool keep_none_closed, bool ext
 
     //Finally optimize all the polygons. Every point removed saves time in the long run.
     const coord_t line_segment_resolution = mesh->getSettingInMicrons("meshfix_maximum_resolution");
-    polygons.simplify(line_segment_resolution, line_segment_resolution / 2); //Maximum error is half of the resolution so it's only a limit when removing really sharp corners.
+    //Use a maximum error of 0 to help maintain z-seam vertical alignment - points are only discarded if they are closer than meshfix_maximum_resolution
+    polygons.simplify(line_segment_resolution, 0);
 
     polygons.removeDegenerateVerts(); // remove verts connected to overlapping line segments
 

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -349,7 +349,6 @@ void PolygonRef::simplify(int smallest_line_segment_squared, int allowed_error_d
 //
 
     ClipperLib::Path this_path = *path;
-    coord_t min_length_2 = std::min(smallest_line_segment_squared, allowed_error_distance_squared);
 
     ListPolygon result_list_poly;
     result_list_poly.emplace_back(path->front());
@@ -382,7 +381,7 @@ void PolygonRef::simplify(int smallest_line_segment_squared, int allowed_error_d
             { // disregard duplicate points without skipping the next point
                 continue;
             }
-            if ( vSize2(here - prev) < min_length_2 && vSize2(next - here) < min_length_2 )
+            if ( vSize2(here - prev) < smallest_line_segment_squared && vSize2(next - here) < smallest_line_segment_squared )
             {
                 // don't add [here] to the result
                 // skip checking whether the next point has to be removed for now
@@ -426,7 +425,7 @@ void PolygonRef::simplify(int smallest_line_segment_squared, int allowed_error_d
                 const Point& prev = skipped_vert.prev().p();
 
                 const Point& next = skipped_vert.next().p();
-                if ( vSize2(here - prev) < min_length_2 && vSize2(next - here) < min_length_2 )
+                if ( vSize2(here - prev) < smallest_line_segment_squared && vSize2(next - here) < smallest_line_segment_squared )
                 {
                     // skip checking whether the next point has to be removed for now
                     skip(skipped_vert_idx, skipped_vert, new_skipped_verts);


### PR DESCRIPTION
A user on the forum was having problems with a wobbly z-seam and I have been looking into it. As far as I can tell, the problem is caused by the simplify() method discarding points that it really shouldn't do if the z-seam is to stand much chance of being straight. That method has two criteria to decide whether a point in a polygon outline can be removed while still preserving the shape of the polygon. (1) distance of the point from the points before and after and (2) distance of the point from the line that joins the before and after points (error distance).

One of the changes in this PR is to not use the error distance criteria when simplifying the outline polygons. This is enough to vastly improve the location of the z-seam, here's a couple of images that show the difference, first, the results for the original code:

![screenshot_2018-05-02_14-22-05](https://user-images.githubusercontent.com/585618/39527583-af70343c-4e19-11e8-85c7-fc4fa21f9f4a.png)

and now the results for the PR code:

![screenshot_2018-05-02_14-20-24](https://user-images.githubusercontent.com/585618/39527599-b93502f4-4e19-11e8-97e9-8c00a9d9ebbf.png)

One downside of not throwing away points is that for models that have a lot of points, the slicing time is going to increase. If this PR is deemed unacceptably slow then one solution would be to introduce another setting that can go with Maximum Resolution (BTW, shouldn't this be called Minimum Resolution as it is specifying the min size of a line segment?) that can specify the max allowed error distance and that could be used to reduce the numbers of points.

Another change in this PR is that I modified the simplify() code so that it no longer accesses elements of a vector using invalid iterators. It may be that the original code does work OK but it can't be guaranteed to do so.
