### PR TITLE
Important bug fix for regression in 3.3 that can vastly increase combed travel distances

### DIFF
--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -146,7 +146,7 @@ void LinePolygonsCrossings::getBasicCombingPath(PolyCrossings& polyCrossings, Co
 {
     ConstPolygonRef poly = boundary[polyCrossings.poly_idx];
     combPath.push_back(transformation_matrix.unapply(Point(polyCrossings.min.x - std::abs(dist_to_move_boundary_point_outside), transformed_startPoint.Y)));
-    if ( ( polyCrossings.max.point_idx - polyCrossings.min.point_idx + poly.size() ) % poly.size() 
+    if ( ( polyCrossings.max.point_idx - polyCrossings.min.point_idx + (int)poly.size() ) % poly.size()
         < poly.size() / 2 )
     { // follow the path in the same direction as the winding order of the boundary polygon
         for(unsigned int point_idx = polyCrossings.min.point_idx

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -697,8 +697,8 @@ ClosestPolygonPoint PolygonUtils::findNearestClosest(Point from, ConstPolygonRef
 
     for (unsigned int p = 0; p<polygon.size(); p++)
     {
-        int p1_idx = (polygon.size() + direction*p + start_idx) % polygon.size();
-        int p2_idx = (polygon.size() + direction*(p+1) + start_idx) % polygon.size();
+        int p1_idx = ((int)polygon.size() + direction*p + start_idx) % polygon.size();
+        int p2_idx = ((int)polygon.size() + direction*(p+1) + start_idx) % polygon.size();
         const Point& p1 = polygon[p1_idx];
         const Point& p2 = polygon[p2_idx];
 


### PR DESCRIPTION
Commit 9c688e63d changed the result type of ConstPolygonRef::size() from unsigned int to size_t. Unfortunately, this badly broke the combing travel direction calculation. This PR provides a fix.

Personally, I think that changing size() to return a size_t is a mistake because we are never going to need more than 32 bits to represent the number of points in a polygon and it just makes the code bigger and slower.

I have also changed another couple of very similar expressions just in case they are similarly broken.