### PR TITLE
Detect useless travel paths to the current location and ignore them.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1217,7 +1217,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 gcode.writeRetraction(retraction_config);
             }
 
-            if (path.config->isTravelPath() && path.points.size() == 1 && path.points[0] == gcode.getPositionXY())
+            if (path.config->isTravelPath() && path.points.size() == 1 && path.points[0] == gcode.getPositionXY() && z == gcode.getPositionZ())
             {
                 // ignore travel moves to the current location to avoid needless change of acceleration/jerk
                 continue;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1217,7 +1217,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 gcode.writeRetraction(retraction_config);
             }
 
-            if (path.config->isTravelPath() && path.points.size() == 1 && path.points[0] == gcode.getPositionXY() && z == gcode.getPositionZ())
+            if (!path.retract && path.config->isTravelPath() && path.points.size() == 1 && path.points[0] == gcode.getPositionXY() && z == gcode.getPositionZ())
             {
                 // ignore travel moves to the current location to avoid needless change of acceleration/jerk
                 continue;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1217,6 +1217,12 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 gcode.writeRetraction(retraction_config);
             }
 
+            if (path.config->isTravelPath() && path.points.size() == 1 && path.points[0] == gcode.getPositionXY())
+            {
+                // ignore travel moves to the current location to avoid needless change of acceleration/jerk
+                continue;
+            }
+
             if (acceleration_enabled)
             {
                 if (path.config->isTravelPath())


### PR DESCRIPTION
If travel moves use different acceleration or jerk values than the print moves we don't
want to change the accel/jerk for a travel move that doesn't actually cause any movement
so the easiest thing to do is detect a travel move to the current location early.

Without this PR, you can get gcode like this:
````
;TYPE:SUPPORT
G1 F1500 E37.95865
G1 F1560 X186.783 Y124.098 E37.95976
M204 S2812
M205 X18 Y18
M204 S1250
M205 X10 Y10
G1 X187.138 Y123.602 E37.9631
M204 S2812
M205 X18 Y18
M204 S1250
M205 X10 Y10
G1 X187.356 Y123.049 E37.96637
M204 S2812
M205 X18 Y18
M204 S1250
M205 X10 Y10
G1 X187.398 Y122.743 E37.96806
M204 S2812
M205 X18 Y18
M204 S1250
M205 X10 Y10
G1 X187.426 Y122.499 E37.96941
M204 S2812
M205 X18 Y18
M204 S1250
M205 X10 Y10
G1 X187.355 Y121.959 E37.9724
````
With this PR it looks like this:
````
;TYPE:SUPPORT
G1 F1500 E37.95865
G1 F1560 X186.783 Y124.098 E37.95976
G1 X187.138 Y123.602 E37.9631
G1 X187.356 Y123.049 E37.96637
G1 X187.398 Y122.743 E37.96806
G1 X187.426 Y122.499 E37.96941
G1 X187.355 Y121.959 E37.9724
````