### PR TITLE
Fix long standing bug that would cause fan speed gcode to be duplicated for non-integer fan speeds.

### DIFF
--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -125,7 +125,7 @@ private:
     int isZHopped; //!< The amount by which the print head is currently z hopped, or zero if it is not z hopped. (A z hop is used during travel moves to avoid collision with other layer parts)
 
     int current_extruder;
-    int currentFanSpeed;
+    double currentFanSpeed;
     EGCodeFlavor flavor;
 
     std::vector<double> total_print_times; //!< The total estimated print time in seconds for each feature


### PR DESCRIPTION
The current fan speed was being stored as an int but was being compared to the new value
which is a double so the comparison would often fail when it shouldn't have done and so
the fan speed gcode was output when it need not have been.