### PR TITLE
Ensure lib_CuraEngine is static.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ if (ENABLE_ARCUS)
 endif ()
 
 # Compiling CuraEngine itself.
-add_library(_CuraEngine ${engine_SRCS} ${engine_PB_SRCS}) #First compile all of CuraEngine as library, allowing this to be re-used for tests.
+add_library(_CuraEngine STATIC ${engine_SRCS} ${engine_PB_SRCS}) #First compile all of CuraEngine as library, allowing this to be re-used for tests.
 
 if(USE_SYSTEM_LIBS)
     target_link_libraries(_CuraEngine ${Polyclipping_LIBRARIES})


### PR DESCRIPTION
Packagers usually use CMake macros in their build system to set default values
that work in most cases.
If BUILD_SHARED_LIBS is ON or BUILD_STATIC_LIBS is OFF, the CuraEngine
executable won't run.