### PR TITLE
When build plate adhesion is brim, don't fuzzy the skin on the first layer.

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1004,7 +1004,7 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
     int64_t avg_dist_between_points = mesh.getSettingInMicrons("magic_fuzzy_skin_point_dist");
     int64_t min_dist_between_points = avg_dist_between_points * 3 / 4; // hardcoded: the point distance may vary between 3/4 and 5/4 the supplied value
     int64_t range_random_point_dist = avg_dist_between_points / 2;
-    for (unsigned int layer_nr = 0; layer_nr < mesh.layers.size(); layer_nr++)
+    for (unsigned int layer_nr = (mesh.getSettingAsPlatformAdhesion("adhesion_type") == EPlatformAdhesion::BRIM) ? 1 : 0; layer_nr < mesh.layers.size(); layer_nr++)
     {
         SliceLayer& layer = mesh.layers[layer_nr];
         for (SliceLayerPart& part : layer.parts)


### PR DESCRIPTION
Having fuzzy skin on the first layer greatly reduces the bonding between the brim and the skin.

Is it really worth introducing another setting to enable this tweak? I don't think so but, then again, I don't use fuzzy skin and don't often use brim so, personally, I don't care.

Provides a fix for https://github.com/Ultimaker/Cura/issues/3807.