### PR TITLE
Infill outline count

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -584,6 +584,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr bool zig_zaggify_infill = false;
         constexpr bool connect_polygons = true; // causes less jerks, so better adhesion
 
+        constexpr int wall_line_count = 0;
         const Point& infill_origin = Point();
         Polygons* perimeter_gaps = nullptr;
         constexpr bool connected_zigzags = false;
@@ -596,7 +597,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Infill infill_comp(
             EFillMethod::LINES, zig_zaggify_infill, connect_polygons, wall, offset_from_poly_outline, gcode_layer.configs_storage.raft_base_config.getLineWidth(), train->getSettingInMicrons("raft_base_line_spacing"),
             fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
-            infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
+            wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
             );
         infill_comp.generate(raft_polygons, raftLines);
         gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_base_config, SpaceFillType::Lines);
@@ -647,6 +648,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr bool zig_zaggify_infill = true;
         constexpr bool connect_polygons = true; // why not?
 
+        constexpr int wall_line_count = 0;
         const Point& infill_origin = Point();
         Polygons* perimeter_gaps = nullptr;
         constexpr bool connected_zigzags = false;
@@ -659,7 +661,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Infill infill_comp(
             EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, offset_from_poly_outline, infill_outline_width, train->getSettingInMicrons("raft_interface_line_spacing"),
             fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
-            infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
+            wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
             );
         infill_comp.generate(raft_polygons, raftLines);
         gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_interface_config, SpaceFillType::Lines);
@@ -704,6 +706,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         double fill_angle = 90 * raftSurfaceLayer;
         constexpr bool zig_zaggify_infill = true;
 
+        constexpr int wall_line_count = 0;
         const Point& infill_origin = Point();
         Polygons* perimeter_gaps = nullptr;
         constexpr bool connected_zigzags = false;
@@ -716,7 +719,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Infill infill_comp(
             EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, offset_from_poly_outline, infill_outline_width, train->getSettingInMicrons("raft_surface_line_spacing"),
             fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
-            infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
+            wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
             );
         infill_comp.generate(raft_polygons, raft_lines);
         gcode_layer.addLinesByOptimizer(raft_lines, gcode_layer.configs_storage.raft_surface_config, SpaceFillType::Lines);
@@ -1286,6 +1289,7 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                     infill_line_distance_here /= 2;
                 }
 
+                constexpr int wall_line_count = 0; // wall lines are always single layer
                 Polygons* perimeter_gaps = nullptr;
                 constexpr bool connected_zigzags = false;
                 constexpr bool use_endpieces = true;
@@ -1294,7 +1298,7 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                 const coord_t maximum_resolution = mesh.getSettingInMicrons("meshfix_maximum_resolution");
 
                 Infill infill_comp(infill_pattern, zig_zaggify_infill, connect_polygons, part.infill_area_per_combine_per_density[density_idx][combine_idx], /*outline_offset =*/ 0
-                    , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, infill_origin
+                    , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, wall_line_count, infill_origin
                     , perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count
                     , mesh.getSettingInMicrons("cross_infill_pocket_size")
                     , maximum_resolution);
@@ -1340,6 +1344,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     const bool zig_zaggify_infill = mesh.getSettingBoolean("zig_zaggify_infill") || pattern == EFillMethod::ZIG_ZAG;
     const bool connect_polygons = mesh.getSettingBoolean("connect_infill_polygons");
     int infill_multiplier = mesh.getSettingAsCount("infill_multiplier");
+    const int wall_line_count = mesh.getSettingAsCount("infill_wall_line_count");
     for (unsigned int density_idx = part.infill_area_per_combine_per_density.size() - 1; (int)density_idx >= 0; density_idx--)
     {
         int infill_line_distance_here = infill_line_distance << (density_idx + 1); // the highest density infill combines with the next to create a grid with density_factor 1
@@ -1377,7 +1382,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             infill_line_distance_here /= 2;
         }
         Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, part.infill_area_per_combine_per_density[density_idx][0], /*outline_offset =*/ 0
-            , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, infill_origin
+            , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, wall_line_count, infill_origin
             , /*Polygons* perimeter_gaps =*/ nullptr
             , /*bool connected_zigzags =*/ false
             , /*bool use_endpieces =*/ false
@@ -1695,6 +1700,7 @@ void FffGcodeWriter::processOutlineGaps(const SliceDataStorage& storage, LayerPl
     constexpr bool zig_zaggify_infill = false;
     constexpr bool connect_polygons = false; // not applicable
 
+    constexpr int wall_line_count = 0;
     const Point& infill_origin = Point();
     Polygons* perimeter_gaps = nullptr;
     constexpr bool connected_zigzags = false;
@@ -1706,7 +1712,7 @@ void FffGcodeWriter::processOutlineGaps(const SliceDataStorage& storage, LayerPl
 
     Infill infill_comp(
         EFillMethod::LINES, zig_zaggify_infill, connect_polygons, part.outline_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, outline_gap_overlap, infill_multiplier, skin_angle, gcode_layer.z, extra_infill_shift,
-        infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
+        wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
         );
     infill_comp.generate(gap_polygons, gap_lines);
 
@@ -2033,6 +2039,7 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage, La
 
     constexpr int infill_multiplier = 1;
     constexpr int extra_infill_shift = 0;
+    constexpr int wall_line_count = 0;
     constexpr coord_t offset_from_inner_skin_infill = 0;
     const bool zig_zaggify_infill = pattern == EFillMethod::ZIG_ZAG;
     const bool connect_polygons = mesh.getSettingBoolean("connect_skin_polygons");
@@ -2045,7 +2052,7 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage, La
     const coord_t maximum_resolution = mesh.getSettingInMicrons("meshfix_maximum_resolution");
 
     Infill infill_comp(
-        pattern, zig_zaggify_infill, connect_polygons, area, offset_from_inner_skin_infill, config.getLineWidth(), config.getLineWidth() / skin_density, skin_overlap, infill_multiplier, skin_angle, gcode_layer.z, extra_infill_shift, infill_origin, perimeter_gaps_output,
+        pattern, zig_zaggify_infill, connect_polygons, area, offset_from_inner_skin_infill, config.getLineWidth(), config.getLineWidth() / skin_density, skin_overlap, infill_multiplier, skin_angle, gcode_layer.z, extra_infill_shift, wall_line_count, infill_origin, perimeter_gaps_output,
         connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
         );
     infill_comp.generate(skin_polygons, skin_lines);
@@ -2101,6 +2108,7 @@ void FffGcodeWriter::processPerimeterGaps(const SliceDataStorage& storage, Layer
     constexpr int infill_multiplier = 1;
     constexpr int extra_infill_shift = 0;
     const coord_t skin_overlap = mesh.getSettingInMicrons("skin_overlap_mm");
+    constexpr int wall_line_count = 0;
     const Point& infill_origin = Point();
     constexpr Polygons* perimeter_gaps_polyons = nullptr;
     constexpr bool connected_zigzags = false;
@@ -2112,7 +2120,7 @@ void FffGcodeWriter::processPerimeterGaps(const SliceDataStorage& storage, Layer
 
     Infill infill_comp(
         EFillMethod::LINES, zig_zaggify_infill, connect_polygons, perimeter_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, skin_overlap, infill_multiplier, perimeter_gaps_angle, gcode_layer.z, extra_infill_shift,
-        infill_origin, perimeter_gaps_polyons, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution);
+        wall_line_count, infill_origin, perimeter_gaps_polyons, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution);
     infill_comp.generate(gap_polygons, gap_lines);
     if (gap_lines.size() > 0)
     {
@@ -2194,6 +2202,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
     const int default_support_infill_overlap = infill_extruder.getSettingInMicrons("infill_overlap_mm");
     const double support_infill_angle = 0;
     constexpr int infill_multiplier = 1; // there is no frontend setting for this (yet)
+    constexpr int wall_line_count = 0;
     coord_t default_support_line_width = infill_extruder.getSettingInMicrons("support_line_width");
     if (gcode_layer.getLayerNr() == 0 && storage.getSettingAsPlatformAdhesion("adhesion_type") != EPlatformAdhesion::RAFT)
     {
@@ -2283,7 +2292,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                 const coord_t maximum_resolution = infill_extruder.getSettingInMicrons("meshfix_maximum_resolution");
 
                 Infill infill_comp(support_pattern, zig_zaggify_infill, connect_polygons, support_area, offset_from_outline, support_line_width,
-                                   support_line_distance_here, current_support_infill_overlap, infill_multiplier, support_infill_angle, gcode_layer.z, support_shift, infill_origin,
+                                   support_line_distance_here, current_support_infill_overlap, infill_multiplier, support_infill_angle, gcode_layer.z, support_shift, wall_line_count, infill_origin,
                                    perimeter_gaps, infill_extruder.getSettingBoolean("support_connect_zigzags"), use_endpieces,
                                    skip_some_zags, zag_skip_count, pocket_size, maximum_resolution);
                 infill_comp.generate(support_polygons, support_lines, storage.support.cross_fill_provider);
@@ -2332,6 +2341,7 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, Lay
     constexpr int infill_multiplier = 1;
     constexpr int outline_offset =  0;
     constexpr int extra_infill_shift = 0;
+    constexpr int wall_line_count = 0;
     const Point infill_origin;
     constexpr Polygons* perimeter_gaps = nullptr;
     constexpr bool use_endpieces = true;
@@ -2360,7 +2370,7 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, Lay
     Infill roof_computation(
         pattern, zig_zaggify_infill, connect_polygons, infill_outline, outline_offset, gcode_layer.configs_storage.support_roof_config.getLineWidth(),
         support_roof_line_distance, support_roof_overlap, infill_multiplier, fill_angle, gcode_layer.z, extra_infill_shift,
-        infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
+        wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
         );
     Polygons roof_polygons;
     Polygons roof_lines;
@@ -2407,6 +2417,7 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
     constexpr int infill_multiplier = 1;
     constexpr int outline_offset =  0;
     constexpr int extra_infill_shift = 0;
+    constexpr int wall_line_count = 0;
     const Point infill_origin;
     constexpr Polygons* perimeter_gaps = nullptr;
     constexpr bool use_endpieces = true;
@@ -2420,7 +2431,7 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
     Infill bottom_computation(
         pattern, zig_zaggify_infill, connect_polygons, support_layer.support_bottom, outline_offset, gcode_layer.configs_storage.support_bottom_config.getLineWidth(),
         support_bottom_line_distance, support_bottom_overlap, infill_multiplier, fill_angle, gcode_layer.z, extra_infill_shift,
-        infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
+        wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size, maximum_resolution
         );
     Polygons bottom_polygons;
     Polygons bottom_lines;

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -42,6 +42,9 @@ namespace cura {
 
 void Infill::generate(Polygons& result_polygons, Polygons& result_lines, const SierpinskiFillProvider* cross_fill_provider, const SliceMeshStorage* mesh)
 {
+    coord_t outline_offset_raw = outline_offset;
+    outline_offset -= wall_line_count * infill_line_width; // account for extra walls
+
     if (infill_multiplier > 1)
     {
         bool zig_zaggify_real = zig_zaggify;
@@ -60,6 +63,12 @@ void Infill::generate(Polygons& result_polygons, Polygons& result_lines, const S
     else
     {
         _generate(result_polygons, result_lines, cross_fill_provider, mesh);
+    }
+
+    // generate walls around infill pattern
+    for (unsigned int wall_idx = 0; wall_idx < wall_line_count; wall_idx++)
+    {
+        result_polygons.add(in_outline.offset(outline_offset_raw - wall_idx * infill_line_width - infill_line_width / 2));
     }
 
     if (connect_polygons)

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -68,7 +68,8 @@ void Infill::generate(Polygons& result_polygons, Polygons& result_lines, const S
     // generate walls around infill pattern
     for (unsigned int wall_idx = 0; wall_idx < wall_line_count; wall_idx++)
     {
-        result_polygons.add(in_outline.offset(outline_offset_raw - wall_idx * infill_line_width - infill_line_width / 2));
+        const coord_t distance_from_outline_to_wall = outline_offset_raw - infill_line_width / 2 - wall_idx * infill_line_width;
+        result_polygons.add(in_outline.offset(distance_from_outline_to_wall));
     }
 
     if (connect_polygons)

--- a/src/infill.h
+++ b/src/infill.h
@@ -32,6 +32,7 @@ class Infill
     double fill_angle; //!< for linear infill types: the angle of the infill lines (or the angle of the grid)
     coord_t z; //!< height of the layer for which we generate infill
     coord_t shift; //!< shift of the scanlines in the direction perpendicular to the fill_angle
+    int wall_line_count; //!< Number of walls to generate at the boundary of the infill region, spaced \ref infill_line_width apart
     const Point infill_origin; //!< origin of the infill pattern
     Polygons* perimeter_gaps; //!< (optional output) The areas in between consecutive insets when Concentric infill is used.
     bool connected_zigzags; //!< (ZigZag) Whether endpieces of zigzag infill should be connected to the nearest infill line on both sides of the zigzag connector
@@ -63,6 +64,7 @@ public:
         , double fill_angle
         , coord_t z
         , coord_t shift
+        , int wall_line_count = 0
         , const Point& infill_origin = Point()
         , Polygons* perimeter_gaps = nullptr
         , bool connected_zigzags = false
@@ -84,6 +86,7 @@ public:
     , fill_angle(fill_angle)
     , z(z)
     , shift(shift)
+    , wall_line_count(wall_line_count)
     , infill_origin(infill_origin)
     , perimeter_gaps(perimeter_gaps)
     , connected_zigzags(connected_zigzags)

--- a/src/infill/SpaghettiInfillPathGenerator.cpp
+++ b/src/infill/SpaghettiInfillPathGenerator.cpp
@@ -20,6 +20,7 @@ bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage
     const unsigned int infill_line_width = config.getLineWidth();
     constexpr int infill_multiplier = 1;
     const int64_t infill_shift = 0;
+    constexpr int wall_line_count = 0;
     const int64_t outline_offset = 0;
     const double layer_height_mm = (gcode_layer.getLayerNr() == 0) ? mesh.getSettingInMillimeters("layer_height_0") : mesh.getSettingInMillimeters("layer_height");
 
@@ -42,7 +43,7 @@ bool SpaghettiInfillPathGenerator::processSpaghettiInfill(const SliceDataStorage
         const bool use_endpieces = false;
         Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, area, outline_offset
             , infill_line_width, infill_line_distance, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z,
-            infill_shift, infill_origin, perimeter_gaps_output, connected_zigzags, use_endpieces
+            infill_shift, wall_line_count, infill_origin, perimeter_gaps_output, connected_zigzags, use_endpieces
             , mesh.getSettingInMicrons("cross_infill_pocket_size"));
         // cross_fill_patterns is only generated when spaghetti infill is not used,
         // so we pass nullptr here.


### PR DESCRIPTION
WARNING!
This PR incorporates two other PRs!
https://github.com/Ultimaker/CuraEngine/pull/774

Generate extra walls around the infill.

You can reduce the normal wall line count by 1 and introduce an extra infill wall line.
That way the inner wall is printed with the infill settings, which generally print faster.

Also, because the skin is always printed after the infill, the skin is surrounded by normal wall and infill wall, meaning it can better grab onto the walls, without falling in between infill lines. 

Also: the feature can make the whole infill region with a single extrusion path without interruption for travel and/or retraction.

