### PR TITLE
Avoid erroneous travels to 0,0 if no positions had been planned before extruder change.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -194,7 +194,10 @@ bool LayerPlan::setExtruder(int extruder)
             Point extruder_offset(train->getSettingInMicrons("machine_nozzle_offset_x"), train->getSettingInMicrons("machine_nozzle_offset_y"));
             end_pos += extruder_offset; // absolute end pos is given as a head position
         }
-        addTravel(end_pos); //  + extruder_offset cause it 
+        if (end_pos_absolute || last_planned_position)
+        {
+            addTravel(end_pos); //  + extruder_offset cause it
+        }
     }
     if (extruder_plans.back().paths.empty() && extruder_plans.back().inserts.empty())
     { // first extruder plan in a layer might be empty, cause it is made with the last extruder planned in the previous layer
@@ -222,7 +225,10 @@ bool LayerPlan::setExtruder(int extruder)
             Point extruder_offset(train->getSettingInMicrons("machine_nozzle_offset_x"), train->getSettingInMicrons("machine_nozzle_offset_y"));
             start_pos += extruder_offset; // absolute start pos is given as a head position
         }
-        last_planned_position = start_pos;
+        if (start_pos_absolute || last_planned_position)
+        {
+            last_planned_position = start_pos;
+        }
     }
     return true;
 }


### PR DESCRIPTION
When extruder end positions are not absolute, only add a travel for the old extruder if
no positions have been planned for this layer and don't set last_planned_position unless
there have already been positions planned for this layer.

This fixes a particular issue (https://github.com/Ultimaker/Cura/issues/3829) and probably makes sense but I would be the first to admit that I am not sure. I only use single extrusion printers and have no experience of extruder changing, etc.

However, the code in LayerPlan::setExtruder() does look wrong to me. I would expect to see something like this for the situation where the start and end positions are not absolute:

````
last_planned_position += new_extruder_nozzle_offset - old_extruder_nozzle_offset;
````

Anyway, please test this PR on some multi-extruder machines, it may be OK.
