### PR TITLE
Fix no skin combing so that it doesn't cross skin areas!

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -153,7 +153,8 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode, int max_
             if (mesh.getSettingBoolean("infill_mesh")) {
                 continue;
             }
-            if (mesh.getSettingAsCombingMode("retraction_combing") == CombingMode::NO_SKIN)
+            const CombingMode combing_mode = mesh.getSettingAsCombingMode("retraction_combing");
+            if (combing_mode == CombingMode::NO_SKIN)
             {
                 // we need to include the walls in the comb boundary otherwise it's not possible to tell if a travel move crosses a skin region
 
@@ -220,6 +221,15 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode, int max_
 
                     // combine the wall combing region (outer - inner) with the infill (if any)
                     comb_boundary.add(part.infill_area.unionPolygons(outer.difference(inner)));
+                }
+            }
+            else if (combing_mode == CombingMode::INFILL)
+            {
+                // this is the old "no skin" code which was completely misnamed as it totally ignores the existence of walls
+                // and skin and so will route straight across them when the travel doesn't cross any infill
+                for (const SliceLayerPart& part : layer.parts)
+                {
+                    comb_boundary.add(part.infill_area);
                 }
             }
             else

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -165,15 +165,15 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode, int max_
                     // in the wall polygons are within the combing area and that the infill area polygons that extend to the part's walls do get joined
                     // to the wall polygons so that combing travels can route via the combined infill and wall regions
 
-                    Polygons walls_and_infill;
-                    for (int innermost = part.insets.size() - 1; innermost >= 0 && walls_and_infill.size() == 0; --innermost)
+                    Polygons walls;
+                    for (int innermost = part.insets.size() - 1; innermost >= 0 && walls.size() == 0; --innermost)
                     {
                         if (part.insets[innermost].size() > 0)
                         {
-                            walls_and_infill = part.infill_area.unionPolygons(part.insets[0].offset(10).difference(part.insets[innermost].offset(-10-line_width/2)));
+                            walls = part.insets[0].offset(10).difference(part.insets[innermost].offset(-10-line_width/2));
                         }
                     }
-                    comb_boundary.add(walls_and_infill);
+                    comb_boundary.add(part.infill_area.unionPolygons(walls));
                 }
             }
             else

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -155,46 +155,64 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode, int max_
             }
             if (mesh.getSettingAsCombingMode("retraction_combing") == CombingMode::NO_SKIN)
             {
+                // we need to include the walls in the comb boundary otherwise it's not possible to tell if a travel move crosses a skin region
+
                 int line_width_0 = mesh.getSettingInMicrons("wall_line_width_0");
 
                 for (const SliceLayerPart& part : layer.parts)
                 {
-                    int inner_wall_line_width = (part.insets.size() > 1) ? mesh.getSettingInMicrons( "wall_line_width_x") : line_width_0;
-
-                    // determine the outer boundary - to try and keep the nozzle away from the outer wall edge, first see if the
-                    // outer boundary can be set to the inside edge of the outer wall
-
-                    Polygons outer = part.insets[0].offset(-line_width_0/2);
-
-                    // if outer doesn't have the same number of polygons as the original wall centre line, it must have been
-                    // partioned due to narrowing of the part's outline so try again with an outline that will be a 1/4 line width
-                    // inside the centre line
-
-                    if (outer.size() != part.insets[0].size())
+                    if (part.insets.size() == 1)
                     {
-                        outer = part.insets[0].offset(-line_width_0/4);
+                        // the part's wall only has one line so determine a wall combing region that is just the
+                        // inner 1/4 of the line's area
 
-                        // if that outline is not OK, just use the original centre line
+                        Polygons outer = part.insets[0].offset(-line_width_0/4);
+
+                        // the inside of the wall combing region is just inside the wall's inner edge so it can meet up
+                        // with the infill (if any)
+                        Polygons wall_combing_region = outer.difference(part.insets[0].offset(-10-line_width_0/2));
+
+                        // combine the wall combing region with the infill (if any)
+                        comb_boundary.add(part.infill_area.unionPolygons(wall_combing_region));
+                    }
+                    else
+                    {
+                        int inner_wall_line_width = mesh.getSettingInMicrons("wall_line_width_x");
+
+                        // determine the outer boundary - to try and keep the nozzle away from the outer wall edge, first see if the
+                        // outer boundary can be set to the inside edge of the outer wall
+
+                        Polygons outer = part.insets[0].offset(-line_width_0/2);
+
+                        // if outer doesn't have the same number of polygons as the original wall centre line, it must have been
+                        // partioned due to narrowing of the part's outline so try again with an outline that will be a 1/4 line width
+                        // inside the centre line
+
                         if (outer.size() != part.insets[0].size())
                         {
-                            outer = part.insets[0];
+                            outer = part.insets[0].offset(-line_width_0/4);
+
+                            // if that outline is not OK, just use the original centre line
+                            if (outer.size() != part.insets[0].size())
+                            {
+                                outer = part.insets[0];
+                            }
                         }
-                    }
 
-                    // we need to include the walls in the comb boundary otherwise it's not possible to tell if a travel move crosses a skin region
-                    // so we combine the part's infill area with the area that is from just inside (by 10um) the part's inner wall
-                    // to the outer boundary calculated above - the slight expansion of the inner boundary is to ensure that the infill area polygons
-                    // that extend to the part's walls do get joined to the wall polygons so that combing travels can route via the combined infill and wall regions
+                        // combine the part's infill area with the area that is from just inside (by 10um) the part's inner wall
+                        // to the outer boundary calculated above - the slight expansion of the inner boundary is to ensure that the infill area polygons
+                        // that extend to the part's walls do get joined to the wall polygons so that combing travels can route via the combined infill and wall regions
 
-                    Polygons wall_combing_region;
-                    for (int innermost = part.insets.size() - 1; innermost >= 0 && wall_combing_region.size() == 0; --innermost)
-                    {
-                        if (part.insets[innermost].size() > 0)
+                        Polygons wall_combing_region;
+                        for (int innermost = part.insets.size() - 1; innermost >= 0 && wall_combing_region.size() == 0; --innermost)
                         {
-                            wall_combing_region = outer.difference(part.insets[innermost].offset(-10-inner_wall_line_width/2));
+                            if (part.insets[innermost].size() > 0)
+                            {
+                                wall_combing_region = outer.difference(part.insets[innermost].offset(-10-inner_wall_line_width/2));
+                            }
                         }
+                        comb_boundary.add(part.infill_area.unionPolygons(wall_combing_region));
                     }
-                    comb_boundary.add(part.infill_area.unionPolygons(wall_combing_region));
                 }
             }
             else

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -157,62 +157,69 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode, int max_
             {
                 // we need to include the walls in the comb boundary otherwise it's not possible to tell if a travel move crosses a skin region
 
-                int line_width_0 = mesh.getSettingInMicrons("wall_line_width_0");
+                const coord_t line_width_0 = mesh.getSettingInMicrons("wall_line_width_0");
 
                 for (const SliceLayerPart& part : layer.parts)
                 {
-                    if (part.insets.size() == 1)
+                    const unsigned num_insets = part.insets.size();
+                    Polygons outer = part.outline; // outer boundary of wall combing region
+                    coord_t outer_to_outline_dist = 0; // distance from outer to the part's outline
+
+                    if (num_insets > 1 && part.insets[1].size() == part.outline.size())
                     {
-                        // the part's wall only has one line so determine a wall combing region that is just the
-                        // inner 1/4 of the line's area
+                        // part's wall has multiple lines and the 2nd wall line is complete
+                        // set the outer boundary to the inside edge of the outer wall
 
-                        Polygons outer = part.insets[0].offset(-line_width_0/4);
-
-                        // the inside of the wall combing region is just inside the wall's inner edge so it can meet up
-                        // with the infill (if any)
-                        Polygons wall_combing_region = outer.difference(part.insets[0].offset(-10-line_width_0/2));
-
-                        // combine the wall combing region with the infill (if any)
-                        comb_boundary.add(part.infill_area.unionPolygons(wall_combing_region));
+                        outer = part.insets[0].offset(-line_width_0/2);
+                        outer_to_outline_dist = line_width_0;
                     }
-                    else
+                    else if (num_insets > 0)
                     {
-                        int inner_wall_line_width = mesh.getSettingInMicrons("wall_line_width_x");
+                        // set the outer boundary to be 1/4 line width inside the centre line of the outer wall
 
-                        // determine the outer boundary - to try and keep the nozzle away from the outer wall edge, first see if the
-                        // outer boundary can be set to the inside edge of the outer wall
-
-                        Polygons outer = part.insets[0].offset(-line_width_0/2);
-
-                        // if outer doesn't have the same number of polygons as the original wall centre line, it must have been
-                        // partioned due to narrowing of the part's outline so try again with an outline that will be a 1/4 line width
-                        // inside the centre line
-
-                        if (outer.size() != part.insets[0].size())
-                        {
-                            outer = part.insets[0].offset(-line_width_0/4);
-
-                            // if that outline is not OK, just use the original centre line
-                            if (outer.size() != part.insets[0].size())
-                            {
-                                outer = part.insets[0];
-                            }
-                        }
-
-                        // combine the part's infill area with the area that is from just inside (by 10um) the part's inner wall
-                        // to the outer boundary calculated above - the slight expansion of the inner boundary is to ensure that the infill area polygons
-                        // that extend to the part's walls do get joined to the wall polygons so that combing travels can route via the combined infill and wall regions
-
-                        Polygons wall_combing_region;
-                        for (int innermost = part.insets.size() - 1; innermost >= 0 && wall_combing_region.size() == 0; --innermost)
-                        {
-                            if (part.insets[innermost].size() > 0)
-                            {
-                                wall_combing_region = outer.difference(part.insets[innermost].offset(-10-inner_wall_line_width/2));
-                            }
-                        }
-                        comb_boundary.add(part.infill_area.unionPolygons(wall_combing_region));
+                        outer = part.insets[0].offset(-line_width_0/4);
+                        outer_to_outline_dist = line_width_0*3/4;
                     }
+
+                    // finally, check that outer actually has the same number of polygons as the part's outline
+                    // if it doesn't it means that the outer wall is missing where the part narrows so in those
+                    // regions we need to use the part outline for the outer boundary of the combing region
+                    // (expect poor results due to the nozzle being allowed to go right to the part's edge)
+
+                    if (outer.size() != part.outline.size())
+                    {
+                        // first we calculate the part outline for those portions of the part where outer is missing
+                        // this is done by shrinking the part outline so that it is very slightly smaller than outer, then expanding it again so it is very
+                        // slightly larger than its original size and subtracting that from the original part outline
+                        // NOTE - the additional small shrink/expands are required to ensure that the polygons overlap a little so we do not rely on exact results
+
+                        Polygons outline_where_outer_is_missing(part.outline.difference(part.outline.offset(-(outer_to_outline_dist+5)).offset(outer_to_outline_dist+10)));
+
+                        // merge outer with the portions of the part outline we just calculated
+                        // the trick here is to expand the outlines sufficiently so that they overlap when unioned and then the result is shrunk back to the correct size
+
+                        outer = outer.offset(outer_to_outline_dist/2+10).unionPolygons(outline_where_outer_is_missing.offset(outer_to_outline_dist/2+10)).offset(-(outer_to_outline_dist/2+10));
+                    }
+
+                    Polygons inner; // inner boundary of wall combing region
+
+                    // the inside of the wall combing region is just inside the wall's inner edge so it can meet up with the infill (if any)
+
+                    if (num_insets == 0)
+                    {
+                        inner = part.outline.offset(-10);
+                    }
+                    else if (num_insets == 1)
+                    {
+                        inner = part.insets[0].offset(-10-line_width_0/2);
+                    }
+                    else if(num_insets > 1)
+                    {
+                        inner = part.insets[num_insets - 1].offset(-10-mesh.getSettingInMicrons("wall_line_width_x")/2);
+                    }
+
+                    // combine the wall combing region (outer - inner) with the infill (if any)
+                    comb_boundary.add(part.infill_area.unionPolygons(outer.difference(inner)));
                 }
             }
             else

--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -153,7 +153,9 @@ void LinePolygonsCrossings::generateBasicCombingPath(PolyCrossings& polyCrossing
     std::vector<Point> fwd_points;
     Point prev = combPath.back();
     coord_t fwd_len = 0;
-    for (unsigned int point_idx = polyCrossings.min.point_idx; point_idx != polyCrossings.max.point_idx; point_idx = (point_idx < poly.size() - 1) ? (point_idx + 1) : (0))
+    for (unsigned int point_idx = polyCrossings.min.point_idx
+        ; point_idx != polyCrossings.max.point_idx
+        ; point_idx = (point_idx < poly.size() - 1) ? (point_idx + 1) : (0))
     {
         const Point p = PolygonUtils::getBoundaryPointWithOffset(poly, point_idx, dist_to_move_boundary_point_outside);
         fwd_points.push_back(p);
@@ -167,7 +169,9 @@ void LinePolygonsCrossings::generateBasicCombingPath(PolyCrossings& polyCrossing
     coord_t rev_len = 0;
     unsigned int min_idx = (polyCrossings.min.point_idx == 0)? poly.size() - 1 : polyCrossings.min.point_idx - 1;
     unsigned int max_idx = (polyCrossings.max.point_idx == 0)? poly.size() - 1 : polyCrossings.max.point_idx - 1;
-    for (unsigned int point_idx = min_idx; point_idx != max_idx; point_idx = (point_idx > 0) ? (point_idx - 1) : (poly.size() - 1))
+    for (unsigned int point_idx = min_idx
+        ; point_idx != max_idx
+        ; point_idx = (point_idx > 0) ? (point_idx - 1) : (poly.size() - 1))
     {
         const Point p = PolygonUtils::getBoundaryPointWithOffset(poly, point_idx, dist_to_move_boundary_point_outside);
         rev_points.push_back(p);

--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -107,7 +107,7 @@ bool LinePolygonsCrossings::lineSegmentCollidesWithBoundary()
 }
 
 
-bool LinePolygonsCrossings::getCombingPath(CombPath& combPath, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles)
+bool LinePolygonsCrossings::generateCombingPath(CombPath& combPath, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles)
 {
     if (shorterThen(endPoint - startPoint, max_comb_distance_ignored) || !lineSegmentCollidesWithBoundary())
     {
@@ -124,25 +124,25 @@ bool LinePolygonsCrossings::getCombingPath(CombPath& combPath, int64_t max_comb_
     }
 
     CombPath basicPath;
-    getBasicCombingPath(basicPath);
+    generateBasicCombingPath(basicPath);
     optimizePath(basicPath, combPath);
 //     combPath = basicPath; // uncomment to disable comb path optimization
     return true;
 }
 
 
-void LinePolygonsCrossings::getBasicCombingPath(CombPath& combPath) 
+void LinePolygonsCrossings::generateBasicCombingPath(CombPath& combPath)
 {
     for (PolyCrossings* crossing = getNextPolygonAlongScanline(transformed_startPoint.X)
         ; crossing != nullptr
         ; crossing = getNextPolygonAlongScanline(crossing->max.x))
     {
-        getBasicCombingPath(*crossing, combPath);
+        generateBasicCombingPath(*crossing, combPath);
     }
     combPath.push_back(endPoint);
 }
 
-void LinePolygonsCrossings::getBasicCombingPath(PolyCrossings& polyCrossings, CombPath& combPath) 
+void LinePolygonsCrossings::generateBasicCombingPath(PolyCrossings& polyCrossings, CombPath& combPath)
 {
     // minimise the path length by measuring the length of both paths around the polygon so we can determine the shorter path
 

--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -173,6 +173,11 @@ void LinePolygonsCrossings::getBasicCombingPath(PolyCrossings& polyCrossings, Co
         rev_points.push_back(p);
         rev_len += vSize(p - prev);
         prev = p;
+        if (rev_len > fwd_len)
+        {
+            // this path is already longer than the forward path so there's no point in carrying on
+            break;
+        }
     }
 
     const Point last = transformation_matrix.unapply(Point(polyCrossings.max.x + std::abs(dist_to_move_boundary_point_outside), transformed_startPoint.Y));

--- a/src/pathPlanning/LinePolygonsCrossings.h
+++ b/src/pathPlanning/LinePolygonsCrossings.h
@@ -109,16 +109,16 @@ private:
     bool calcScanlineCrossings(bool fail_on_unavoidable_obstacles);
     
     /*! 
-     * Get the basic combing path and optimize it.
+     * Generate the basic combing path and optimize it.
      * 
      * \param combPath Output parameter: the points along the combing path.
      * \param fail_on_unavoidable_obstacles When moving over other parts is inavoidable, stop calculation early and return false.
      * \return Whether combing succeeded, i.e. we didn't cross any gaps/other parts
      */
-    bool getCombingPath(CombPath& combPath, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles);
+    bool generateCombingPath(CombPath& combPath, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles);
     
     /*! 
-     * Get the basic combing path, without shortcuts. The path goes straight toward the endPoint and follows the boundary when it hits it, until it passes the scanline again.
+     * Generate the basic combing path, without shortcuts. The path goes straight toward the endPoint and follows the boundary when it hits it, until it passes the scanline again.
      * 
      * Walk trough the crossings, for every boundary we cross, find the initial cross point and the exit point. Then add all the points in between
      * to the \p combPath and continue with the next boundary we will cross, until there are no more boundaries to cross.
@@ -126,10 +126,10 @@ private:
      * 
      * \param combPath Output parameter: the points along the combing path.
      */
-    void getBasicCombingPath(CombPath& combPath);
+    void generateBasicCombingPath(CombPath& combPath);
     
     /*! 
-     * Get the basic combing path, following a single boundary polygon when it hits it, until it passes the scanline again.
+     * Generate the basic combing path, following a single boundary polygon when it hits it, until it passes the scanline again.
      * 
      * Find the initial cross point and the exit point. Then add all the points in between
      * to the \p combPath and continue with the next boundary we will cross, until there are no more boundaries to cross.
@@ -137,7 +137,7 @@ private:
      * 
      * \param combPath Output parameter: where to add the points along the combing path.
      */
-    void getBasicCombingPath(PolyCrossings& crossings, CombPath& combPath);
+    void generateBasicCombingPath(PolyCrossings& crossings, CombPath& combPath);
     
     /*!
      * Find the first polygon cutting the scanline after \p x.
@@ -190,7 +190,7 @@ public:
     static bool comb(const Polygons& boundary, LocToLineGrid& loc_to_line_grid, Point startPoint, Point endPoint, CombPath& combPath, int64_t dist_to_move_boundary_point_outside, int64_t max_comb_distance_ignored, bool fail_on_unavoidable_obstacles)
     {
         LinePolygonsCrossings linePolygonsCrossings(boundary, loc_to_line_grid, startPoint, endPoint, dist_to_move_boundary_point_outside);
-        return linePolygonsCrossings.getCombingPath(combPath, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
+        return linePolygonsCrossings.generateCombingPath(combPath, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
     };
 };
 

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -490,6 +490,10 @@ CombingMode SettingsBaseVirtual::getSettingAsCombingMode(std::string key) const
     {
         return CombingMode::NO_SKIN;
     }
+    if (value == "infill")
+    {
+        return CombingMode::INFILL;
+    }
     return CombingMode::ALL;
 }
 

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -178,7 +178,8 @@ enum class CombingMode
 {
     OFF,
     ALL,
-    NO_SKIN
+    NO_SKIN,
+    INFILL
 };
 
 /*!


### PR DESCRIPTION
The problem was that previously it considered the part's infill area(s) to define the
boundary of the combing area but then travel moves that didn't actually cross the infill
areas were considered to be OK to do with no retraction and so those travels could cross
skin areas!

So now, it adds the part's walls into the combing area so that any travel moves that cross
the part's outline will be combed correctly.

Provides a solution for https://github.com/Ultimaker/Cura/issues/3840.

Without this PR:

![screenshot_2018-05-21_14-32-25](https://user-images.githubusercontent.com/585618/40328320-db7ca10e-5d3d-11e8-915a-4ebff2a2f2f9.png)

With this PR:

![screenshot_2018-05-21_18-57-47](https://user-images.githubusercontent.com/585618/40328329-e4b3d77e-5d3d-11e8-8b2b-272c3415e3a9.png)

This PR will require quite a bit of testing but a fossil fish printed on the S5 using this PR showed no artifacts that were obviously due to this change.
