### PR TITLE
Feature primetowerinfill

### DIFF
--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -127,7 +127,7 @@ void PrimeTower::generatePatternPerExtruder(const SliceDataStorage& storage)
                 patterns_sparse[pattern_idx].polygons = inner_poly.offset(-line_width / 2);
                 Polygons& result_lines_sparse = patterns_sparse[pattern_idx].lines;
                 int outline_offset = -line_width;
-                int line_distance_sparse = (line_width * 100) / 20 * 2; // 2 for grid
+                int line_distance_sparse = storage.getSettingInMicrons("prime_tower_infill_line_distance");
                 double fill_angle = 45 + pattern_idx * 90;
                 Polygons& result_polygons_sparse = patterns_sparse[pattern_idx].polygons; // should remain empty, since we generate lines pattern!
                 constexpr bool zig_zaggify_infill = false;
@@ -147,7 +147,7 @@ void PrimeTower::generatePatternPerExtruder(const SliceDataStorage& storage)
                 Polygons& result_lines_dense = patterns_dense[pattern_idx].lines;
                 int outline_offset = -line_width;
                 int line_distance_dense = line_width;
-                int line_distance_sparse = (line_width * 100) / 20 * 2; // 2 for grid
+                int line_distance_sparse = storage.getSettingInMicrons("prime_tower_infill_line_distance");
                 double fill_angle = 45 + pattern_idx * 90;
                 Polygons& result_polygons_sparse = patterns_sparse[pattern_idx].polygons; // should remain empty, since we generate lines pattern!
                 Polygons& result_polygons_dense = patterns_dense[pattern_idx].polygons; // should remain empty, since we generate lines pattern!
@@ -211,7 +211,9 @@ void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_la
     }
 
     // determine whether to print solid or as sparse infill
-    bool as_infill = prev_extruder == new_extruder && layer_nr != 0;
+    bool as_infill = prev_extruder == new_extruder
+        && layer_nr != 0
+        && storage.getSettingBoolean("prime_tower_sparse_on_nochange");
 
     addPrimeTowerMovesToGcode(storage, gcode_layer, new_extruder, as_infill);
 

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -159,7 +159,7 @@ void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_la
         return;
     }
 
-    if (gcode_layer.getLayerNr() > storage.max_print_height_second_to_last_extruder + 1)
+    if (gcode_layer.getLayerNr() > storage.max_print_height_second_to_last_extruder )
     {
         return;
     }

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -47,7 +47,8 @@ private:
     const unsigned int number_of_pre_wipe_locations = 21; //!< The required size of \ref PrimeTower::wipe_locations
     // note that the above are two consecutive numbers in the Fibonacci sequence
 
-    std::vector<std::vector<ExtrusionMoves>> patterns_per_extruder; //!< For each extruder a vector of patterns to alternate between, over the layers
+    std::vector<std::vector<ExtrusionMoves>> patterns_per_extruder_dense; //!< For each extruder a vector of patterns to alternate between, over the layers
+    std::vector<std::vector<ExtrusionMoves>> patterns_per_extruder_sparse; //!< For each extruder a vector of patterns to alternate between, over the layers for printing sparse layers
     std::vector<ExtrusionMoves> pattern_per_extruder_layer0; //!< For each extruder the pattern to print on the first layer
 
 public:
@@ -117,13 +118,13 @@ private:
 
     /*!
      * \see WipeTower::generatePaths
-     * 
+     *
      * Generate the extrude paths for each extruder on even and odd layers
      * Fill the ground poly with dense infill.
-     * 
+     *
      * \param storage where to get settings from
      */
-    void generatePaths_denseInfill(const SliceDataStorage& storage);
+    void generatePatternPerExtruder(const SliceDataStorage& storage);
 
     /*!
      * \see PrimeTower::addToGcode
@@ -134,7 +135,7 @@ private:
      * \param extruder The extruder we just switched to, with which the prime
      * tower paths should be drawn.
      */
-    void addToGcode_denseInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder) const;
+    void addPrimeTowerMovesToGcode(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder, bool as_infill) const;
 
     /*!
      * Plan the moves for wiping and purging (if enabled) the current nozzles oozed material before starting


### PR DESCRIPTION
This solves feature request #3550 in Cura. 
In particular for n-in-1-out nozzles the layers of the prime tower that are just there to support the rest of the prime tower are filled with a grid grather than solid. The feature as well as the grid density are configurable.
See also pull request 3891 on Cura.