### PR TITLE
Now getInnermostWalls() will use 1st wall only for those regions where 2nd wall is missing.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -162,7 +162,7 @@ Polygons LayerPlan::computeCombBoundaryInside(CombingMode combing_mode, int max_
             }
             else
             {
-                layer.getInnermostWalls(comb_boundary, max_inset);
+                layer.getInnermostWalls(comb_boundary, max_inset, mesh);
             }
         }
         return comb_boundary;

--- a/src/infill/SubDivCube.cpp
+++ b/src/infill/SubDivCube.cpp
@@ -227,7 +227,7 @@ int SubDivCube::distanceFromPointToMesh(SliceMeshStorage& mesh, int layer_nr, Po
         *distance2 = 0;
     }
     Polygons collide;
-    mesh.layers[layer_nr].getInnermostWalls(collide, 2);
+    mesh.layers[layer_nr].getInnermostWalls(collide, 2, mesh);
     Point centerpoint = location;
     bool inside = collide.inside(centerpoint);
     ClosestPolygonPoint border_point = PolygonUtils::moveInside2(collide, centerpoint);

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -72,57 +72,74 @@ void SliceLayer::getOutlines(Polygons& result, bool external_polys_only) const
 
 void SliceLayer::getInnermostWalls(Polygons& layer_walls, int max_inset, const SliceMeshStorage& mesh) const
 {
+    const coord_t half_line_width_0 = mesh.getSettingInMicrons("wall_line_width_0") / 2;
+    const coord_t half_line_width_x = mesh.getSettingInMicrons("wall_line_width_x") / 2;
+
     for (const SliceLayerPart& part : parts)
     {
-        switch (max_inset) {
-            case 1:
-                // take the 1st wall
-                if (part.insets.size() >= 1) {
-                    layer_walls.add(part.insets[0]);
-                    continue;
-                }
-                break;
-            case 2:
-            default:
-                // we want the 2nd inner walls
-                if (part.insets.size() >= 2) {
-                    // if the 2nd wall is missing in some places because the part is narrow, we use the 2nd wall where it does exist
-                    // and where the 2nd wall is missing, we use the 1st wall instead
-                    // this somewhat complex bit of code constructs the polygons that are the union of the 2nd wall outline and those bits of the 1st wall outline that
-                    // correspond to the places where the 2nd wall is missing
-                    const coord_t half_line_width_0 = mesh.getSettingInMicrons("wall_line_width_0") / 2;
-                    const coord_t half_line_width_x = mesh.getSettingInMicrons("wall_line_width_x") / 2;
-                    const coord_t inset_spacing = half_line_width_0 + half_line_width_x; // distance between the centre lines of the 1st and 2nd walls
-                    // first we calculate the 1st wall outline for those portions of the part where the 2nd wall is missing
-                    // this is done by shrinking the 1st wall outline so that it is very slightly smaller than the 2nd wall outline, then expanding it again so it is very
-                    // slightly larger than its original size and subtracting that from the original 1st wall outline, the result is expanded again by half the outer wall
-                    // line width as that is required by the next step
-                    // NOTE - the additional small shrink/expands are required to ensure that the polygons overlap a little so we do not rely on exact results
-                    Polygons outer_inset_where_there_are_no_inner_insets(part.insets[0].difference(part.insets[0].offset(-(inset_spacing+5)).offset(inset_spacing + 10)).offset(half_line_width_0 + 15));
-                    if (outer_inset_where_there_are_no_inner_insets.size() > 0)
-                    {
-                        // there are some regions where the 2nd wall is missing so we must merge the 2nd wall outline with the portions of the 1st wall outline we
-                        // just calculated - the trick here is to expand the outlines sufficiently so that they overlap slightly when unioned and then the result is
-                        // shrunk back to the correct size
-                        layer_walls.add(part.insets[1].offset(half_line_width_x).unionPolygons(outer_inset_where_there_are_no_inner_insets).offset(-std::min(half_line_width_0, half_line_width_x)));
-                    }
-                    else
-                    {
-                        // the 2nd wall is complete so use it verbatim
-                        layer_walls.add(part.insets[1]);
-                    }
-                    continue;
-                }
-                // but we'll also take the inner wall if the 2nd doesn't exist
-                if (part.insets.size() == 1) {
-                    layer_walls.add(part.insets[0]);
-                    continue;
-                }
+        Polygons outer; // outer boundary limit (centre of 1st wall where present, otherwise part's outline)
+
+        if (part.insets.size() > 0)
+        {
+            // part has at least one wall, test if it is complete
+
+            if (part.insets[0].size() == part.outline.size())
+            {
+                // 1st wall is complete, use it for the outer boundary
+                outer = part.insets[0];
+            }
+            else
+            {
+                // 1st wall is incomplete, merge the 1st wall with the part's outline (where the 1st wall is missing)
+
+                // first we calculate the part outline for those portions of the part where the 1st wall is missing
+                // this is done by shrinking the part outline so that it is very slightly smaller than the 1st wall outline, then expanding it again so it is very
+                // slightly larger than its original size and subtracting that from the original part outline
+                // NOTE - the additional small shrink/expands are required to ensure that the polygons overlap a little so we do not rely on exact results
+
+                Polygons outline_where_there_are_no_inner_insets(part.outline.difference(part.outline.offset(-(half_line_width_0+5)).offset(half_line_width_0+10)));
+
+                // merge the 1st wall outline with the portions of the part outline we just calculated
+                // the trick here is to expand the outlines sufficiently so that they overlap when unioned and then the result is shrunk back to the correct size
+
+                outer = part.insets[0].offset(half_line_width_0).unionPolygons(outline_where_there_are_no_inner_insets.offset(half_line_width_0)).offset(-half_line_width_0);
+            }
         }
-        // offset_from_outlines was so large that it completely destroyed our isle,
-        // so we'll just use the regular outline
-        layer_walls.add(part.outline);
-        continue;
+        else
+        {
+            // part has no walls, just use its outline
+            outer = part.outline;
+        }
+
+        if (max_inset >= 2 && part.insets.size() >= 2)
+        {
+            // use the 2nd wall - if the 2nd wall is incomplete because the part is narrow, we use the 2nd wall where it does exist
+            // and where it is missing, we use outer instead
+
+            const coord_t inset_spacing = half_line_width_0 + half_line_width_x; // distance between the centre lines of the 1st and 2nd walls
+
+            // first we calculate the regions of outer that correspond to where the 2nd wall is missing using a similar technique to what we used to calculate outer
+
+            Polygons outer_where_there_are_no_inner_insets(outer.difference(outer.offset(-(inset_spacing+5)).offset(inset_spacing+10)));
+
+            if (outer_where_there_are_no_inner_insets.size() > 0)
+            {
+                // there are some regions where the 2nd wall is missing so we must merge the 2nd wall outline
+                // with the portions of outer we just calculated
+
+                layer_walls.add(part.insets[1].offset(half_line_width_x).unionPolygons(outer_where_there_are_no_inner_insets.offset(half_line_width_0+15)).offset(-std::min(half_line_width_0, half_line_width_x)));
+            }
+            else
+            {
+                // the 2nd wall is complete so use it verbatim
+                layer_walls.add(part.insets[1]);
+            }
+        }
+        else
+        {
+            // fall back to using outer computed above
+            layer_walls.add(outer);
+        }
     }
 }
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -175,7 +175,7 @@ public:
      * Add those polygons to @p result.
      * \param result The result: the collection of all polygons thus obtained
      */
-    void getInnermostWalls(Polygons& result, int max_inset) const;
+    void getInnermostWalls(Polygons& result, int max_inset, const SliceMeshStorage& mesh) const;
 
     ~SliceLayer();
 };


### PR DESCRIPTION

When a part narrows so that there is only enough room for the outer wall, the combing code
fell back to use the 1st wall as the combing region boundary when combing mode was "all"
rather than using the 2nd wall. This new code recognises when the 2nd wall has missing regions
and builds a polygon that is the combination of the regions of the 2nd wall that are present
along with regions from the outer wall as replacements for the missing 2nd wall regions.

This keeps the combing boundary away from the outer wall as much as possible.

Provides a fix for https://github.com/Ultimaker/Cura/issues/3890

Without this PR:

![screenshot_2018-06-06_13-45-25](https://user-images.githubusercontent.com/585618/41038966-ed255de8-698f-11e8-8d9d-3a4baeb1f2b4.png)

With this PR:

![screenshot_2018-06-06_13-44-19](https://user-images.githubusercontent.com/585618/41038979-f5938270-698f-11e8-9944-07942133c3e3.png)
