### PR TITLE
Infill/skin line order tweaks

### DIFF
--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -245,6 +245,8 @@ void LineOrderOptimizer::optimize(bool find_chains)
     {
         // locate the chain ends by finding lines that join exactly one other line at one end and join either 0 or 2 or more lines at the other end
 
+        // we also consider lines that meet 2 or more lines at one end and nothing at the other end as chain ends
+
         for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++)
         {
             int num_joined_lines[2];
@@ -271,6 +273,16 @@ void LineOrderOptimizer::optimize(bool find_chains)
             else if (num_joined_lines[1] != 1 && num_joined_lines[0] == 1)
             {
                 // point 1 of candidate line starts a chain of 2 or more lines
+                chain_ends[poly_idx] = 1;
+            }
+            else if (num_joined_lines[0] == 0 && num_joined_lines[1] > 1)
+            {
+                // point 0 is the free end of a line that meets 2 or more lines at a junction
+                chain_ends[poly_idx] = 0;
+            }
+            else if (num_joined_lines[1] == 0 && num_joined_lines[0] > 1)
+            {
+                // point 1 is the free end of a line that meets 2 or more lines at a junction
                 chain_ends[poly_idx] = 1;
             }
         }


### PR DESCRIPTION
This PR tweaks the order in which infill/skins lines are output in a couple of ways so as to reduce the amount of travel required.

1 - lines that join 2 or more lines at one end and no lines at the other are now considered a chain end and this helps in situations where you have a forked end like this -----<. Before, when the line was being output, the end of one of the forked ends would be reached and then because the other forked end was not being considered to be a chain end, it would go find a chain end somewhere else and leave the little fork line to be done later. Now, it will do the remaining end line before moving away to find the next chain.

2 - previously, when chains were being followed, all singleton lines (lines not connected to any other) were printed after all the chains had been printed. Now, it considers singletons to be "short chains" and so when it is looking for the next chain to follow, it will print a singleton if it is closer than the nearest chain end. This tends to "mop up" the singletons as the chains are being printed rather than having to go back later.
