### PR TITLE
Now passes machine_cooling_fan_number as parameter to M106/M107.

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -41,6 +41,8 @@ GCodeExport::GCodeExport()
 
     extruder_count = 0;
 
+    fan_number = 0;
+
     total_bounding_box = AABB3D();
 }
 
@@ -83,6 +85,8 @@ void GCodeExport::preSetup(const MeshGroup* meshgroup)
     layer_height = meshgroup->getSettingInMillimeters("layer_height");
 
     relative_extrusion = meshgroup->getSettingBoolean("relative_extrusion");
+
+    fan_number = meshgroup->getSettingAsCount("machine_cooling_fan_number");
 
     if (flavor == EGCodeFlavor::BFB)
     {
@@ -1019,15 +1023,16 @@ void GCodeExport::writeFanCommand(double speed)
         if (flavor == EGCodeFlavor::MAKERBOT)
             *output_stream << "M126 T0" << new_line; //value = speed * 255 / 100 // Makerbot cannot set fan speed...;
         else
-            *output_stream << "M106 S" << PrecisionedDouble{1, speed * 255 / 100} << new_line;
+            *output_stream << "M106 S" << PrecisionedDouble{1, speed * 255 / 100} << " P" << fan_number << new_line;
     }
     else
     {
         if (flavor == EGCodeFlavor::MAKERBOT)
             *output_stream << "M127 T0" << new_line;
         else
-            *output_stream << "M107" << new_line;
+            *output_stream << "M107 P" << fan_number << new_line;
     }
+
     currentFanSpeed = speed;
 }
 

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -128,6 +128,7 @@ private:
 
     int current_extruder;
     double currentFanSpeed;
+    unsigned fan_number;
     EGCodeFlavor flavor;
 
     std::vector<double> total_print_times; //!< The total estimated print time in seconds for each feature


### PR DESCRIPTION
Until now, M106/M107 (cooling fan speed control) didn't get a P parameter and so defaulted
to fan 0. Now it can be specified through the machine_cooling_fan_number setting.