### PR TITLE
Avoid crashing in optimizingInsetsIsWorthwhile() when part has no walls.

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -585,6 +585,11 @@ bool InsetOrderOptimizer::optimizingInsetsIsWorthwhile(const SliceMeshStorage& m
         // optimization disabled
         return false;
     }
+    if (part.insets.size() == 0)
+    {
+        // no outlines at all, definitely not worth optimizing
+        return false;
+    }
     if (part.insets.size() < 2 && part.insets[0].size() < 2)
     {
         // only a single outline and no holes, definitely not worth optimizing


### PR DESCRIPTION
When a part has no walls, it just returns false.

This fixes the crash reported in https://github.com/Ultimaker/Cura/issues/3983.