### PR TITLE
fix slowdown regression introduced in #738

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1467,7 +1467,7 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
             {
                 if (m.isPrinted())
                 {
-                    for (auto prevLayerPart : m.layers[gcode_layer.getLayerNr() - 1].parts)
+                    for (const SliceLayerPart& prevLayerPart : m.layers[gcode_layer.getLayerNr() - 1].parts)
                     {
                         if (boundaryBox.hit(prevLayerPart.boundaryBox))
                         {
@@ -1500,7 +1500,7 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
                     }
                     else
                     {
-                        for (auto support_part : support_layer.support_infill_parts)
+                        for (const SupportInfillPart& support_part : support_layer.support_infill_parts)
                         {
                             AABB support_part_bb(support_part.getInfillArea());
                             if (boundaryBox.hit(support_part_bb))
@@ -1885,9 +1885,9 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
 
         if (bridge_layer > 1)
         {
-            for (auto layer_part : mesh.layers[layer_nr - (bridge_layer - 1)].parts)
+            for (const SliceLayerPart& layer_part : mesh.layers[layer_nr - (bridge_layer - 1)].parts)
             {
-                for (auto other_skin_part : layer_part.skin_parts)
+                for (const SkinPart& other_skin_part : layer_part.skin_parts)
                 {
                     if (PolygonUtils::polygonsIntersect(skin_part.outline.outerPolygon(), other_skin_part.outline.outerPolygon()))
                     {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1463,7 +1463,7 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
 
             Polygons outlines_below;
             AABB boundaryBox(part.outline);
-            for (auto m : storage.meshes)
+            for (const SliceMeshStorage& m : storage.meshes)
             {
                 if (m.isPrinted())
                 {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1465,11 +1465,14 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
             AABB boundaryBox(part.outline);
             for (auto m : storage.meshes)
             {
-                for (auto prevLayerPart : m.layers[gcode_layer.getLayerNr() - 1].parts)
+                if (m.isPrinted())
                 {
-                    if (boundaryBox.hit(prevLayerPart.boundaryBox))
+                    for (auto prevLayerPart : m.layers[gcode_layer.getLayerNr() - 1].parts)
                     {
-                        outlines_below.add(prevLayerPart.outline);
+                        if (boundaryBox.hit(prevLayerPart.boundaryBox))
+                        {
+                            outlines_below.add(prevLayerPart.outline);
+                        }
                     }
                 }
             }

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -16,14 +16,17 @@ int bridgeAngle(const Polygons& skin_outline, const SliceDataStorage& storage, c
     // include parts from all meshes
     for (auto mesh : storage.meshes)
     {
-        for (auto prev_layer_part : mesh.layers[layer_nr].parts)
+        if (mesh.isPrinted())
         {
-            prev_layer_outline.add(prev_layer_part.outline); // not intersected with skin
+            for (auto prev_layer_part : mesh.layers[layer_nr].parts)
+            {
+                prev_layer_outline.add(prev_layer_part.outline); // not intersected with skin
 
-            if (!boundary_box.hit(prev_layer_part.boundaryBox))
-                continue;
+                if (!boundary_box.hit(prev_layer_part.boundaryBox))
+                    continue;
 
-            islands.add(skin_outline.intersection(prev_layer_part.outline));
+                islands.add(skin_outline.intersection(prev_layer_part.outline));
+            }
         }
     }
     supported_regions = islands;

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -18,7 +18,7 @@ int bridgeAngle(const Polygons& skin_outline, const SliceDataStorage& storage, c
     {
         if (mesh.isPrinted())
         {
-            for (auto prev_layer_part : mesh.layers[layer_nr].parts)
+            for (const SliceLayerPart& prev_layer_part : mesh.layers[layer_nr].parts)
             {
                 prev_layer_outline.add(prev_layer_part.outline); // not intersected with skin
 
@@ -55,7 +55,7 @@ int bridgeAngle(const Polygons& skin_outline, const SliceDataStorage& storage, c
         }
         else
         {
-            for (auto support_part : support_layer->support_infill_parts)
+            for (const SupportInfillPart& support_part : support_layer->support_infill_parts)
             {
                 AABB support_part_bb(support_part.getInfillArea());
                 if (boundary_box.hit(support_part_bb))

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -14,7 +14,7 @@ int bridgeAngle(const Polygons& skin_outline, const SliceDataStorage& storage, c
     Polygons prev_layer_outline; // we also want the complete outline of the previous layer
 
     // include parts from all meshes
-    for (auto mesh : storage.meshes)
+    for (const SliceMeshStorage& mesh : storage.meshes)
     {
         if (mesh.isPrinted())
         {


### PR DESCRIPTION
Use explicit const reference types for loop variables rather than auto to avoid costly construction of temp objects.