### PR TITLE
Prime Tower Shells

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2358,11 +2358,14 @@ void FffGcodeWriter::setExtruder_addPrime(const SliceDataStorage& storage, Layer
 {
     if (extruder_nr == -1) // an object with extruder_nr==-1 means it will be printed with any current nozzle
         return;
-    
+
     int previous_extruder = gcode_layer.getExtruder();
-    if (previous_extruder == extruder_nr) { return; }
+    if (previous_extruder == extruder_nr && !(extruder_nr == 0 && gcode_layer.getLayerNr() >= -Raft::getFillerLayerCount(storage))) //No unnecessary switches, unless switching to extruder 0 for the outer shell of the prime tower.
+    {
+        return;
+    }
     bool extruder_changed = gcode_layer.setExtruder(extruder_nr);
-    
+
     if (extruder_changed)
     {
         if (extruder_prime_layer_nr[extruder_nr] == gcode_layer.getLayerNr())
@@ -2386,10 +2389,10 @@ void FffGcodeWriter::setExtruder_addPrime(const SliceDataStorage& storage, Layer
         {
             processSkirtBrim(storage, gcode_layer, extruder_nr);
         }
-        if (gcode_layer.getLayerNr() >= -Raft::getFillerLayerCount(storage))
-        {
-            addPrimeTower(storage, gcode_layer, previous_extruder);
-        }
+    }
+    if ((extruder_changed || extruder_nr == 0) && gcode_layer.getLayerNr() >= -Raft::getFillerLayerCount(storage)) //Always print a prime tower with extruder 0.
+    {
+        addPrimeTower(storage, gcode_layer, previous_extruder);
     }
 }
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -861,7 +861,6 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, int lay
 
     if (include_helper_parts)
     { // add prime tower if it hasn't already been added
-        // print the prime tower if it hasn't been printed yet
         int prev_extruder = gcode_layer.getExtruder(); // most likely the same extruder as we are extruding with now
         addPrimeTower(storage, gcode_layer, prev_extruder);
     }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1024,7 +1024,13 @@ std::vector<unsigned int> FffGcodeWriter::getUsedExtrudersOnLayerExcludingStarti
     std::vector<unsigned int> ret;
     ret.push_back(start_extruder);
     std::vector<bool> extruder_is_used_on_this_layer = storage.getExtrudersUsed(layer_nr);
-    
+
+    //The outermost prime tower extruder is always used if there is a prime tower.
+    if (getSettingBoolean("prime_tower_enable"))
+    {
+        extruder_is_used_on_this_layer[storage.primeTower.extruder_order[0]] = true;
+    }
+
     // check if we are on the first layer
     if ((getSettingAsPlatformAdhesion("adhesion_type") == EPlatformAdhesion::RAFT && layer_nr == -Raft::getTotalExtraLayers(storage))
         || (getSettingAsPlatformAdhesion("adhesion_type") != EPlatformAdhesion::RAFT && layer_nr == 0))

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -1,3 +1,6 @@
+//Copyright (c) 2018 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
 #ifndef GCODE_WRITER_H
 #define GCODE_WRITER_H
 
@@ -667,7 +670,7 @@ public:
      * \param gcode_layer The initial planning of the gcode of the layer.
      * \param extruder_nr The extruder to which to switch
      */
-    void setExtruder_addPrime(const SliceDataStorage& storage, LayerPlan& gcode_layer, int extruder_nr) const;
+    void setExtruder_addPrime(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder_nr) const;
 
 private:
     /*!

--- a/src/FffProcessor.cpp
+++ b/src/FffProcessor.cpp
@@ -1,3 +1,6 @@
+//Copyright (c) 2018 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
 #include "FffProcessor.h" 
 
 namespace cura 

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -14,6 +14,7 @@ ExtruderPlan::ExtruderPlan(int extruder, int layer_nr, bool is_initial_layer, bo
 : extruder(extruder)
 , heated_pre_travel_time(0)
 , required_start_temperature(-1)
+, has_prime_tower_planned(false)
 , layer_nr(layer_nr)
 , is_initial_layer(is_initial_layer)
 , is_raft_layer(is_raft_layer)
@@ -80,7 +81,6 @@ LayerPlan::LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int l
 , is_initial_layer(layer_nr == 0 - Raft::getTotalExtraLayers(storage))
 , is_raft_layer(layer_nr < 0 - Raft::getFillerLayerCount(storage))
 , layer_thickness(layer_thickness)
-, has_prime_tower_planned(false)
 , last_extruder_previous_layer(start_extruder)
 , last_planned_extruder_setting_base(storage.meshgroup->getExtruderTrain(start_extruder))
 , first_travel_destination_is_inside(false) // set properly when addTravel is called for the first time (otherwise not set properly)
@@ -243,6 +243,16 @@ void LayerPlan::moveInsideCombBoundary(int distance)
             forceNewPathStart();
         }
     }
+}
+
+bool LayerPlan::getPrimeTowerIsPlanned(unsigned int extruder_nr) const
+{
+    return extruder_plans[extruder_nr].has_prime_tower_planned;
+}
+
+void LayerPlan::setPrimeTowerIsPlanned(unsigned int extruder_nr)
+{
+    extruder_plans[extruder_nr].has_prime_tower_planned = true;
 }
 
 std::optional<std::pair<Point, bool>> LayerPlan::getFirstTravelDestinationState() const

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -14,7 +14,6 @@ ExtruderPlan::ExtruderPlan(int extruder, int layer_nr, bool is_initial_layer, bo
 : extruder(extruder)
 , heated_pre_travel_time(0)
 , required_start_temperature(-1)
-, has_prime_tower_planned(false)
 , layer_nr(layer_nr)
 , is_initial_layer(is_initial_layer)
 , is_raft_layer(is_raft_layer)
@@ -81,6 +80,7 @@ LayerPlan::LayerPlan(const SliceDataStorage& storage, int layer_nr, int z, int l
 , is_initial_layer(layer_nr == 0 - Raft::getTotalExtraLayers(storage))
 , is_raft_layer(layer_nr < 0 - Raft::getFillerLayerCount(storage))
 , layer_thickness(layer_thickness)
+, has_prime_tower_planned_per_extruder(storage.meshgroup->getExtruderCount(), false)
 , last_extruder_previous_layer(start_extruder)
 , last_planned_extruder_setting_base(storage.meshgroup->getExtruderTrain(start_extruder))
 , first_travel_destination_is_inside(false) // set properly when addTravel is called for the first time (otherwise not set properly)
@@ -247,12 +247,12 @@ void LayerPlan::moveInsideCombBoundary(int distance)
 
 bool LayerPlan::getPrimeTowerIsPlanned(unsigned int extruder_nr) const
 {
-    return extruder_plans[extruder_nr].has_prime_tower_planned;
+    return has_prime_tower_planned_per_extruder[extruder_nr];
 }
 
 void LayerPlan::setPrimeTowerIsPlanned(unsigned int extruder_nr)
 {
-    extruder_plans[extruder_nr].has_prime_tower_planned = true;
+    has_prime_tower_planned_per_extruder[extruder_nr] = true;
 }
 
 std::optional<std::pair<Point, bool>> LayerPlan::getFirstTravelDestinationState() const

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -63,9 +63,8 @@ protected:
     std::optional<double> prev_extruder_standby_temp; //!< The temperature to which to set the previous extruder. Not used if the previous extruder plan was the same extruder.
 
     TimeMaterialEstimates estimates; //!< Accumulated time and material estimates for all planned paths within this extruder plan.
-public:
-    bool has_prime_tower_planned; //!< Whether a prime tower is planned for this extruder yet.
 
+public:
     /*!
      * Simple contructor.
      * 
@@ -245,7 +244,7 @@ private:
     int layer_thickness;
 
     std::vector<Point> layer_start_pos_per_extruder; //!< The starting position of a layer for each extruder
-
+    std::vector<bool> has_prime_tower_planned_per_extruder; //!< For each extruder, whether the prime tower is planned yet or not.
     std::optional<Point> last_planned_position; //!< The last planned XY position of the print head (if known)
 
     /*!

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -238,7 +238,7 @@ public:
     int z;
 
 private:
-    int layer_nr; //!< The layer number of this layer plan
+    const int layer_nr; //!< The layer number of this layer plan
     const bool is_initial_layer; //!< Whether this is the first layer (which might be raft)
     const bool is_raft_layer; //!< Whether this is a layer which is part of the raft
     int layer_thickness;

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -64,6 +64,8 @@ protected:
 
     TimeMaterialEstimates estimates; //!< Accumulated time and material estimates for all planned paths within this extruder plan.
 public:
+    bool has_prime_tower_planned; //!< Whether a prime tower is planned for this extruder yet.
+
     /*!
      * Simple contructor.
      * 
@@ -246,8 +248,6 @@ private:
 
     std::optional<Point> last_planned_position; //!< The last planned XY position of the print head (if known)
 
-    bool has_prime_tower_planned;
-
     /*!
      * Whether the skirt or brim polygons have been processed into planned paths
      * for each extruder train.
@@ -355,15 +355,18 @@ public:
         return was_inside;
     }
 
-    bool getPrimeTowerIsPlanned() const
-    {
-        return has_prime_tower_planned;
-    }
+    /*!
+     * Whether the prime tower is already planned for the specified extruder.
+     * \param extruder_nr The extruder to check.
+     */
+    bool getPrimeTowerIsPlanned(unsigned int extruder_nr) const;
 
-    void setPrimeTowerIsPlanned()
-    {
-        has_prime_tower_planned = true;
-    }
+    /*!
+     * Mark the prime tower as planned for the specified extruder.
+     * \param extruder_nr The extruder to mark as having its prime tower
+     * planned.
+     */
+    void setPrimeTowerIsPlanned(unsigned int extruder_nr);
 
     bool getSkirtBrimIsPlanned(unsigned int extruder_nr) const
     {

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -83,8 +83,8 @@ void PrimeTower::generatePaths_denseInfill(const SliceDataStorage& storage)
     EFillMethod first_layer_infill_method;
     for (int extruder = 0; extruder < extruder_count; extruder++)
     {
-        coord_t line_width = storage.meshgroup->getExtruderTrain(extruder)->getSettingInMicrons("prime_tower_line_width");
-        coord_t wall_thickness = storage.meshgroup->getExtruderTrain(extruder)->getSettingInMicrons("prime_tower_wall_thickness");
+        const coord_t line_width = storage.meshgroup->getExtruderTrain(extruder)->getSettingInMicrons("prime_tower_line_width");
+        const coord_t wall_thickness = storage.meshgroup->getExtruderTrain(extruder)->getSettingInMicrons("prime_tower_wall_thickness");
         patterns_per_extruder.emplace_back(n_patterns);
         std::vector<ExtrusionMoves>& patterns = patterns_per_extruder.back();
         patterns.resize(n_patterns);
@@ -154,8 +154,8 @@ void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_la
     {
         return;
     }
-    if (gcode_layer.getPrimeTowerIsPlanned())
-    { // don't print the prime tower if it has been printed already
+    if (gcode_layer.getPrimeTowerIsPlanned(new_extruder))
+    { // don't print the prime tower if it has been printed already with this extruder.
         return;
     }
 
@@ -188,7 +188,7 @@ void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_la
         gcode_layer.addTravel(post_wipe_point - gcode.getExtruderOffset(prev_extruder) + gcode.getExtruderOffset(new_extruder));
     }
 
-    gcode_layer.setPrimeTowerIsPlanned();
+    gcode_layer.setPrimeTowerIsPlanned(new_extruder);
 }
 
 void PrimeTower::addToGcode_denseInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder_nr) const

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -94,15 +94,16 @@ void PrimeTower::generatePaths_denseInfill(const SliceDataStorage& storage)
     coord_t extra_infill_shift = 0;
     coord_t tower_size = storage.getSettingInMicrons("prime_tower_size");
 
+    patterns_per_extruder.resize(extruder_order.size());
     coord_t cumulative_inset = 0; //Each tower shape is going to be printed inside the other. This is the inset we're doing for each extruder.
     coord_t z = 0; // (TODO) because the prime tower stores the paths for each extruder for once instead of generating each layer, we don't know the z position
     EFillMethod first_layer_infill_method;
-    for (unsigned int extruder = 0; extruder < extruder_count; extruder++)
+    for (unsigned int extruder : extruder_order)
     {
         const coord_t line_width = storage.meshgroup->getExtruderTrain(extruder)->getSettingInMicrons("prime_tower_line_width");
         const coord_t wall_thickness = storage.meshgroup->getExtruderTrain(extruder)->getSettingInMicrons("prime_tower_wall_thickness");
-        patterns_per_extruder.emplace_back(n_patterns);
-        std::vector<ExtrusionMoves>& patterns = patterns_per_extruder.back();
+        patterns_per_extruder[extruder] = std::vector<ExtrusionMoves>(n_patterns);
+        std::vector<ExtrusionMoves>& patterns = patterns_per_extruder[extruder];
         patterns.resize(n_patterns);
 
         // If the prime tower is circular, instead of creating a concentric infill in the normal layers, the tower is

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -67,7 +67,6 @@ void PrimeTower::generatePaths(const SliceDataStorage& storage)
     if (enabled)
     {
         generatePaths_denseInfill(storage);
-        generateWipeLocations(storage);
     }
 }
 
@@ -164,20 +163,13 @@ void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_la
         return;
     }
 
-    bool pre_wipe = storage.meshgroup->getExtruderTrain(new_extruder)->getSettingBoolean("dual_pre_wipe");
     bool post_wipe = storage.meshgroup->getExtruderTrain(prev_extruder)->getSettingBoolean("prime_tower_wipe_enabled");
 
     // Do not wipe on the first layer, we will generate non-hollow prime tower there for better bed adhesion.
     const int layer_nr = gcode_layer.getLayerNr();
     if (prev_extruder == new_extruder || layer_nr == 0)
     {
-        pre_wipe = false;
         post_wipe = false;
-    }
-    // pre-wipe:
-    if (pre_wipe)
-    {
-        preWipeAndPurge(storage, gcode_layer, new_extruder);
     }
 
     addToGcode_denseInfill(storage, gcode_layer, new_extruder);
@@ -227,121 +219,6 @@ Point PrimeTower::getLocationBeforePrimeTower(const SliceDataStorage& storage) c
     return ret;
 }
 
-void PrimeTower::generateWipeLocations(const SliceDataStorage& storage)
-{
-    wipe_from_middle = false; //TODO
-    // only wipe from the middle of the prime tower if we have a z hop already on the first move after the layer switch
-    for (int extruder_nr = 0; extruder_nr < storage.meshgroup->getExtruderCount(); extruder_nr++)
-    {
-        const ExtruderTrain& train = *storage.meshgroup->getExtruderTrain(extruder_nr);
-        wipe_from_middle &= train.getSettingBoolean("retraction_hop_enabled") 
-                        && (!train.getSettingBoolean("retraction_hop_only_when_collides") || train.getSettingBoolean("retraction_hop_after_extruder_switch"));
-    }
-
-    PolygonsPointIndex segment_start; // from where to start the sequence of wipe points
-    PolygonsPointIndex segment_end; // where to end the sequence of wipe points
-
-    if (wipe_from_middle)
-    {
-        // take the same start as end point so that the whole poly os covered.
-        // find the inner polygon.
-        segment_start = segment_end = PolygonUtils::findNearestVert(middle, outer_poly);
-    }
-    else
-    {
-        // take the closer corner of the wipe tower and generate wipe locations on that side only:
-        //
-        //     |
-        //     |
-        //     +-----
-        //  .
-        //  ^ nozzle switch location
-        Point from = getLocationBeforePrimeTower(storage);
-
-        // find the single line segment closest to [from] pointing most toward [from]
-        PolygonsPointIndex closest_vert = PolygonUtils::findNearestVert(from, outer_poly);
-        PolygonsPointIndex prev = closest_vert.prev();
-        PolygonsPointIndex next = closest_vert.next();
-        int64_t prev_dot_score = dot(from - closest_vert.p(), turn90CCW(prev.p() - closest_vert.p()));
-        int64_t next_dot_score = dot(from - closest_vert.p(), turn90CCW(closest_vert.p() - next.p()));
-        if (prev_dot_score > next_dot_score)
-        {
-            segment_start = prev;
-            segment_end = closest_vert;
-        }
-        else
-        {
-            segment_start = closest_vert;
-            segment_end = next;
-        }
-    }
-
-    PolygonUtils::spreadDots(segment_start, segment_end, number_of_pre_wipe_locations, pre_wipe_locations);
-}
-
-void PrimeTower::preWipeAndPurge(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder_nr) const
-{
-    int current_pre_wipe_location_idx = (pre_wipe_location_skip * gcode_layer.getLayerNr()) % number_of_pre_wipe_locations;
-    const ClosestPolygonPoint wipe_location = pre_wipe_locations[current_pre_wipe_location_idx];
-
-    const ExtruderTrain* train = storage.meshgroup->getExtruderTrain(extruder_nr);
-    const coord_t inward_dist = train->getSettingInMicrons("machine_nozzle_size") * 3 / 2 ;
-    const coord_t start_dist = train->getSettingInMicrons("machine_nozzle_size") * 2;
-    const Point prime_end = PolygonUtils::moveInsideDiagonally(wipe_location, inward_dist);
-    const Point outward_dir = wipe_location.location - prime_end;
-    const Point prime_start = wipe_location.location + normal(outward_dir, start_dist);
-
-    const double purge_volume = std::max(0.0, train->getSettingInCubicMillimeters("prime_tower_purge_volume")); // Volume to be primed
-    if (wipe_from_middle)
-    {
-        // for hollow wipe tower:
-        // start from above
-        // go to wipe start
-        // go to the Z height of the previous/current layer
-        // wipe
-        // go to normal layer height (automatically on the next extrusion move)...
-        GCodePath& toward_middle = gcode_layer.addTravel(middle);
-        toward_middle.perform_z_hop = true;
-        gcode_layer.forceNewPathStart();
-
-        if (purge_volume > 0)
-        {
-            // start purging away from middle to prevent tower in the middle of the purge tower
-            const Point purge_move = prime_start - middle;
-            const coord_t purge_dist = vSize(purge_move);
-            coord_t pre_move_dist = purge_dist / 4; // shorten the purge move by a third
-            Point purge_start = middle + normal(purge_move, pre_move_dist);
-            gcode_layer.addTravel(purge_start);
-
-            addPurgeMove(gcode_layer, extruder_nr, train, middle, prime_start, purge_volume);
-        }
-        else
-        {
-            // Normal move behavior to wipe start location.
-            GCodePath& toward_wipe_start = gcode_layer.addTravel_simple(prime_start);
-            toward_wipe_start.perform_z_hop = false;
-            toward_wipe_start.retract = true;
-        }
-    }
-    else
-    {
-        if (purge_volume > 0)
-        {
-            // Find location to start purge (we're purging right outside of the tower)
-            const Point purge_start = prime_start + normal(outward_dir, start_dist);
-            gcode_layer.addTravel(purge_start);
-
-            addPurgeMove(gcode_layer, extruder_nr, train, purge_start, prime_start, purge_volume);
-        }
-        gcode_layer.addTravel(prime_start);
-    }
-
-    float flow = 0.0001; // Force this path being interpreted as an extrusion path, so that no Z hop will occur (TODO: really separately handle travel and extrusion moves)
-    gcode_layer.addExtrusionMove(prime_end, gcode_layer.configs_storage.prime_tower_config_per_extruder[extruder_nr], SpaceFillType::None, flow);
-    // Explicitly add a travel move to the wipe location to force the planner to start from the inner_poly.
-    gcode_layer.addTravel(wipe_location.location);
-}
-
 void PrimeTower::subtractFromSupport(SliceDataStorage& storage)
 {
     const Polygons outside_polygon = outer_poly.getOutsidePolygons();
@@ -352,37 +229,6 @@ void PrimeTower::subtractFromSupport(SliceDataStorage& storage)
         // take the differences of the support infill parts and the prime tower area
         support_layer.excludeAreasFromSupportInfillAreas(outside_polygon, outside_polygon_boundary_box);
     }
-}
-
-void PrimeTower::addPurgeMove(LayerPlan& gcode_layer, int extruder_nr, const ExtruderTrain *train, const Point& start_pos, const Point& end_pos, double purge_volume) const
-{
-    // Find out how much purging needs to be done.
-    const GCodePathConfig& current_gcode_path_config = gcode_layer.configs_storage.prime_tower_config_per_extruder[extruder_nr];
-    const coord_t purge_move_length = vSize(start_pos - end_pos);
-    const unsigned int line_width = current_gcode_path_config.getLineWidth();
-    const double layer_height_mm = (gcode_layer.getLayerNr() == 0) ? train->getSettingInMillimeters("layer_height_0") : train->getSettingInMillimeters("layer_height");
-    const double normal_volume = INT2MM(INT2MM(purge_move_length * line_width)) * layer_height_mm; // Volume extruded on the "normal" move
-    float purge_flow = purge_volume / normal_volume;
-
-    const double purge_move_length_mm = INT2MM(purge_move_length);
-    const double purge_move_time = purge_move_length_mm / current_gcode_path_config.getSpeed();
-    const double purge_extrusion_speed_mm3_per_sec = purge_volume / purge_move_time;
-    const double max_possible_extursion_speed_mm3_per_sec = 3.0;
-
-    const double speed = current_gcode_path_config.getSpeed();
-    double speed_factor = 1.0;
-
-    if (purge_extrusion_speed_mm3_per_sec > max_possible_extursion_speed_mm3_per_sec)
-    {
-        // compensate the travel speed for the large extrusion amount
-        const double min_time_needed_for_extrusion = purge_volume / max_possible_extursion_speed_mm3_per_sec;
-        const double compensated_speed = purge_move_length_mm / min_time_needed_for_extrusion;
-        speed_factor = compensated_speed / speed;
-    }
-
-    // As we need a plan, which can't have a stationary extrusion, we use an extrusion move to prime.
-    // This has the added benefit that it will evenly spread the primed material inside the tower.
-    gcode_layer.addExtrusionMove(end_pos, current_gcode_path_config, SpaceFillType::None, purge_flow, false, speed_factor);
 }
 
 

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -99,7 +99,7 @@ void PrimeTower::generatePaths_denseInfill(const SliceDataStorage& storage)
     {
         const coord_t line_width = storage.meshgroup->getExtruderTrain(extruder)->getSettingInMicrons("prime_tower_line_width");
         const coord_t required_volume = storage.meshgroup->getExtruderTrain(extruder)->getSettingInCubicMillimeters("prime_tower_min_volume") * 1000000000; //To cubic microns.
-        const double flow = storage.meshgroup->getExtruderTrain(extruder)->getSettingAsRatio("material_flow");
+        const double flow = storage.meshgroup->getExtruderTrain(extruder)->getSettingAsRatio("prime_tower_flow");
         coord_t current_volume = 0;
         patterns_per_extruder[extruder] = std::vector<ExtrusionMoves>(n_patterns);
         std::vector<ExtrusionMoves>& patterns = patterns_per_extruder[extruder];

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -40,11 +40,6 @@ private:
 
     Point post_wipe_point; //!< Location to post-wipe the unused nozzle off on
 
-    std::vector<ClosestPolygonPoint> pre_wipe_locations; //!< The differernt locations where to pre-wipe the active nozzle
-    const unsigned int pre_wipe_location_skip = 13; //!< How big the steps are when stepping through \ref PrimeTower::wipe_locations
-    const unsigned int number_of_pre_wipe_locations = 21; //!< The required size of \ref PrimeTower::wipe_locations
-    // note that the above are two consecutive numbers in the Fibonacci sequence
-
     std::vector<std::vector<ExtrusionMoves>> patterns_per_extruder; //!< For each extruder a vector of patterns to alternate between, over the layers
     std::vector<ExtrusionMoves> pattern_per_extruder_layer0; //!< For each extruder the pattern to print on the first layer
 
@@ -107,12 +102,6 @@ private:
     Point getLocationBeforePrimeTower(const SliceDataStorage& storage) const;
 
     /*!
-     * \param storage where to get settings from
-     * Depends on inner_poly being generated
-     */
-    void generateWipeLocations(const SliceDataStorage& storage);
-
-    /*!
      * \see WipeTower::generatePaths
      * 
      * Generate the extrude paths for each extruder on even and odd layers
@@ -132,34 +121,6 @@ private:
      * tower paths should be drawn.
      */
     void addToGcode_denseInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder) const;
-
-    /*!
-     * Plan the moves for wiping and purging (if enabled) the current nozzles oozed material before starting
-     * to print the prime tower.
-     * This generates wipe moves from inside the tower towards the outside if the tower is hollow. Otherwise
-     * it wipes from outside to inside.
-     * 
-     * \param storage where to get settings from
-     * \param[out] gcode_layer where to add the planned paths for wiping
-     * \param extruder_nr The current extruder
-     */
-    void preWipeAndPurge(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder_nr) const;
-
-    /*!
-     * Plan a purge move using the prime tower.
-     *
-     * The purge move starts from the center of the prime tower and moves outwards towards the prime tower.
-     * This is an extrusion move so the nozzle will extrude a certain amount of material during the move,
-     * and this is called "purge". This feature can be enabled when prime tower wipe is enabled.
-     *
-     * \param gcode_layer the layer plan to used
-     * \param extruder_nr the extruder number that will be purged
-     * \param train the extruder train of the extruder what will be purged
-     * \param start_pos the start position of the purge move
-     * \param end_pos the end position of the purge move
-     * \param purge_volume the purge volume in mm^3
-     */
-    void addPurgeMove(LayerPlan& gcode_layer, int extruder_nr, const ExtruderTrain *train, const Point& start_pos, const Point& end_pos, double purge_volume) const;
 };
 
 

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -34,7 +34,15 @@ private:
         Polygons lines;
     };
     unsigned int extruder_count; //!< Number of extruders
-    std::vector<unsigned int> extruder_order; //!< In which order, from outside to inside, will we be printing the prime towers for maximum strength?
+
+    /*
+     * In which order, from outside to inside, will we be printing the prime
+     * towers for maximum strength?
+     *
+     * This is the spatial order from outside to inside. This is NOT the actual
+     * order in time in which they are printed.
+     */
+    std::vector<unsigned int> extruder_order;
 
     bool wipe_from_middle; //!< Whether to wipe on the inside of the hollow prime tower
     Point middle; //!< The middle of the prime tower

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -35,15 +35,6 @@ private:
     };
     unsigned int extruder_count; //!< Number of extruders
 
-    /*
-     * In which order, from outside to inside, will we be printing the prime
-     * towers for maximum strength?
-     *
-     * This is the spatial order from outside to inside. This is NOT the actual
-     * order in time in which they are printed.
-     */
-    std::vector<unsigned int> extruder_order;
-
     bool wipe_from_middle; //!< Whether to wipe on the inside of the hollow prime tower
     Point middle; //!< The middle of the prime tower
 
@@ -55,6 +46,15 @@ private:
 public:
     bool enabled; //!< Whether the prime tower is enabled.
     Polygons outer_poly; //!< The outline of the outermost prime tower.
+
+    /*
+     * In which order, from outside to inside, will we be printing the prime
+     * towers for maximum strength?
+     *
+     * This is the spatial order from outside to inside. This is NOT the actual
+     * order in time in which they are printed.
+     */
+    std::vector<unsigned int> extruder_order;
 
     /*!
      * \brief Creates a prime tower instance that will determine where and how

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -35,8 +35,6 @@ private:
     };
     int extruder_count; //!< Number of extruders
 
-    bool is_hollow; //!< Whether the prime tower is hollow
-
     bool wipe_from_middle; //!< Whether to wipe on the inside of the hollow prime tower
     Point middle; //!< The middle of the prime tower
 
@@ -52,8 +50,7 @@ private:
 
 public:
     bool enabled; //!< Whether the prime tower is enabled.
-    Polygons inner_poly; //!< The inline of the prime tower to be used for each layer if it is hollow
-    Polygons outer_poly; //!< The outline of the prime tower to be used for each layer for the first layer
+    Polygons outer_poly; //!< The outline of the outermost prime tower.
 
     /*!
      * \brief Creates a prime tower instance that will determine where and how

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -40,7 +40,7 @@ private:
 
     Point post_wipe_point; //!< Location to post-wipe the unused nozzle off on
 
-    std::vector<std::vector<ExtrusionMoves>> patterns_per_extruder; //!< For each extruder a vector of patterns to alternate between, over the layers
+    std::vector<ExtrusionMoves> pattern_per_extruder; //!< For each extruder the pattern to print on all layers of the prime tower.
     std::vector<ExtrusionMoves> pattern_per_extruder_layer0; //!< For each extruder the pattern to print on the first layer
 
 public:

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -33,7 +33,8 @@ private:
         Polygons polygons;
         Polygons lines;
     };
-    int extruder_count; //!< Number of extruders
+    unsigned int extruder_count; //!< Number of extruders
+    std::vector<unsigned int> extruder_order; //!< In which order, from outside to inside, will we be printing the prime towers for maximum strength?
 
     bool wipe_from_middle; //!< Whether to wipe on the inside of the hollow prime tower
     Point middle; //!< The middle of the prime tower

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -374,7 +374,7 @@ Polygons SliceDataStorage::getLayerOutlines(int layer_nr, bool include_helper_pa
             }
             if (primeTower.enabled)
             {
-                total.add(primeTower.inner_poly);
+                total.add(primeTower.outer_poly);
             }
         }
         total.simplify(maximum_resolution, maximum_resolution);
@@ -424,7 +424,7 @@ Polygons SliceDataStorage::getLayerSecondOrInnermostWalls(int layer_nr, bool inc
             }
             if (primeTower.enabled)
             {
-                total.add(primeTower.inner_poly);
+                total.add(primeTower.outer_poly);
             }
         }
         return total;


### PR DESCRIPTION
This is a reimplementation of parts of the prime tower that should make the prime tower much more stable for high prime towers.

Instead of interweaving layers of the prime tower, alternating between the two extruders, it prints two (or more) prime towers inside each other.

This is a summary of all changes:
* Prime towers are now printed inside each other rather than alternating per layer.
* The outermost prime tower is always printed up to the height of the last extruder switch.
* Inner prime towers will typically only have half of their layers printed, because you only need to prime if you didn't start with that extruder.
* If a range of layers uses only one extruder and the extruder for the inner prime tower is not used, the inner prime tower will hang in mid-air once it starts again. This is accepted behaviour. If the extruder for the outer prime tower is not used, the outer prime tower gets printed anywhere (as per the second point in this summary).
* The square prime tower no longer has lines infill but concentric, similar to the round one.
* Prime tower post-purging is *gone*.
* The Prime Tower Thickness setting has been removed, since the thickness must depend on whether the prime tower is on the outside or on the inside due to the smaller radius on the inside and the required minimum volume.
* The prime towers are ordered from outside to inside according to the "Adhesion Tendency" setting (lowest on the outside). This setting is disabled by default, so you can't see it. This setting is set to 2 for Nylon, 3 for TPU, 10 for PVA, BAM and PP, and 0 for all the rest. That should give an indication of the ordering that you can expect.
* A bug is fixed in the calculation from minimum volume to prime tower thickness, which causes all thicknesses to become different. To counteract that, the volumes of all profiles have been adjusted.

See also the Cura front-end pull request: https://github.com/Ultimaker/Cura/pull/4027

Implements CURA-5457.