### PR TITLE
CURA-5455 Add addPolylines() for line-based infills to fix tiny movements in infill.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1390,7 +1390,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         const bool enable_travel_optimization = mesh.getSettingBoolean("infill_enable_travel_optimization");
         if (pattern == EFillMethod::GRID || pattern == EFillMethod::LINES || pattern == EFillMethod::TRIANGLES || pattern == EFillMethod::CUBIC || pattern == EFillMethod::TETRAHEDRAL || pattern == EFillMethod::QUARTER_CUBIC || pattern == EFillMethod::CUBICSUBDIV)
         {
-            gcode_layer.addLinesByOptimizer(infill_lines, mesh_config.infill_config[0], SpaceFillType::Lines, enable_travel_optimization, mesh.getSettingInMicrons("infill_wipe_dist"));
+            gcode_layer.addPolylines(infill_lines, mesh_config.infill_config[0], SpaceFillType::Lines, enable_travel_optimization, mesh.getSettingInMicrons("infill_wipe_dist"));
         }
         else
         {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -962,7 +962,6 @@ static void addLineToPolylines(std::vector<Polyline>& all_separate_lines, const 
 
 void LayerPlan::addPolylines(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location, double fan_speed)
 {
-    Polygons all_separate_lines = polygons;
     std::vector<Polyline> all_separate_lines;
 
     // Split into separate lines

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -555,6 +555,12 @@ public:
     void addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization = false, int wipe_dist = 0, float flow_ratio = 1.0, std::optional<Point> near_start_location = std::optional<Point>(), double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
 
     /*!
+     * Add lines to the gcode.
+     * This is used for infill patterns such as grid because they generate lines.
+     */
+    void addPolylines(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization = false, int wipe_dist = 0, float flow_ratio = 1.0, std::optional<Point> near_start_location = std::optional<Point>(), double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
+
+    /*!
      * Add a spiralized slice of wall that is interpolated in X/Y between \p last_wall and \p wall.
      *
      * At the start of the wall slice, the points are closest to \p last_wall and at the end of the polygon, the points are closest to \p wall.

--- a/src/utils/Line.h
+++ b/src/utils/Line.h
@@ -1,0 +1,43 @@
+#ifndef CURAENGINE_UTILS_LINE_H
+#define CURAENGINE_UTILS_LINE_H
+
+#include "IntPoint.h"
+
+
+namespace cura
+{
+
+struct Line
+{
+    Point p0;
+    Point p1;
+
+    Line()
+    {}
+
+    Line(const Point& p0, const Point& p1)
+        : p0(p0)
+        , p1(p1)
+    {}
+
+    bool operator==(const Line& l) const
+    {
+        return ((p0 == l.p0 && p1 == l.p1) || (p0 == l.p1 && p1 == l.p0));
+    }
+};
+
+
+struct Polyline
+{
+    std::vector<Line> lines;
+    bool              is_closed;
+
+    Polyline(bool is_closed = false)
+        : is_closed(is_closed)
+    {}
+};
+
+
+}
+
+#endif // CURAENGINE_UTILS_LINE_H


### PR DESCRIPTION
Line-based infill patterns generate polylines which contain connected line segments. `addLinesByOptimizer()` reorders all lines and treats them as individual lines with extra wiping extrusions, and this can cause tiny movements. `addPolylines()` adds each polyline continuously and only add an extra wiping extrusion (if needed) in the end of each polyline.