### PR TITLE
Add setting for Support Infill Line Direction

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2200,7 +2200,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
     }
 
     const int default_support_infill_overlap = infill_extruder.getSettingInMicrons("infill_overlap_mm");
-    const double support_infill_angle = 0;
+    const double support_infill_angle = infill_extruder.getSettingInAngleRadians("support_infill_angle");
     constexpr int infill_multiplier = 1; // there is no frontend setting for this (yet)
     constexpr int wall_line_count = 0;
     coord_t default_support_line_width = infill_extruder.getSettingInMicrons("support_line_width");

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2210,7 +2210,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
     }
 
     const int default_support_infill_overlap = infill_extruder.getSettingInMicrons("infill_overlap_mm");
-    const double support_infill_angle = infill_extruder.getSettingInAngleRadians("support_infill_angle");
+    const double support_infill_angle = infill_extruder.getSettingInAngleDegrees("support_infill_angle");
     constexpr int infill_multiplier = 1; // there is no frontend setting for this (yet)
     constexpr int wall_line_count = 0;
     coord_t default_support_line_width = infill_extruder.getSettingInMicrons("support_line_width");


### PR DESCRIPTION
This PR makes the orientation of infill lines settable. It fixes https://github.com/Ultimaker/Cura/issues/3481

Also see the matching PR for the frontend: https://github.com/Ultimaker/Cura/pull/4212