### PR TITLE
Cura 5614 support minimum x y

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -980,6 +980,16 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage, const S
             layer_this = layer_this.unionPolygons(storage.support.supportLayers[layer_idx].support_mesh_drop_down);
         }
 
+
+        support_areas[layer_idx] = layer_this;
+        Progress::messageProgress(Progress::Stage::SUPPORT, layer_count * (mesh_idx + 1) - layer_idx, layer_count * storage.meshes.size());
+    }
+    
+    // Remove disallowed area only after generating initial layers
+    for (unsigned int layer_idx = layer_count - 1 - layer_z_distance_top; layer_idx != (unsigned int)-1; layer_idx--)
+    {
+        Polygons layer_this = support_areas[layer_idx];
+        
         // Enforce XY distance before bottom distance,
         // because xy_offset might have introduced overlap between model and support,
         // which makes stair stepping conclude the support already rests on the model,
@@ -990,14 +1000,12 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage, const S
         {
             layer_this = layer_this.difference(xy_disallowed_per_layer[layer_idx]);
         }
-
+        
         // move up from model
         moveUpFromModel(storage, stair_removal, layer_this, layer_idx, bottom_empty_layer_count, bottom_stair_step_layer_count, bottom_stair_step_width);
-
         support_areas[layer_idx] = layer_this;
-
-        Progress::messageProgress(Progress::Stage::SUPPORT, layer_count * (mesh_idx + 1) - layer_idx, layer_count * storage.meshes.size());
     }
+    
     
     // do stuff for when support on buildplate only
     if (support_type == ESupportType::PLATFORM_ONLY)

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -1,6 +1,7 @@
 /** Copyright (C) 2017 Tim Kuipers - Released under terms of the AGPLv3 License */
 #include "SVG.h"
-
+#include <exception>
+#include <stdexcept>
 
 namespace cura {
 
@@ -17,17 +18,19 @@ std::string SVG::toString(Color color)
         case SVG::Color::BLUE: return "blue";
         case SVG::Color::GREEN: return "green";
         case SVG::Color::YELLOW: return "yellow";
+        case SVG::Color::NONE: return "none";
         default: return "black";
     }
 }
 
 
 
-SVG::SVG(const char* filename, AABB aabb, Point canvas_size)
+SVG::SVG(const char* filename, AABB aabb, Point canvas_size, Color background)
 : aabb(aabb)
 , aabb_size(aabb.max - aabb.min)
 , border(canvas_size.X / 5, canvas_size.Y / 10)
 , canvas_size(canvas_size)
+, background(background)
 , scale(std::min(double(canvas_size.X - border.X * 2) / aabb_size.X, double(canvas_size.Y - border.Y * 2) / aabb_size.Y))
 {
     output_is_html = strcmp(filename + strlen(filename) - 4, "html") == 0;
@@ -45,6 +48,12 @@ SVG::SVG(const char* filename, AABB aabb, Point canvas_size)
         fprintf(out, "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
     }
     fprintf(out, "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" style=\"width:%llipx;height:%llipx\">\n", canvas_size.X, canvas_size.Y);
+    
+    if(background != Color::NONE)
+    {
+        fprintf(out, "<rect width=\"100%\" height=\"100%\" fill=\"%s\"/>\n", toString(background).c_str());
+    }
+
 }
 
 SVG::~SVG()

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -1,7 +1,5 @@
 /** Copyright (C) 2017 Tim Kuipers - Released under terms of the AGPLv3 License */
 #include "SVG.h"
-#include <exception>
-#include <stdexcept>
 
 namespace cura {
 

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -26,7 +26,8 @@ public:
         BLUE,
         GREEN,
         YELLOW,
-        RAINBOW
+        RAINBOW,
+        NONE
     };
 
 private:
@@ -39,11 +40,12 @@ private:
     const Point border;
     const Point canvas_size;
     const double scale;
+    Color background;
 
     bool output_is_html;
 
 public:
-    SVG(const char* filename, AABB aabb, Point canvas_size = Point(1024, 1024));
+    SVG(const char* filename, AABB aabb, Point canvas_size = Point(1024, 1024), Color background = Color::NONE);
 
     ~SVG();
 


### PR DESCRIPTION
This fix should fix a case when a round arc shape with support enabled, support overhang angle set to 0, the support minimum distance set to 5mm, the support disappears.


[SupportXYDistance.curaproject.3mf.zip](https://github.com/Ultimaker/CuraEngine/files/2288418/SupportXYDistance.curaproject.3mf.zip)
