### PR TITLE
Reorder constructor expressions to avoid compilation warnings.

### DIFF
--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -42,8 +42,8 @@ public:
         static constexpr Node* NO_PARENT = nullptr;
 
         Node() :
-            position(Point(0, 0)),
             distance_to_top(0),
+            position(Point(0, 0)),
             skin_direction(false),
             support_roof_layers_below(0),
             to_buildplate(true),


### PR DESCRIPTION
Fix another recent change that introduced compilation warnings.