### PR TITLE
CURA-5654 Always prime an extruder

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2508,17 +2508,13 @@ void FffGcodeWriter::setExtruder_addPrime(const SliceDataStorage& storage, Layer
         {
             ExtruderTrain* train = storage.meshgroup->getExtruderTrain(extruder_nr);
 
-            if (train->getSettingBoolean("prime_blob_enable"))
-            { // only move to prime position if we do a blob/poop
-                // ideally the prime position would be respected whether we do a blob or not,
-                // but the frontend currently doesn't support a value function of an extruder setting depending on an fdmprinter setting,
-                // which is needed to automatically ignore the prime position for the UM3 machine when blob is disabled
-                bool prime_pos_is_abs = train->getSettingBoolean("extruder_prime_pos_abs");
-                Point prime_pos = Point(train->getSettingInMicrons("extruder_prime_pos_x"), train->getSettingInMicrons("extruder_prime_pos_y"));
-                gcode_layer.addTravel(prime_pos_is_abs? prime_pos : gcode_layer.getLastPlannedPositionOrStartingPosition() + prime_pos);
+            // We always prime an extruder, but whether it will be a prime blob/poop depends on if prime blob is enabled.
+            // This is decided in GCodeExport::writePrimeTrain().
+            bool prime_pos_is_abs = train->getSettingBoolean("extruder_prime_pos_abs");
+            Point prime_pos = Point(train->getSettingInMicrons("extruder_prime_pos_x"), train->getSettingInMicrons("extruder_prime_pos_y"));
+            gcode_layer.addTravel(prime_pos_is_abs? prime_pos : gcode_layer.getLastPlannedPositionOrStartingPosition() + prime_pos);
 
-                gcode_layer.planPrime();
-            }
+            gcode_layer.planPrime();
         }
 
         if (gcode_layer.getLayerNr() == 0 && !gcode_layer.getSkirtBrimIsPlanned(extruder_nr))


### PR DESCRIPTION
Always prime an extruder, whether it will be a normal prime or a prime blob/poop depends on the setting prime_blob_enabled. For normal prime, it will be "G280 S1"; for prime blob, it will be "G280".