### PR TITLE
CURA-5666 Spread start locations on prime tower to avoid Z-seam blob

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -548,7 +548,6 @@ void LayerPlan::addPolygon(ConstPolygonRef polygon, int start_idx, const GCodePa
 
 void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePathConfig& config, WallOverlapComputation* wall_overlap_computation, const ZSeamConfig& z_seam_config, coord_t wall_0_wipe_dist, bool spiralize, float flow_ratio, bool always_retract, bool reverse_order)
 {
-    
     if (polygons.size() == 0)
     {
         return;

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -85,7 +85,7 @@ void PrimeTower::generatePaths(const SliceDataStorage& storage)
     if (enabled)
     {
         generatePaths_denseInfill(storage);
-        generateStartLocations(storage);
+        generateStartLocations();
     }
 }
 
@@ -141,12 +141,12 @@ void PrimeTower::generatePaths_denseInfill(const SliceDataStorage& storage)
 }
 
 
-void PrimeTower::generateStartLocations(const SliceDataStorage& storage)
+void PrimeTower::generateStartLocations()
 {
-    PolygonsPointIndex segment_start; // from where to start the sequence of wipe points
-    PolygonsPointIndex segment_end; // where to end the sequence of wipe points
-
-    segment_start = segment_end = PolygonUtils::findNearestVert(middle, outer_poly);
+    // Evenly spread out a number of dots along the prime tower's outline. This is done for the complete outline,
+    // so use the same start and end segments for this.
+    PolygonsPointIndex segment_start = PolygonsPointIndex(&outer_poly, 0, 0);
+    PolygonsPointIndex segment_end = segment_start;
 
     PolygonUtils::spreadDots(segment_start, segment_end, number_of_prime_tower_start_locations, prime_tower_start_locations);
 }

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -16,6 +16,7 @@
 
 #define CIRCLE_RESOLUTION 32 //The number of vertices in each circle.
 
+
 namespace cura 
 {
 
@@ -84,6 +85,7 @@ void PrimeTower::generatePaths(const SliceDataStorage& storage)
     if (enabled)
     {
         generatePaths_denseInfill(storage);
+        generateStartLocations(storage);
     }
 }
 
@@ -139,6 +141,17 @@ void PrimeTower::generatePaths_denseInfill(const SliceDataStorage& storage)
 }
 
 
+void PrimeTower::generateStartLocations(const SliceDataStorage& storage)
+{
+    PolygonsPointIndex segment_start; // from where to start the sequence of wipe points
+    PolygonsPointIndex segment_end; // where to end the sequence of wipe points
+
+    segment_start = segment_end = PolygonUtils::findNearestVert(middle, outer_poly);
+
+    PolygonUtils::spreadDots(segment_start, segment_end, number_of_prime_tower_start_locations, prime_tower_start_locations);
+}
+
+
 void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_layer, const GCodeExport& gcode, const int prev_extruder, const int new_extruder) const
 {
     if (!enabled)
@@ -162,6 +175,11 @@ void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_la
     if (prev_extruder == new_extruder || layer_nr == 0)
     {
         post_wipe = false;
+    }
+
+    // Go to the start location if it's not the first layer
+    if (layer_nr != 0) {
+        gotoStartLocation(storage, gcode_layer, new_extruder);
     }
 
     addToGcode_denseInfill(storage, gcode_layer, new_extruder);
@@ -221,6 +239,22 @@ void PrimeTower::subtractFromSupport(SliceDataStorage& storage)
         // take the differences of the support infill parts and the prime tower area
         support_layer.excludeAreasFromSupportInfillAreas(outside_polygon, outside_polygon_boundary_box);
     }
+}
+
+
+void PrimeTower::gotoStartLocation(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder_nr) const
+{
+    int current_start_location_idx = ((extruder_nr + 1) * gcode_layer.getLayerNr()) % number_of_prime_tower_start_locations;
+    const ClosestPolygonPoint wipe_location = prime_tower_start_locations[current_start_location_idx];
+
+    const ExtruderTrain* train = storage.meshgroup->getExtruderTrain(extruder_nr);
+    const coord_t inward_dist = train->getSettingInMicrons("machine_nozzle_size") * 3 / 2 ;
+    const coord_t start_dist = train->getSettingInMicrons("machine_nozzle_size") * 2;
+    const Point prime_end = PolygonUtils::moveInsideDiagonally(wipe_location, inward_dist);
+    const Point outward_dir = wipe_location.location - prime_end;
+    const Point prime_start = wipe_location.location + normal(outward_dir, start_dist);
+
+    gcode_layer.addTravel(prime_start);
 }
 
 

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -245,24 +245,8 @@ void PrimeTower::subtractFromSupport(SliceDataStorage& storage)
 
 void PrimeTower::gotoStartLocation(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder_nr) const
 {
-    // start location index = ([Ei + 1] * abs([LR]) ) mod [DOT_COUNT]
-    // where:
-    //  - [Ei] is the current extruder index starting from 0
-    //  - [LR] is the current layer number (converted)
-    //  - [DOT_COUNT] is the total number of dots around the prime tower's perimeter.
-
-    // Because layer number can be negative, it needs to be converted to a non-negative number.
-    int lr = gcode_layer.getLayerNr();
-    int ei = extruder_nr + 1;
-    if (lr < 0)
-    {
-        // Treat extruder index on an negative layer in the reversed order, i.e.
-        //    [DOT_COUNT] - (index mod [DOT_COUNT])
-        // to above having the same starting location for layers such as -1 and 1, -2 and 2, etc.
-        ei = number_of_prime_tower_start_locations - (ei % number_of_prime_tower_start_locations);
-        lr = -lr;
-    }
-    int current_start_location_idx = ((ei) * lr) % number_of_prime_tower_start_locations;
+    int current_start_location_idx = ((((extruder_nr + 1) * gcode_layer.getLayerNr()) % number_of_prime_tower_start_locations)
+            + number_of_prime_tower_start_locations) % number_of_prime_tower_start_locations;
 
     const ClosestPolygonPoint wipe_location = prime_tower_start_locations[current_start_location_idx];
 

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -245,7 +245,25 @@ void PrimeTower::subtractFromSupport(SliceDataStorage& storage)
 
 void PrimeTower::gotoStartLocation(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder_nr) const
 {
-    int current_start_location_idx = ((extruder_nr + 1) * gcode_layer.getLayerNr()) % number_of_prime_tower_start_locations;
+    // start location index = ([Ei + 1] * abs([LR]) ) mod [DOT_COUNT]
+    // where:
+    //  - [Ei] is the current extruder index starting from 0
+    //  - [LR] is the current layer number (converted)
+    //  - [DOT_COUNT] is the total number of dots around the prime tower's perimeter.
+
+    // Because layer number can be negative, it needs to be converted to a non-negative number.
+    int lr = gcode_layer.getLayerNr();
+    int ei = extruder_nr + 1;
+    if (lr < 0)
+    {
+        // Treat extruder index on an negative layer in the reversed order, i.e.
+        //    [DOT_COUNT] - (index mod [DOT_COUNT])
+        // to above having the same starting location for layers such as -1 and 1, -2 and 2, etc.
+        ei = number_of_prime_tower_start_locations - (ei % number_of_prime_tower_start_locations);
+        lr = -lr;
+    }
+    int current_start_location_idx = ((ei) * lr) % number_of_prime_tower_start_locations;
+
     const ClosestPolygonPoint wipe_location = prime_tower_start_locations[current_start_location_idx];
 
     const ExtruderTrain* train = storage.meshgroup->getExtruderTrain(extruder_nr);

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -206,30 +206,6 @@ void PrimeTower::addToGcode_denseInfill(const SliceDataStorage& storage, LayerPl
     gcode_layer.addLinesByOptimizer(pattern.lines, config, SpaceFillType::Lines);
 }
 
-Point PrimeTower::getLocationBeforePrimeTower(const SliceDataStorage& storage) const
-{
-    Point ret(0, 0);
-    int absolute_starting_points = 0;
-    for (unsigned int extruder_nr = 0; extruder_nr < storage.meshgroup->getExtruderCount(); extruder_nr++)
-    {
-        ExtruderTrain& train = *storage.meshgroup->getExtruderTrain(0);
-        if (train.getSettingBoolean("machine_extruder_start_pos_abs"))
-        {
-            ret += Point(train.getSettingInMicrons("machine_extruder_start_pos_x"), train.getSettingInMicrons("machine_extruder_start_pos_y"));
-            absolute_starting_points++;
-        }
-    }
-    if (absolute_starting_points > 0)
-    { // take the average over all absolute starting positions
-        ret /= absolute_starting_points;
-    }
-    else
-    { // use the middle of the bed
-        ret = storage.machine_size.flatten().getMiddle();
-    }
-    return ret;
-}
-
 void PrimeTower::subtractFromSupport(SliceDataStorage& storage)
 {
     const Polygons outside_polygon = outer_poly.getOutsidePolygons();

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -178,7 +178,8 @@ void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_la
     }
 
     // Go to the start location if it's not the first layer
-    if (layer_nr != 0) {
+    if (layer_nr != 0)
+    {
         gotoStartLocation(storage, gcode_layer, new_extruder);
     }
 

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -40,6 +40,10 @@ private:
 
     Point post_wipe_point; //!< Location to post-wipe the unused nozzle off on
 
+    std::vector<ClosestPolygonPoint> prime_tower_start_locations; //!< The differernt locations where to pre-wipe the active nozzle
+    const unsigned int prime_tower_start_location_skip = 13; //!< How big the steps are when stepping through \ref PrimeTower::wipe_locations
+    const unsigned int number_of_prime_tower_start_locations = 21; //!< The required size of \ref PrimeTower::wipe_locations
+
     std::vector<ExtrusionMoves> pattern_per_extruder; //!< For each extruder the pattern to print on all layers of the prime tower.
     std::vector<ExtrusionMoves> pattern_per_extruder_layer0; //!< For each extruder the pattern to print on the first layer
 
@@ -121,6 +125,12 @@ private:
     void generatePaths_denseInfill(const SliceDataStorage& storage);
 
     /*!
+     * \param storage where to get settings from
+     * Depends on outer_poly being generated
+     */
+    void generateStartLocations(const SliceDataStorage& storage);
+
+    /*!
      * \see PrimeTower::addToGcode
      *
      * Add path plans for the prime tower to the \p gcode_layer
@@ -130,6 +140,8 @@ private:
      * tower paths should be drawn.
      */
     void addToGcode_denseInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder) const;
+
+    void gotoStartLocation(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder) const;
 };
 
 

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -142,6 +142,11 @@ private:
      */
     void addToGcode_denseInfill(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder) const;
 
+    /*!
+     * For an extruder switch that happens not on the first layer, the extruder needs to be primed on the prime tower.
+     * This function picks a start location for this extruder on the prime tower's perimeter and travels there to avoid
+     * starting at the location everytime which can result in z-seam blobs.
+     */
     void gotoStartLocation(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int extruder) const;
 };
 

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -41,7 +41,6 @@ private:
     Point post_wipe_point; //!< Location to post-wipe the unused nozzle off on
 
     std::vector<ClosestPolygonPoint> prime_tower_start_locations; //!< The differernt locations where to pre-wipe the active nozzle
-    const unsigned int prime_tower_start_location_skip = 13; //!< How big the steps are when stepping through \ref PrimeTower::wipe_locations
     const unsigned int number_of_prime_tower_start_locations = 21; //!< The required size of \ref PrimeTower::wipe_locations
 
     std::vector<ExtrusionMoves> pattern_per_extruder; //!< For each extruder the pattern to print on all layers of the prime tower.
@@ -103,16 +102,6 @@ public:
     void subtractFromSupport(SliceDataStorage& storage);
 
 private:
-
-    /*!
-     * Find an appropriate representation for the point representing the location before going to the prime tower
-     * 
-     * \warning This is not the actual position each time before the wipe tower
-     * 
-     * \param storage where to get settings from
-     * \return that location
-     */
-    Point getLocationBeforePrimeTower(const SliceDataStorage& storage) const;
 
     /*!
      * \see WipeTower::generatePaths

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -105,7 +105,7 @@ public:
 private:
 
     /*!
-     * Find an approriate representation for the point representing the location before going to the prime tower
+     * Find an appropriate representation for the point representing the location before going to the prime tower
      * 
      * \warning This is not the actual position each time before the wipe tower
      * 
@@ -125,10 +125,11 @@ private:
     void generatePaths_denseInfill(const SliceDataStorage& storage);
 
     /*!
-     * \param storage where to get settings from
-     * Depends on outer_poly being generated
+     * Generate start locations on the prime tower. The locations are evenly spread around the prime tower's perimeter.
+     * The number of starting points is defined by "number_of_prime_tower_start_locations". The generated points will
+     * be stored in "prime_tower_start_locations".
      */
-    void generateStartLocations(const SliceDataStorage& storage);
+    void generateStartLocations();
 
     /*!
      * \see PrimeTower::addToGcode


### PR DESCRIPTION
Z-seam blob can build up if with the current prime tower because it always starts at the same location. This commit spreads the start location evenly around the prime tower to avoid the blob being built up.