### PR TITLE
Fix polygon connector

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -78,6 +78,11 @@ void Infill::generate(Polygons& result_polygons, Polygons& result_lines, const S
 
     if (connect_polygons)
     {
+        // remove too small polygons
+        coord_t snap_distance = infill_line_width * 2; // polygons with a span of max 1 * nozzle_size are too small
+        auto it = std::remove_if(result_polygons.begin(), result_polygons.end(), [snap_distance](PolygonRef poly) { return poly.shorterThan(snap_distance); });
+        result_polygons.erase(it, result_polygons.end());
+
         PolygonConnector connector(infill_line_width, infill_line_width * 3 / 2);
         connector.add(result_polygons);
         result_polygons = connector.connect();

--- a/src/utils/AABB.cpp
+++ b/src/utils/AABB.cpp
@@ -80,6 +80,12 @@ void AABB::include(Point point)
     max.Y = std::max(max.Y,point.Y);
 }
 
+void AABB::include(const AABB other)
+{
+    include(other.min);
+    include(other.max);
+}
+
 void AABB::expand(int dist)
 {
     if (min == Point(POINT_MAX, POINT_MAX) || max == Point(POINT_MIN, POINT_MIN))

--- a/src/utils/AABB.h
+++ b/src/utils/AABB.h
@@ -60,6 +60,17 @@ public:
     void include(Point point);
 
     /*!
+     * \brief Includes the specified bounding box in the bounding box.
+     * 
+     * The bounding box is expanded to include the other bounding box.
+     * 
+     * This performs a union on two bounding boxes.
+     * 
+     * \param other The bounding box to include in this one.
+     */
+    void include(const AABB other);
+
+    /*!
      * Expand the borders of the bounding box in each direction with the given amount
      * 
      * \param dist The distance by which to expand the borders of the bounding box

--- a/src/utils/LinearAlg2D.cpp
+++ b/src/utils/LinearAlg2D.cpp
@@ -112,6 +112,35 @@ bool LinearAlg2D::getPointOnLineWithDist(const Point& p, const Point& a, const P
     }
 }
 
+
+std::pair<Point, Point> LinearAlg2D::getClosestConnection(Point a1, Point a2, Point b1, Point b2)
+{
+    Point b1_on_a = getClosestOnLineSegment(b1, a1, a2);
+    coord_t b1_on_a_dist2 = vSize2(b1_on_a - b1);
+    Point b2_on_a = getClosestOnLineSegment(b2, a1, a2);
+    coord_t b2_on_a_dist2 = vSize2(b2_on_a - b2);
+    Point a1_on_b = getClosestOnLineSegment(a1, b1, b2);
+    coord_t a1_on_b_dist2 = vSize2(a1_on_b - a1);
+    Point a2_on_b = getClosestOnLineSegment(a1, b1, b2);
+    coord_t a2_on_b_dist2 = vSize2(a2_on_b - a2);
+    if (b1_on_a_dist2 < b2_on_a_dist2 && b1_on_a_dist2 < a1_on_b_dist2 && b1_on_a_dist2 < a2_on_b_dist2)
+    {
+        return std::make_pair(b1_on_a, b1);
+    }
+    else if (b2_on_a_dist2 < a1_on_b_dist2 && b2_on_a_dist2 < a2_on_b_dist2)
+    {
+        return std::make_pair(b2_on_a, b2);
+    }
+    else if (a1_on_b_dist2 < a2_on_b_dist2)
+    {
+        return std::make_pair(a1, a1_on_b);
+    }
+    else
+    {
+        return std::make_pair(a2, a2_on_b);
+    }
+}
+
 bool LinearAlg2D::lineSegmentsCollide(const Point& a_from_transformed, const Point& a_to_transformed, Point b_from_transformed, Point b_to_transformed)
 {
     assert(std::abs(a_from_transformed.Y - a_to_transformed.Y) < 2 && "line a is supposed to be transformed to be aligned with the X axis!");

--- a/src/utils/PolygonConnector.cpp
+++ b/src/utils/PolygonConnector.cpp
@@ -252,7 +252,7 @@ std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getConnecti
         to_polys.add(poly);
     }
 
-    std::pair<ClosestPolygonPoint, ClosestPolygonPoint> connection_points = PolygonUtils::findSmallestConnection(from_poly, to_polys, line_width * 4 / 3, line_width * 3 / 2);
+    std::pair<ClosestPolygonPoint, ClosestPolygonPoint> connection_points = PolygonUtils::findSmallestConnection(from_poly, to_polys, line_width - 10, line_width * 3 / 2);
 
     if (!connection_points.first.isValid() || !connection_points.second.isValid())
     {

--- a/src/utils/PolygonConnector.cpp
+++ b/src/utils/PolygonConnector.cpp
@@ -208,7 +208,7 @@ std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondCo
 
     const Point shift = turn90CCW(first.from.p() - first.to.p());
     
-    PolygonConnection best;
+    std::optional<PolygonConnection> best;
     coord_t best_total_distance2 = std::numeric_limits<coord_t>::max();
     for (unsigned int from_idx = 0; from_idx < 2; from_idx++)
     {
@@ -238,8 +238,7 @@ std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondCo
             const coord_t total_distance2 = vSize2(from.p() - to.p()) + vSize2(from.p() - first.from.p()) + vSize(to.p() - first.to.p());
             if (total_distance2 < best_total_distance2)
             {
-                best.from = from;
-                best.to = to;
+                best.emplace(from, to);
                 best_total_distance2 = total_distance2;
             }
             
@@ -253,13 +252,13 @@ std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondCo
             break;
         }
     }
-    if (best_total_distance2 > max_dist * max_dist + 2 * (line_width + 10) * (line_width + 10))
+    if (!best || best_total_distance2 > max_dist * max_dist + 2 * (line_width + 10) * (line_width + 10))
     {
         return std::optional<PolygonConnector::PolygonConnection>();
     }
     else
     {
-        return best;
+        return *best;
     }
 }
 

--- a/src/utils/PolygonConnector.cpp
+++ b/src/utils/PolygonConnector.cpp
@@ -146,7 +146,7 @@ std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(Const
             {
                 return false;
             }
-            second_connection = PolygonConnector::getSecondConnection(*first_connection, line_width);
+            second_connection = PolygonConnector::getSecondConnection(*first_connection);
             if (!second_connection)
             {
                 return false;
@@ -181,22 +181,22 @@ std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(Const
     }
 }
 
-std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondConnection(PolygonConnection& first, coord_t shift_distance)
+std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondConnection(PolygonConnection& first)
 {
     bool forward = true;
-    std::optional<ClosestPolygonPoint> from_a = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), shift_distance, forward);
+    std::optional<ClosestPolygonPoint> from_a = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), line_width, forward);
     if (!from_a)
     { // then there's also not going to be a b
         return std::optional<PolygonConnector::PolygonConnection>();
     }
-    std::optional<ClosestPolygonPoint> from_b = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), shift_distance, !forward);
+    std::optional<ClosestPolygonPoint> from_b = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), line_width, !forward);
 
-    std::optional<ClosestPolygonPoint> to_a = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), shift_distance, forward);
+    std::optional<ClosestPolygonPoint> to_a = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), line_width, forward);
     if (!to_a)
     {
         return std::optional<PolygonConnector::PolygonConnection>();
     }
-    std::optional<ClosestPolygonPoint> to_b = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), shift_distance, !forward);
+    std::optional<ClosestPolygonPoint> to_b = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), line_width, !forward);
 
 
     const Point shift = turn90CCW(first.from.p() - first.to.p());
@@ -246,7 +246,7 @@ std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondCo
             break;
         }
     }
-    if (best_total_distance2 > max_dist * max_dist + 2 * (shift_distance + 10) * (shift_distance + 10))
+    if (best_total_distance2 > max_dist * max_dist + 2 * (line_width + 10) * (line_width + 10))
     {
         return std::optional<PolygonConnector::PolygonConnection>();
     }

--- a/src/utils/PolygonConnector.cpp
+++ b/src/utils/PolygonConnector.cpp
@@ -10,7 +10,12 @@ namespace cura
 Polygons PolygonConnector::connect()
 {
     Polygons ret;
-    
+
+    if (input_polygons.empty())
+    {
+        return ret;
+    }
+
     std::vector<Polygon> to_connect;
     to_connect.reserve(input_polygons.size());
     for (ConstPolygonPointer poly : input_polygons)
@@ -20,6 +25,11 @@ Polygons PolygonConnector::connect()
 
     while (!to_connect.empty())
     {
+        if (to_connect.size() == 1)
+        {
+            ret.add(std::move(to_connect.back()));
+            break;
+        }
         Polygon current = std::move(to_connect.back());
         to_connect.pop_back();
 

--- a/src/utils/PolygonConnector.cpp
+++ b/src/utils/PolygonConnector.cpp
@@ -157,7 +157,7 @@ std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(Const
     std::pair<ClosestPolygonPoint, ClosestPolygonPoint> connection_points = PolygonUtils::findConnection(from_poly, to_polys, line_width - 10, line_width * 3 / 2, can_make_bridge);
 
     if (!connection_points.first.isValid() || !connection_points.second.isValid())
-    { // We didn;t find a connection which can make a bridge
+    { // We didn't find a connection which can make a bridge
         // We might have found a first_connection and a second_connection, but maybe they didn't satisfy all criteria.
         std::optional<PolygonConnector::PolygonBridge> uninitialized;
         return uninitialized;

--- a/src/utils/PolygonConnector.cpp
+++ b/src/utils/PolygonConnector.cpp
@@ -128,6 +128,13 @@ char PolygonConnector::getPolygonDirection(const ClosestPolygonPoint& from, cons
 
 std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(ConstPolygonRef from_poly, std::vector<Polygon>& to_polygons)
 {
+    // line distance between consecutive polygons should be at least the line_width
+    const coord_t min_connection_length = line_width - 10;
+    // Only connect polygons if they are next to each other
+    // allow for a bit of wiggle room for when the polygons are very curved,
+    // which causes any connection distance to be larger than the offset amount
+    const coord_t max_connection_length = line_width * 3 / 2;
+
     std::optional<PolygonConnector::PolygonConnection> first_connection;
     std::optional<PolygonConnector::PolygonConnection> second_connection;
 
@@ -154,7 +161,7 @@ std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(Const
             return true;
         };
 
-    std::pair<ClosestPolygonPoint, ClosestPolygonPoint> connection_points = PolygonUtils::findConnection(from_poly, to_polys, line_width - 10, line_width * 3 / 2, can_make_bridge);
+    std::pair<ClosestPolygonPoint, ClosestPolygonPoint> connection_points = PolygonUtils::findConnection(from_poly, to_polys, min_connection_length, max_connection_length, can_make_bridge);
 
     if (!connection_points.first.isValid() || !connection_points.second.isValid())
     { // We didn't find a connection which can make a bridge

--- a/src/utils/PolygonConnector.h
+++ b/src/utils/PolygonConnector.h
@@ -81,12 +81,6 @@ protected:
         ClosestPolygonPoint from; //!< from location in the source polygon
         ClosestPolygonPoint to; //!< to location in the destination polygon
 
-        /* 
-         * \warning Doesn't properly initialize the members
-         */
-        PolygonConnection()
-        {}
-
         PolygonConnection(ClosestPolygonPoint from, ClosestPolygonPoint to)
         : from(from)
         , to(to)

--- a/src/utils/PolygonConnector.h
+++ b/src/utils/PolygonConnector.h
@@ -171,17 +171,17 @@ protected:
     std::optional<PolygonBridge> getBridge(ConstPolygonRef poly, std::vector<Polygon>& polygons);
 
     /*!
-     * Get a connection parallel to a given \p first connection at an orthogonal distance \p shift from the \p first connection.
+     * Get a connection parallel to a given \p first connection at an orthogonal distance line_width from the \p first connection.
      * 
      * From a given \p first connection,
      * walk along both polygons in each direction
-     * until we are at a distance of \p shift away orthogonally from the line segment of the \p first connection.
+     * until we are at a distance of line_width away orthogonally from the line segment of the \p first connection.
      * 
      * For all combinations of such found points:
      * - check whether they are both on the same side of the \p first connection
      * - choose the connection which woukd form the smalles bridge
      */
-    std::optional<PolygonConnection> getSecondConnection(PolygonConnection& first, coord_t shift);
+    std::optional<PolygonConnection> getSecondConnection(PolygonConnection& first);
 };
 
 

--- a/src/utils/PolygonConnector.h
+++ b/src/utils/PolygonConnector.h
@@ -81,6 +81,17 @@ protected:
         ClosestPolygonPoint from; //!< from location in the source polygon
         ClosestPolygonPoint to; //!< to location in the destination polygon
 
+        /* 
+         * \warning Doesn't properly initialize the members
+         */
+        PolygonConnection()
+        {}
+
+        PolygonConnection(ClosestPolygonPoint from, ClosestPolygonPoint to)
+        : from(from)
+        , to(to)
+        {}
+
         coord_t getDistance2()
         {
             return vSize2(to.p() - from.p());
@@ -101,6 +112,9 @@ protected:
     {
         PolygonConnection a; //!< first connection
         PolygonConnection b; //!< second connection
+        PolygonBridge(PolygonConnection a, PolygonConnection b)
+        : a(a), b(b)
+        {}
     };
 
     std::vector<PolygonBridge> all_bridges; //!< All bridges generated during any call to \ref PolygonConnector::connect(). This is just for keeping scores for debugging etc.
@@ -155,11 +169,6 @@ protected:
      * So as to try and find a bridge which is centered around the initiall found first connection
      */
     std::optional<PolygonBridge> getBridge(ConstPolygonRef poly, std::vector<Polygon>& polygons);
-
-    /*!
-     * Find the smallest single connection between a polygon \p poly and all \p polygons
-     */
-    std::optional<PolygonConnection> getConnection(ConstPolygonRef poly, std::vector<Polygon>& polygons);
 
     /*!
      * Get a connection parallel to a given \p first connection at an orthogonal distance \p shift from the \p first connection.

--- a/src/utils/SparseGrid.h
+++ b/src/utils/SparseGrid.h
@@ -84,15 +84,6 @@ public:
     bool processNearby(const Point &query_pt, coord_t radius,
                        const std::function<bool (const ElemT&)>& process_func) const;
 
-    /*! \brief Process elements from all cells.
-     *
-     * Processes all elements.
-     * \param[in] process_func Processes each element.  process_func(elem) is
-     *    called for each element in the cells. Processing stops if function returns false.
-     * \return Whether we need to continue processing after this function
-     */
-    bool processAll(const std::function<bool(const Elem& elem)>& process_elem_func) const;
-
     /*! \brief Process elements from cells that might contain sought after points along a line.
      *
      * Processes elements from cells that cross the line \p query_line.
@@ -348,25 +339,6 @@ bool SGI_THIS::processNearby(const Point &query_pt, coord_t radius,
             {
                 return false;
             }
-        }
-    }
-    return true;
-}
-
-SGI_TEMPLATE
-bool SGI_THIS::processAll(const std::function<bool (const Elem&)>& process_elem_func) const
-{
-    const std::function<bool (const GridPoint&)> process_cell_func = [&process_elem_func, this](GridPoint grid_loc)
-        {
-            return processFromCell(grid_loc, process_elem_func);
-        };
-    for (auto pair : m_grid)
-    {
-        const Elem& elem = pair.second;
-        bool continue_ = process_elem_func(elem);
-        if (!continue_)
-        {
-            return false;
         }
     }
     return true;

--- a/src/utils/SparseGrid.h
+++ b/src/utils/SparseGrid.h
@@ -79,7 +79,7 @@ public:
      * \param[in] radius The search radius.
      * \param[in] process_func Processes each element.  process_func(elem) is
      *    called for each element in the cell. Processing stops if function returns false.
-     * \return Whether we need to continue procesing after this function
+     * \return Whether we need to continue processing after this function
      */
     bool processNearby(const Point &query_pt, coord_t radius,
                        const std::function<bool (const ElemT&)>& process_func) const;
@@ -87,10 +87,9 @@ public:
     /*! \brief Process elements from all cells.
      *
      * Processes all elements.
-     *\
      * \param[in] process_func Processes each element.  process_func(elem) is
      *    called for each element in the cells. Processing stops if function returns false.
-     * \return Whether we need to continue procesing after this function
+     * \return Whether we need to continue processing after this function
      */
     bool processAll(const std::function<bool(const Elem& elem)>& process_elem_func) const;
 
@@ -102,7 +101,7 @@ public:
      * \param[in] query_line The line along which to check each cell
      * \param[in] process_func Processes each element.  process_func(elem) is
      *    called for each element in the cells. Processing stops if function returns false.
-     * \return Whether we need to continue procesing after this function
+     * \return Whether we need to continue processing after this function
      */
     bool processLine(const std::pair<Point, Point> query_line,
                        const std::function<bool (const Elem&)>& process_elem_func) const;
@@ -129,7 +128,7 @@ protected:
      * \param[in] line The line along which to process cells
      * \param[in] process_func Processes each cell.  process_func(elem) is
      *    called for each cell. Processing stops if function returns false.
-     * \return Whether we need to continue procesing after this function
+     * \return Whether we need to continue processing after this function
      */
     bool processLineCells(const std::pair<Point, Point> line,
                          const std::function<bool (GridPoint)>& process_cell_func);
@@ -139,7 +138,7 @@ protected:
      * \param[in] line The line along which to process cells
      * \param[in] process_func Processes each cell.  process_func(elem) is
      *    called for each cell. Processing stops if function returns false.
-     * \return Whether we need to continue procesing after this function
+     * \return Whether we need to continue processing after this function
      */
     bool processLineCells(const std::pair<Point, Point> line,
                          const std::function<bool (GridPoint)>& process_cell_func) const;

--- a/src/utils/SparseGrid.h
+++ b/src/utils/SparseGrid.h
@@ -83,6 +83,15 @@ public:
     void processNearby(const Point &query_pt, coord_t radius,
                        const std::function<bool (const ElemT&)>& process_func) const;
 
+    /*! \brief Process elements from all cells.
+     *
+     * Processes all elements.
+     *\
+     * \param[in] process_func Processes each element.  process_func(elem) is
+     *    called for each element in the cells. Processing stops if function returns false.
+     */
+    void processAll(const std::function<bool(const Elem& elem)>& process_elem_func) const;
+
     /*! \brief Process elements from cells that might contain sought after points along a line.
      *
      * Processes elements from cells that cross the line \p query_line.
@@ -334,6 +343,24 @@ void SGI_THIS::processNearby(const Point &query_pt, coord_t radius,
             {
                 return;
             }
+        }
+    }
+}
+
+SGI_TEMPLATE
+void SGI_THIS::processAll(const std::function<bool (const Elem&)>& process_elem_func) const
+{
+    const std::function<bool (const GridPoint&)> process_cell_func = [&process_elem_func, this](GridPoint grid_loc)
+        {
+            return processFromCell(grid_loc, process_elem_func);
+        };
+    for (auto pair : m_grid)
+    {
+        const Elem& elem = pair.second;
+        bool continue_ = process_elem_func(elem);
+        if (!continue_)
+        {
+            return;
         }
     }
 }

--- a/src/utils/SparseGrid.h
+++ b/src/utils/SparseGrid.h
@@ -79,8 +79,9 @@ public:
      * \param[in] radius The search radius.
      * \param[in] process_func Processes each element.  process_func(elem) is
      *    called for each element in the cell. Processing stops if function returns false.
+     * \return Whether we need to continue procesing after this function
      */
-    void processNearby(const Point &query_pt, coord_t radius,
+    bool processNearby(const Point &query_pt, coord_t radius,
                        const std::function<bool (const ElemT&)>& process_func) const;
 
     /*! \brief Process elements from all cells.
@@ -89,8 +90,9 @@ public:
      *\
      * \param[in] process_func Processes each element.  process_func(elem) is
      *    called for each element in the cells. Processing stops if function returns false.
+     * \return Whether we need to continue procesing after this function
      */
-    void processAll(const std::function<bool(const Elem& elem)>& process_elem_func) const;
+    bool processAll(const std::function<bool(const Elem& elem)>& process_elem_func) const;
 
     /*! \brief Process elements from cells that might contain sought after points along a line.
      *
@@ -100,8 +102,9 @@ public:
      * \param[in] query_line The line along which to check each cell
      * \param[in] process_func Processes each element.  process_func(elem) is
      *    called for each element in the cells. Processing stops if function returns false.
+     * \return Whether we need to continue procesing after this function
      */
-    void processLine(const std::pair<Point, Point> query_line,
+    bool processLine(const std::pair<Point, Point> query_line,
                        const std::function<bool (const Elem&)>& process_elem_func) const;
 
     coord_t getCellSize() const;
@@ -126,8 +129,9 @@ protected:
      * \param[in] line The line along which to process cells
      * \param[in] process_func Processes each cell.  process_func(elem) is
      *    called for each cell. Processing stops if function returns false.
+     * \return Whether we need to continue procesing after this function
      */
-    void processLineCells(const std::pair<Point, Point> line,
+    bool processLineCells(const std::pair<Point, Point> line,
                          const std::function<bool (GridPoint)>& process_cell_func);
 
     /*! \brief Process cells along a line indicated by \p line.
@@ -135,8 +139,9 @@ protected:
      * \param[in] line The line along which to process cells
      * \param[in] process_func Processes each cell.  process_func(elem) is
      *    called for each cell. Processing stops if function returns false.
+     * \return Whether we need to continue procesing after this function
      */
-    void processLineCells(const std::pair<Point, Point> line,
+    bool processLineCells(const std::pair<Point, Point> line,
                          const std::function<bool (GridPoint)>& process_cell_func) const;
 
     /*! \brief Compute the grid coordinates of a point.
@@ -249,15 +254,15 @@ bool SGI_THIS::processFromCell(
 }
 
 SGI_TEMPLATE
-void SGI_THIS::processLineCells(
+bool SGI_THIS::processLineCells(
     const std::pair<Point, Point> line,
     const std::function<bool (GridPoint)>& process_cell_func)
 {
-    static_cast<const SGI_THIS*>(this)->processLineCells(line, process_cell_func);
+    return static_cast<const SGI_THIS*>(this)->processLineCells(line, process_cell_func);
 }
 
 SGI_TEMPLATE
-void SGI_THIS::processLineCells(
+bool SGI_THIS::processLineCells(
     const std::pair<Point, Point> line,
     const std::function<bool (GridPoint)>& process_cell_func) const
 {
@@ -302,11 +307,11 @@ void SGI_THIS::processLineCells(
             bool continue_ = process_cell_func(grid_loc);
             if (!continue_)
             {
-                return;
+                return false;
             }
             if (grid_loc == end_cell)
             {
-                return;
+                return true;
             }
         }
         // TODO: this causes at least a one cell overlap for each row, which
@@ -315,6 +320,7 @@ void SGI_THIS::processLineCells(
         x_cell_start = x_cell_end;
     }
     assert(false && "We should have returned already before here!");
+    return false;
 }
 
 SGI_TEMPLATE
@@ -324,7 +330,7 @@ typename SGI_THIS::grid_coord_t SGI_THIS::nonzero_sign(const grid_coord_t z) con
 }
 
 SGI_TEMPLATE
-void SGI_THIS::processNearby(const Point &query_pt, coord_t radius,
+bool SGI_THIS::processNearby(const Point &query_pt, coord_t radius,
                              const std::function<bool (const Elem&)>& process_func) const
 {
     Point min_loc(query_pt.X - radius, query_pt.Y - radius);
@@ -341,14 +347,15 @@ void SGI_THIS::processNearby(const Point &query_pt, coord_t radius,
             bool continue_ = processFromCell(grid_pt, process_func);
             if (!continue_)
             {
-                return;
+                return false;
             }
         }
     }
+    return true;
 }
 
 SGI_TEMPLATE
-void SGI_THIS::processAll(const std::function<bool (const Elem&)>& process_elem_func) const
+bool SGI_THIS::processAll(const std::function<bool (const Elem&)>& process_elem_func) const
 {
     const std::function<bool (const GridPoint&)> process_cell_func = [&process_elem_func, this](GridPoint grid_loc)
         {
@@ -360,20 +367,21 @@ void SGI_THIS::processAll(const std::function<bool (const Elem&)>& process_elem_
         bool continue_ = process_elem_func(elem);
         if (!continue_)
         {
-            return;
+            return false;
         }
     }
+    return true;
 }
 
 SGI_TEMPLATE
-void SGI_THIS::processLine(const std::pair<Point, Point> query_line,
+bool SGI_THIS::processLine(const std::pair<Point, Point> query_line,
                             const std::function<bool (const Elem&)>& process_elem_func) const
 {
     const std::function<bool (const GridPoint&)> process_cell_func = [&process_elem_func, this](GridPoint grid_loc)
         {
             return processFromCell(grid_loc, process_elem_func);
         };
-    processLineCells(query_line, process_cell_func);
+    return processLineCells(query_line, process_cell_func);
 }
 
 SGI_TEMPLATE

--- a/src/utils/linearAlg2D.h
+++ b/src/utils/linearAlg2D.h
@@ -124,7 +124,18 @@ public:
         }
     }
 
-
+    /*!
+     * Find the two points on two line segments closest to each other.
+     * 
+     * Find the smallest line segment connecting the two line segments a and b.
+     * 
+     * \param a1 first point on line a
+     * \param a2 second point on line a
+     * \param b1 first point on line b
+     * \param b2 second point on line b
+     * \return A pair: the first point on line a and the second pouint on line b
+     */
+    static std::pair<Point, Point> getClosestConnection(Point a1, Point a2, Point b1, Point b2);
 
     /*!
     * Get the squared distance from point \p b to a line *segment* from \p a to \p c.
@@ -215,6 +226,24 @@ public:
                 || getDist2FromLineSegment(a, d, b) <= max_dist2
                 || getDist2FromLineSegment(c, a, d) <= max_dist2
                 || getDist2FromLineSegment(c, b, d) <= max_dist2;
+    }
+
+    /*!
+     * Get the minimal distance between two line segments
+     * The first line semgent is given by end points \p a and \p b, the second by \p c and \p d.
+     * 
+     * \param a One end point of the first line segment
+     * \param b Another end point of the first line segment
+     * \param c One end point of the second line segment
+     * \param d Another end point of the second line segment
+     */
+    static coord_t getDist2BetweenLineSegments(const Point& a, const Point& b, const Point& c, const Point& d)
+    {
+        return
+            std::min(getDist2FromLineSegment(a, c, b), 
+            std::min(getDist2FromLineSegment(a, d, b),
+            std::min(getDist2FromLineSegment(c, a, d),
+                     getDist2FromLineSegment(c, b, d))));
     }
 
     /*!

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -652,9 +652,11 @@ void PolygonUtils::findSmallestConnection(ClosestPolygonPoint& poly1_result, Clo
         return;
     }
 
-    Point center1 = poly1.centerOfMass();
+    Point center1 = poly1[0];
+    ClosestPolygonPoint intermediate_poly2_result = findClosest(center1, poly2);
+    ClosestPolygonPoint intermediate_poly1_result = findClosest(intermediate_poly2_result.p(), poly1);
 
-    poly2_result = findClosest(center1, poly2);
+    poly2_result = findClosest(intermediate_poly1_result.p(), poly2);
     poly1_result = findClosest(poly2_result.p(), poly1);
     walkToNearestSmallestConnection(poly1_result, poly2_result);
 }

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -669,6 +669,8 @@ void PolygonUtils::walkToNearestSmallestConnection(ClosestPolygonPoint& poly1_re
     }
     ConstPolygonRef poly1 = *poly1_result.poly;
     ConstPolygonRef poly2 = *poly2_result.poly;
+    size_t poly1_idx = poly1_result.poly_idx;
+    size_t poly2_idx = poly2_result.poly_idx;
     if (poly1_result.point_idx == NO_INDEX || poly2_result.point_idx == NO_INDEX)
     {
         return;
@@ -712,6 +714,9 @@ void PolygonUtils::walkToNearestSmallestConnection(ClosestPolygonPoint& poly1_re
     check_neighboring_vert(poly1, poly2, poly1_result, poly2_result, true);
     check_neighboring_vert(poly2, poly1, poly2_result, poly1_result, false);
     check_neighboring_vert(poly2, poly1, poly2_result, poly1_result, true);
+
+    poly1_result.poly_idx = poly1_idx;
+    poly2_result.poly_idx = poly2_idx;
 }
 
 ClosestPolygonPoint PolygonUtils::findNearestClosest(Point from, ConstPolygonRef polygon, int start_idx)

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -645,7 +645,8 @@ std::pair<ClosestPolygonPoint, ClosestPolygonPoint> PolygonUtils::findSmallestCo
                     ret = std::make_pair(
                         ClosestPolygonPoint(connection.first, point_idx, poly1),
                         ClosestPolygonPoint(connection.second, line_from.point_idx, polys2[line_from.poly_idx], line_from.poly_idx));
-                    if (min_connection_dist2 < dist2 && dist2 < max_connection_dist2)
+                    if (min_connection_dist2 < dist2 && dist2 < max_connection_dist2
+                        && !polys2[line_from.poly_idx].shorterThan(max_connection_length * 2)) // don't settle quickly for small polygons
                     {
                         return false; // stop the search; break the for-loop
                     }
@@ -668,6 +669,7 @@ std::pair<ClosestPolygonPoint, ClosestPolygonPoint> PolygonUtils::findSmallestCo
         continue_ = grid->processLine(line3, process_elem_func);
         if (!continue_) break;
     }
+    ret.first.poly_idx = 0;
     delete grid;
     return ret;
 }

--- a/src/utils/polygonUtils.h
+++ b/src/utils/polygonUtils.h
@@ -325,20 +325,16 @@ public:
     static ClosestPolygonPoint ensureInsideOrOutside(const Polygons& polygons, Point& from, const ClosestPolygonPoint& closest_polygon_point, int preferred_dist_inside, const Polygons* loc_to_line_polygons = nullptr, const LocToLineGrid* loc_to_line_grid = nullptr, const std::function<int(Point)>& penalty_function = no_penalty_function);
 
     /*!
-    * Find the two points in two polygons with the smallest distance.
-    * 
-    * Note: The amount of preliminary vertex-to-vertex distance checks is quadratic in \p sample_size : `O(sample_size ^2)`.
-    * Further convergence time depends on polygon size and shape.
-    * 
-    * From these distance checks the closest pair is chosen and from there we walk to the nearest smallest connection.
-    * 
-    * \warning The ClosestPolygonPoint::poly fields output parameters should be initialized with the polygons for which to find the smallest connection.
-    * 
-    * \param poly1_result Output parameter: the point at the one end of the smallest connection between its poly and \p poly2_result.poly.
-    * \param poly2_result Output parameter: the point at the other end of the smallest connection between its poly and \p poly1_result.poly.
-    * \param sample_size The number of points on each polygon to start the hill climbing search from. Use negative values for checking all combinations of points.
-    */
-    static void findSmallestConnection(ClosestPolygonPoint& poly1_result, ClosestPolygonPoint& poly2_result, int sample_size);
+     * Find the smallest connecting line segment from one polygon to a collection of other polygons.
+     * 
+     * This implementation uses a sparse grid to get to an accurate result quickly
+     * 
+     * \param poly1 The polygon in which to search for a conection
+     * \param polys2 The polygons to which to connect
+     * \param min_connection_length The minimal conection length a connection needs to have in order to stop looking for other connections
+     * \param max_connection_length The largest length of a connection to be found
+     */
+    static std::pair<ClosestPolygonPoint, ClosestPolygonPoint> findSmallestConnection(ConstPolygonRef poly1, Polygons& polys2, coord_t min_connection_length, coord_t max_connection_length);
 
     /*!
     * Find the two points in two polygons with the smallest distance.

--- a/src/utils/polygonUtils.h
+++ b/src/utils/polygonUtils.h
@@ -329,6 +329,9 @@ public:
      * 
      * This implementation uses a sparse grid to get to an accurate result quickly
      * 
+     * The first connection larger than \p min_connection_length and smaller than \p max_connection_length is returned.
+     * If no such connection is found the smallest conection is returned, which might be larger than \p max_connection_length or it might be smaller than \p min_connection_length.
+     * 
      * \param poly1 The polygon in which to search for a conection
      * \param polys2 The polygons to which to connect
      * \param min_connection_length The minimal conection length a connection needs to have in order to stop looking for other connections

--- a/src/utils/polygonUtils.h
+++ b/src/utils/polygonUtils.h
@@ -43,6 +43,37 @@ struct ClosestPolygonPoint
     }
 };
 
+} // namespace cura
+
+namespace std
+{
+template <>
+struct hash<cura::ClosestPolygonPoint>
+{
+    size_t operator()(const cura::ClosestPolygonPoint& cpp) const
+    {
+        return std::hash<cura::Point>()(cpp.p());
+    }
+};
+}//namespace std
+
+
+namespace std
+{
+template <typename S, typename T>
+struct hash<std::pair<S, T>>
+{
+    size_t operator()(const std::pair<S, T>& pair) const
+    {
+        return 31 * std::hash<S>()(pair.first) + 59 * std::hash<T>()(pair.second);
+    }
+};
+}//namespace std
+
+
+namespace cura
+{
+
 /*!
  * A point within a polygon and the index of which segment in the polygon the point lies on.
  */

--- a/src/utils/polygonUtils.h
+++ b/src/utils/polygonUtils.h
@@ -325,19 +325,18 @@ public:
     static ClosestPolygonPoint ensureInsideOrOutside(const Polygons& polygons, Point& from, const ClosestPolygonPoint& closest_polygon_point, int preferred_dist_inside, const Polygons* loc_to_line_polygons = nullptr, const LocToLineGrid* loc_to_line_grid = nullptr, const std::function<int(Point)>& penalty_function = no_penalty_function);
 
     /*!
-     * Find the smallest connecting line segment from one polygon to a collection of other polygons.
+     * Find a connecting line segment from one polygon to a collection of other polygons.
      * 
      * This implementation uses a sparse grid to get to an accurate result quickly
      * 
      * The first connection larger than \p min_connection_length and smaller than \p max_connection_length is returned.
-     * If no such connection is found the smallest conection is returned, which might be larger than \p max_connection_length or it might be smaller than \p min_connection_length.
      * 
      * \param poly1 The polygon in which to search for a conection
      * \param polys2 The polygons to which to connect
      * \param min_connection_length The minimal conection length a connection needs to have in order to stop looking for other connections
      * \param max_connection_length The largest length of a connection to be found
      */
-    static std::pair<ClosestPolygonPoint, ClosestPolygonPoint> findSmallestConnection(ConstPolygonRef poly1, Polygons& polys2, coord_t min_connection_length, coord_t max_connection_length);
+    static std::pair<ClosestPolygonPoint, ClosestPolygonPoint> findConnection(ConstPolygonRef poly1, Polygons& polys2, coord_t min_connection_length, coord_t max_connection_length, std::function<bool (std::pair<ClosestPolygonPoint, ClosestPolygonPoint>)> precondition);
 
     /*!
     * Find the two points in two polygons with the smallest distance.

--- a/tests/utils/PolygonConnectorTest.cpp
+++ b/tests/utils/PolygonConnectorTest.cpp
@@ -70,11 +70,13 @@ void PolygonConnectorTest::tearDown()
 void PolygonConnectorTest::getBridgeTest()
 {
 
-    PolygonConnector::PolygonBridge predicted;
-    predicted.a.from = ClosestPolygonPoint(Point(0, 500), 2, test_square);
-    predicted.a.to = ClosestPolygonPoint(Point(-100, 500), 0, test_convex_shape);
-    predicted.b.from = ClosestPolygonPoint(Point(0, 600), 2, test_square);
-    predicted.b.to = ClosestPolygonPoint(Point(-100, 600), 0, test_convex_shape);
+    PolygonConnector::PolygonBridge predicted(
+        PolygonConnector::PolygonConnection{
+            ClosestPolygonPoint(Point(0, 500), 2, test_square),
+            ClosestPolygonPoint(Point(-100, 500), 0, test_convex_shape)},
+        PolygonConnector::PolygonConnection{
+            ClosestPolygonPoint(Point(0, 600), 2, test_square),
+            ClosestPolygonPoint(Point(-100, 600), 0, test_convex_shape)});
     std::vector<Polygon> polys;
     polys.push_back(test_convex_shape);
     getBridgeAssert(predicted, test_square, polys);


### PR DESCRIPTION
I've fixed some problems with the PolygonConnector and improved performance.

The performance improvement should mostly come from the fact that we now use a sparse grid to efficiently lookup where polygons are close enough to each other to be connected.

I haven't done any performance tests to see whether performance is actually increased, but the tests below certainly show that some bugs are fixed and that the code is improved a lot!

Before:
(line dist 0.76)
random connection: (happened on roughly 2% of the layers)
![image](https://user-images.githubusercontent.com/8895761/45265664-ebb8b680-b44e-11e8-8618-f6f451d4abb3.png)

![image](https://user-images.githubusercontent.com/8895761/45265671-fe32f000-b44e-11e8-8a05-06da2cdd6142.png)

no connection: (happened on roughly 50% of the layers, now on roughly 5%)
![image](https://user-images.githubusercontent.com/8895761/45265678-186cce00-b44f-11e8-9e44-1dd5aad4b2ed.png)


After:
![image](https://user-images.githubusercontent.com/8895761/45265713-df812900-b44f-11e8-8ddb-c6a8f47a06e1.png)

![image](https://user-images.githubusercontent.com/8895761/45265709-d1330d00-b44f-11e8-89e8-54c4f808a665.png)

![image](https://user-images.githubusercontent.com/8895761/45265704-b6609880-b44f-11e8-83ac-ea203351d16f.png)

Project:
[lil_L_x2__cross_3d.curaproject.3mf.remove_extension.zip](https://github.com/Ultimaker/CuraEngine/files/2364347/lil_L_x2__cross_3d.curaproject.3mf.remove_extension.zip)
