### PR TITLE
Cura 5690 fat skin lines

### DIFF
--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -153,8 +153,8 @@ namespace cura
         const coord_t line_width = first_path.config->getLineWidth();
 
         // Reintroduction of this check prevents [CURA-5674] printing spurious infill-lines to origin:
-        const auto line_width_sqrd = line_width * line_width;
-        if (vSize2(first_path_end - second_path_start) < line_width_sqrd && vSize2(first_path_start - second_path_end) < line_width_sqrd)
+        const coord_t line_width_squared = line_width * line_width;
+        if (vSize2(first_path_end - second_path_start) < line_width_squared && vSize2(first_path_start - second_path_end) < line_width_squared)
         {
             return false;
         }

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -156,7 +156,17 @@ namespace cura
         const coord_t line_width_squared = line_width * line_width;
         if (vSize2(first_path_end - second_path_start) < line_width_squared || vSize2(first_path_start - second_path_end) < line_width_squared)
         {
-            return false;
+            // Define max_dot_product_squared as 20*20, where 20 micron is the allowed inaccuracy in the dot product, allowing a slight curve:
+            constexpr coord_t max_dot_product_squared = 400;
+
+            const Point first_direction = first_path_end - first_path_start;
+            const Point second_direction = second_path_end - second_path_start;
+
+            // Only continue to try-merge at this point if the lines line up straight:
+            if (dot(first_direction, second_direction) + max_dot_product_squared > vSize(first_direction) * vSize(second_direction))
+            {
+                return false;
+            }
         }
 
         //Lines may be adjacent side-by-side then.

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -152,9 +152,9 @@ namespace cura
         const Point second_path_end = second_path.points.back();
         const coord_t line_width = first_path.config->getLineWidth();
 
-        // Reintroduction of this check prevents [CURA-5674] printing spurious infill-lines to origin:
+        // This check prevents [CURA-5690] fat skin lines:
         const coord_t line_width_squared = line_width * line_width;
-        if (vSize2(first_path_end - second_path_start) < line_width_squared && vSize2(first_path_start - second_path_end) < line_width_squared)
+        if (vSize2(first_path_end - second_path_start) < line_width_squared || vSize2(first_path_start - second_path_end) < line_width_squared)
         {
             return false;
         }

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -195,7 +195,7 @@ namespace cura
         if (merged_direction.X == 0 && merged_direction.Y == 0)
         {
             new_first_path_start = first_path_start;
-            return true;  // we can just disregard the second point as it's exactly at the leave point of the first path.
+            return false;  // returning true will not work for the gradual infill
         }
 
         // Max 1 line width to the side of the merged_direction

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -184,6 +184,7 @@ namespace cura
         }
         if (merged_direction.X == 0 && merged_direction.Y == 0)
         {
+            new_first_path_start = first_path_start;
             return true;  // we can just disregard the second point as it's exactly at the leave point of the first path.
         }
 


### PR DESCRIPTION
devs: Branch based on CURA-5742 fix (printing to origin after line-merge, in rare cases), since the issues where/seemed/are related at one point (through CURA-5699, see the comments there, specifically about printing time).