### PR TITLE
[bug fix] Correct optimisation in combing path generation that can cut corners.

### DIFF
--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -190,11 +190,6 @@ void LinePolygonsCrossings::generateBasicCombingPath(PolyCrossings& polyCrossing
         rev_points.push_back(p);
         rev_len += vSize(p - prev);
         prev = p;
-        if (rev_len > fwd_len)
-        {
-            // this path is already longer than the forward path so there's no point in carrying on
-            break;
-        }
     }
 
     const Point last = transformation_matrix.unapply(Point(polyCrossings.max.x + std::abs(dist_to_move_boundary_point_outside), transformed_startPoint.Y));

--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -176,6 +176,13 @@ void LinePolygonsCrossings::generateBasicCombingPath(PolyCrossings& polyCrossing
         prev = p;
     }
 
+    const Point last = transformation_matrix.unapply(Point(polyCrossings.max.x + std::abs(dist_to_move_boundary_point_outside), transformed_startPoint.Y));
+
+    if (fwd_points.size() > 0)
+    {
+        fwd_len += vSize(last - fwd_points.back());
+    }
+
     // follow the path in the opposite direction of the winding order of the boundary polygon
     std::vector<Point> rev_points;
     prev = combPath.back();
@@ -197,12 +204,6 @@ void LinePolygonsCrossings::generateBasicCombingPath(PolyCrossings& polyCrossing
         }
     }
 
-    const Point last = transformation_matrix.unapply(Point(polyCrossings.max.x + std::abs(dist_to_move_boundary_point_outside), transformed_startPoint.Y));
-
-    if (fwd_points.size() > 0)
-    {
-        fwd_len += vSize(last - fwd_points.back());
-    }
     if (rev_points.size() > 0)
     {
         rev_len += vSize(last - rev_points.back());

--- a/src/pathPlanning/LinePolygonsCrossings.cpp
+++ b/src/pathPlanning/LinePolygonsCrossings.cpp
@@ -190,6 +190,11 @@ void LinePolygonsCrossings::generateBasicCombingPath(PolyCrossings& polyCrossing
         rev_points.push_back(p);
         rev_len += vSize(p - prev);
         prev = p;
+        if (rev_len > fwd_len)
+        {
+            // this path is already longer than the forward path so there's no point in carrying on
+            break;
+        }
     }
 
     const Point last = transformation_matrix.unapply(Point(polyCrossings.max.x + std::abs(dist_to_move_boundary_point_outside), transformed_startPoint.Y));


### PR DESCRIPTION
It would be good if this could be merged ASAP as it can cause combing travels to cut corners.