### PR TITLE
CURA-5798 Fix a segfault in tree support

### DIFF
--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -109,7 +109,7 @@ public:
          * can't be on the model and the path to the buildplate isn't clear),
          * the entire branch needs to be known.
          */
-        Node * parent;
+        Node *parent;
 
         /*!
         * \brief All neighbours (on the same layer) that where merged into this node.

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -59,11 +59,13 @@ public:
          , parent(parent)
         {}
 
+#ifdef DEBUG // Clear the delete node's data so if there's invalid access after, we may get a clue by inspecting that node.
         ~Node()
         {
             parent = nullptr;
             merged_neighbours.clear();
         }
+#endif // DEBUG
 
         /*!
          * \brief The number of layers to go to the top of this branch.

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -59,6 +59,12 @@ public:
          , parent(parent)
         {}
 
+        ~Node()
+        {
+            parent = nullptr;
+            merged_neighbours.clear();
+        }
+
         /*!
          * \brief The number of layers to go to the top of this branch.
          */
@@ -103,7 +109,7 @@ public:
          * can't be on the model and the path to the buildplate isn't clear),
          * the entire branch needs to be known.
          */
-        Node *const parent;
+        Node * parent;
 
         /*!
         * \brief All neighbours (on the same layer) that where merged into this node.


### PR DESCRIPTION
Fixes https://github.com/Ultimaker/Cura/issues/4491

 - Delete all allocated nodes at the end to avoid invalid address access
   in the loop.
 - Add destructor to struct Node so it resets its pointers and cleans
   its data properly.