### PR TITLE
Bug Fix: Zap short lines in gyroid connectors

### DIFF
--- a/src/infill/GyroidInfill.cpp
+++ b/src/infill/GyroidInfill.cpp
@@ -319,8 +319,15 @@ void GyroidInfill::generateTotalGyroidInfill(Polygons& result_lines, bool zig_za
                     }
                     const unsigned point_index = points_on_outline_point_index[nearest_point_index];
                     const unsigned chain_index = points_on_outline_chain_index[nearest_point_index];
+
                     // make the chain end the current point and add it to the connector line
                     cur_point = chains[point_index][chain_index];
+
+                    if (drawing && connector_points.size() > 0 && vSize2(cur_point - connector_points.back()) < 100)
+                    {
+                        // this chain end will be too close to the last connector point so throw away the last connector point
+                        connector_points.pop_back();
+                    }
                     connector_points.push_back(cur_point);
 
                     if (first_chain_chain_index == std::numeric_limits<unsigned>::max())

--- a/src/infill/GyroidInfill.cpp
+++ b/src/infill/GyroidInfill.cpp
@@ -260,15 +260,17 @@ void GyroidInfill::generateTotalGyroidInfill(Polygons& result_lines, bool zig_za
             unsigned connector_start_chain_index = std::numeric_limits<unsigned>::max();
             unsigned connector_start_point_index = std::numeric_limits<unsigned>::max();
 
+            Point cur_point; // current point of interest - either an outline point or a chain end
+
             // go round all of the region's outline and find the chain ends that meet it
             // quit the loop early if we have seen all the chain ends and are not currently drawing a connector
             for (unsigned outline_point_index = 0; (chain_ends_remaining > 0 || drawing) && outline_point_index < outline_poly.size(); ++outline_point_index)
             {
                 Point op0 = outline_poly[outline_point_index];
                 Point op1 = outline_poly[(outline_point_index + 1) % outline_poly.size()];
-                Point cur_point = op0;
                 std::vector<unsigned> points_on_outline_chain_index;
                 std::vector<unsigned> points_on_outline_point_index;
+
                 // collect the chain ends that meet this segment of the outline
                 for (unsigned chain_index = 0; chain_index < chains[0].size(); ++chain_index)
                 {

--- a/src/infill/GyroidInfill.cpp
+++ b/src/infill/GyroidInfill.cpp
@@ -284,16 +284,22 @@ void GyroidInfill::generateTotalGyroidInfill(Polygons& result_lines, bool zig_za
                     }
                 }
 
-                if (first_chain_chain_index == std::numeric_limits<unsigned>::max())
+                if (outline_point_index == 0 || vSize2(op0 - cur_point) > 100)
                 {
-                    // include the outline point in the path to the first chain
-                    path_to_first_chain.push_back(op0);
-                }
+                    // this is either the first outline point or it is another outline point that is not too close to cur_point
 
-                if (drawing)
-                {
-                    // include the start point of this outline segment in the connector
-                    connector_points.push_back(op0);
+                    if (first_chain_chain_index == std::numeric_limits<unsigned>::max())
+                    {
+                        // include the outline point in the path to the first chain
+                        path_to_first_chain.push_back(op0);
+                    }
+
+                    cur_point = op0;
+                    if (drawing)
+                    {
+                        // include the start point of this outline segment in the connector
+                        connector_points.push_back(op0);
+                    }
                 }
 
                 // iterate through each of the chain ends that meet the current outline segment

--- a/src/infill/GyroidInfill.cpp
+++ b/src/infill/GyroidInfill.cpp
@@ -276,7 +276,9 @@ void GyroidInfill::generateTotalGyroidInfill(Polygons& result_lines, bool zig_za
                 {
                     for (unsigned point_index = 0; point_index < 2; ++point_index)
                     {
-                        if (LinearAlg2D::getDist2FromLineSegment(op0, chains[point_index][chain_index], op1) < 10)
+                        // don't include chain ends that are close to the segment but are beyond the segment ends
+                        char beyond = 0;
+                        if (LinearAlg2D::getDist2FromLineSegment(op0, chains[point_index][chain_index], op1, &beyond) < 10 && !beyond)
                         {
                             points_on_outline_point_index.push_back(point_index);
                             points_on_outline_chain_index.push_back(chain_index);


### PR DESCRIPTION
This PR stops very small (< 10 uM) line segments being created when the gyroid infill lines are connected. The small line segments are not really harmful as such but they screw up the chained lines detection and require extra travel moves so it's better if they are eradicated.

Before this PR you could get this:

![screenshot_2018-10-11_08-48-35](https://user-images.githubusercontent.com/585618/46788673-8b10e800-cd32-11e8-9bd9-80873dab0dfb.png)

There's a short line just above the kink in the infill to the left of the centre of the image.

With the PR it looks like this:

![screenshot_2018-10-11_08-49-51](https://user-images.githubusercontent.com/585618/46788721-a976e380-cd32-11e8-8ed3-7cb4965c0236.png)
