### PR TITLE
feat: ability to omit bottom skin for inital layers

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1217,7 +1217,7 @@ void FffGcodeWriter::addMeshPartToGCode(const SliceDataStorage& storage, const S
     added_something = added_something | processSkinAndPerimeterGaps(storage, gcode_layer, mesh, extruder_nr, mesh_config, part);
 
     //After a layer part, make sure the nozzle is inside the comb boundary, so we do not retract on the perimeter.
-    if (added_something && (!mesh_group_settings.get<bool>("magic_spiralize") || gcode_layer.getLayerNr() < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers"))))
+    if (added_something && (!mesh_group_settings.get<bool>("magic_spiralize") || gcode_layer.getLayerNr() < static_cast<LayerIndex>(mesh.settings.get<size_t>("initial_bottom_layers"))))
     {
         coord_t innermost_wall_line_width = mesh.settings.get<coord_t>((mesh.settings.get<size_t>("wall_line_count") > 1) ? "wall_line_width_x" : "wall_line_width_0");
         if (gcode_layer.getLayerNr() == 0)
@@ -1481,12 +1481,12 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
                 // nothing to do
                 return false;
             }
-            const size_t bottom_layers = mesh.settings.get<size_t>("bottom_layers");
-            if (gcode_layer.getLayerNr() >= static_cast<LayerIndex>(bottom_layers))
+            const size_t initial_bottom_layers = mesh.settings.get<size_t>("initial_bottom_layers");
+            if (gcode_layer.getLayerNr() >= static_cast<LayerIndex>(initial_bottom_layers))
             {
                 spiralize = true;
             }
-            if (spiralize && gcode_layer.getLayerNr() == static_cast<LayerIndex>(bottom_layers) && !part.insets.empty() && extruder_nr == mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr)
+            if (spiralize && gcode_layer.getLayerNr() == static_cast<LayerIndex>(initial_bottom_layers) && !part.insets.empty() && extruder_nr == mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr)
             { // on the last normal layer first make the outer wall normally and then start a second outer wall from the same hight, but gradually moving upward
                 added_something = true;
                 setExtruder_addPrime(storage, gcode_layer, extruder_nr);

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -446,21 +446,21 @@ void FffPolygonGenerator::processBasicWallsSkinInfill(SliceDataStorage& storage,
     // skin & infill
 
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-    size_t mesh_max_bottom_layer_count = 0;
+    size_t mesh_max_initial_bottom_layer_count = 0;
     if (mesh_group_settings.get<bool>("magic_spiralize"))
     {
-        mesh_max_bottom_layer_count = std::max(mesh_max_bottom_layer_count, mesh.settings.get<size_t>("bottom_layers"));
+        mesh_max_initial_bottom_layer_count = std::max(mesh_max_initial_bottom_layer_count, mesh.settings.get<size_t>("initial_bottom_layers"));
     }
 
     processed_layer_count = 0;
-#pragma omp parallel default(none) shared(mesh_layer_count, mesh, mesh_max_bottom_layer_count, process_infill, inset_skin_progress_estimate, processed_layer_count, mesh_group_settings)
+#pragma omp parallel default(none) shared(mesh_layer_count, mesh, mesh_max_initial_bottom_layer_count, process_infill, inset_skin_progress_estimate, processed_layer_count, mesh_group_settings)
     {
 
 #pragma omp for schedule(dynamic)
         for (size_t layer_number = 0; layer_number < mesh.layers.size(); layer_number++)
         {
             logDebug("Processing skins and infill layer %i of %i\n", layer_number, mesh_layer_count);
-            if (!mesh_group_settings.get<bool>("magic_spiralize") || layer_number < mesh_max_bottom_layer_count)    //Only generate up/downskin and infill for the first X layers when spiralize is choosen.
+            if (!mesh_group_settings.get<bool>("magic_spiralize") || layer_number < mesh_max_initial_bottom_layer_count)    //Only generate up/downskin and infill for the first X layers when spiralize is choosen.
             {
                 processSkinsAndInfill(mesh, layer_number, process_infill);
             }

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -21,7 +21,7 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
 {
     size_t inset_count = settings.get<size_t>("wall_line_count");
     const bool spiralize = settings.get<bool>("magic_spiralize");
-    if (spiralize && layer_nr < LayerIndex(settings.get<size_t>("bottom_layers")) && ((layer_nr % 2) + 2) % 2 == 1) //Add extra insets every 2 layers when spiralizing. This makes bottoms of cups watertight.
+    if (spiralize && layer_nr < LayerIndex(settings.get<size_t>("initial_bottom_layers")) && ((layer_nr % 2) + 2) % 2 == 1) //Add extra insets every 2 layers when spiralizing. This makes bottoms of cups watertight.
     {
         inset_count += 5;
     }

--- a/src/infill/SpaghettiInfill.cpp
+++ b/src/infill/SpaghettiInfill.cpp
@@ -15,7 +15,7 @@ void SpaghettiInfill::generateTotalSpaghettiInfill(SliceMeshStorage& mesh)
     for (int layer_idx = 0; layer_idx <= max_layer; layer_idx++)
     {
         const coord_t layer_height = (layer_idx == 0) ? mesh.settings.get<coord_t>("layer_height_0") : mesh.settings.get<coord_t>("layer_height");
-        if (layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers")))
+        if (layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers")) && mesh.settings.get<bool>("layer_0_skin_enabled"))
         { // nothing to add
             continue;
         }
@@ -85,7 +85,7 @@ void SpaghettiInfill::generateSpaghettiInfill(SliceMeshStorage& mesh)
     {
         const coord_t layer_height = (layer_idx == 0) ? mesh.settings.get<coord_t>("layer_height_0") : mesh.settings.get<coord_t>("layer_height");
         current_z += layer_height;
-        if (layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers")))
+        if (layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers")) && mesh.settings.get<bool>("layer_0_skin_enabled"))
         { // nothing to add to pillar base
             continue;
         }

--- a/src/infill/SpaghettiInfill.cpp
+++ b/src/infill/SpaghettiInfill.cpp
@@ -15,7 +15,8 @@ void SpaghettiInfill::generateTotalSpaghettiInfill(SliceMeshStorage& mesh)
     for (int layer_idx = 0; layer_idx <= max_layer; layer_idx++)
     {
         const coord_t layer_height = (layer_idx == 0) ? mesh.settings.get<coord_t>("layer_height_0") : mesh.settings.get<coord_t>("layer_height");
-        if (layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers")) && mesh.settings.get<bool>("layer_0_skin_enabled"))
+        if (layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers"))
+            && layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("initial_bottom_layers")))
         { // nothing to add
             continue;
         }
@@ -85,7 +86,8 @@ void SpaghettiInfill::generateSpaghettiInfill(SliceMeshStorage& mesh)
     {
         const coord_t layer_height = (layer_idx == 0) ? mesh.settings.get<coord_t>("layer_height_0") : mesh.settings.get<coord_t>("layer_height");
         current_z += layer_height;
-        if (layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers")) && mesh.settings.get<bool>("layer_0_skin_enabled"))
+        if (layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers"))
+            && layer_idx < static_cast<LayerIndex>(mesh.settings.get<size_t>("initial_bottom_layers")))
         { // nothing to add to pillar base
             continue;
         }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -64,6 +64,7 @@ SkinInfillAreaComputation::SkinInfillAreaComputation(const LayerIndex& layer_nr,
 : layer_nr(layer_nr)
 , mesh(mesh)
 , bottom_layer_count(mesh.settings.get<size_t>("bottom_layers"))
+, layer_0_skin_enabled(mesh.settings.get<bool>("layer_0_skin_enabled"))
 , top_layer_count(mesh.settings.get<size_t>("top_layers"))
 , wall_line_count(mesh.settings.get<size_t>("wall_line_count"))
 , skin_line_width(getSkinLineWidth(mesh, layer_nr))
@@ -241,12 +242,13 @@ void SkinInfillAreaComputation::generateSkinAndInfillAreas(SliceLayerPart& part)
  */
 void SkinInfillAreaComputation::calculateBottomSkin(const SliceLayerPart& part, Polygons& downskin)
 {
-    if (static_cast<int>(layer_nr - bottom_layer_count) >= 0 && bottom_layer_count > 0)
+    if ((static_cast<int>(layer_nr - bottom_layer_count) >= 0 || !layer_0_skin_enabled) && bottom_layer_count > 0)
     {
-        Polygons not_air = getWalls(part, layer_nr - bottom_layer_count, bottom_reference_wall_idx).offset(bottom_reference_wall_expansion);
+        LayerIndex bottom_check_start_layer_idx = std::max(LayerIndex(0), layer_nr - bottom_layer_count);
+        Polygons not_air = getWalls(part, bottom_check_start_layer_idx, bottom_reference_wall_idx).offset(bottom_reference_wall_expansion);
         if (!no_small_gaps_heuristic)
         {
-            for (int downskin_layer_nr = layer_nr - bottom_layer_count + 1; downskin_layer_nr < layer_nr; downskin_layer_nr++)
+            for (int downskin_layer_nr = bottom_check_start_layer_idx + 1; downskin_layer_nr < layer_nr; downskin_layer_nr++)
             {
                 not_air = not_air.intersection(getWalls(part, downskin_layer_nr, bottom_reference_wall_idx).offset(bottom_reference_wall_expansion));
             }
@@ -549,7 +551,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
     layer_skip_count = gradual_infill_step_layer_count / n_skip_steps_per_gradual_step;
     const size_t max_infill_steps = mesh.settings.get<size_t>("gradual_infill_steps");
 
-    const LayerIndex min_layer = mesh.settings.get<size_t>("bottom_layers");
+    const LayerIndex min_layer = mesh.settings.get<bool>("layer_0_skin_enabled")? mesh.settings.get<size_t>("bottom_layers") : 0;
     const LayerIndex max_layer = mesh.layers.size() - 1 - mesh.settings.get<size_t>("top_layers");
 
     for (LayerIndex layer_idx = 0; layer_idx < static_cast<LayerIndex>(mesh.layers.size()); layer_idx++)
@@ -631,7 +633,8 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
     divisible index. Otherwise we get some parts that have infill at divisible
     layers and some at non-divisible layers. Those layers would then miss each
     other. */
-    LayerIndex min_layer = static_cast<LayerIndex>(mesh.settings.get<size_t>("bottom_layers") + amount) - 1;
+    int bottom_most_layers = mesh.settings.get<bool>("layer_0_skin_enabled")? mesh.settings.get<size_t>("bottom_layers") : 0;
+    LayerIndex min_layer = static_cast<LayerIndex>(bottom_most_layers + amount) - 1;
     min_layer -= min_layer % amount; //Round upwards to the nearest layer divisible by infill_sparse_combine.
     LayerIndex max_layer = static_cast<LayerIndex>(mesh.layers.size()) - 1 - mesh.settings.get<size_t>("top_layers");
     max_layer -= max_layer % amount; //Round downwards to the nearest layer divisible by infill_sparse_combine.

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -250,21 +250,21 @@ void SkinInfillAreaComputation::calculateBottomSkin(const SliceLayerPart& part, 
     {
         return; // don't subtract anything form the downskin
     }
-        LayerIndex bottom_check_start_layer_idx = std::max(LayerIndex(0), layer_nr - bottom_layer_count);
-        Polygons not_air = getWalls(part, bottom_check_start_layer_idx, bottom_reference_wall_idx).offset(bottom_reference_wall_expansion);
-        if (!no_small_gaps_heuristic)
+    LayerIndex bottom_check_start_layer_idx = std::max(LayerIndex(0), layer_nr - bottom_layer_count);
+    Polygons not_air = getWalls(part, bottom_check_start_layer_idx, bottom_reference_wall_idx).offset(bottom_reference_wall_expansion);
+    if (!no_small_gaps_heuristic)
+    {
+        for (int downskin_layer_nr = bottom_check_start_layer_idx + 1; downskin_layer_nr < layer_nr; downskin_layer_nr++)
         {
-            for (int downskin_layer_nr = bottom_check_start_layer_idx + 1; downskin_layer_nr < layer_nr; downskin_layer_nr++)
-            {
-                not_air = not_air.intersection(getWalls(part, downskin_layer_nr, bottom_reference_wall_idx).offset(bottom_reference_wall_expansion));
-            }
+            not_air = not_air.intersection(getWalls(part, downskin_layer_nr, bottom_reference_wall_idx).offset(bottom_reference_wall_expansion));
         }
-        const double min_infill_area = mesh.settings.get<double>("min_infill_area");
-        if (min_infill_area > 0.0)
-        {
-            not_air.removeSmallAreas(min_infill_area);
-        }
-        downskin = downskin.difference(not_air); // skin overlaps with the walls
+    }
+    const double min_infill_area = mesh.settings.get<double>("min_infill_area");
+    if (min_infill_area > 0.0)
+    {
+        not_air.removeSmallAreas(min_infill_area);
+    }
+    downskin = downskin.difference(not_air); // skin overlaps with the walls
 }
 
 void SkinInfillAreaComputation::calculateTopSkin(const SliceLayerPart& part, Polygons& upskin)

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -64,7 +64,7 @@ SkinInfillAreaComputation::SkinInfillAreaComputation(const LayerIndex& layer_nr,
 : layer_nr(layer_nr)
 , mesh(mesh)
 , bottom_layer_count(mesh.settings.get<size_t>("bottom_layers"))
-, layer_0_skin_enabled(mesh.settings.get<bool>("layer_0_skin_enabled"))
+, initial_bottom_layer_count(mesh.settings.get<size_t>("initial_bottom_layers"))
 , top_layer_count(mesh.settings.get<size_t>("top_layers"))
 , wall_line_count(mesh.settings.get<size_t>("wall_line_count"))
 , skin_line_width(getSkinLineWidth(mesh, layer_nr))
@@ -205,7 +205,7 @@ void SkinInfillAreaComputation::generateSkinAndInfillAreas(SliceLayerPart& part)
         upskin = Polygons(original_outline);
     }
     Polygons downskin;
-    if (bottom_layer_count > 0)
+    if (bottom_layer_count > 0 || layer_nr < LayerIndex(initial_bottom_layer_count))
     {
         downskin = Polygons(original_outline);
     }
@@ -242,8 +242,14 @@ void SkinInfillAreaComputation::generateSkinAndInfillAreas(SliceLayerPart& part)
  */
 void SkinInfillAreaComputation::calculateBottomSkin(const SliceLayerPart& part, Polygons& downskin)
 {
-    if ((static_cast<int>(layer_nr - bottom_layer_count) >= 0 || !layer_0_skin_enabled) && bottom_layer_count > 0)
+    if (bottom_layer_count == 0 && initial_bottom_layer_count == 0)
     {
+        return; // downskin remains empty
+    }
+    if (layer_nr < LayerIndex(initial_bottom_layer_count))
+    {
+        return; // don't subtract anything form the downskin
+    }
         LayerIndex bottom_check_start_layer_idx = std::max(LayerIndex(0), layer_nr - bottom_layer_count);
         Polygons not_air = getWalls(part, bottom_check_start_layer_idx, bottom_reference_wall_idx).offset(bottom_reference_wall_expansion);
         if (!no_small_gaps_heuristic)
@@ -259,7 +265,6 @@ void SkinInfillAreaComputation::calculateBottomSkin(const SliceLayerPart& part, 
             not_air.removeSmallAreas(min_infill_area);
         }
         downskin = downskin.difference(not_air); // skin overlaps with the walls
-    }
 }
 
 void SkinInfillAreaComputation::calculateTopSkin(const SliceLayerPart& part, Polygons& upskin)
@@ -551,7 +556,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
     layer_skip_count = gradual_infill_step_layer_count / n_skip_steps_per_gradual_step;
     const size_t max_infill_steps = mesh.settings.get<size_t>("gradual_infill_steps");
 
-    const LayerIndex min_layer = mesh.settings.get<bool>("layer_0_skin_enabled")? mesh.settings.get<size_t>("bottom_layers") : 0;
+    const LayerIndex min_layer = mesh.settings.get<size_t>("initial_bottom_layers");
     const LayerIndex max_layer = mesh.layers.size() - 1 - mesh.settings.get<size_t>("top_layers");
 
     for (LayerIndex layer_idx = 0; layer_idx < static_cast<LayerIndex>(mesh.layers.size()); layer_idx++)
@@ -633,7 +638,7 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
     divisible index. Otherwise we get some parts that have infill at divisible
     layers and some at non-divisible layers. Those layers would then miss each
     other. */
-    int bottom_most_layers = mesh.settings.get<bool>("layer_0_skin_enabled")? mesh.settings.get<size_t>("bottom_layers") : 0;
+    size_t bottom_most_layers = mesh.settings.get<size_t>("initial_bottom_layers");
     LayerIndex min_layer = static_cast<LayerIndex>(bottom_most_layers + amount) - 1;
     min_layer -= min_layer % amount; //Round upwards to the nearest layer divisible by infill_sparse_combine.
     LayerIndex max_layer = static_cast<LayerIndex>(mesh.layers.size()) - 1 - mesh.settings.get<size_t>("top_layers");

--- a/src/skin.h
+++ b/src/skin.h
@@ -156,6 +156,7 @@ protected:
     const LayerIndex layer_nr; //!< The index of the layer for which to generate the skins and infill.
     SliceMeshStorage& mesh; //!< The storage where the layer outline information (input) is stored and where the skin insets and fill areas (output) are stored.
     const size_t bottom_layer_count; //!< The number of layers of bottom skin
+    const bool layer_0_skin_enabled; //!< Whether to make bottom skin for the initial layer
     const size_t top_layer_count; //!< The number of layers of top skin
     const size_t wall_line_count; //!< The number of walls, i.e. the number of the wall from which to offset.
     const coord_t skin_line_width; //!< The line width of the skin.

--- a/src/skin.h
+++ b/src/skin.h
@@ -156,7 +156,7 @@ protected:
     const LayerIndex layer_nr; //!< The index of the layer for which to generate the skins and infill.
     SliceMeshStorage& mesh; //!< The storage where the layer outline information (input) is stored and where the skin insets and fill areas (output) are stored.
     const size_t bottom_layer_count; //!< The number of layers of bottom skin
-    const bool layer_0_skin_enabled; //!< Whether to make bottom skin for the initial layer
+    const size_t initial_bottom_layer_count; //!< Whether to make bottom skin for the initial layer
     const size_t top_layer_count; //!< The number of layers of top skin
     const size_t wall_line_count; //!< The number of walls, i.e. the number of the wall from which to offset.
     const coord_t skin_line_width; //!< The line width of the skin.


### PR DESCRIPTION
I quite often find myself setting the bottom layers to zero because of the first layer only, so I made an option for only the very bottom.

Disabling the bottom skin is nice when:
- you want to save material / print time
- you want to remove the infill afterwards (e.d. when using PVA infill)
- you want to fill the print afterward with some material to make it a solid part
- you want to show what the infill looks like
- you cut a big model into parts and the bottom of this part is not the bottom of the eventual assembled product 

The build plate is counted as a solid model, so infill is generated for the bottom.

Pictures taken from below:
![image](https://user-images.githubusercontent.com/8895761/46863911-0220ac00-ce19-11e8-94cc-a76cbe129e78.png)

![image](https://user-images.githubusercontent.com/8895761/46863918-0a78e700-ce19-11e8-86fd-d148e462a38b.png)

Angled cube from top:
![image](https://user-images.githubusercontent.com/8895761/46863963-34320e00-ce19-11e8-8d00-2f2eb8112997.png)
