### PR TITLE
Feat: flow per print-feature

### DIFF
--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -71,17 +71,16 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
 
     //Add the lines as travel moves to the layer plan.
     bool added = false;
-    const Ratio ironing_flow = mesh.settings.get<Ratio>("ironing_flow");
     if (!ironing_polygons.empty())
     {
         constexpr bool force_comb_retract = false;
         layer.addTravel(ironing_polygons[0][0], force_comb_retract);
-        layer.addPolygonsByOptimizer(ironing_polygons, line_config, nullptr, ZSeamConfig(), 0, false, ironing_flow);
+        layer.addPolygonsByOptimizer(ironing_polygons, line_config, nullptr, ZSeamConfig());
         added = true;
     }
     if (!ironing_lines.empty())
     {
-        layer.addLinesByOptimizer(ironing_lines, line_config, SpaceFillType::PolyLines, false, 0, ironing_flow);
+        layer.addLinesByOptimizer(ironing_lines, line_config, SpaceFillType::PolyLines);
         added = true;
     }
     return added;

--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -219,7 +219,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, const Laye
                 , train.settings.get<coord_t>("prime_tower_line_width")
                     * ((mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") == EPlatformAdhesion::RAFT) ? 1.0_r : line_width_factor_per_extruder[extruder_nr])
                 , layer_thickness
-                , train.settings.get<Ratio>("prime_tower_flow")
+                , train.settings.get<Ratio>("prime_tower_flow") * ((layer_nr == 0) ? train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
                 , GCodePathConfig::SpeedDerivatives{train.settings.get<Velocity>("speed_prime_tower"), train.settings.get<Acceleration>("acceleration_prime_tower"), train.settings.get<Velocity>("jerk_prime_tower")}
             );
     }

--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -119,14 +119,14 @@ PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh
     PrintFeatureType::Skin
     , mesh.settings.get<coord_t>("roofing_line_width")
     , layer_thickness
-    , (layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : mesh.settings.get<Ratio>("material_flow")
+    , mesh.settings.get<Ratio>("roofing_material_flow") * ((layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
     , GCodePathConfig::SpeedDerivatives{mesh.settings.get<Velocity>("speed_roofing"), mesh.settings.get<Acceleration>("acceleration_roofing"), mesh.settings.get<Velocity>("jerk_roofing")}
 )
 , ironing_config(
     PrintFeatureType::Skin
     , mesh.settings.get<coord_t>("skin_line_width")
     , layer_thickness
-    , (layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : mesh.settings.get<Ratio>("material_flow")
+    , mesh.settings.get<Ratio>("ironing_flow")
     , GCodePathConfig::SpeedDerivatives{mesh.settings.get<Velocity>("speed_ironing"), mesh.settings.get<Acceleration>("acceleration_ironing"), mesh.settings.get<Velocity>("jerk_ironing")}
 )
 

--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -43,7 +43,7 @@ GCodePathConfig createPerimeterGapConfig(const SliceMeshStorage& mesh, int layer
             PrintFeatureType::Skin
             , perimeter_gaps_line_width
             , layer_thickness
-            , (layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : mesh.settings.get<Ratio>("material_flow")
+            , mesh.settings.get<Ratio>("wall_x_material_flow") * ((layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
             , GCodePathConfig::SpeedDerivatives{perimeter_gaps_speed, mesh.settings.get<Velocity>("acceleration_topbottom"), mesh.settings.get<Velocity>("jerk_topbottom")}
         );
 }
@@ -134,23 +134,13 @@ PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh
 {
     infill_config.reserve(MAX_INFILL_COMBINE);
 
-    Ratio flow;
-    const std::string flow_setting = (layer_nr == 0) ? "material_flow_layer_0" : "material_flow";
-    if (mesh.settings.has(flow_setting)) //Just for this particular case, the flow is limited to the infill extruder.
-    {
-        flow = mesh.settings.get<Ratio>(flow_setting);
-    }
-    else
-    {
-        flow = mesh.settings.get<ExtruderTrain&>("infill_extruder_nr").settings.get<Ratio>(flow_setting);
-    }
     for (int combine_idx = 0; combine_idx < MAX_INFILL_COMBINE; combine_idx++)
     {
         infill_config.emplace_back(
                 PrintFeatureType::Infill
                 , mesh.settings.get<coord_t>("infill_line_width") * (combine_idx + 1) * line_width_factor_per_extruder[mesh.settings.get<ExtruderTrain&>("infill_extruder_nr").extruder_nr]
                 , layer_thickness
-                , flow
+                , mesh.settings.get<Ratio>("wall_x_material_flow") * ((layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
                 , GCodePathConfig::SpeedDerivatives{mesh.settings.get<Velocity>("speed_infill"), mesh.settings.get<Acceleration>("acceleration_infill"), mesh.settings.get<Velocity>("jerk_infill")}
             );
     }

--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -53,14 +53,14 @@ PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh
     PrintFeatureType::OuterWall
     , mesh.settings.get<coord_t>("wall_line_width_0") * line_width_factor_per_extruder[mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr]
     , layer_thickness
-    , (layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : mesh.settings.get<Ratio>("material_flow")
+    , mesh.settings.get<Ratio>("wall_0_material_flow") * ((layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
     , GCodePathConfig::SpeedDerivatives{mesh.settings.get<Velocity>("speed_wall_0"), mesh.settings.get<Acceleration>("acceleration_wall_0"), mesh.settings.get<Velocity>("jerk_wall_0")}
 )
 , insetX_config(
     PrintFeatureType::InnerWall
     , mesh.settings.get<coord_t>("wall_line_width_x") * line_width_factor_per_extruder[mesh.settings.get<ExtruderTrain&>("wall_x_extruder_nr").extruder_nr]
     , layer_thickness
-    , (layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : mesh.settings.get<Ratio>("material_flow")
+    , mesh.settings.get<Ratio>("wall_x_material_flow") * ((layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
     , GCodePathConfig::SpeedDerivatives{mesh.settings.get<Velocity>("speed_wall_x"), mesh.settings.get<Acceleration>("acceleration_wall_x"), mesh.settings.get<Velocity>("jerk_wall_x")}
 )
 , bridge_inset0_config(
@@ -85,7 +85,7 @@ PathConfigStorage::MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh
     PrintFeatureType::Skin
     , mesh.settings.get<coord_t>("skin_line_width") * line_width_factor_per_extruder[mesh.settings.get<ExtruderTrain&>("top_bottom_extruder_nr").extruder_nr]
     , layer_thickness
-    , (layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : mesh.settings.get<Ratio>("material_flow")
+    , mesh.settings.get<Ratio>("skin_material_flow") * ((layer_nr == 0) ? mesh.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
     , GCodePathConfig::SpeedDerivatives{mesh.settings.get<Velocity>("speed_topbottom"), mesh.settings.get<Acceleration>("acceleration_topbottom"), mesh.settings.get<Velocity>("jerk_topbottom")}
 )
 , bridge_skin_config( // use bridge skin flow, speed and fan
@@ -159,35 +159,35 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, const Laye
             PrintFeatureType::SupportInterface
             , adhesion_extruder_train.settings.get<coord_t>("raft_base_line_width")
             , adhesion_extruder_train.settings.get<coord_t>("raft_base_thickness")
-            , (layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : adhesion_extruder_train.settings.get<Ratio>("material_flow")
+            , ((layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train.settings.get<Velocity>("raft_base_speed"), adhesion_extruder_train.settings.get<Acceleration>("raft_base_acceleration"), adhesion_extruder_train.settings.get<Velocity>("raft_base_jerk")}
         )
 , raft_interface_config(
             PrintFeatureType::Support
             , adhesion_extruder_train.settings.get<coord_t>("raft_interface_line_width")
             , adhesion_extruder_train.settings.get<coord_t>("raft_interface_thickness")
-            , (layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : adhesion_extruder_train.settings.get<Ratio>("material_flow")
+            , (layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0)
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train.settings.get<Velocity>("raft_interface_speed"), adhesion_extruder_train.settings.get<Acceleration>("raft_interface_acceleration"), adhesion_extruder_train.settings.get<Velocity>("raft_interface_jerk")}
         )
 , raft_surface_config(
             PrintFeatureType::SupportInterface
             , adhesion_extruder_train.settings.get<coord_t>("raft_surface_line_width")
             , adhesion_extruder_train.settings.get<coord_t>("raft_surface_thickness")
-            , (layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : adhesion_extruder_train.settings.get<Ratio>("material_flow")
+            , (layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0)
             , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train.settings.get<Velocity>("raft_surface_speed"), adhesion_extruder_train.settings.get<Acceleration>("raft_surface_acceleration"), adhesion_extruder_train.settings.get<Velocity>("raft_surface_jerk")}
         )
 , support_roof_config(
             PrintFeatureType::SupportInterface
             , support_roof_train.settings.get<coord_t>("support_roof_line_width") * line_width_factor_per_extruder[support_roof_extruder_nr]
             , layer_thickness
-            , (layer_nr == 0) ? support_roof_train.settings.get<Ratio>("material_flow_layer_0") : support_roof_train.settings.get<Ratio>("material_flow")
+            , support_roof_train.settings.get<Ratio>("support_roof_material_flow") * ((layer_nr == 0) ? support_roof_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
             , GCodePathConfig::SpeedDerivatives{support_roof_train.settings.get<Velocity>("speed_support_roof"), support_roof_train.settings.get<Acceleration>("acceleration_support_roof"), support_roof_train.settings.get<Velocity>("jerk_support_roof")}
         )
 , support_bottom_config(
             PrintFeatureType::SupportInterface
             , support_bottom_train.settings.get<coord_t>("support_bottom_line_width") * line_width_factor_per_extruder[support_bottom_extruder_nr]
             , layer_thickness
-            , (layer_nr == 0) ? support_bottom_train.settings.get<Ratio>("material_flow_layer_0") : support_bottom_train.settings.get<Ratio>("material_flow")
+            , support_roof_train.settings.get<Ratio>("support_bottom_material_flow") * ((layer_nr == 0) ? support_roof_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
             , GCodePathConfig::SpeedDerivatives{support_bottom_train.settings.get<Velocity>("speed_support_bottom"), support_bottom_train.settings.get<Acceleration>("acceleration_support_bottom"), support_bottom_train.settings.get<Velocity>("jerk_support_bottom")}
         )
 {
@@ -211,7 +211,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, const Laye
                 , train.settings.get<coord_t>("skirt_brim_line_width")
                     * ((mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") == EPlatformAdhesion::RAFT) ? 1.0_r : line_width_factor_per_extruder[extruder_nr]) // cause it's also used for the draft/ooze shield
                 , layer_thickness
-                , (layer_nr == 0) ? train.settings.get<Ratio>("material_flow_layer_0") : train.settings.get<Ratio>("material_flow")
+                , train.settings.get<Ratio>("skirt_brim_material_flow") * ((layer_nr == 0) ? train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
                 , GCodePathConfig::SpeedDerivatives{train.settings.get<Velocity>("skirt_brim_speed"), train.settings.get<Acceleration>("acceleration_skirt_brim"), train.settings.get<Velocity>("jerk_skirt_brim")}
             );
         prime_tower_config_per_extruder.emplace_back(
@@ -238,7 +238,7 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, const Laye
             PrintFeatureType::Support
             , support_infill_train.settings.get<coord_t>("support_line_width") * (combine_idx + 1) * support_infill_line_width_factor
             , layer_thickness
-            , (layer_nr == 0) ? support_infill_train.settings.get<Ratio>("material_flow_layer_0") : support_infill_train.settings.get<Ratio>("material_flow")
+            , support_infill_train.settings.get<Ratio>("infill_material_flow") * ((layer_nr == 0) ? support_infill_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
             , GCodePathConfig::SpeedDerivatives{support_infill_train.settings.get<Velocity>("speed_support_infill"), support_infill_train.settings.get<Acceleration>("acceleration_support_infill"), support_infill_train.settings.get<Velocity>("jerk_support_infill")}
         );
     }


### PR DESCRIPTION
Have separate flow settings per print feature.

This way we can control the line spacing separately from the flow.
This has been a long standing deficit. 
Because Cura models the cross-section of a printed line as a square thing, while it is in fact rounded, lines are wider than computed.
This is a problem in densely filled regions (skin, walls, prime tower, brim, etc etc) because it leads to overextrusion.

Because the materials team reminded me of this deficit I decided to fix what should have been fixed a long time ago!

The only way to combat this problem before this PR is to set the global flow to something lower, or to set the steps_per_mm in the firmware to something which is in fact incorrect.

Now we have flow settings per print feature.

I was doubting whether I should make settings for the line spacing instead, but that proved to be quite difficult as there are spacings between several print features and we wouldn;t want to introduce setting for the spacing of ewach possible combination of two print features (e.g. skin-walls, skin-infill, etc)


Because the flow settings are now per print-feature it doesn't make sense to have a global flow for the first layer only. Therefore, the initial layer flow is a multiplier on top of the material_flow, instead of replacing it for the first layer. Luckiuly no single material profile set the material_flow_layer_0, so it's not a problem.
Now the initial layer flow doesn';t inherit from the material_flow anymore, because they are multiplied together.


There are no flow settings for the raft, but I don;t know whether it's really useful to introduce those.
The initial layer flow does work on the first raft layer in the same way as it used to, though.


Also the perimeter gaps now get their multiplier directly from the wall_x_extruder, so there's no more need to use a weird work-around which was in the code previously.


I hope you see this is something which Cura needs. This is not something I want and made in my free time, but something which was requested by the material team which I decided to make a headstart in for the Cura team.
Hope this is a nice kick-start!