### PR TITLE
Fix Mingw build failure

### DIFF
--- a/tests/arcus/MockSocket.h
+++ b/tests/arcus/MockSocket.h
@@ -14,7 +14,7 @@ namespace cura
  * \brief Mocks a socket connection from libArcus such that we can test with it
  * without creating an actual connection.
  */
-class MockSocket : public Arcus::Socket
+class ARCUS_EXPORT MockSocket : public Arcus::Socket
 {
 public:
     MockSocket();


### PR DESCRIPTION
The refactoring in commit 8089744 broke the build on windows under mingw due to a mismatch in the dllexport attributes. This commit adds the macro used in libArcus to ensure that theyre the same.