### PR TITLE
Bug Fix: regression in skin/infill line ordering that came with the gyroid infill

### DIFF
--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -329,7 +329,7 @@ void LineOrderOptimizer::optimize(bool find_chains)
             // we didn't find a chained line segment so now look for any lines that start within close_point_radius
             for(unsigned int close_line_idx : line_bucket_grid.getNearbyVals(prev_point, close_point_radius))
             {
-                if (picked[close_line_idx] || polygons[close_line_idx]->size() < 1)
+                if (picked[close_line_idx])
                 {
                     continue;
                 }
@@ -398,11 +398,10 @@ void LineOrderOptimizer::optimize(bool find_chains)
         {
             for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++)
             {
-                if (picked[poly_idx] || polygons[poly_idx]->size() < 1) /// skip single-point-polygons
+                if (picked[poly_idx])
                 {
                     continue;
                 }
-                assert(polygons[poly_idx]->size() == 2);
 
                 updateBestLine(poly_idx, best_line_idx, best_score, prev_point);
 
@@ -412,7 +411,6 @@ void LineOrderOptimizer::optimize(bool find_chains)
         if (best_line_idx > -1) /// should always be true; we should have been able to identify the best next polygon
         {
             ConstPolygonRef best_line = *polygons[best_line_idx];
-            assert(best_line.size() == 2);
 
             int line_start_point_idx = polyStart[best_line_idx];
             int line_end_point_idx = line_start_point_idx * -1 + 1; /// 1 -> 0 , 0 -> 1

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -316,7 +316,8 @@ void LineOrderOptimizer::optimize(bool find_chains)
             // this will find the next line segment in a chain
             for(unsigned int close_line_idx : line_bucket_grid.getNearbyVals(prev_point, 10))
             {
-                if (picked[close_line_idx] || polygons[close_line_idx]->size() < 1)
+                if (picked[close_line_idx]
+                    || !(pointsAreCoincident(prev_point,(*polygons[close_line_idx])[0]) || pointsAreCoincident(prev_point, (*polygons[close_line_idx])[1])))
                 {
                     continue;
                 }


### PR DESCRIPTION
This PR fixes a recently introduced regression that can occasionally cause the line ordering to choose a line that is further away from a better candidate. Here's an example that shows that when printing some skin, the bug caused it to skip over a couple of lines (which do get filled in later).

Without this PR:

![screenshot_2018-10-24_07-21-22](https://user-images.githubusercontent.com/585618/47412039-77b64180-d762-11e8-8546-e11c1d59e262.png)

With this PR:

![screenshot_2018-10-24_07-22-23](https://user-images.githubusercontent.com/585618/47412049-7edd4f80-d762-11e8-819a-7739f502c177.png)
