### PR TITLE
[3.6] [CURA-5831] Use takeNextMessage as a blocking call to fix busy loop

### DIFF
--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -481,7 +481,7 @@ void ArcusCommunication::setExtruderForSend(const ExtruderTrain& extruder)
 
 void ArcusCommunication::sliceNext()
 {
-    const Arcus::MessagePtr message = private_data->socket->takeNextMessage();
+    const Arcus::MessagePtr message = private_data->socket->takeNextMessage(true);
 
     //Handle the main Slice message.
     const cura::proto::Slice* slice_message = dynamic_cast<cura::proto::Slice*>(message.get()); //See if the message is of the message type Slice. Returns nullptr otherwise.

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -481,7 +481,7 @@ void ArcusCommunication::setExtruderForSend(const ExtruderTrain& extruder)
 
 void ArcusCommunication::sliceNext()
 {
-    const Arcus::MessagePtr message = private_data->socket->takeNextMessageBlocking();
+    const Arcus::MessagePtr message = private_data->socket->takeNextMessage();
 
     //Handle the main Slice message.
     const cura::proto::Slice* slice_message = dynamic_cast<cura::proto::Slice*>(message.get()); //See if the message is of the message type Slice. Returns nullptr otherwise.

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -481,7 +481,7 @@ void ArcusCommunication::setExtruderForSend(const ExtruderTrain& extruder)
 
 void ArcusCommunication::sliceNext()
 {
-    const Arcus::MessagePtr message = private_data->socket->takeNextMessage();
+    const Arcus::MessagePtr message = private_data->socket->takeNextMessageBlocking();
 
     //Handle the main Slice message.
     const cura::proto::Slice* slice_message = dynamic_cast<cura::proto::Slice*>(message.get()); //See if the message is of the message type Slice. Returns nullptr otherwise.


### PR DESCRIPTION
…a new message is received. It will

reduce performance issue, it usess less CPU then constantly requesting for a new message.