### PR TITLE
Remove blocking parameter

### DIFF
--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -481,7 +481,7 @@ void ArcusCommunication::setExtruderForSend(const ExtruderTrain& extruder)
 
 void ArcusCommunication::sliceNext()
 {
-    const Arcus::MessagePtr message = private_data->socket->takeNextMessage(true);
+    const Arcus::MessagePtr message = private_data->socket->takeNextMessage();
 
     //Handle the main Slice message.
     const cura::proto::Slice* slice_message = dynamic_cast<cura::proto::Slice*>(message.get()); //See if the message is of the message type Slice. Returns nullptr otherwise.


### PR DESCRIPTION
In libArcus, the 'blocking' parameter was accused of always being true. So it's now no longer a parameter and we pretend it is always true.

This depends on https://github.com/Ultimaker/libArcus/pull/78, so merge them at the same time if you merge them.