### PR TITLE
TreeSupport: Lazily calculate the collision, avoidance and internal model guide volumes

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -93,7 +93,7 @@ TreeSupport::TreeSupport(const SliceDataStorage& storage)
         = (angle < TAU / 4) ? (coord_t)(tan(angle) * layer_height) : std::numeric_limits<coord_t>::max();
     const coord_t radius_sample_resolution = mesh_group_settings.get<coord_t>("support_tree_collision_resolution");
 
-    volumes_ = ModelVolumes(storage, machine_volume_border, xy_distance, maximum_move_distance, radius_sample_resolution);
+    volumes_ = ModelVolumes(storage, std::move(machine_volume_border), xy_distance, maximum_move_distance, radius_sample_resolution);
 }
 
 void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
@@ -612,7 +612,7 @@ void TreeSupport::insertDroppedNode(std::unordered_set<Node*>& nodes_layer, Node
 
 ModelVolumes::ModelVolumes(const SliceDataStorage& storage, Polygons machine_border, coord_t xy_distance,
                            coord_t max_move, coord_t radius_sample_resolution) :
-    machine_border_{machine_border},
+    machine_border_{std::move(machine_border)},
     xy_distance_{xy_distance},
     max_move_{max_move},
     radius_sample_resolution_{radius_sample_resolution}

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -703,11 +703,16 @@ const Polygons& ModelVolumes::calculateAvoidance(const RadiusLayerPair& key) con
     }
 
     // Avoidance for a given layer depends on all layers beneath it so could have very deep recursion depths if
-    // called at high layer heights
+    // called at high layer heights. We can limit the reqursion depth to N by checking if the if the layer N
+    // below the current one exists and if not, forcing the calculation of that layer. This may cause another recursion
+    // if the layer at 2N below the current one but we won't exceed our limit unless there are N*N uncalculated layers
+    // below our current one.
     constexpr auto max_recursion_depth = 100;
+    // Check if we would exceed the recursion limit by trying to process this layer
     if (layer_idx >= max_recursion_depth
         && avoidance_cache_.find({radius, layer_idx - max_recursion_depth}) == avoidance_cache_.end())
     {
+        // Force the calculation of the layer `max_recursion_depth` below our current one, ignoring the result.
         getAvoidance(radius, layer_idx - max_recursion_depth);
     }
     auto avoidance_areas = getAvoidance(radius, layer_idx - 1).offset(-max_move_).smooth(5);

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -623,7 +623,7 @@ ModelVolumes::ModelVolumes(const SliceDataStorage& storage, Polygons machine_bor
     }
 }
 
-const Polygons& ModelVolumes::getCollision(coord_t radius, int layer_idx) const
+const Polygons& ModelVolumes::getCollision(coord_t radius, LayerIndex layer_idx) const
 {
     radius = ceilRadius(radius);
     RadiusLayerPair key{radius, layer_idx};
@@ -638,7 +638,7 @@ const Polygons& ModelVolumes::getCollision(coord_t radius, int layer_idx) const
     }
 }
 
-const Polygons& ModelVolumes::getAvoidance(coord_t radius, int layer_idx) const
+const Polygons& ModelVolumes::getAvoidance(coord_t radius, LayerIndex layer_idx) const
 {
     radius = ceilRadius(radius);
     RadiusLayerPair key{radius, layer_idx};
@@ -653,7 +653,7 @@ const Polygons& ModelVolumes::getAvoidance(coord_t radius, int layer_idx) const
     }
 }
 
-const Polygons& ModelVolumes::getInternalModel(coord_t radius, int layer_idx) const
+const Polygons& ModelVolumes::getInternalModel(coord_t radius, LayerIndex layer_idx) const
 {
     radius = ceilRadius(radius);
     RadiusLayerPair key{radius, layer_idx};

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -7,10 +7,92 @@
 #include <forward_list>
 #include <unordered_set>
 
+#include <memory>
+#include <vector>
+#include <utility>
+#include <unordered_map>
+
 #include "sliceDataStorage.h"
+
 
 namespace cura
 {
+/*!
+ * \brief Lazily generates tree guidance volumes.
+ *
+ * NOTE: This class is not currently thread-safe and should not be accessed in OpenMP blocks
+ */
+class ModelVolumes
+{
+public:
+    ModelVolumes() = default;
+    ModelVolumes(const SliceDataStorage& storage, Polygons machine_border, coord_t xy_distance, coord_t max_move,
+                 coord_t radius_sample_resolution);
+
+    ModelVolumes(ModelVolumes&&) = default;
+    ModelVolumes& operator=(ModelVolumes&&) = default;
+
+    ModelVolumes(const ModelVolumes&) = delete;
+    ModelVolumes& operator=(const ModelVolumes&) = delete;
+
+    /*!
+     * \brief Creates the areas that have to be avoided by the tree's branches.
+     *
+     * The result is a 2D area that would cause nodes of radius \p radius to
+     * collide with the model.
+     *
+     * \param radius The radius of the node of interest
+     * \param layer The layer of interest
+     * \return Polygons object
+     */
+    const Polygons& collision(coord_t radius, int layer) const;
+
+    /*!
+     * \brief Creates the areas that have to be avoided by the tree's branches
+     * in order to reach the build plate.
+     *
+     * The result is a 2D area that would cause nodes of radius \p radius to
+     * collide with the model or be unable to reach the build platform.
+     *
+     * The input collision areas are inset by the maximum move distance and
+     * propagated upwards.
+     *
+     * \param radius The radius of the node of interest
+     * \param layer The layer of interest
+     * \return Polygons object
+     */
+    const Polygons& avoidance(coord_t radius, int layer) const;
+
+    /*!
+     * \brief Generates the area of a given layer that must be avoided if the
+     * branches wish to go towards the model
+     *
+     * The area represents the areas that do not collide with the model but
+     * are unable to reach the build platform
+     *
+     * \param radius The radius of the node of interest
+     * \param layer The layer of interest
+     * \return Polygons object
+     */
+    const Polygons& internal_model(coord_t radius, int layer) const;
+
+private:
+    using RadiusLayerPair = std::pair<coord_t, int>;
+
+    coord_t roundRadius(coord_t radius) const;
+    const Polygons& calculateCollision(const RadiusLayerPair& key) const;
+    const Polygons& calculateAvoidance(const RadiusLayerPair& key) const;
+    const Polygons& calculateInternalModel(const RadiusLayerPair& key) const;
+
+    Polygons machine_border_;
+    coord_t xy_distance_;
+    coord_t max_move_;
+    coord_t radius_sample_resolution_;
+    std::vector<Polygons> layer_outlines_;
+    mutable std::unordered_map<RadiusLayerPair, Polygons> collision_cache_;
+    mutable std::unordered_map<RadiusLayerPair, Polygons> avoidance_cache_;
+    mutable std::unordered_map<RadiusLayerPair, Polygons> internal_model_cache_;
+};
 
 /*!
  * \brief Generates a tree structure to support your models.
@@ -130,28 +212,12 @@ public:
 
 private:
     /*!
-     * \brief The border of the printer where we may not put tree branches.
+     * \brief Generator for model collision, avoidance and internal guide volumes
      *
-     * Lest they produce g-code that goes outside the build volume.
+     * Lazily computes volumes as needed.
+     *  Note: This class is NOT currently thread-safe and should not be accessed in OpenMP blocks
      */
-    Polygons machine_volume_border;
-
-    /*!
-     * \brief Creates the areas that have to be avoided by the tree's branches.
-     *
-     * The result is a vector of 3D volumes that have to be avoided, where each
-     * volume consists of a number of layers where the branch would collide with
-     * the model.
-     * There will be a volume for each sample of branch radius. The radii of the
-     * branches are unknown at this point (there will be several radii at any
-     * given layer too), so a collision area is generated for every possible
-     * radius.
-     *
-     * \param storage The settings storage to get settings from.
-     * \param model_collision[out] A vector to fill with the output collision
-     * areas.
-     */
-    void collisionAreas(const SliceDataStorage& storage, std::vector<std::vector<Polygons>>& model_collision);
+    ModelVolumes volumes_;
 
     /*!
      * \brief Draws circles around each node of the tree into the final support.
@@ -162,10 +228,8 @@ private:
      * \param storage[in, out] The settings storage to get settings from and to
      * save the resulting support polygons to.
      * \param contact_nodes The nodes to draw as support.
-     * \param model_collision The model infill with the X/Y distance already
-     * subtracted.
      */
-    void drawCircles(SliceDataStorage& storage, const std::vector<std::unordered_set<Node*>>& contact_nodes, const std::vector<std::vector<Polygons>>& model_collision);
+    void drawCircles(SliceDataStorage& storage, const std::vector<std::unordered_set<Node*>>& contact_nodes);
 
     /*!
      * \brief Drops down the nodes of the tree support towards the build plate.
@@ -178,17 +242,8 @@ private:
      * \param contact_nodes[in, out] The nodes in the space that need to be
      * dropped down. The nodes are dropped to lower layers inside the same
      * vector of layers.
-     * \param model_collision For each sample of radius, a list of layers with
-     * the polygons of the collision areas of the model. Any node in there will
-     * collide with the model.
-     * \param model_avoidance For each sample of radius, a list of layers with
-     * the polygons that must be avoided if the branches wish to go towards the
-     * build plate.
-     * \param model_internal_guide For each sample of radius, a list of layers
-     * with the polygons that must be avoided if the branches wish to go towards
-     * the model.
      */
-    void dropNodes(std::vector<std::unordered_set<Node*>>& contact_nodes, const std::vector<std::vector<Polygons>>& model_collision, const std::vector<std::vector<Polygons>>& model_avoidance, const std::vector<std::vector<Polygons>>& model_internal_guide);
+    void dropNodes(std::vector<std::unordered_set<Node*>>& contact_nodes);
 
     /*!
      * \brief Creates points where support contacts the model.
@@ -203,7 +258,7 @@ private:
      * \return For each layer, a list of points where the tree should connect
      * with the model.
      */
-    void generateContactPoints(const SliceMeshStorage& mesh, std::vector<std::unordered_set<Node*>>& contact_nodes, const std::vector<Polygons>& collision_areas);
+    void generateContactPoints(const SliceMeshStorage& mesh, std::vector<std::unordered_set<Node*>>& contact_nodes);
 
     /*!
      * \brief Add a node to the next layer.
@@ -211,30 +266,6 @@ private:
      * If a node is already at that position in the layer, the nodes are merged.
      */
     void insertDroppedNode(std::unordered_set<Node*>& nodes_layer, Node* node);
-
-    /*!
-     * \brief Creates the areas that have to be avoided by the tree's branches
-     * in order to reach the build plate.
-     *
-     * The result is a vector of 3D volumes that have to be avoided, where each
-     * volume consists of a number of layers where the branch would collide with
-     * the model.
-     * There will be a volume for each sample of branch radius. The radii of the
-     * branches are unknown at this point (there will be several radii at any
-     * given layer too), so a collision area is generated for every possible
-     * radius.
-     *
-     * The input collision areas are inset by the maximum move distance and
-     * propagated upwards. This generates volumes so that the branches can
-     * predict in time when they need to be moving away in order to avoid
-     * hitting the model.
-     * \param storage The settings storage to get settings from.
-     * \param model_collision The collision areas that may not be hit by the
-     * model.
-     * \param model_avoidance[out] A vector to fill with the output avoidance
-     * areas.
-     */
-    void propagateCollisionAreas(const SliceDataStorage& storage, const std::vector<std::vector<Polygons>>& model_collision, std::vector<std::vector<Polygons>>& model_avoidance);
 };
 
 }
@@ -251,4 +282,3 @@ namespace std
 }
 
 #endif /* TREESUPPORT_H */
-

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -40,7 +40,7 @@ public:
      * adjacent layers
      * \param radius_sample_resolution Sample size used to round requested node radii.
      */
-    ModelVolumes(const SliceDataStorage& storage, Polygons machine_border, coord_t xy_distance, coord_t max_move,
+    ModelVolumes(const SliceDataStorage& storage, coord_t xy_distance, coord_t max_move,
                  coord_t radius_sample_resolution);
 
     ModelVolumes(ModelVolumes&&) = default;

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -13,6 +13,7 @@
 #include <unordered_map>
 
 #include "sliceDataStorage.h"
+#include "settings/types/LayerIndex.h"
 
 
 namespace cura
@@ -45,7 +46,7 @@ public:
      * \param layer The layer of interest
      * \return Polygons object
      */
-    const Polygons& getCollision(coord_t radius, int layer_idx) const;
+    const Polygons& getCollision(coord_t radius, LayerIndex layer_idx) const;
 
     /*!
      * \brief Creates the areas that have to be avoided by the tree's branches
@@ -61,7 +62,7 @@ public:
      * \param layer The layer of interest
      * \return Polygons object
      */
-    const Polygons& getAvoidance(coord_t radius, int layer_idx) const;
+    const Polygons& getAvoidance(coord_t radius, LayerIndex layer_idx) const;
 
     /*!
      * \brief Generates the area of a given layer that must be avoided if the
@@ -74,10 +75,10 @@ public:
      * \param layer The layer of interest
      * \return Polygons object
      */
-    const Polygons& getInternalModel(coord_t radius, int layer_idx) const;
+    const Polygons& getInternalModel(coord_t radius, LayerIndex layer_idx) const;
 
 private:
-    using RadiusLayerPair = std::pair<coord_t, int>;
+    using RadiusLayerPair = std::pair<coord_t, LayerIndex>;
     coord_t ceilRadius(coord_t radius) const;
 
     const Polygons& calculateCollision(const RadiusLayerPair& key) const;

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -45,7 +45,7 @@ public:
      * \param layer The layer of interest
      * \return Polygons object
      */
-    const Polygons& collision(coord_t radius, int layer) const;
+    const Polygons& getCollision(coord_t radius, int layer_idx) const;
 
     /*!
      * \brief Creates the areas that have to be avoided by the tree's branches
@@ -61,7 +61,7 @@ public:
      * \param layer The layer of interest
      * \return Polygons object
      */
-    const Polygons& avoidance(coord_t radius, int layer) const;
+    const Polygons& getAvoidance(coord_t radius, int layer_idx) const;
 
     /*!
      * \brief Generates the area of a given layer that must be avoided if the
@@ -74,12 +74,12 @@ public:
      * \param layer The layer of interest
      * \return Polygons object
      */
-    const Polygons& internal_model(coord_t radius, int layer) const;
+    const Polygons& getInternalModel(coord_t radius, int layer_idx) const;
 
 private:
     using RadiusLayerPair = std::pair<coord_t, int>;
+    coord_t ceilRadius(coord_t radius) const;
 
-    coord_t roundRadius(coord_t radius) const;
     const Polygons& calculateCollision(const RadiusLayerPair& key) const;
     const Polygons& calculateAvoidance(const RadiusLayerPair& key) const;
     const Polygons& calculateInternalModel(const RadiusLayerPair& key) const;

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -32,8 +32,6 @@ public:
      *
      * \param storage The slice data storage object to extract the model
      * contours from.
-     * \param machine_border The polygons representing the limits of the
-     * printable area of the machine.
      * \param xy_distance The required clearance between the model and the
      * tree branches.
      * \param max_move The maximum allowable movement between nodes on
@@ -126,6 +124,13 @@ private:
      * \param key The radius and layer of the node of interest
      */
     const Polygons& calculateInternalModel(const RadiusLayerPair& key) const;
+
+    /*!
+     * \brief Calculate the collision area around the printable area of the machine.
+     *
+     * \param a Polygons object representing the non-printable areas on and around the build platform
+     */
+    static Polygons calculateMachineBorderCollision(Polygon machine_border);
 
     /*!
      * \brief Polygons representing the limits of the printable area of the

--- a/src/settings/types/LayerIndex.h
+++ b/src/settings/types/LayerIndex.h
@@ -4,6 +4,8 @@
 #ifndef LAYERINDEX_H
 #define LAYERINDEX_H
 
+#include <functional>
+
 namespace cura
 {
 
@@ -107,6 +109,18 @@ struct LayerIndex
     int value = 0;
 };
 
+}
+
+namespace std
+{
+    template<>
+    struct hash<cura::LayerIndex>
+    {
+        size_t operator()(const cura::LayerIndex& layer_index) const
+        {
+            return hash<int>()(layer_index.value);
+        }
+    };
 }
 
 #endif //LAYERINDEX_H

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -6,6 +6,7 @@
 #include "sliceDataStorage.h"
 #include "infill/SubDivCube.h" // For the destructor
 #include "infill/DensityProvider.h" // for destructor
+#include "utils/math.h" //For PI.
 
 
 namespace cura
@@ -580,6 +581,70 @@ bool SliceDataStorage::getExtruderPrimeBlobEnabled(const size_t extruder_nr) con
 
     const ExtruderTrain& train = Application::getInstance().current_slice->scene.extruders[extruder_nr];
     return train.settings.get<bool>("prime_blob_enable");
+}
+
+Polygon SliceDataStorage::getMachineBorder(bool adhesion_offset) const
+{
+    const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
+
+    Polygon border{};
+    switch(mesh_group_settings.get<BuildPlateShape>("machine_shape"))
+    {
+        case BuildPlateShape::ELLIPTIC:
+        {
+            //Construct an ellipse to approximate the build volume.
+            const coord_t width = machine_size.max.x - machine_size.min.x;
+            const coord_t depth = machine_size.max.y - machine_size.min.y;
+            constexpr unsigned int circle_resolution = 50;
+            for (unsigned int i = 0; i < circle_resolution; i++)
+            {
+                const double angle = M_PI * 2 * i / circle_resolution;
+                border.emplace_back(machine_size.getMiddle().x + std::cos(angle) * width / 2,
+                                    machine_size.getMiddle().y + std::sin(angle) * depth / 2);
+            }
+            break;
+        }
+        case BuildPlateShape::RECTANGULAR:
+        default:
+            border = machine_size.flatten().toPolygon();
+            break;
+    }
+    if (!adhesion_offset) {
+        return border;
+    }
+
+    coord_t adhesion_size = 0; //Make sure there is enough room for the platform adhesion around support.
+    const ExtruderTrain& adhesion_extruder = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr");
+    coord_t extra_skirt_line_width = 0;
+    const std::vector<bool> is_extruder_used = getExtrudersUsed();
+    for (size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
+    {
+        if (extruder_nr == adhesion_extruder.extruder_nr || !is_extruder_used[extruder_nr]) //Unused extruders and the primary adhesion extruder don't generate an extra skirt line.
+        {
+            continue;
+        }
+        const ExtruderTrain& other_extruder = Application::getInstance().current_slice->scene.extruders[extruder_nr];
+        extra_skirt_line_width += other_extruder.settings.get<coord_t>("skirt_brim_line_width") * other_extruder.settings.get<Ratio>("initial_layer_line_width_factor");
+    }
+    switch (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type"))
+    {
+        case EPlatformAdhesion::BRIM:
+            adhesion_size = adhesion_extruder.settings.get<coord_t>("skirt_brim_line_width") * adhesion_extruder.settings.get<Ratio>("initial_layer_line_width_factor") * adhesion_extruder.settings.get<size_t>("brim_line_count") + extra_skirt_line_width;
+            break;
+        case EPlatformAdhesion::RAFT:
+            adhesion_size = adhesion_extruder.settings.get<coord_t>("raft_margin");
+            break;
+        case EPlatformAdhesion::SKIRT:
+            adhesion_size = adhesion_extruder.settings.get<coord_t>("skirt_gap") + adhesion_extruder.settings.get<coord_t>("skirt_brim_line_width") * adhesion_extruder.settings.get<Ratio>("initial_layer_line_width_factor") * adhesion_extruder.settings.get<size_t>("skirt_line_count") + extra_skirt_line_width;
+            break;
+        case EPlatformAdhesion::NONE:
+            adhesion_size = 0;
+            break;
+        default: //Also use 0.
+            log("Unknown platform adhesion type! Please implement the width of the platform adhesion here.");
+            break;
+    }
+    return border.offset(-adhesion_size)[0];
 }
 
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -355,6 +355,15 @@ public:
      */
     bool getExtruderPrimeBlobEnabled(const size_t extruder_nr) const;
 
+    /*!
+     * Gets the border of the usable print area for this machine.
+     *
+     * \param adhesion_offset whether to offset the border by the adhesion width to account for brims, skirts and
+     * rafts, if present.
+     * \return a Polygon representing the usable area of the print bed.
+     */
+    Polygon getMachineBorder(bool adhesion_offset = false) const;
+
 private:
     /*!
      * Construct the retraction_config_per_extruder


### PR DESCRIPTION
The ModelVolumes object lazily calculates the volumes as required, singificantly reducing the amount of work done since most radius samples were never read in the old code.
The object is not thread-safe and we lose the parallelism of generating the volumes with OpenMP but this is still faster because only the required areas are genereated.

There is a slight change in behaviour due inconsistent behaviour in the old code regarding radius sample index calculation. The new code consistently uses ceiling when calculating the sample radius whereas the old code used ceiling for generating the volumes and rounding when accessing later on.