### PR TITLE
Move optional to namespace cura

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1687,11 +1687,11 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
     return added_something;
 }
 
-std::optional<Point> FffGcodeWriter::getSeamAvoidingLocation(const Polygons& filling_part, int filling_angle, Point last_position) const
+cura::optional<Point> FffGcodeWriter::getSeamAvoidingLocation(const Polygons& filling_part, int filling_angle, Point last_position) const
 {
     if (filling_part.empty())
     {
-        return std::optional<Point>();
+        return cura::optional<Point>();
     }
     // start with the BB of the outline
     AABB skin_part_bb(filling_part);
@@ -1707,18 +1707,18 @@ std::optional<Point> FffGcodeWriter::getSeamAvoidingLocation(const Polygons& fil
     const PolygonsPointIndex pb = PolygonUtils::findNearestVert(bb_middle - vec, filling_part);
     if (!pa.initialized() || !pb.initialized())
     {
-        return std::optional<Point>();
+        return cura::optional<Point>();
     }
     // now go to whichever of those vertices that is closest to where we are now
     if (vSize2(pa.p() - last_position) < vSize2(pb.p() - last_position))
     {
         bool bs_arg = true;
-        return std::optional<Point>(bs_arg, pa.p());
+        return cura::optional<Point>(bs_arg, pa.p());
     }
     else
     {
         bool bs_arg = true;
-        return std::optional<Point>(bs_arg, pb.p());
+        return cura::optional<Point>(bs_arg, pb.p());
     }
 }
 
@@ -2115,7 +2115,7 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage, La
             gcode_layer.addPolygonsByOptimizer(skin_polygons, config);
         }
 
-        std::optional<Point> near_start_location;
+        cura::optional<Point> near_start_location;
         const EFillMethod pattern = (gcode_layer.getLayerNr() == 0) ?
             mesh.settings.get<EFillMethod>("top_bottom_pattern_0") :
             mesh.settings.get<EFillMethod>("top_bottom_pattern");

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1691,7 +1691,7 @@ cura::optional<Point> FffGcodeWriter::getSeamAvoidingLocation(const Polygons& fi
 {
     if (filling_part.empty())
     {
-        return cura::optional<Point>();
+        return cura::nullopt;
     }
     // start with the BB of the outline
     AABB skin_part_bb(filling_part);
@@ -1707,7 +1707,7 @@ cura::optional<Point> FffGcodeWriter::getSeamAvoidingLocation(const Polygons& fi
     const PolygonsPointIndex pb = PolygonUtils::findNearestVert(bb_middle - vec, filling_part);
     if (!pa.initialized() || !pb.initialized())
     {
-        return cura::optional<Point>();
+        return cura::nullopt;
     }
     // now go to whichever of those vertices that is closest to where we are now
     if (vSize2(pa.p() - last_position) < vSize2(pb.p() - last_position))

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1712,13 +1712,11 @@ cura::optional<Point> FffGcodeWriter::getSeamAvoidingLocation(const Polygons& fi
     // now go to whichever of those vertices that is closest to where we are now
     if (vSize2(pa.p() - last_position) < vSize2(pb.p() - last_position))
     {
-        bool bs_arg = true;
-        return cura::optional<Point>(bs_arg, pa.p());
+        return cura::optional<Point>(cura::in_place, pa.p());
     }
     else
     {
-        bool bs_arg = true;
-        return cura::optional<Point>(bs_arg, pb.p());
+        return cura::optional<Point>(cura::in_place, pb.p());
     }
 }
 

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -596,7 +596,7 @@ private:
      * \param last_position The position the print head is in before going to fill the part
      * \return The location near where to start filling the part
      */
-    std::optional<Point> getSeamAvoidingLocation(const Polygons& filling_part, int filling_angle, Point last_position) const;
+    cura::optional<Point> getSeamAvoidingLocation(const Polygons& filling_part, int filling_angle, Point last_position) const;
 
     /*!
      * Add the g-code for ironing the top surface.

--- a/src/GcodeLayerThreader.h
+++ b/src/GcodeLayerThreader.h
@@ -92,7 +92,7 @@ private:
     std::vector<T*> produced; //!< ordered list for every item to be produced; contains pointers to produced items which aren't consumed yet; rest is nullptr
     int last_produced_argument_index; //!< Counter to see which item next to produce
 
-    std::optional<int> to_be_consumed_item_idx; //!< The index into \ref GcodeLayerThreader::produced where to find the next item ready to be consumed (if any)
+    cura::optional<int> to_be_consumed_item_idx; //!< The index into \ref GcodeLayerThreader::produced where to find the next item ready to be consumed (if any)
     Lock consume_lock; //!< Lock to make sure no two threads consume at the same time
     int last_consumed_idx = -1; //!< The index into \ref GcodeLayerThreader::produced for the last item consumed
 
@@ -197,7 +197,7 @@ void GcodeLayerThreader<T>::act()
     }
 
     {
-        std::optional<int> item_argument_index;
+        cura::optional<int> item_argument_index;
         #pragma omp critical
         {
             if (active_task_count < max_task_count)

--- a/src/GcodeLayerThreader.h
+++ b/src/GcodeLayerThreader.h
@@ -185,7 +185,7 @@ void GcodeLayerThreader<T>::act()
             if (to_be_consumed_item_idx && consume_lock.test_lock())
             {
                 item_idx = *to_be_consumed_item_idx;
-                to_be_consumed_item_idx = nullptr;
+                to_be_consumed_item_idx = cura::nullopt;
             }
         }
         if (item_idx >= 0)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -332,9 +332,9 @@ void LayerPlan::setPrimeTowerIsPlanned(unsigned int extruder_nr)
     has_prime_tower_planned_per_extruder[extruder_nr] = true;
 }
 
-std::optional<std::pair<Point, bool>> LayerPlan::getFirstTravelDestinationState() const
+cura::optional<std::pair<Point, bool>> LayerPlan::getFirstTravelDestinationState() const
 {
-    std::optional<std::pair<Point, bool>> ret;
+    cura::optional<std::pair<Point, bool>> ret;
     if (first_travel_destination)
     {
         ret = std::make_pair(*first_travel_destination, first_travel_destination_is_inside);
@@ -977,7 +977,7 @@ unsigned LayerPlan::locateFirstSupportedVertex(ConstPolygonRef wall, const unsig
     }
 }
 
-void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization, int wipe_dist, float flow_ratio, std::optional<Point> near_start_location, double fan_speed)
+void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization, int wipe_dist, float flow_ratio, cura::optional<Point> near_start_location, double fan_speed)
 {
     Polygons boundary;
     if (enable_travel_optimization && comb_boundary_inside2.size() > 0)

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -578,7 +578,7 @@ public:
      * \param near_start_location Optional: Location near where to add the first line. If not provided the last position is used.
      * \param fan_speed optional fan speed override for this path
      */
-    void addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization = false, int wipe_dist = 0, float flow_ratio = 1.0, cura::optional<Point> near_start_location = cura::optional<Point>(), double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
+    void addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization = false, int wipe_dist = 0, float flow_ratio = 1.0, cura::optional<Point> near_start_location = cura::nullopt, double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
 
     /*!
      * Add a spiralized slice of wall that is interpolated in X/Y between \p last_wall and \p wall.

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -58,9 +58,9 @@ protected:
      * In this case this member is only used as a way to convey information between different calls of \ref LayerPlanBuffer::processBuffer
      */
     double required_start_temperature;
-    std::optional<double> extrusion_temperature; //!< The normal temperature for printing this extruder plan. That start and end of this extruder plan may deviate because of the initial and final print temp (none if extruder plan has no extrusion moves)
-    std::optional<std::list<NozzleTempInsert>::iterator> extrusion_temperature_command; //!< The command to heat from the printing temperature of this extruder plan to the printing temperature of the next extruder plan (if it has the same extruder).
-    std::optional<double> prev_extruder_standby_temp; //!< The temperature to which to set the previous extruder. Not used if the previous extruder plan was the same extruder.
+    cura::optional<double> extrusion_temperature; //!< The normal temperature for printing this extruder plan. That start and end of this extruder plan may deviate because of the initial and final print temp (none if extruder plan has no extrusion moves)
+    cura::optional<std::list<NozzleTempInsert>::iterator> extrusion_temperature_command; //!< The command to heat from the printing temperature of this extruder plan to the printing temperature of the next extruder plan (if it has the same extruder).
+    cura::optional<double> prev_extruder_standby_temp; //!< The temperature to which to set the previous extruder. Not used if the previous extruder plan was the same extruder.
 
     TimeMaterialEstimates estimates; //!< Accumulated time and material estimates for all planned paths within this extruder plan.
 
@@ -249,7 +249,7 @@ private:
 
     std::vector<Point> layer_start_pos_per_extruder; //!< The starting position of a layer for each extruder
     std::vector<bool> has_prime_tower_planned_per_extruder; //!< For each extruder, whether the prime tower is planned yet or not.
-    std::optional<Point> last_planned_position; //!< The last planned XY position of the print head (if known)
+    cura::optional<Point> last_planned_position; //!< The last planned XY position of the print head (if known)
 
     std::string current_mesh; //<! A unique ID for the mesh of the last planned move.
 
@@ -264,7 +264,7 @@ private:
     size_t last_extruder_previous_layer; //!< The last id of the extruder with which was printed in the previous layer
     ExtruderTrain* last_planned_extruder; //!< The extruder for which a move has most recently been planned.
 
-    std::optional<Point> first_travel_destination; //!< The destination of the first (travel) move (if this layer is not empty)
+    cura::optional<Point> first_travel_destination; //!< The destination of the first (travel) move (if this layer is not empty)
     bool first_travel_destination_is_inside; //!< Whether the destination of the first planned travel move is inside a layer part
     bool was_inside; //!< Whether the last planned (extrusion) move was inside a layer part
     bool is_inside; //!< Whether the destination of the next planned travel move is inside a layer part
@@ -398,7 +398,7 @@ public:
      * 
      * Returns nothing if the layer is empty and no travel move was ever made.
      */
-    std::optional<std::pair<Point, bool>> getFirstTravelDestinationState() const;
+    cura::optional<std::pair<Point, bool>> getFirstTravelDestinationState() const;
 
     /*!
     * Set whether the next destination is inside a layer part or not.
@@ -578,7 +578,7 @@ public:
      * \param near_start_location Optional: Location near where to add the first line. If not provided the last position is used.
      * \param fan_speed optional fan speed override for this path
      */
-    void addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization = false, int wipe_dist = 0, float flow_ratio = 1.0, std::optional<Point> near_start_location = std::optional<Point>(), double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
+    void addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, SpaceFillType space_fill_type, bool enable_travel_optimization = false, int wipe_dist = 0, float flow_ratio = 1.0, cura::optional<Point> near_start_location = cura::optional<Point>(), double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
 
     /*!
      * Add a spiralized slice of wall that is interpolated in X/Y between \p last_wall and \p wall.

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -73,7 +73,7 @@ void LayerPlanBuffer::flush()
 
 void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const LayerPlan* newest_layer)
 {
-    std::optional<std::pair<Point, bool>> new_layer_destination_state = newest_layer->getFirstTravelDestinationState();
+    cura::optional<std::pair<Point, bool>> new_layer_destination_state = newest_layer->getFirstTravelDestinationState();
 
     if (!new_layer_destination_state)
     {
@@ -356,7 +356,7 @@ void LayerPlanBuffer::insertFinalPrintTempCommand(std::vector<ExtruderPlan*>& ex
 
     double time_window = 0; // The time window within which the nozzle needs to heat from the initial print temp to the printing temperature and then back to the final print temp; i.e. from the first to the last extrusion move with this extruder
     double weighted_average_extrusion_temp = 0; // The average of the normal extrusion temperatures of the extruder plans (which might be different due to flow dependent temp or due to initial layer temp) Weighted by time
-    std::optional<double> initial_print_temp; // The initial print temp of the first extruder plan with this extruder
+    cura::optional<double> initial_print_temp; // The initial print temp of the first extruder plan with this extruder
     { // compute time window and print temp statistics
         double heated_pre_travel_time = -1; // The time before the first extrude move from the start of the extruder plan during which the nozzle is stable at the initial print temperature
         for (unsigned int prev_extruder_plan_idx = last_extruder_plan_idx; (int)prev_extruder_plan_idx >= 0; prev_extruder_plan_idx--)

--- a/src/infill/SierpinskiFillProvider.cpp
+++ b/src/infill/SierpinskiFillProvider.cpp
@@ -9,7 +9,6 @@
 namespace cura
 {
 
-
 constexpr bool SierpinskiFillProvider::use_dithering;
 
 SierpinskiFillProvider::SierpinskiFillProvider(const AABB3D aabb_3d, coord_t min_line_distance, const coord_t line_width)

--- a/src/infill/SierpinskiFillProvider.cpp
+++ b/src/infill/SierpinskiFillProvider.cpp
@@ -10,20 +10,19 @@ namespace cura
 {
 
 
-constexpr bool SierpinskiFillProvider::get_constructor;
 constexpr bool SierpinskiFillProvider::use_dithering;
 
 SierpinskiFillProvider::SierpinskiFillProvider(const AABB3D aabb_3d, coord_t min_line_distance, const coord_t line_width)
 : fractal_config(getFractalConfig(aabb_3d, min_line_distance))
 , density_provider(new UniformDensityProvider((float)line_width / min_line_distance))
-, fill_pattern_for_all_layers(get_constructor, *density_provider, fractal_config.aabb, fractal_config.depth, line_width, use_dithering)
+, fill_pattern_for_all_layers(cura::in_place, *density_provider, fractal_config.aabb, fractal_config.depth, line_width, use_dithering)
 {
 }
 
 SierpinskiFillProvider::SierpinskiFillProvider(const AABB3D aabb_3d, coord_t min_line_distance, coord_t line_width, std::string cross_subdisivion_spec_image_file)
 : fractal_config(getFractalConfig(aabb_3d, min_line_distance))
 , density_provider(new ImageBasedDensityProvider(cross_subdisivion_spec_image_file, aabb_3d.flatten()))
-, fill_pattern_for_all_layers(get_constructor, *density_provider, fractal_config.aabb, fractal_config.depth, line_width, use_dithering)
+, fill_pattern_for_all_layers(cura::in_place, *density_provider, fractal_config.aabb, fractal_config.depth, line_width, use_dithering)
 {
 }
 

--- a/src/infill/SierpinskiFillProvider.h
+++ b/src/infill/SierpinskiFillProvider.h
@@ -26,7 +26,6 @@ namespace cura
  */
 class SierpinskiFillProvider
 {
-    static constexpr bool get_constructor = true;
     static constexpr bool use_dithering = true; // !< Whether to employ dithering and error propagation
 protected:
     //! Basic parameters from which to start constructing the sierpinski fractal

--- a/src/infill/SierpinskiFillProvider.h
+++ b/src/infill/SierpinskiFillProvider.h
@@ -38,7 +38,7 @@ protected:
 public:
     FractalConfig fractal_config;
     DensityProvider* density_provider; //!< The object which determines the requested density at each region
-    std::optional<SierpinskiFill> fill_pattern_for_all_layers; //!< The fill pattern if one and the same pattern is used on all layers
+    cura::optional<SierpinskiFill> fill_pattern_for_all_layers; //!< The fill pattern if one and the same pattern is used on all layers
 
     SierpinskiFillProvider(const AABB3D aabb_3d, coord_t min_line_distance, const coord_t line_width);
 

--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -386,7 +386,7 @@ bool Comb::Crossing::findOutside(const Polygons& outside, const Point close_to, 
     { // move outside
         Point preferred_crossing_1_out = in_or_mid + normal(close_to - in_or_mid, comber.offset_from_inside_to_outside);
         std::function<int(Point)> close_to_penalty_function([preferred_crossing_1_out](Point candidate){ return vSize2((candidate - preferred_crossing_1_out) / 2); });
-        std::optional<ClosestPolygonPoint> crossing_1_out_cpp = PolygonUtils::findClose(in_or_mid, outside, comber.getOutsideLocToLine(), close_to_penalty_function);
+        cura::optional<ClosestPolygonPoint> crossing_1_out_cpp = PolygonUtils::findClose(in_or_mid, outside, comber.getOutsideLocToLine(), close_to_penalty_function);
         if (crossing_1_out_cpp)
         {
             out = PolygonUtils::moveOutside(*crossing_1_out_cpp, comber.offset_dist_to_get_from_on_the_polygon_to_outside);

--- a/src/pathPlanning/Comb.h
+++ b/src/pathPlanning/Comb.h
@@ -60,7 +60,7 @@ private:
         Point in_or_mid; //!< The point on the inside boundary, or in between the inside and outside boundary if the start/end point isn't inside the inside boudary
         Point out; //!< The point on the outside boundary
         PolygonsPart dest_part; //!< The assembled inside-boundary PolygonsPart in which the dest_point lies. (will only be initialized when Crossing::dest_is_inside holds)
-        std::optional<ConstPolygonPointer> dest_crossing_poly; //!< The polygon of the part in which dest_point lies, which will be crossed (often will be the outside polygon)
+        cura::optional<ConstPolygonPointer> dest_crossing_poly; //!< The polygon of the part in which dest_point lies, which will be crossed (often will be the outside polygon)
         const Polygons& boundary_inside; //!< The inside boundary as in \ref Comb::boundary_inside
         const LocToLineGrid* inside_loc_to_line; //!< The loc to line grid \ref Comb::inside_loc_to_line
 

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -607,7 +607,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
             part.infill_area_per_combine_per_density.emplace_back();
             std::vector<Polygons>& infill_area_per_combine_current_density = part.infill_area_per_combine_per_density.back();
             infill_area_per_combine_current_density.push_back(infill_area);
-            part.infill_area_own = nullptr; // clear infill_area_own, it's not needed any more.
+            part.infill_area_own = cura::nullopt; // clear infill_area_own, it's not needed any more.
             assert(part.infill_area_per_combine_per_density.size() != 0 && "infill_area_per_combine_per_density is now initialized");
         }
     }

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -70,7 +70,7 @@ public:
      * 
      * If these polygons are not initialized, simply use the normal infill area.
      */
-    std::optional<Polygons> infill_area_own;
+    cura::optional<Polygons> infill_area_own;
 
     /*!
      * The areas which need to be filled with sparse (0-99%) infill for different thicknesses.

--- a/src/utils/LazyInitialization.h
+++ b/src/utils/LazyInitialization.h
@@ -18,7 +18,7 @@ namespace cura
  * \tparam Args The types of the arguments to the constructor or constructor function object
  */
 template <typename T, typename... Args>
-class LazyInitialization : public std::optional<T>
+class LazyInitialization : public cura::optional<T>
 {
 public:
 
@@ -29,7 +29,7 @@ public:
      * Make sure these references/pointers are not invalidated between construction of the lazy object and the evaluation.
      */
     LazyInitialization(Args... args)
-    : std::optional<T>()
+    : cura::optional<T>()
     , constructor(
             [args...]()
             {
@@ -47,7 +47,7 @@ public:
      * Make sure these references/pointers are not invalidated between construction of the lazy object and the evaluation.
      */
     LazyInitialization(const std::function<T (Args...)>& f, Args... args)
-    : std::optional<T>()
+    : cura::optional<T>()
     , constructor(
             [f, args...]()
             {
@@ -63,7 +63,7 @@ public:
      * Make sure these references/pointers are not invalidated between construction of the lazy object and the evaluation.
      */
     LazyInitialization(const std::function<T* (Args...)>& f, Args... args)
-    : std::optional<T>()
+    : cura::optional<T>()
     , constructor(
             [f, args...]()
             {
@@ -74,13 +74,13 @@ public:
     }
 
     LazyInitialization(LazyInitialization<T, Args...>& other) //!< copy constructor
-    : std::optional<T>(other)
+    : cura::optional<T>(other)
     , constructor(other.constructor)
     {
     }
 
     LazyInitialization(LazyInitialization<T, Args...>&& other) //!< move constructor
-    : std::optional<T>(other)
+    : cura::optional<T>(other)
     {
         constructor = std::move(other.constructor);
     }
@@ -92,32 +92,32 @@ public:
      */
     T& operator*()
     {
-        if (!std::optional<T>::instance)
+        if (!cura::optional<T>::instance)
         {
-            std::optional<T>::instance = constructor();
+            cura::optional<T>::instance = constructor();
         }
-        return std::optional<T>::operator*();
+        return cura::optional<T>::operator*();
     }
 
     T* operator->() const
     {
-        if (!std::optional<T>::instance)
+        if (!cura::optional<T>::instance)
         {
-            std::optional<T>::instance = constructor();
+            cura::optional<T>::instance = constructor();
         }
-        return std::optional<T>::operator->();
+        return cura::optional<T>::operator->();
     }
 
     LazyInitialization<T, Args...>& operator=(LazyInitialization<T, Args...>&& other)
     {
-        std::optional<T>::operator=(other);
+        cura::optional<T>::operator=(other);
         constructor = other.constructor;
         return *this;
     }
 
     void swap(LazyInitialization<T, Args...>& other)
     {
-        std::optional<T>::swap(other);
+        cura::optional<T>::swap(other);
         std::swap(constructor, other.constructor);
     }
 

--- a/src/utils/PolygonConnector.cpp
+++ b/src/utils/PolygonConnector.cpp
@@ -34,7 +34,7 @@ Polygons PolygonConnector::connect()
         Polygon current = std::move(to_connect.back());
         to_connect.pop_back();
 
-        std::optional<PolygonBridge> bridge = getBridge(current, to_connect);
+        cura::optional<PolygonBridge> bridge = getBridge(current, to_connect);
         if (bridge)
         {
             all_bridges.push_back(*bridge); // just for keeping scores
@@ -126,7 +126,7 @@ char PolygonConnector::getPolygonDirection(const ClosestPolygonPoint& from, cons
     }
 }
 
-std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(ConstPolygonRef from_poly, std::vector<Polygon>& to_polygons)
+cura::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(ConstPolygonRef from_poly, std::vector<Polygon>& to_polygons)
 {
     // line distance between consecutive polygons should be at least the line_width
     const coord_t min_connection_length = line_width - 10;
@@ -135,8 +135,8 @@ std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(Const
     // which causes any connection distance to be larger than the offset amount
     const coord_t max_connection_length = line_width * 3 / 2;
 
-    std::optional<PolygonConnector::PolygonConnection> first_connection;
-    std::optional<PolygonConnector::PolygonConnection> second_connection;
+    cura::optional<PolygonConnector::PolygonConnection> first_connection;
+    cura::optional<PolygonConnector::PolygonConnection> second_connection;
 
     Polygons to_polys;
     for (const Polygon& poly : to_polygons)
@@ -166,7 +166,7 @@ std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(Const
     if (!connection_points.first.isValid() || !connection_points.second.isValid())
     { // We didn't find a connection which can make a bridge
         // We might have found a first_connection and a second_connection, but maybe they didn't satisfy all criteria.
-        std::optional<PolygonConnector::PolygonBridge> uninitialized;
+        cura::optional<PolygonConnector::PolygonBridge> uninitialized;
         return uninitialized;
     }
 
@@ -184,42 +184,42 @@ std::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(Const
     }
     else
     { // we couldn't find a connection; maybe the polygon was too small or maybe it is just too far away from other polygons.
-        return std::optional<PolygonConnector::PolygonBridge>();
+        return cura::optional<PolygonConnector::PolygonBridge>();
     }
 }
 
-std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondConnection(PolygonConnection& first)
+cura::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondConnection(PolygonConnection& first)
 {
     bool forward = true;
-    std::optional<ClosestPolygonPoint> from_a = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), line_width, forward);
+    cura::optional<ClosestPolygonPoint> from_a = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), line_width, forward);
     if (!from_a)
     { // then there's also not going to be a b
-        return std::optional<PolygonConnector::PolygonConnection>();
+        return cura::optional<PolygonConnector::PolygonConnection>();
     }
-    std::optional<ClosestPolygonPoint> from_b = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), line_width, !forward);
+    cura::optional<ClosestPolygonPoint> from_b = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), line_width, !forward);
 
-    std::optional<ClosestPolygonPoint> to_a = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), line_width, forward);
+    cura::optional<ClosestPolygonPoint> to_a = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), line_width, forward);
     if (!to_a)
     {
-        return std::optional<PolygonConnector::PolygonConnection>();
+        return cura::optional<PolygonConnector::PolygonConnection>();
     }
-    std::optional<ClosestPolygonPoint> to_b = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), line_width, !forward);
+    cura::optional<ClosestPolygonPoint> to_b = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), line_width, !forward);
 
 
     const Point shift = turn90CCW(first.from.p() - first.to.p());
     
-    std::optional<PolygonConnection> best;
+    cura::optional<PolygonConnection> best;
     coord_t best_total_distance2 = std::numeric_limits<coord_t>::max();
     for (unsigned int from_idx = 0; from_idx < 2; from_idx++)
     {
-        std::optional<ClosestPolygonPoint> from_opt = (from_idx == 0)? from_a : from_b;
+        cura::optional<ClosestPolygonPoint> from_opt = (from_idx == 0)? from_a : from_b;
         if (!from_opt)
         {
             continue;
         }
         for (unsigned int to_idx = 0; to_idx < 2; to_idx++)
         {
-            std::optional<ClosestPolygonPoint> to_opt = (to_idx == 0)? to_a : to_b;
+            cura::optional<ClosestPolygonPoint> to_opt = (to_idx == 0)? to_a : to_b;
             // for each combination of from and to
             if (!to_opt)
             {
@@ -254,7 +254,7 @@ std::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondCo
     }
     if (!best || best_total_distance2 > max_dist * max_dist + 2 * (line_width + 10) * (line_width + 10))
     {
-        return std::optional<PolygonConnector::PolygonConnection>();
+        return cura::optional<PolygonConnector::PolygonConnection>();
     }
     else
     {

--- a/src/utils/PolygonConnector.cpp
+++ b/src/utils/PolygonConnector.cpp
@@ -184,7 +184,7 @@ cura::optional<PolygonConnector::PolygonBridge> PolygonConnector::getBridge(Cons
     }
     else
     { // we couldn't find a connection; maybe the polygon was too small or maybe it is just too far away from other polygons.
-        return cura::optional<PolygonConnector::PolygonBridge>();
+        return cura::nullopt;
     }
 }
 
@@ -194,14 +194,14 @@ cura::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondC
     cura::optional<ClosestPolygonPoint> from_a = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), line_width, forward);
     if (!from_a)
     { // then there's also not going to be a b
-        return cura::optional<PolygonConnector::PolygonConnection>();
+        return cura::nullopt;
     }
     cura::optional<ClosestPolygonPoint> from_b = PolygonUtils::getNextParallelIntersection(first.from, first.to.p(), line_width, !forward);
 
     cura::optional<ClosestPolygonPoint> to_a = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), line_width, forward);
     if (!to_a)
     {
-        return cura::optional<PolygonConnector::PolygonConnection>();
+        return cura::nullopt;
     }
     cura::optional<ClosestPolygonPoint> to_b = PolygonUtils::getNextParallelIntersection(first.to, first.from.p(), line_width, !forward);
 
@@ -254,7 +254,7 @@ cura::optional<PolygonConnector::PolygonConnection> PolygonConnector::getSecondC
     }
     if (!best || best_total_distance2 > max_dist * max_dist + 2 * (line_width + 10) * (line_width + 10))
     {
-        return cura::optional<PolygonConnector::PolygonConnection>();
+        return cura::nullopt;
     }
     else
     {

--- a/src/utils/PolygonConnector.h
+++ b/src/utils/PolygonConnector.h
@@ -162,7 +162,7 @@ protected:
      * - the first connection at a whole line distance away
      * So as to try and find a bridge which is centered around the initiall found first connection
      */
-    std::optional<PolygonBridge> getBridge(ConstPolygonRef poly, std::vector<Polygon>& polygons);
+    cura::optional<PolygonBridge> getBridge(ConstPolygonRef poly, std::vector<Polygon>& polygons);
 
     /*!
      * Get a connection parallel to a given \p first connection at an orthogonal distance line_width from the \p first connection.
@@ -175,7 +175,7 @@ protected:
      * - check whether they are both on the same side of the \p first connection
      * - choose the connection which woukd form the smalles bridge
      */
-    std::optional<PolygonConnection> getSecondConnection(PolygonConnection& first);
+    cura::optional<PolygonConnection> getSecondConnection(PolygonConnection& first);
 };
 
 

--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -142,12 +142,22 @@ public:
         }
         return *this;
     }
-    constexpr T* operator->() const
+    T* operator->()
     {
         assert(instance && "Instance should be instantiated!");
         return instance;
     }
-    constexpr T& operator*() const&
+    constexpr const T* operator->() const
+    {
+        assert(instance && "Instance should be instantiated!");
+        return instance;
+    }
+    T& operator*() &
+    {
+        assert(instance && "Instance should be instantiated!");
+        return *instance;
+    }
+    constexpr const T& operator*() const&
     {
         assert(instance && "Instance should be instantiated!");
         return *instance;
@@ -156,7 +166,11 @@ public:
     {
         return instance;
     }
-    constexpr T& value() const&
+    const T& value() &
+    {
+        return *instance;
+    }
+    constexpr const T& value() const&
     {
         return *instance;
     }
@@ -182,7 +196,7 @@ public:
         }
     }
     template<class U>
-    constexpr bool operator==(const optional<U>& rhs)
+    constexpr bool operator==(const optional<U>& rhs) const
     {
         return (*this && rhs) ? (**this == *rhs) : (static_cast<bool>(*this) == static_cast<bool>(rhs));
     }

--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -11,11 +11,17 @@
 namespace cura
 {
 
+struct nullopt_t {
+    explicit constexpr nullopt_t(int) {}
+};
+
 struct in_place_t {
     explicit in_place_t() = default;
 };
 
 constexpr in_place_t in_place{};
+constexpr nullopt_t nullopt{0};
+
 /*!
  * optional value
  * 
@@ -32,6 +38,10 @@ protected:
 public:
     optional() //!< create an optional value which is not instantiated
     : instance(nullptr)
+    {
+    }
+    optional(nullopt_t) //!< create an optional value which is not instantiated
+    : optional()
     {
     }
     optional(const optional& other) //!< copy construction

--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -11,7 +11,11 @@
 namespace cura
 {
 
+struct in_place_t {
+    explicit in_place_t() = default;
+};
 
+constexpr in_place_t in_place{};
 /*!
  * optional value
  * 
@@ -47,7 +51,7 @@ public:
         other.instance = nullptr;
     }
     template<class... Args>
-    constexpr explicit optional(bool, Args&&... args ) //!< construct the value in place
+    constexpr explicit optional(cura::in_place_t, Args&&... args) //!< construct the value in place
     : instance(new T(args...))
     {
     }

--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -62,7 +62,7 @@ public:
     }
     template<class... Args>
     constexpr explicit optional(cura::in_place_t, Args&&... args) //!< construct the value in place
-    : instance(new T(args...))
+    : instance(new T(std::forward<Args>(args)...))
     {
     }
     template<class U = T
@@ -70,7 +70,7 @@ public:
         >
     optional(U&& value)
     {
-        instance = new T(value);
+        instance = new T(std::forward<U>(value));
     }
     virtual ~optional() //!< simple destructor
     {
@@ -138,7 +138,7 @@ public:
         }
         else
         {
-            instance = new T(value);
+            instance = new T(std::forward<U>(value));
         }
         return *this;
     }
@@ -163,7 +163,7 @@ public:
     template<class U> 
     constexpr T value_or(U&& default_value) const&
     {
-        return instance ? *instance : default_value;
+        return instance ? *instance : std::forward<U>(default_value);
     }
     void swap(optional& other)
     {
@@ -174,11 +174,11 @@ public:
     {
         if (instance)
         {
-            *instance = T(args...);
+            *instance = T(std::forward<Args>(args)...);
         }
         else
         {
-            instance = new T(args...);
+            instance = new T(std::forward<Args>(args)...);
         }
     }
     template<class U>

--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -8,7 +8,7 @@
 #include <type_traits> // enable_if  is_same
 #include <cassert> // assert
 
-namespace std
+namespace cura
 {
 
 

--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -82,10 +82,10 @@ public:
     /*!
      * Assign none to this optional value.
      * 
-     * \param null_ptr exactly [nullptr]
+     * \param nullopt object of type nullopt_t
      * \return this
      */
-    optional& operator=(std::nullptr_t)
+    optional& operator=(cura::nullopt_t)
     {
         if (instance)
         {

--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -36,11 +36,11 @@ class optional
 protected:
     T* instance;
 public:
-    optional() //!< create an optional value which is not instantiated
+    constexpr optional() //!< create an optional value which is not instantiated
     : instance(nullptr)
     {
     }
-    optional(nullopt_t) //!< create an optional value which is not instantiated
+    constexpr optional(nullopt_t) //!< create an optional value which is not instantiated
     : optional()
     {
     }
@@ -61,7 +61,7 @@ public:
         other.instance = nullptr;
     }
     template<class... Args>
-    constexpr explicit optional(cura::in_place_t, Args&&... args) //!< construct the value in place
+    explicit optional(cura::in_place_t, Args&&... args) //!< construct the value in place
     : instance(new T(std::forward<Args>(args)...))
     {
     }

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -152,7 +152,7 @@ unsigned int PolygonUtils::moveOutside(const Polygons& polygons, Point& from, in
 
 ClosestPolygonPoint PolygonUtils::moveInside2(const Polygons& polygons, Point& from, const int distance, const int64_t max_dist2, const Polygons* loc_to_line_polygons, const LocToLineGrid* loc_to_line_grid, const std::function<int(Point)>& penalty_function)
 {
-    std::optional<ClosestPolygonPoint> closest_polygon_point;
+    cura::optional<ClosestPolygonPoint> closest_polygon_point;
     if (loc_to_line_grid)
     {
         closest_polygon_point = findClose(from, *loc_to_line_polygons, *loc_to_line_grid, penalty_function);
@@ -166,7 +166,7 @@ ClosestPolygonPoint PolygonUtils::moveInside2(const Polygons& polygons, Point& f
 
 ClosestPolygonPoint PolygonUtils::moveInside2(const Polygons& loc_to_line_polygons, ConstPolygonRef polygon, Point& from, const int distance, const int64_t max_dist2, const LocToLineGrid* loc_to_line_grid, const std::function<int(Point)>& penalty_function)
 {
-    std::optional<ClosestPolygonPoint> closest_polygon_point;
+    cura::optional<ClosestPolygonPoint> closest_polygon_point;
     if (loc_to_line_grid)
     {
         closest_polygon_point = findClose(from, loc_to_line_polygons, *loc_to_line_grid, penalty_function);
@@ -951,7 +951,7 @@ LocToLineGrid* PolygonUtils::createLocToLineGrid(const Polygons& polygons, int s
  * We could skip the duplication by keeping a vector of vectors of bools.
  *
  */
-std::optional<ClosestPolygonPoint> PolygonUtils::findClose(
+cura::optional<ClosestPolygonPoint> PolygonUtils::findClose(
     Point from, const Polygons& polygons,
     const LocToLineGrid& loc_to_line,
     const std::function<int(Point)>& penalty_function)
@@ -980,12 +980,12 @@ std::optional<ClosestPolygonPoint> PolygonUtils::findClose(
     }
     if (best_point_poly_idx.poly_idx == NO_INDEX)
     {
-        return std::optional<ClosestPolygonPoint>();
+        return cura::optional<ClosestPolygonPoint>();
     }
     else
     {
         bool bs_arg = true; // doesn't mean anything. Just to make clear we call the variable arguments of the constructor.
-        return std::optional<ClosestPolygonPoint>(bs_arg, best, best_point_poly_idx.point_idx, polygons[best_point_poly_idx.poly_idx], best_point_poly_idx.poly_idx);
+        return cura::optional<ClosestPolygonPoint>(bs_arg, best, best_point_poly_idx.point_idx, polygons[best_point_poly_idx.poly_idx], best_point_poly_idx.poly_idx);
     }
 }
 
@@ -1002,7 +1002,7 @@ std::vector<std::pair<ClosestPolygonPoint, ClosestPolygonPoint>> PolygonUtils::f
     for (unsigned int p1_idx = 0; p1_idx < from.size(); p1_idx++)
     {
         const Point& p1 = from[p1_idx];
-        std::optional<ClosestPolygonPoint> best_here = findClose(p1, destination, destination_loc_to_line, penalty_function);
+        cura::optional<ClosestPolygonPoint> best_here = findClose(p1, destination, destination_loc_to_line, penalty_function);
         if (best_here)
         {
             ret.push_back(std::make_pair(ClosestPolygonPoint(p1, p1_idx, from), *best_here));
@@ -1014,7 +1014,7 @@ std::vector<std::pair<ClosestPolygonPoint, ClosestPolygonPoint>> PolygonUtils::f
             Point x = p0 + normal(p0p1, middle_point_nr * grid_size);
             dist_to_p1 -= grid_size;
 
-            std::optional<ClosestPolygonPoint> best_here = findClose(x, destination, destination_loc_to_line, penalty_function);
+            cura::optional<ClosestPolygonPoint> best_here = findClose(x, destination, destination_loc_to_line, penalty_function);
             if (best_here)
             {
                 ret.push_back(std::make_pair(ClosestPolygonPoint(x, p0_idx, from), *best_here));
@@ -1106,7 +1106,7 @@ bool PolygonUtils::getNextPointWithDistance(Point from, int64_t dist, ConstPolyg
 }
 
 
-std::optional<ClosestPolygonPoint> PolygonUtils::getNextParallelIntersection(const ClosestPolygonPoint& start, const Point& line_to, const coord_t dist, const bool forward)
+cura::optional<ClosestPolygonPoint> PolygonUtils::getNextParallelIntersection(const ClosestPolygonPoint& start, const Point& line_to, const coord_t dist, const bool forward)
 {
     // <--o--t-----y----< poly 1
     //       :     :
@@ -1161,7 +1161,7 @@ std::optional<ClosestPolygonPoint> PolygonUtils::getNextParallelIntersection(con
         prev_projected = projected;
     }
 
-    return std::optional<ClosestPolygonPoint>();
+    return cura::optional<ClosestPolygonPoint>();
 }
 
 

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -980,7 +980,7 @@ cura::optional<ClosestPolygonPoint> PolygonUtils::findClose(
     }
     if (best_point_poly_idx.poly_idx == NO_INDEX)
     {
-        return cura::optional<ClosestPolygonPoint>();
+        return cura::nullopt;
     }
     else
     {
@@ -1160,7 +1160,7 @@ cura::optional<ClosestPolygonPoint> PolygonUtils::getNextParallelIntersection(co
         prev_projected = projected;
     }
 
-    return cura::optional<ClosestPolygonPoint>();
+    return cura::nullopt;
 }
 
 

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -984,8 +984,7 @@ cura::optional<ClosestPolygonPoint> PolygonUtils::findClose(
     }
     else
     {
-        bool bs_arg = true; // doesn't mean anything. Just to make clear we call the variable arguments of the constructor.
-        return cura::optional<ClosestPolygonPoint>(bs_arg, best, best_point_poly_idx.point_idx, polygons[best_point_poly_idx.poly_idx], best_point_poly_idx.poly_idx);
+        return cura::optional<ClosestPolygonPoint>(cura::in_place, best, best_point_poly_idx.point_idx, polygons[best_point_poly_idx.poly_idx], best_point_poly_idx.poly_idx);
     }
 }
 

--- a/src/utils/polygonUtils.h
+++ b/src/utils/polygonUtils.h
@@ -435,7 +435,7 @@ public:
      * \param penalty_function A function returning a penalty term on the squared distance score of a candidate point.
      * \return The nearest point on the polygon if the polygon was within a distance equal to the cell_size of the SparsePointGridInclusive
      */
-    static std::optional<ClosestPolygonPoint> findClose(Point from, const Polygons& polygons, const LocToLineGrid& loc_to_line, const std::function<int(Point)>& penalty_function = no_penalty_function);
+    static cura::optional<ClosestPolygonPoint> findClose(Point from, const Polygons& polygons, const LocToLineGrid& loc_to_line, const std::function<int(Point)>& penalty_function = no_penalty_function);
 
     /*!
      * Find the line segment closest to any point on \p from within cell-blocks of a size defined in the SparsePointGridInclusive \p destination_loc_to_line
@@ -491,7 +491,7 @@ public:
      * \param forward Whether to look forward from \p start in the direction of the polygon, or go in the other direction.
      * \return The earliest point on the polygon in the given direction which crosses a line parallel to the given one at the distance \p dist - if any
      */
-    static std::optional<ClosestPolygonPoint> getNextParallelIntersection(const ClosestPolygonPoint& start, const Point& line_to, const coord_t dist, const bool forward);
+    static cura::optional<ClosestPolygonPoint> getNextParallelIntersection(const ClosestPolygonPoint& start, const Point& line_to, const coord_t dist, const bool forward);
 
     /*!
      * Checks whether a given line segment collides with a given polygon(s).

--- a/src/utils/polygonUtils.h
+++ b/src/utils/polygonUtils.h
@@ -35,7 +35,7 @@ struct ClosestPolygonPoint
     {
         return point_idx != NO_INDEX;
     }
-    bool operator==(const ClosestPolygonPoint& rhs)
+    bool operator==(const ClosestPolygonPoint& rhs) const
     {
         // no need to compare on poy_idx
         // it's sometimes unused while poly is always initialized

--- a/tests/utils/PolygonConnectorTest.cpp
+++ b/tests/utils/PolygonConnectorTest.cpp
@@ -82,9 +82,9 @@ void PolygonConnectorTest::getBridgeTest()
     getBridgeAssert(predicted, test_square, polys);
 }
 
-void PolygonConnectorTest::getBridgeAssert(std::optional<PolygonConnector::PolygonBridge> predicted, ConstPolygonRef from_poly, std::vector<Polygon>& to_polygons)
+void PolygonConnectorTest::getBridgeAssert(cura::optional<PolygonConnector::PolygonBridge> predicted, ConstPolygonRef from_poly, std::vector<Polygon>& to_polygons)
 {
-    std::optional<PolygonConnector::PolygonBridge> computed = pc->getBridge(from_poly, to_polygons);
+    cura::optional<PolygonConnector::PolygonBridge> computed = pc->getBridge(from_poly, to_polygons);
     
     std::stringstream ss;
     ss << "PolygonConnector::getBridge(test_square, test_triangle) ";

--- a/tests/utils/PolygonConnectorTest.h
+++ b/tests/utils/PolygonConnectorTest.h
@@ -65,7 +65,7 @@ private:
     /*!
      * cppunit assert for PolygonUtils::getNextParallelIntersection
      */
-    void getBridgeAssert(std::optional<PolygonConnector::PolygonBridge> predicted, ConstPolygonRef from_poly, std::vector<Polygon>& to_polygons);
+    void getBridgeAssert(cura::optional<PolygonConnector::PolygonBridge> predicted, ConstPolygonRef from_poly, std::vector<Polygon>& to_polygons);
 };
 
 }

--- a/tests/utils/PolygonUtilsTest.cpp
+++ b/tests/utils/PolygonUtilsTest.cpp
@@ -250,7 +250,7 @@ void PolygonUtilsTest::findCloseAssert(const PolygonRef poly, Point close_to, Po
     polys.add(poly);
     SparseLineGrid<PolygonsPointIndex, PolygonsPointIndexSegmentLocator>* loc_to_line = PolygonUtils::createLocToLineGrid(polys, cell_size);
     
-    std::optional<ClosestPolygonPoint> cpp;
+    cura::optional<ClosestPolygonPoint> cpp;
     if (penalty_function)
     {
         cpp = PolygonUtils::findClose(close_to, polys, *loc_to_line, *penalty_function);
@@ -491,7 +491,7 @@ void PolygonUtilsTest::getNextParallelIntersectionTest9()
     Point line_to = Point(200, 200);
     bool forward = true;
     coord_t dist = 80;
-    getNextParallelIntersectionAssert(std::optional<Point>(), start_point, line_to, forward, dist);
+    getNextParallelIntersectionAssert(cura::optional<Point>(), start_point, line_to, forward, dist);
 }
 
 void PolygonUtilsTest::getNextParallelIntersectionTest10()
@@ -503,10 +503,10 @@ void PolygonUtilsTest::getNextParallelIntersectionTest10()
     getNextParallelIntersectionAssert(Point(0, 45), start_point, line_to, forward, dist);
 }
 
-void PolygonUtilsTest::getNextParallelIntersectionAssert(std::optional<Point> predicted, Point start_point, Point line_to, bool forward, coord_t dist)
+void PolygonUtilsTest::getNextParallelIntersectionAssert(cura::optional<Point> predicted, Point start_point, Point line_to, bool forward, coord_t dist)
 {
     ClosestPolygonPoint start = PolygonUtils::findClosest(start_point, test_squares);
-    std::optional<ClosestPolygonPoint> computed = PolygonUtils::getNextParallelIntersection(start, line_to, dist, forward);
+    cura::optional<ClosestPolygonPoint> computed = PolygonUtils::getNextParallelIntersection(start, line_to, dist, forward);
 
     std::stringstream ss;
     ss << "PolygonUtils::getNextParallelIntersection(" << start_point << ", " << line_to << ", " << dist << ", " << forward << ") ";

--- a/tests/utils/PolygonUtilsTest.cpp
+++ b/tests/utils/PolygonUtilsTest.cpp
@@ -491,7 +491,7 @@ void PolygonUtilsTest::getNextParallelIntersectionTest9()
     Point line_to = Point(200, 200);
     bool forward = true;
     coord_t dist = 80;
-    getNextParallelIntersectionAssert(cura::optional<Point>(), start_point, line_to, forward, dist);
+    getNextParallelIntersectionAssert(cura::nullopt, start_point, line_to, forward, dist);
 }
 
 void PolygonUtilsTest::getNextParallelIntersectionTest10()

--- a/tests/utils/PolygonUtilsTest.h
+++ b/tests/utils/PolygonUtilsTest.h
@@ -162,7 +162,7 @@ private:
     /*!
      * cppunit assert for PolygonUtils::getNextParallelIntersection
      */
-    void getNextParallelIntersectionAssert(std::optional<Point> predicted, Point start_point, Point line_to, bool forward, coord_t dist);
+    void getNextParallelIntersectionAssert(cura::optional<Point> predicted, Point start_point, Point line_to, bool forward, coord_t dist);
 };
 
 }


### PR DESCRIPTION
Adding names to namespace std is undefined behaviour. This probably wont bite anyone until the project adopts a new c++ version, but is UB nonetheless.

This PR also cleans up the interface of optional to behave a bit more like the std::optional from c++17 which should make the upgrade a bit easier later on. Perhaps not as easy as `namespace cura { using optional = std::optional }`, but still easier.