### PR TITLE
EM-2882 Add number of print groups to header

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -189,6 +189,8 @@ std::string GCodeExport::getFileHeader(const std::vector<bool>& extruder_is_used
             prefix << ";PRINT.TIME:" << static_cast<int>(*print_time) << new_line;
         }
 
+        prefix << ";PRINT.GROUPS:" << Application::getInstance().current_slice->scene.mesh_groups.size() << new_line;
+
         if (total_bounding_box.min.x > total_bounding_box.max.x) //We haven't encountered any movement (yet). This probably means we're command-line slicing.
         {
             //Put some small default in there.


### PR DESCRIPTION
EM-2882 Add number of print groups to header
Embedded wants to use this for footprint probing. Normally you can stop reading the g-code after layer 0 is done, but in case of `one at the time` that's not sufficient.