### PR TITLE
Improve the no-skin combing boundary

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -220,8 +220,14 @@ Polygons LayerPlan::computeCombBoundaryInside(const size_t max_inset)
                             inner = part.insets[num_insets - 1].offset(-10 - mesh.settings.get<coord_t>("wall_line_width_x") / 2);
                         }
 
+                        Polygons infill(part.infill_area);
+                        if (part.perimeter_gaps.size() > 0)
+                        {
+                            infill = infill.unionPolygons(part.perimeter_gaps.offset(10)); // ensure polygons overlap slightly
+                        }
+
                         // combine the wall combing region (outer - inner) with the infill (if any)
-                        comb_boundary.add(part.infill_area.unionPolygons(outer.difference(inner)));
+                        comb_boundary.add(infill.unionPolygons(outer.difference(inner)));
                     }
                 }
             }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -201,25 +201,28 @@ Polygons LayerPlan::computeCombBoundaryInside(const size_t max_inset)
                         outer = outer.offset(outer_to_outline_dist/2+10).unionPolygons(outline_where_outer_is_missing.offset(outer_to_outline_dist/2+10)).offset(-(outer_to_outline_dist/2+10));
                     }
 
-                    Polygons inner; // inner boundary of wall combing region
-
-                    // the inside of the wall combing region is just inside the wall's inner edge so it can meet up with the infill (if any)
-
                     if (num_insets == 0)
                     {
-                        inner = part.outline.offset(-10);
+                        comb_boundary.add(outer);
                     }
-                    else if (num_insets == 1)
+                    else
                     {
-                        inner = part.insets[0].offset(-10-line_width_0/2);
-                    }
-                    else if(num_insets > 1)
-                    {
-                        inner = part.insets[num_insets - 1].offset(-10 - mesh.settings.get<coord_t>("wall_line_width_x") / 2);
-                    }
+                        Polygons inner; // inner boundary of wall combing region
 
-                    // combine the wall combing region (outer - inner) with the infill (if any)
-                    comb_boundary.add(part.infill_area.unionPolygons(outer.difference(inner)));
+                        // the inside of the wall combing region is just inside the wall's inner edge so it can meet up with the infill (if any)
+
+                        if (num_insets == 1)
+                        {
+                            inner = part.insets[0].offset(-10-line_width_0/2);
+                        }
+                        else
+                        {
+                            inner = part.insets[num_insets - 1].offset(-10 - mesh.settings.get<coord_t>("wall_line_width_x") / 2);
+                        }
+
+                        // combine the wall combing region (outer - inner) with the infill (if any)
+                        comb_boundary.add(part.infill_area.unionPolygons(outer.difference(inner)));
+                    }
                 }
             }
             else if (combing_mode == CombingMode::INFILL)


### PR DESCRIPTION
This fixes a problem when no-skin combing on a part that has thin walls and no normal insets.

Without this PR, you can get travels that cross air when they could be over walls. Like this...

![screenshot_2018-11-28_17-26-34](https://user-images.githubusercontent.com/585618/49169890-c8f1bc00-f332-11e8-980c-11b022551d6e.png)

With this PR you get this...

![screenshot_2018-11-28_17-22-29](https://user-images.githubusercontent.com/585618/49169860-b5465580-f332-11e8-801a-17f47382ad70.png)
