### PR TITLE
Bug Fix - Only add S1 param to G10 when generating repetier flavour gcode.

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -874,7 +874,7 @@ void GCodeExport::writeRetraction(const RetractionConfig& config, bool force, bo
             return; 
         }
         *output_stream << "G10";
-        if (extruder_switch)
+        if (extruder_switch && flavor == EGCodeFlavor::REPETIER)
         {
             *output_stream << " S1";
         }


### PR DESCRIPTION
The other firmwares can interpret the S1 differently so don't let them see it.