### PR TITLE
CMake: Depend on Protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,11 @@ option (ENABLE_ARCUS
 
 if (ENABLE_ARCUS)
     message(STATUS "Building with Arcus")
-    find_package(Protobuf REQUIRED)
+    # We want to have access to protobuf_generate_cpp and other FindProtobuf features.
+    # However, if ProtobufConfig is used instead, there is a CMake option that controls
+    # this, which defaults to OFF. We need to force this option to ON instead.
+    set(protobuf_MODULE_COMPATIBLE ON CACHE "" INTERNAL FORCE)
+    find_package(Protobuf 3.0.0 REQUIRED)
     find_package(Arcus REQUIRED)
     add_definitions(-DARCUS)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option (ENABLE_ARCUS
 
 if (ENABLE_ARCUS)
     message(STATUS "Building with Arcus")
+    find_package(Protobuf REQUIRED)
     find_package(Arcus REQUIRED)
     add_definitions(-DARCUS)
 endif ()


### PR DESCRIPTION
When building the engine with Arcus, we are in the following lines generating C code using protoc.
However, if your installation is not complete and you've got all libs and headers installed, but no protoc installed, then the build fails.
At least that is the case on Windows, when protoc can't be found in %PATH%.

find_package should ensure here, that all libs, headers and command line tools are installed and found. If not this should throw an error and prevent the situation I ran into.