### PR TITLE
CURA-6002 fix support brim

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -818,8 +818,8 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, LayerIn
     if (include_helper_parts && layer_nr == 0)
     { // process the skirt or the brim of the starting extruder.
         const int extruder_nr = gcode_layer.getExtruder();
-        processSkirtBrim(false, storage.skirt_brim[extruder_nr], gcode_layer, extruder_nr);
-        processSkirtBrim(true, storage.support_brim[extruder_nr], gcode_layer, extruder_nr);
+        processSkirtBrim(storage.skirt_brim[extruder_nr], gcode_layer, extruder_nr, false);
+        processSkirtBrim(storage.support_brim[extruder_nr], gcode_layer, extruder_nr, true);
     }
     if (include_helper_parts)
     { // handle shield(s) first in a layer so that chances are higher that the other nozzle is wiped (for the ooze shield)
@@ -903,13 +903,13 @@ bool FffGcodeWriter::getExtruderNeedPrimeBlobDuringFirstLayer(const SliceDataSto
     return need_prime_blob;
 }
 
-void FffGcodeWriter::processSkirtBrim(const bool for_support, const Polygons& skirt_brim, LayerPlan& gcode_layer, unsigned int extruder_nr) const
+void FffGcodeWriter::processSkirtBrim(const Polygons& skirt_brim, LayerPlan& gcode_layer, unsigned int extruder_nr, bool for_support = false) const
 {
-    if (gcode_layer.getSkirtBrimIsPlanned(for_support, extruder_nr))
+    if (gcode_layer.getSkirtBrimIsPlanned(extruder_nr, for_support))
     {
         return;
     }
-    gcode_layer.setSkirtBrimIsPlanned(for_support, extruder_nr);
+    gcode_layer.setSkirtBrimIsPlanned(extruder_nr, for_support);
     if (skirt_brim.size() == 0)
     {
         return;
@@ -2569,8 +2569,8 @@ void FffGcodeWriter::setExtruder_addPrime(const SliceDataStorage& storage, Layer
 
         if (gcode_layer.getLayerNr() == 0)
         {
-            processSkirtBrim(false, storage.skirt_brim[extruder_nr], gcode_layer, extruder_nr);
-            processSkirtBrim(true, storage.support_brim[extruder_nr], gcode_layer, extruder_nr);
+            processSkirtBrim(storage.skirt_brim[extruder_nr], gcode_layer, extruder_nr, false);
+            processSkirtBrim(storage.support_brim[extruder_nr], gcode_layer, extruder_nr, true);
         }
     }
 

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -270,7 +270,7 @@ private:
      * \param extruder_nr The extruder train for which to process the skirt or
      * brim.
      */
-    void processSkirtBrim(const bool for_support, const Polygons& skirt_brim, LayerPlan& gcodeLayer, unsigned int extruder_nr) const;
+    void processSkirtBrim(const Polygons& skirt_brim, LayerPlan& gcodeLayer, unsigned int extruder_nr, bool for_support) const;
 
     /*!
      * Adds the ooze shield to the layer plan \p gcodeLayer.

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -264,12 +264,13 @@ private:
      * This function should be called for only one layer;
      * calling it for multiple layers results in the skirt/brim being printed on multiple layers.
      * 
-     * \param storage where the slice data is stored.
+     * \param for_support Whether or not this is brim specially made underneath support-infill.
+     * \param skirt_brim The outline of the polygons that'll be skirt/brim.
      * \param gcodeLayer The initial planning of the g-code of the layer.
      * \param extruder_nr The extruder train for which to process the skirt or
      * brim.
      */
-    void processSkirtBrim(const SliceDataStorage& storage, LayerPlan& gcodeLayer, unsigned int extruder_nr) const;
+    void processSkirtBrim(const bool for_support, const Polygons& skirt_brim, LayerPlan& gcodeLayer, unsigned int extruder_nr) const;
 
     /*!
      * Adds the ooze shield to the layer plan \p gcodeLayer.

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -117,6 +117,7 @@ LayerPlan::LayerPlan(const SliceDataStorage& storage, LayerIndex layer_nr, coord
     for (size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
     { //Skirt and brim.
         skirt_brim_is_processed[extruder_nr] = false;
+        support_brim_is_processed[extruder_nr] = false;
     }
 }
 

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -256,6 +256,7 @@ private:
      * for each extruder train.
      */
     bool skirt_brim_is_processed[MAX_EXTRUDERS];
+    bool support_brim_is_processed[MAX_EXTRUDERS];
 
     std::vector<ExtruderPlan> extruder_plans; //!< should always contain at least one ExtruderPlan
 
@@ -380,14 +381,14 @@ public:
      */
     void setPrimeTowerIsPlanned(unsigned int extruder_nr);
 
-    bool getSkirtBrimIsPlanned(unsigned int extruder_nr) const
+    bool getSkirtBrimIsPlanned(const bool for_support, const unsigned int extruder_nr) const
     {
-        return skirt_brim_is_processed[extruder_nr];
+        return (for_support ? support_brim_is_processed : skirt_brim_is_processed)[extruder_nr];
     }
 
-    void setSkirtBrimIsPlanned(unsigned int extruder_nr)
+    void setSkirtBrimIsPlanned(const bool for_support, const unsigned int extruder_nr)
     {
-        skirt_brim_is_processed[extruder_nr] = true;
+        (for_support ? support_brim_is_processed : skirt_brim_is_processed)[extruder_nr] = true;
     }
 
     /*!

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -381,12 +381,12 @@ public:
      */
     void setPrimeTowerIsPlanned(unsigned int extruder_nr);
 
-    bool getSkirtBrimIsPlanned(const bool for_support, const unsigned int extruder_nr) const
+    bool getSkirtBrimIsPlanned(const unsigned int extruder_nr, const bool for_support = false) const
     {
         return (for_support ? support_brim_is_processed : skirt_brim_is_processed)[extruder_nr];
     }
 
-    void setSkirtBrimIsPlanned(const bool for_support, const unsigned int extruder_nr)
+    void setSkirtBrimIsPlanned(const unsigned int extruder_nr, const bool for_support = false)
     {
         (for_support ? support_brim_is_processed : skirt_brim_is_processed)[extruder_nr] = true;
     }

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -235,7 +235,7 @@ void SkirtBrim::generateSupportBrim(SliceDataStorage& storage)
     }
 
     const coord_t brim_width = brim_line_width * line_count;
-    Polygons& skirt_brim = storage.skirt_brim[support_infill_extruder.extruder_nr];
+    Polygons& skirt_brim = storage.support_brim[support_infill_extruder.extruder_nr];
 
     SupportLayer& support_layer = storage.support.supportLayers[0];
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -300,7 +300,8 @@ public:
 
     SupportStorage support;
 
-    Polygons skirt_brim[MAX_EXTRUDERS]; //!< Skirt and brim polygons per extruder, ordered from inner to outer polygons.
+    Polygons skirt_brim[MAX_EXTRUDERS];   //!< Skirt and brim polygons per extruder, excluding support-brim (see below), ordered from inner to outer polygons.
+    Polygons support_brim[MAX_EXTRUDERS]; //!< Brim underneath the support-infill (and _only_ _underneath_ the support _infill_).
     Polygons raftOutline;               //Storage for the outline of the raft. Will be filled with lines when the GCode is generated.
 
     int max_print_height_second_to_last_extruder; //!< Used in multi-extrusion: the layer number beyond which all models are printed with the same extruder


### PR DESCRIPTION
Print support-brim later than other skirt/brim, so if skirt/brim is also used to prime, then this option works without impacting support.