### PR TITLE
RepRap firmware ignores jerk during travel moves so there's no benefit in changing it.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1455,7 +1455,11 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
             }
             if (jerk_enabled)
             {
-                gcode.writeJerk(path.config->getJerk());
+                // RepRap firmware ignores jerk for travel moves so don't bother changing it when travelling
+                if (!path.config->isTravelPath() || gcode.getFlavor() != EGCodeFlavor::REPRAP)
+                {
+                    gcode.writeJerk(path.config->getJerk());
+                }
             }
 
             if (path.retract)


### PR DESCRIPTION
This PR omits jerk changes for travel moves when generating RepRap flavour gcode as that firmware
ignores jerk for non-printing moves. This can save outputting many M566 lines when printing skin and infill.