### PR TITLE
Use maximum deviation setting to limit deviation from original polygon

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -733,8 +733,9 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Application::getInstance().communication->sendLayerComplete(layer_nr, z, layer_height);
 
         const coord_t maximum_resolution = train.settings.get<coord_t>("meshfix_maximum_resolution");
+        const coord_t maximum_deviation = train.settings.get<coord_t>("meshfix_maximum_deviation");
         Polygons raft_outline_path = storage.raftOutline.offset(-gcode_layer.configs_storage.raft_surface_config.getLineWidth() / 2); //Do this manually because of micron-movement created in corners when insetting a polygon that was offset with round joint type.
-        raft_outline_path.simplify(maximum_resolution); //Remove those micron-movements.
+        raft_outline_path.simplify(maximum_resolution, maximum_deviation); //Remove those micron-movements.
         constexpr coord_t infill_outline_width = 0;
         Polygons raft_lines;
         int offset_from_poly_outline = 0;

--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -14,7 +14,7 @@ namespace cura
 MergeInfillLines::MergeInfillLines(ExtruderPlan& plan)
 : extruder_plan(plan)
 , nozzle_size(Application::getInstance().current_slice->scene.extruders[extruder_plan.extruder_nr].settings.get<coord_t>("machine_nozzle_size"))
-, maximum_resolution(Application::getInstance().current_slice->scene.extruders[extruder_plan.extruder_nr].settings.get<coord_t>("meshfix_maximum_resolution"))
+, maximum_deviation(Application::getInstance().current_slice->scene.extruders[extruder_plan.extruder_nr].settings.get<coord_t>("meshfix_maximum_deviation"))
     {
         //Just copy the parameters to their fields.
     }
@@ -104,8 +104,8 @@ MergeInfillLines::MergeInfillLines(ExtruderPlan& plan)
                 merged_part_length = vSize(first_path.points[first_path.points.size() - 2] - average_second_path);
                 new_error_area = sqrt(dist2_from_line) * merged_part_length / 2;
             }
-            // The max error margin uses the meshfix_maximum_resolution setting
-            if (first_path.points.size() > 1 && error_area + new_error_area < merged_part_length * maximum_resolution)
+            // The max error margin uses the meshfix_maximum_deviation setting.
+            if (first_path.points.size() > 1 && error_area + new_error_area < merged_part_length * maximum_deviation)
             {
                 new_path_length -= vSize(first_path.points[first_path.points.size() - 2] - first_path.points[first_path.points.size() - 1]);
                 new_path_length += vSize(first_path.points[first_path.points.size() - 2] - average_second_path);

--- a/src/MergeInfillLines.h
+++ b/src/MergeInfillLines.h
@@ -32,8 +32,16 @@ private:
      * we can use.
      */
     ExtruderPlan& extruder_plan;
+
+    /*
+     * The nozzle size that's printing these lines.
+     */
     const coord_t nozzle_size;
-    const coord_t maximum_resolution;
+
+    /*
+     * The allowed deviation in the line positioning.
+     */
+    const coord_t maximum_deviation;
 
     /*
      *

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -410,6 +410,7 @@ Polygons SliceDataStorage::getLayerOutlines(const LayerIndex layer_nr, const boo
     {
         Polygons total;
         coord_t maximum_resolution = std::numeric_limits<coord_t>::max();
+        coord_t maximum_deviation = std::numeric_limits<coord_t>::max();
         if (layer_nr >= 0)
         {
             for (const SliceMeshStorage& mesh : meshes)
@@ -425,6 +426,7 @@ Polygons SliceDataStorage::getLayerOutlines(const LayerIndex layer_nr, const boo
                     total = total.unionPolygons(layer.openPolyLines.offsetPolyLine(100));
                 }
                 maximum_resolution = std::min(maximum_resolution, mesh.settings.get<coord_t>("meshfix_maximum_resolution"));
+                maximum_deviation = std::min(maximum_deviation, mesh.settings.get<coord_t>("meshfix_maximum_deviation"));
             }
         }
         if (include_support)
@@ -447,7 +449,7 @@ Polygons SliceDataStorage::getLayerOutlines(const LayerIndex layer_nr, const boo
                 total.add(layer_nr == 0 ? primeTower.outer_poly_first_layer : primeTower.outer_poly);
             }
         }
-        total.simplify(maximum_resolution, maximum_resolution);
+        total.simplify(maximum_resolution, maximum_deviation);
         return total;
     }
 }

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -780,7 +780,8 @@ void SlicerLayer::makePolygons(const Mesh* mesh)
 
     //Finally optimize all the polygons. Every point removed saves time in the long run.
     const coord_t line_segment_resolution = mesh->settings.get<coord_t>("meshfix_maximum_resolution");
-    polygons.simplify(line_segment_resolution, line_segment_resolution / 2); //Maximum error is half of the resolution so it's only a limit when removing really sharp corners.
+    const coord_t line_segment_deviation = mesh->settings.get<coord_t>("meshfix_maximum_deviation");
+    polygons.simplify(line_segment_resolution, line_segment_deviation);
 
     polygons.removeDegenerateVerts(); // remove verts connected to overlapping line segments
 }

--- a/tests/integration/SlicePhaseTest.cpp
+++ b/tests/integration/SlicePhaseTest.cpp
@@ -35,6 +35,7 @@ class SlicePhaseTest : public testing::Test
         scene.settings.add("meshfix_keep_open_polygons", "false");
         scene.settings.add("minimum_polygon_circumference", "1");
         scene.settings.add("meshfix_maximum_resolution", "0.04");
+        scene.settings.add("meshfix_maximum_deviation", "0.02");
         scene.settings.add("xy_offset", "0");
         scene.settings.add("xy_offset_layer_0", "0");
     }


### PR DESCRIPTION
We want to be able to tweak this separately from the maximum resolution, rather than having a high resolution in curves that don't deviate a whole lot if you leave some vertices out.

Contributes to issue CURA-6458.