### PR TITLE
Remove non-standard double suffix

### DIFF
--- a/tests/settings/SettingsTest.cpp
+++ b/tests/settings/SettingsTest.cpp
@@ -120,13 +120,13 @@ TEST_F(SettingsTest, AddSettingAngleRadians)
     EXPECT_DOUBLE_EQ(AngleRadians(M_PI), settings.get<AngleRadians>("test_setting")) << "180 degrees is 1 pi radians.";
 
     settings.add("test_setting", "810");
-    EXPECT_NEAR(AngleRadians(M_PI / 2.0), settings.get<AngleRadians>("test_setting"), 0.00000001d) << "810 degrees in clock arithmetic is 90 degrees, which is 0.5 pi radians.";
+    EXPECT_NEAR(AngleRadians(M_PI / 2.0), settings.get<AngleRadians>("test_setting"), 0.00000001) << "810 degrees in clock arithmetic is 90 degrees, which is 0.5 pi radians.";
 }
 
 TEST_F(SettingsTest, AddSettingAngleDegrees)
 {
     settings.add("test_setting", "4442.4");
-    EXPECT_NEAR(AngleDegrees(122.4), settings.get<AngleDegrees>("test_setting"), 0.00000001d) << "4320 is divisible by 360, so 4442.4 in clock arithmetic is 122.4 degrees.";
+    EXPECT_NEAR(AngleDegrees(122.4), settings.get<AngleDegrees>("test_setting"), 0.00000001) << "4320 is divisible by 360, so 4442.4 in clock arithmetic is 122.4 degrees.";
 }
 
 TEST_F(SettingsTest, AddSettingTemperature)

--- a/tests/utils/StringTest.cpp
+++ b/tests/utils/StringTest.cpp
@@ -67,7 +67,7 @@ TEST_P(WriteDoubleToStreamTest, WriteDoubleToStream)
 }
 
 INSTANTIATE_TEST_CASE_P(WriteDoubleToStreamTestInstantiation, WriteDoubleToStreamTest,
-        testing::Values(-10.000, -1.000, -0.100, -0.010, -0.001, 0.010, 0.100, 1.000, 10.000, 123456.789, 0.00000001d,
+        testing::Values(-10.000, -1.000, -0.100, -0.010, -0.001, 0.010, 0.100, 1.000, 10.000, 123456.789, 0.00000001,
         std::numeric_limits<double>::min(), std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), -std::numeric_limits<double>::lowest()));
 
 }


### PR DESCRIPTION
The d suffix is not standard c++ and breaks the build for MSVC. All the places it's used are already doubles without the suffix