### PR TITLE
Implement cool_fan_lag setting.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1623,12 +1623,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                             if (path_time >= fan_speed_override_at)
                             {
                                 // time for the fan override to kick in
-                                if (default_fan_speed != fan_override_events[0].second)
-                                {
-                                    gcode.writeComment("FAN OVERRIDE");
-                                    default_fan_speed = fan_override_events[0].second;
-                                    gcode.writeFanCommand(default_fan_speed);
-                                }
+                                default_fan_speed = fan_override_events[0].second;
+                                gcode.writeFanCommand(default_fan_speed);
                                 fan_speed_override_at = -1;
                             }
                         }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1607,12 +1607,15 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 { // normal path to gcode algorithm
                     double path_time = 0;
                     Point last_point = gcode.getPositionXY();
-                    if (fan_speed_override_at < 0)
-                    {
-                        gcode.writeFanCommand(path_fan_speed != GCodePathConfig::FAN_SPEED_DEFAULT ? path_fan_speed : default_fan_speed);
-                    }
                     for(unsigned int point_idx = 0; point_idx < path.points.size(); point_idx++)
                     {
+                        // if this is the first extrusion in the path
+                        // and either there is no fan speed override scheduled or the fan speed override doesn't occur before the first extrusion,
+                        // update the fan speed
+                        if (point_idx == 0 && fan_speed_override_at != 0)
+                        {
+                            gcode.writeFanCommand(path_fan_speed != GCodePathConfig::FAN_SPEED_DEFAULT ? path_fan_speed : default_fan_speed);
+                        }
                         if (fan_speed_override_at >= 0)
                         {
                             path_time += vSizeMM(path.points[point_idx] - last_point) / speed;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1455,7 +1455,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         if (path_fan_speed != default_fan_speed)
                         {
                             double lag = cool_fan_lag * std::abs(path_fan_speed - default_fan_speed) / 100;
-                            if (lag > 0.25)
+                            if (lag >= 0.1)
                             {
                                 fan_override_events.emplace_back(elapsed_time, path_fan_speed);
                                 default_fan_speed = path_fan_speed;


### PR DESCRIPTION
This PR makes print cooling fan speed overrides happen earlier so that the requested speed change has been achieved by the time the nozzle reaches the override zone.