### PR TITLE
Separate move on z axis for final travel.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1599,6 +1599,12 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
             { // early comp for travel paths, which are handled more simply
                 if (!path.perform_z_hop && final_travel_z != z && extruder_plan_idx == (extruder_plans.size() - 1) && path_idx == (paths.size() - 1))
                 {
+                    // Before the final travel, move up to the next layer height, on the current spot, with a sensible speed.
+                    Point3 current_position = gcode.getPosition();
+                    current_position.z = final_travel_z;
+                    gcode.writeTravel(current_position, extruder.settings.get<Velocity>("speed_z_hop"));
+
+                    // Prevent the final travel(s) from resetting to the 'previous' layer height.
                     gcode.setZ(final_travel_z);
                 }
                 for(unsigned int point_idx = 0; point_idx < path.points.size(); point_idx++)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -82,6 +82,7 @@ LayerPlan::LayerPlan(const SliceDataStorage& storage, LayerIndex layer_nr, coord
 : storage(storage)
 , configs_storage(storage, layer_nr, layer_thickness)
 , z(z)
+, final_travel_z(z)
 , mode_skip_agressive_merge(false)
 , layer_nr(layer_nr)
 , is_initial_layer(layer_nr == 0 - static_cast<LayerIndex>(Raft::getTotalExtraLayers()))
@@ -1596,6 +1597,10 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
             }
             if (path.config->isTravelPath())
             { // early comp for travel paths, which are handled more simply
+                if (!path.perform_z_hop && final_travel_z != z && extruder_plan_idx == (extruder_plans.size() - 1) && path_idx == (paths.size() - 1))
+                {
+                    gcode.setZ(final_travel_z);
+                }
                 for(unsigned int point_idx = 0; point_idx < path.points.size(); point_idx++)
                 {
                     gcode.writeTravel(path.points[point_idx], speed);

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -236,7 +236,8 @@ private:
 
 public:
     const PathConfigStorage configs_storage; //!< The line configs for this layer for each feature type
-    int z;
+    coord_t z;
+    coord_t final_travel_z;
     bool mode_skip_agressive_merge; //!< Wheter to give every new path the 'skip_agressive_merge_hint' property (see GCodePath); default is false.
 
 private:

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -100,6 +100,7 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
         prev_layer->setIsInside(new_layer_destination_state->second);
         const bool force_retract = extruder_settings.get<bool>("retract_at_layer_change") ||
           (mesh_group_settings.get<bool>("travel_retract_before_outer_wall") && (mesh_group_settings.get<bool>("outer_inset_first") || mesh_group_settings.get<size_t>("wall_line_count") == 1)); //Moving towards an outer wall.
+        prev_layer->final_travel_z = newest_layer->z;
         prev_layer->addTravel(first_location_new_layer, force_retract);
     }
 }


### PR DESCRIPTION
Diff proposed by @smartavionics during discussion of (now reverted) PR 1076

Part of CURA-6582.

(I was a bit worried about the 'moved around' M204/M205 commands at first, but in the end I don't think it's harmful.)