### PR TITLE
infill: Remove stb basedir from include

### DIFF
--- a/src/infill/ImageBasedDensityProvider.cpp
+++ b/src/infill/ImageBasedDensityProvider.cpp
@@ -4,7 +4,7 @@
 
 #define STBI_FAILURE_USERMSG // enable user friendly bug messages for STB lib
 #define STB_IMAGE_IMPLEMENTATION // needed in order to enable the implementation of libs/std_image.h
-#include <stb/stb_image.h>
+#include <stb_image.h>
 
 #include "ImageBasedDensityProvider.h"
 #include "SierpinskiFill.h"


### PR DESCRIPTION
For some reason, someone decided to include stb_image.h from stb. But CMake already does the job well and will look for this directory during build configuration.
During build, it appears in the compilation command and therefore telling to look into "stb" will even fail, if there is no stb directory in any detected include directory.
Therefore, let's include stb_image.h directly and use all stb headers from one place as found by CMake.