### PR TITLE
When adding lines, ignore lines less than 5um long.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1043,8 +1043,13 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathCon
         const size_t start = orderOptimizer.polyStart[poly_idx];
         const size_t end = 1 - start;
         const Point& p0 = polygon[start];
-        addTravel(p0);
         const Point& p1 = polygon[end];
+        // ignore line segments that are less than 5uM long
+        if(vSize2(p1 - p0) < 25)
+        {
+            continue;
+        }
+        addTravel(p0);
         addExtrusionMove(p1, config, space_fill_type, flow_ratio, false, 1.0, fan_speed);
 
         // Wipe


### PR DESCRIPTION
Those lines occasionally get created when skins and infill are generated and cause
unwanted travels to occur to their start locations.

As discussed in https://community.ultimaker.com/topic/28980-unnecessary-travel-moves-at-the-end-of-the-layer/