### PR TITLE
Avoid unwanted travel move when ironing is enabled but no lines/polygons are generated.

### DIFF
--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -50,6 +50,11 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
     Polygons ironing_lines;
     infill_generator.generate(ironing_polygons, ironing_lines);
 
+    if (ironing_polygons.empty() && ironing_lines.empty())
+    {
+        return false; //Nothing to do.
+    }
+
     layer.mode_skip_agressive_merge = true;
 
     if (pattern == EFillMethod::LINES || pattern == EFillMethod::ZIG_ZAG)

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -87,7 +87,7 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
                 layer.addTravel(back_side);
             }
         }
-        
+
         layer.addLinesByOptimizer(ironing_lines, line_config, SpaceFillType::PolyLines);
         added = true;
     }


### PR DESCRIPTION
When ironing is enabled it could generate a travel move even when no ironing lines/polygons were
going to be output. Now it doesn't.

As discussed in https://community.ultimaker.com/topic/28980-unnecessary-travel-moves-at-the-end-of-the-layer/