### PR TITLE
[4.2.1] Fix ignored wireframe_strategy configuration

### DIFF
--- a/src/Wireframe2gcode.cpp
+++ b/src/Wireframe2gcode.cpp
@@ -538,11 +538,11 @@ Wireframe2gcode::Wireframe2gcode(Weaver& weaver, GCodeExport& gcode)
     drag_along = scene_settings.get<coord_t>("wireframe_drag_along");
     
     strategy = STRATEGY_COMPENSATE;
-    if (scene_settings.get<std::string>("wireframe_strategy") == "Compensate")
+    if (scene_settings.get<std::string>("wireframe_strategy") == "compensate")
         strategy = STRATEGY_COMPENSATE;
-    if (scene_settings.get<std::string>("wireframe_strategy") == "Knot")
+    if (scene_settings.get<std::string>("wireframe_strategy") == "knot")
         strategy = STRATEGY_KNOT;
-    if (scene_settings.get<std::string>("wireframe_strategy") == "Retract")
+    if (scene_settings.get<std::string>("wireframe_strategy") == "retract")
         strategy = STRATEGY_RETRACT;
     
     go_back_to_last_top = false;


### PR DESCRIPTION
The `wireframe_strategy` configuration check in Wireframe2gcode tests for a capitalized version of the 3 strategy strings, but this configuration is stored lowercase, so only the default strategy (`STRATEGY_COMPENSATE`) can be used via the UI.

Other strategies can be used currently by manually editing the cura configs, but any strategy change made via the UI will then revert the strategy back to compensate by default.