### PR TITLE
Still engage prime-train in dual extrusion (for 2nd exttruder).

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2677,6 +2677,11 @@ void FffGcodeWriter::setExtruder_addPrime(const SliceDataStorage& storage, Layer
                 gcode_layer.addTravel(prime_pos_is_abs ? prime_pos : gcode_layer.getLastPlannedPositionOrStartingPosition() + prime_pos);
                 gcode_layer.planPrime();
             }
+            else
+            {
+                // Otherwise still prime, but don't do any other travels.
+                gcode_layer.planPrime(0.0);
+            }
         }
 
         if (gcode_layer.getLayerNr() == 0 && !gcode_layer.getSkirtBrimIsPlanned(extruder_nr))

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -499,10 +499,9 @@ GCodePath& LayerPlan::addTravel_simple(Point p, GCodePath* path)
     return *path;
 }
 
-void LayerPlan::planPrime()
+void LayerPlan::planPrime(const float& prime_blob_wipe_length)
 {
     forceNewPathStart();
-    constexpr float prime_blob_wipe_length = 10.0;
     GCodePath& prime_travel = addTravel_simple(getLastPlannedPositionOrStartingPosition() + Point(0, MM2INT(prime_blob_wipe_length)));
     prime_travel.retract = false;
     prime_travel.perform_z_hop = false;

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -474,7 +474,7 @@ public:
     /*!
      * Plan a prime blob at the current location.
      */
-    void planPrime();
+    void planPrime(const float& prime_blob_wipe_length = 10.0);
 
     /*!
      * Add an extrusion move to a certain point, optionally with a different flow than the one in the \p config.


### PR DESCRIPTION
Soft-reverts (without destroying the fix) a fix made to prevent a spurious 10mm travel move. This had the side effect of not putting any G280 in the gcode, needed when the 2nd extruder is engaged for the first time.

part of CURA-6699