### PR TITLE
Only calculate the retraction region once rather than for every outer wall inset.

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -33,8 +33,13 @@ void InsetOrderOptimizer::moveInside()
     // try to move p inside the outer wall by 1.1 times the outer wall line width
     if (PolygonUtils::moveInside(part.insets[0], p, outer_wall_line_width * 1.1f) != NO_INDEX)
     {
+        if (!retraction_region_calculated)
+        {
+            retraction_region = part.insets[0].offset(-outer_wall_line_width);
+            retraction_region_calculated = true;
+        }
         // move to p if it is not closer than a line width from the centre line of the outer wall
-        if (part.insets[0].offset(-outer_wall_line_width).inside(p))
+        if (retraction_region.inside(p))
         {
             gcode_layer.addTravel_simple(p);
             gcode_layer.forceNewPathStart();
@@ -47,7 +52,7 @@ void InsetOrderOptimizer::moveInside()
             if (PolygonUtils::moveInside(part.insets[0], p, outer_wall_line_width * 1.1f) != NO_INDEX)
             {
                 // move to p if it is not closer than a line width from the centre line of the outer wall
-                if (part.insets[0].offset(-outer_wall_line_width).inside(p))
+                if (retraction_region.inside(p))
                 {
                     gcode_layer.addTravel_simple(p);
                     gcode_layer.forceNewPathStart();

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -40,7 +40,8 @@ public:
     z_seam_config(mesh.settings.get<EZSeamType>("z_seam_type"), mesh.getZSeamHint(), mesh.settings.get<EZSeamCornerPrefType>("z_seam_corner")),
     added_something(false),
     wall_overlapper_0(nullptr),
-    wall_overlapper_x(nullptr)
+    wall_overlapper_x(nullptr),
+    retraction_region_calculated(false)
     {
     }
 private:
@@ -58,6 +59,8 @@ private:
     WallOverlapComputation* wall_overlapper_0;
     WallOverlapComputation* wall_overlapper_x;
     std::vector<std::vector<ConstPolygonPointer>> inset_polys; // vector of vectors holding the inset polygons
+    Polygons retraction_region; // after printing an outer wall, move into this region so that retractions do not leave visible blobs
+    bool retraction_region_calculated;
 
     /*!
      * Generate the insets for the holes of a given layer part after optimizing the ordering.


### PR DESCRIPTION
This was wasting a lot of time when the part had a lot of holes or the outer wall was
fragmented.

Part 1 of the fixes required for https://github.com/Ultimaker/Cura/issues/6164.

Part 2 to follow and is not related to this PR.