### PR TITLE
Remove prime after coasting

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1861,8 +1861,6 @@ bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, const size_t extruder_
         const Velocity speed = Velocity(coasting_speed_modifier * path.config->getSpeed() * extruder_plan.getExtrudeSpeedFactor());
         gcode.writeTravel(path.points[point_idx], speed);
     }
-
-    gcode.addLastCoastedVolume(path.getExtrusionMM3perMM() * INT2MM(actual_coasting_dist));
     return true;
 }
 

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -240,11 +240,6 @@ public:
 
     void setFlowRateExtrusionSettings(double max_extrusion_offset, double extrusion_offset_factor);
 
-    void addLastCoastedVolume(double last_coasted_volume) 
-    {
-        extruder_attr[current_extruder].prime_volume += last_coasted_volume; 
-    }
-
     /*!
      * Add extra amount of material to be primed after an unretraction.
      *


### PR DESCRIPTION
Currently running a small print test if this improves the print quality in any way. Or deteriorates it...

Contributes to issue CURA-6726. Fixes Ultimaker/Cura#6108.