### PR TITLE
First travel move on first layer should be z-hopped if applicable.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -382,6 +382,11 @@ GCodePath& LayerPlan::addTravel(Point p, bool force_comb_retract)
         bypass_combing = true; // first travel move is bogus; it is added after this and the previous layer have been planned in LayerPlanBuffer::addConnectingTravelMove
         first_travel_destination = p;
         first_travel_destination_is_inside = is_inside;
+        if (layer_nr == 0 && extruder->settings.get<bool>("retraction_hop_enabled"))
+        {
+            path->retract = true;
+            path->perform_z_hop = true;
+        }
         forceNewPathStart(); // force a new travel path after this first bogus move
     }
     else if (force_comb_retract && last_planned_position && !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -382,7 +382,7 @@ GCodePath& LayerPlan::addTravel(Point p, bool force_comb_retract)
         bypass_combing = true; // first travel move is bogus; it is added after this and the previous layer have been planned in LayerPlanBuffer::addConnectingTravelMove
         first_travel_destination = p;
         first_travel_destination_is_inside = is_inside;
-        if (layer_nr == 0 && extruder->settings.get<bool>("retraction_hop_enabled"))
+        if (layer_nr == 0 && extruder->settings.get<bool>("retraction_enable") && extruder->settings.get<bool>("retraction_hop_enabled"))
         {
             path->retract = true;
             path->perform_z_hop = true;


### PR DESCRIPTION
Users might have start gCode that depends on z-hopping, even if there is only one extruder.
part of CURA-6718