### PR TITLE
Ignore slight kinks in almost straight lines when z-seam preference is sharpest corner.

### DIFF
--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -142,7 +142,12 @@ int PathOrderOptimizer::getClosestPointInPolygon(Point prev_point, int poly_idx)
         const Point& p2 = poly[(point_idx + 1) % poly.size()];
         // when type is SHARPEST_CORNER, actual distance is ignored, we use a fixed distance and decision is based on curvature only
         float dist_score = (config.type == EZSeamType::SHARPEST_CORNER && config.corner_pref != EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE)? 10000 : vSize2(p1 - prev_point);
-        const float corner_angle = LinearAlg2D::getAngleLeft(p0, p1, p2) / M_PI; // 0 -> 2
+        float corner_angle = LinearAlg2D::getAngleLeft(p0, p1, p2) / M_PI; // 0 -> 2
+        if (std::abs(corner_angle - 1) < 0.05)
+        {
+            // ignore slight kinks in almost straight lines
+            corner_angle = 1;
+        }
         float corner_shift;
         if (config.type == EZSeamType::SHORTEST)
         {


### PR DESCRIPTION
Now, the corner angle has to be at least +/- 0.05 radians to be considered.

Prompted by the issue raised in https://community.ultimaker.com/topic/29326-cura-line-startz-seam-problem/.

The model there was getting some bad z-seam locations when z-seam alignment was sharpest corner and the corner preference was hide seam. The model only has convex corners but there are some rogue points in one of the long sides that produce a very slight concave outline and so they were being picked up as the best location for the z-seam.
