### PR TITLE
Fix compilation with clang80/90

### DIFF
--- a/src/utils/logoutput.cpp
+++ b/src/utils/logoutput.cpp
@@ -24,72 +24,72 @@ void enableProgressLogging()
 
 void logError(const char* fmt, ...)
 {
+    va_list args;
+    va_start(args, fmt);
     #pragma omp critical
     {
-        va_list args;
-        va_start(args, fmt);
         fprintf(stderr, "[ERROR] ");
         vfprintf(stderr, fmt, args);
-        va_end(args);
         fflush(stderr);
     }
+    va_end(args);
 }
 
 void logWarning(const char* fmt, ...)
 {
+    va_list args;
+    va_start(args, fmt);
     #pragma omp critical
     {
-        va_list args;
-        va_start(args, fmt);
         fprintf(stderr, "[WARNING] ");
         vfprintf(stderr, fmt, args);
-        va_end(args);
         fflush(stderr);
     }
+    va_end(args);
 }
 
 void logAlways(const char* fmt, ...)
 {
+    va_list args;
+    va_start(args, fmt);
     #pragma omp critical
     {
-        va_list args;
-        va_start(args, fmt);
         vfprintf(stderr, fmt, args);
-        va_end(args);
         fflush(stderr);
     }
+    va_end(args);
 }
 
 void log(const char* fmt, ...)
 {
+    va_list args;
     if (verbose_level < 1)
         return;
 
+    va_start(args, fmt);
     #pragma omp critical
     {
-        va_list args;
-        va_start(args, fmt);
         vfprintf(stderr, fmt, args);
-        va_end(args);
         fflush(stderr);
     }
+    va_end(args);
 }
 
 void logDebug(const char* fmt, ...)
 {
+    va_list args;
     if (verbose_level < 2)
     {
         return;
     }
+    va_start(args, fmt);
     #pragma omp critical
     {
-        va_list args;
-        va_start(args, fmt);
         fprintf(stderr, "[DEBUG] ");
         vfprintf(stderr, fmt, args);
-        va_end(args);
         fflush(stderr);
     }
+    va_end(args);
 }
 
 void logProgress(const char* type, int value, int maxValue, float percent)


### PR DESCRIPTION
clang 8.0 and later, at the very least, will not allow va_start inside a
critical section like this, otherwise it will issue the following:

error: 'va_start' cannot be used in a captured statement

Move vararg manipulation out of the critical sections to fix this, as there
is little value in keeping them inside when the critical section is
primarily to synchronize output.

Mentioned in #984 but not the primary issue; rediscovered on FreeBSD.