### PR TITLE
Use steeper slope for low angles rather than shifiting pivot point

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -140,7 +140,7 @@ void Application::printLicense() const
 {
     logAlways("\n");
     logAlways("Cura_SteamEngine version %s\n", VERSION);
-    logAlways("Copyright (C) 2018 Ultimaker\n");
+    logAlways("Copyright (C) 2019 Ultimaker\n");
     logAlways("\n");
     logAlways("This program is free software: you can redistribute it and/or modify\n");
     logAlways("it under the terms of the GNU Affero General Public License as published by\n");

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -182,7 +182,11 @@ int PathOrderOptimizer::getClosestPointInPolygon(Point prev_point, int poly_idx)
                 break;
             case EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_WEIGHTED:
                 //More curve is better score (reduced distance), but slightly in favour of concave curves.
-                dist_score -= fabs(corner_angle - 0.8) * corner_shift;
+                dist_score -= fabs(corner_angle - 1) * corner_shift;
+                if (corner_angle < 1)
+                {
+                    dist_score *= 2;
+                }
                 break;
             case EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE:
             default:

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -181,13 +181,16 @@ int PathOrderOptimizer::getClosestPointInPolygon(Point prev_point, int poly_idx)
                 dist_score -= fabs(corner_angle - 1) * corner_shift;
                 break;
             case EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_WEIGHTED:
+            {
                 //More curve is better score (reduced distance), but slightly in favour of concave curves.
-                dist_score -= fabs(corner_angle - 1) * corner_shift;
+                float dist_score_corner = fabs(corner_angle - 1) * corner_shift;
                 if (corner_angle < 1)
                 {
-                    dist_score *= 2;
+                    dist_score_corner *= 2;
                 }
+                dist_score -= dist_score_corner;
                 break;
+            }
             case EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE:
             default:
                 // do nothing


### PR DESCRIPTION
This prevents edge cases where angles around 150 degrees would get avoided rather than angles around 180 degrees.

Fixes CURA-6760.