### PR TITLE
Don't do xor nor union when in surface mode

### DIFF
--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -40,7 +40,20 @@ void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, Sl
 
     std::vector<PolygonsPart> result;
     const bool union_layers = settings.get<bool>("meshfix_union_all");
-    result = layer->polygons.splitIntoParts(union_layers || union_all_remove_holes);
+    const ESurfaceMode surface_only = settings.get<ESurfaceMode>("magic_mesh_surface_mode");
+    if (surface_only == ESurfaceMode::SURFACE && !union_layers)
+    { // Don't do anything with overlapping areas; no union nor xor
+        result.reserve(layer->polygons.size());
+        for (const PolygonRef poly : layer->polygons)
+        {
+            result.emplace_back();
+            result.back().add(poly);
+        }
+    }
+    else
+    {
+        result = layer->polygons.splitIntoParts(union_layers || union_all_remove_holes);
+    }
     for(unsigned int i=0; i<result.size(); i++)
     {
         storageLayer.parts.emplace_back();


### PR DESCRIPTION
In surface mode we don't want to do Union overlapping volumes, but we also don;t want to perform a XOR on overlapping volumes, which is the implicit alternative when Union Overlapping Volumes is disabled.

Before with Union overlapping volumes:
![image](https://user-images.githubusercontent.com/8895761/66912095-30c7f880-f012-11e9-871b-43ee568723cd.png)

Before without Union overlapping volumes:
![image](https://user-images.githubusercontent.com/8895761/66912063-1ee65580-f012-11e9-946f-c90ab7064197.png)

After this PR without Union overlapping volumes:
![image](https://user-images.githubusercontent.com/8895761/66912033-11c96680-f012-11e9-98a2-7185cc26fb42.png)
