### PR TITLE
Fix Z hops when retracting

### DIFF
--- a/docs/assets/retraction_combing_hop.svg
+++ b/docs/assets/retraction_combing_hop.svg
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.2" width="210mm" height="410mm" viewBox="0 0 21000 41000" preserveAspectRatio="xMidYMid" fill-rule="evenodd" stroke-width="28.222" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" xmlns:ooo="http://xml.openoffice.org/svg/export" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:presentation="http://sun.com/xmlns/staroffice/presentation" xmlns:smil="http://www.w3.org/2001/SMIL20/" xmlns:anim="urn:oasis:names:tc:opendocument:xmlns:animation:1.0" xml:space="preserve">
+ <defs class="ClipPathGroup">
+  <clipPath id="presentation_clip_path" clipPathUnits="userSpaceOnUse">
+   <rect x="0" y="0" width="21000" height="41000"/>
+  </clipPath>
+  <clipPath id="presentation_clip_path_shrink" clipPathUnits="userSpaceOnUse">
+   <rect x="21" y="41" width="20958" height="40918"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <font id="EmbeddedFont_1" horiz-adv-x="2048">
+   <font-face font-family="Liberation Sans embedded" units-per-em="2048" font-weight="normal" font-style="normal" ascent="1852" descent="423"/>
+   <missing-glyph horiz-adv-x="2048" d="M 0,0 L 2047,0 2047,2047 0,2047 0,0 Z"/>
+   <glyph unicode="z" horiz-adv-x="848" d="M 83,0 L 83,137 688,943 117,943 117,1082 901,1082 901,945 295,139 922,139 922,0 83,0 Z"/>
+   <glyph unicode="x" horiz-adv-x="1006" d="M 801,0 L 510,444 217,0 23,0 408,556 41,1082 240,1082 510,661 778,1082 979,1082 612,558 1002,0 801,0 Z"/>
+   <glyph unicode="w" horiz-adv-x="1509" d="M 1174,0 L 965,0 776,765 740,934 C 734,904 725,861 712,805 699,748 631,480 508,0 L 300,0 -3,1082 175,1082 358,347 C 363,331 377,265 401,149 L 418,223 644,1082 837,1082 1026,339 1072,149 1103,288 1308,1082 1484,1082 1174,0 Z"/>
+   <glyph unicode="u" horiz-adv-x="874" d="M 314,1082 L 314,396 C 314,325 321,269 335,230 349,191 371,162 402,145 433,128 478,119 537,119 624,119 692,149 742,208 792,267 817,350 817,455 L 817,1082 997,1082 997,231 C 997,105 999,28 1003,0 L 833,0 C 832,3 832,12 831,27 830,42 830,59 829,78 828,97 826,132 825,185 L 822,185 C 781,110 733,58 679,27 624,-4 557,-20 476,-20 357,-20 271,10 216,69 161,128 133,225 133,361 L 133,1082 314,1082 Z"/>
+   <glyph unicode="t" horiz-adv-x="531" d="M 554,8 C 495,-8 434,-16 372,-16 228,-16 156,66 156,229 L 156,951 31,951 31,1082 163,1082 216,1324 336,1324 336,1082 536,1082 536,951 336,951 336,268 C 336,216 345,180 362,159 379,138 408,127 450,127 474,127 509,132 554,141 L 554,8 Z"/>
+   <glyph unicode="s" horiz-adv-x="901" d="M 950,299 C 950,197 912,118 835,63 758,8 650,-20 511,-20 376,-20 273,2 200,47 127,91 79,160 57,254 L 216,285 C 231,227 263,185 311,158 359,131 426,117 511,117 602,117 669,131 712,159 754,187 775,229 775,285 775,328 760,362 731,389 702,416 654,438 589,455 L 460,489 C 357,516 283,542 240,568 196,593 162,624 137,661 112,698 100,743 100,796 100,895 135,970 206,1022 276,1073 378,1099 513,1099 632,1099 727,1078 798,1036 868,994 912,927 931,834 L 769,814 C 759,862 732,899 689,925 645,950 586,963 513,963 432,963 372,951 333,926 294,901 275,864 275,814 275,783 283,758 299,738 315,718 339,701 370,687 401,673 467,654 568,629 663,605 732,583 774,563 816,542 849,520 874,495 898,470 917,442 930,410 943,377 950,340 950,299 Z"/>
+   <glyph unicode="r" horiz-adv-x="530" d="M 142,0 L 142,830 C 142,906 140,990 136,1082 L 306,1082 C 311,959 314,886 314,861 L 318,861 C 347,954 380,1017 417,1051 454,1085 507,1102 575,1102 599,1102 623,1099 648,1092 L 648,927 C 624,934 592,937 552,937 477,937 420,905 381,841 342,776 322,684 322,564 L 322,0 142,0 Z"/>
+   <glyph unicode="p" horiz-adv-x="953" d="M 1053,546 C 1053,169 920,-20 655,-20 488,-20 376,43 319,168 L 314,168 C 317,163 318,106 318,-2 L 318,-425 138,-425 138,861 C 138,972 136,1046 132,1082 L 306,1082 C 307,1079 308,1070 309,1054 310,1037 312,1012 314,978 315,944 316,921 316,908 L 320,908 C 352,975 394,1024 447,1055 500,1086 569,1101 655,1101 788,1101 888,1056 954,967 1020,878 1053,737 1053,546 Z M 864,542 C 864,693 844,800 803,865 762,930 698,962 609,962 538,962 482,947 442,917 401,887 371,840 350,777 329,713 318,630 318,528 318,386 341,281 386,214 431,147 505,113 607,113 696,113 762,146 803,212 844,277 864,387 864,542 Z"/>
+   <glyph unicode="o" horiz-adv-x="980" d="M 1053,542 C 1053,353 1011,212 928,119 845,26 724,-20 565,-20 407,-20 288,28 207,125 126,221 86,360 86,542 86,915 248,1102 571,1102 736,1102 858,1057 936,966 1014,875 1053,733 1053,542 Z M 864,542 C 864,691 842,800 798,868 753,935 679,969 574,969 469,969 393,935 346,866 299,797 275,689 275,542 275,399 298,292 345,221 391,149 464,113 563,113 671,113 748,148 795,217 841,286 864,395 864,542 Z"/>
+   <glyph unicode="n" horiz-adv-x="874" d="M 825,0 L 825,686 C 825,757 818,813 804,852 790,891 768,920 737,937 706,954 661,963 602,963 515,963 447,933 397,874 347,815 322,732 322,627 L 322,0 142,0 142,851 C 142,977 140,1054 136,1082 L 306,1082 C 307,1079 307,1070 308,1055 309,1040 310,1024 311,1005 312,986 313,950 314,897 L 317,897 C 358,972 406,1025 461,1056 515,1087 582,1102 663,1102 782,1102 869,1073 924,1014 979,955 1006,857 1006,721 L 1006,0 825,0 Z"/>
+   <glyph unicode="m" horiz-adv-x="1457" d="M 768,0 L 768,686 C 768,791 754,863 725,903 696,943 645,963 570,963 493,963 433,934 388,875 343,816 321,734 321,627 L 321,0 142,0 142,851 C 142,977 140,1054 136,1082 L 306,1082 C 307,1079 307,1070 308,1055 309,1040 310,1024 311,1005 312,986 313,950 314,897 L 317,897 C 356,974 400,1027 450,1057 500,1087 561,1102 633,1102 715,1102 780,1086 828,1053 875,1020 908,968 927,897 L 930,897 C 967,970 1013,1022 1066,1054 1119,1086 1183,1102 1258,1102 1367,1102 1447,1072 1497,1013 1546,954 1571,856 1571,721 L 1571,0 1393,0 1393,686 C 1393,791 1379,863 1350,903 1321,943 1270,963 1195,963 1116,963 1055,934 1012,876 968,817 946,734 946,627 L 946,0 768,0 Z"/>
+   <glyph unicode="l" horiz-adv-x="187" d="M 138,0 L 138,1484 318,1484 318,0 138,0 Z"/>
+   <glyph unicode="i" horiz-adv-x="187" d="M 137,1312 L 137,1484 317,1484 317,1312 137,1312 Z M 137,0 L 137,1082 317,1082 317,0 137,0 Z"/>
+   <glyph unicode="h" horiz-adv-x="874" d="M 317,897 C 356,968 402,1020 457,1053 511,1086 580,1102 663,1102 780,1102 867,1073 923,1015 978,956 1006,858 1006,721 L 1006,0 825,0 825,686 C 825,762 818,819 804,856 790,893 767,920 735,937 703,954 659,963 602,963 517,963 450,934 399,875 348,816 322,737 322,638 L 322,0 142,0 142,1484 322,1484 322,1098 C 322,1057 321,1015 319,972 316,929 315,904 314,897 L 317,897 Z"/>
+   <glyph unicode="g" horiz-adv-x="927" d="M 548,-425 C 430,-425 336,-402 266,-356 196,-309 151,-243 131,-158 L 312,-132 C 324,-182 351,-220 392,-248 433,-274 486,-288 553,-288 732,-288 822,-183 822,27 L 822,201 820,201 C 786,132 739,80 680,45 621,10 551,-8 472,-8 339,-8 242,36 180,124 117,212 86,350 86,539 86,730 120,872 187,963 254,1054 355,1099 492,1099 569,1099 635,1082 692,1047 748,1012 791,962 822,897 L 824,897 C 824,917 825,952 828,1001 831,1050 833,1077 836,1082 L 1007,1082 C 1003,1046 1001,971 1001,858 L 1001,31 C 1001,-273 850,-425 548,-425 Z M 822,541 C 822,629 810,705 786,769 762,832 728,881 685,915 641,948 591,965 536,965 444,965 377,932 335,865 293,798 272,690 272,541 272,393 292,287 331,222 370,157 438,125 533,125 590,125 640,142 684,175 728,208 762,256 786,319 810,381 822,455 822,541 Z"/>
+   <glyph unicode="e" horiz-adv-x="980" d="M 276,503 C 276,379 302,283 353,216 404,149 479,115 578,115 656,115 719,131 766,162 813,193 844,233 861,281 L 1019,236 C 954,65 807,-20 578,-20 418,-20 296,28 213,123 129,218 87,360 87,548 87,727 129,864 213,959 296,1054 416,1102 571,1102 889,1102 1048,910 1048,527 L 1048,503 276,503 Z M 862,641 C 852,755 823,838 775,891 727,943 658,969 568,969 481,969 412,940 361,882 310,823 282,743 278,641 L 862,641 Z"/>
+   <glyph unicode="d" horiz-adv-x="927" d="M 821,174 C 788,105 744,55 689,25 634,-5 565,-20 484,-20 347,-20 247,26 183,118 118,210 86,349 86,536 86,913 219,1102 484,1102 566,1102 634,1087 689,1057 744,1027 788,979 821,914 L 823,914 821,1035 821,1484 1001,1484 1001,223 C 1001,110 1003,36 1007,0 L 835,0 C 833,11 831,35 829,74 826,113 825,146 825,174 L 821,174 Z M 275,542 C 275,391 295,282 335,217 375,152 440,119 530,119 632,119 706,154 752,225 798,296 821,405 821,554 821,697 798,802 752,869 706,936 633,969 532,969 441,969 376,936 336,869 295,802 275,693 275,542 Z"/>
+   <glyph unicode="c" horiz-adv-x="901" d="M 275,546 C 275,402 298,295 343,226 388,157 457,122 548,122 612,122 666,139 709,174 752,209 778,262 788,334 L 970,322 C 956,218 912,135 837,73 762,11 668,-20 553,-20 402,-20 286,28 207,124 127,219 87,359 87,542 87,724 127,863 207,959 287,1054 402,1102 551,1102 662,1102 754,1073 827,1016 900,959 945,880 964,779 L 779,765 C 770,825 746,873 708,908 670,943 616,961 546,961 451,961 382,929 339,866 296,803 275,696 275,546 Z"/>
+   <glyph unicode="b" horiz-adv-x="953" d="M 1053,546 C 1053,169 920,-20 655,-20 573,-20 505,-5 451,25 396,54 352,102 318,168 L 316,168 C 316,147 315,116 312,74 309,31 307,7 306,0 L 132,0 C 136,36 138,110 138,223 L 138,1484 318,1484 318,1061 C 318,1018 317,967 314,908 L 318,908 C 351,977 396,1027 451,1057 506,1087 574,1102 655,1102 792,1102 892,1056 957,964 1021,872 1053,733 1053,546 Z M 864,540 C 864,691 844,800 804,865 764,930 699,963 609,963 508,963 434,928 388,859 341,790 318,680 318,529 318,387 341,282 386,215 431,147 505,113 607,113 698,113 763,147 804,214 844,281 864,389 864,540 Z"/>
+   <glyph unicode="a" horiz-adv-x="1060" d="M 414,-20 C 305,-20 224,9 169,66 114,123 87,202 87,302 87,414 124,500 198,560 271,620 390,652 554,656 L 797,660 797,719 C 797,807 778,870 741,908 704,946 645,965 565,965 484,965 426,951 389,924 352,897 330,853 323,793 L 135,810 C 166,1005 310,1102 569,1102 705,1102 807,1071 876,1009 945,946 979,856 979,738 L 979,272 C 979,219 986,179 1000,152 1014,125 1041,111 1080,111 1097,111 1117,113 1139,118 L 1139,6 C 1094,-5 1047,-10 1000,-10 933,-10 885,8 855,43 824,78 807,132 803,207 L 797,207 C 751,124 698,66 637,32 576,-3 501,-20 414,-20 Z M 455,115 C 521,115 580,130 631,160 682,190 723,231 753,284 782,336 797,390 797,445 L 797,534 600,530 C 515,529 451,520 408,504 364,488 330,463 307,430 284,397 272,353 272,299 272,240 288,195 320,163 351,131 396,115 455,115 Z"/>
+   <glyph unicode="Z" horiz-adv-x="1139" d="M 1187,0 L 65,0 65,143 923,1253 138,1253 138,1409 1140,1409 1140,1270 282,156 1187,156 1187,0 Z"/>
+   <glyph unicode="Y" horiz-adv-x="1298" d="M 777,584 L 777,0 587,0 587,584 45,1409 255,1409 684,738 1111,1409 1321,1409 777,584 Z"/>
+   <glyph unicode="S" horiz-adv-x="1192" d="M 1272,389 C 1272,259 1221,158 1120,87 1018,16 875,-20 690,-20 347,-20 148,99 93,338 L 278,375 C 299,290 345,228 414,189 483,149 578,129 697,129 820,129 916,150 983,193 1050,235 1083,297 1083,379 1083,425 1073,462 1052,491 1031,520 1001,543 963,562 925,581 880,596 827,609 774,622 716,635 652,650 541,675 456,699 399,724 341,749 295,776 262,807 229,837 203,872 186,913 168,954 159,1000 159,1053 159,1174 205,1267 298,1332 390,1397 522,1430 694,1430 854,1430 976,1406 1061,1357 1146,1308 1205,1224 1239,1106 L 1051,1073 C 1030,1148 991,1202 933,1236 875,1269 795,1286 692,1286 579,1286 493,1267 434,1230 375,1193 345,1137 345,1063 345,1020 357,984 380,956 403,927 436,903 479,884 522,864 609,840 738,811 781,801 825,791 868,781 911,770 952,758 991,744 1030,729 1067,712 1102,693 1136,674 1166,650 1191,622 1216,594 1236,561 1251,523 1265,485 1272,440 1272,389 Z"/>
+   <glyph unicode="R" horiz-adv-x="1244" d="M 1164,0 L 798,585 359,585 359,0 168,0 168,1409 831,1409 C 990,1409 1112,1374 1199,1303 1285,1232 1328,1133 1328,1006 1328,901 1298,813 1237,742 1176,671 1091,626 984,607 L 1384,0 1164,0 Z M 1136,1004 C 1136,1086 1108,1149 1053,1192 997,1235 917,1256 812,1256 L 359,1256 359,736 820,736 C 921,736 999,760 1054,807 1109,854 1136,919 1136,1004 Z"/>
+   <glyph unicode="N" horiz-adv-x="1165" d="M 1082,0 L 328,1200 333,1103 338,936 338,0 168,0 168,1409 390,1409 1152,201 C 1144,332 1140,426 1140,485 L 1140,1409 1312,1409 1312,0 1082,0 Z"/>
+   <glyph unicode="M" horiz-adv-x="1377" d="M 1366,0 L 1366,940 C 1366,1044 1369,1144 1375,1240 1342,1121 1313,1027 1287,960 L 923,0 789,0 420,960 364,1130 331,1240 334,1129 338,940 338,0 168,0 168,1409 419,1409 794,432 C 807,393 820,351 833,306 845,261 853,228 857,208 862,235 874,275 891,330 908,384 919,418 925,432 L 1293,1409 1538,1409 1538,0 1366,0 Z"/>
+   <glyph unicode="L" horiz-adv-x="927" d="M 168,0 L 168,1409 359,1409 359,156 1071,156 1071,0 168,0 Z"/>
+   <glyph unicode="H" horiz-adv-x="1165" d="M 1121,0 L 1121,653 359,653 359,0 168,0 168,1409 359,1409 359,813 1121,813 1121,1409 1312,1409 1312,0 1121,0 Z"/>
+   <glyph unicode="E" horiz-adv-x="1138" d="M 168,0 L 168,1409 1237,1409 1237,1253 359,1253 359,801 1177,801 1177,647 359,647 359,156 1278,156 1278,0 168,0 Z"/>
+   <glyph unicode="D" horiz-adv-x="1218" d="M 1381,719 C 1381,574 1353,447 1296,338 1239,229 1159,145 1055,87 951,29 831,0 695,0 L 168,0 168,1409 634,1409 C 873,1409 1057,1349 1187,1230 1316,1110 1381,940 1381,719 Z M 1189,719 C 1189,894 1141,1027 1046,1119 950,1210 811,1256 630,1256 L 359,1256 359,153 673,153 C 776,153 867,176 946,221 1024,266 1084,332 1126,417 1168,502 1189,603 1189,719 Z"/>
+   <glyph unicode="C" horiz-adv-x="1324" d="M 792,1274 C 636,1274 515,1224 428,1124 341,1023 298,886 298,711 298,538 343,400 434,295 524,190 646,137 800,137 997,137 1146,235 1245,430 L 1401,352 C 1343,231 1262,138 1157,75 1052,12 930,-20 791,-20 649,-20 526,10 423,69 319,128 240,212 186,322 131,431 104,561 104,711 104,936 165,1112 286,1239 407,1366 575,1430 790,1430 940,1430 1065,1401 1166,1342 1267,1283 1341,1196 1388,1081 L 1207,1021 C 1174,1103 1122,1166 1050,1209 977,1252 891,1274 792,1274 Z"/>
+   <glyph unicode="?" horiz-adv-x="980" d="M 1063,1032 C 1063,982 1056,937 1041,898 1026,859 1005,822 978,789 951,756 906,716 844,671 L 764,612 C 716,577 680,541 657,503 634,464 622,422 621,377 L 446,377 C 447,423 455,463 468,498 481,533 497,563 518,590 539,617 562,641 588,662 614,683 640,703 667,722 694,741 720,760 746,779 771,798 794,819 814,842 834,865 850,892 863,921 875,950 881,985 881,1024 881,1100 855,1160 804,1204 752,1248 679,1270 586,1270 493,1270 419,1247 364,1200 309,1153 277,1089 268,1008 L 84,1020 C 101,1152 153,1253 240,1324 327,1395 441,1430 584,1430 733,1430 850,1395 935,1325 1020,1254 1063,1157 1063,1032 Z M 438,0 L 438,201 633,201 633,0 438,0 Z"/>
+   <glyph unicode=" " horiz-adv-x="556"/>
+  </font>
+ </defs>
+ <defs class="TextShapeIndex">
+  <g ooo:slide="id1" ooo:id-list="id3 id4 id5 id6 id7 id8 id9 id10 id11 id12 id13 id14 id15 id16 id17 id18 id19 id20 id21 id22 id23 id24 id25 id26 id27 id28 id29 id30 id31 id32 id33 id34 id35 id36 id37 id38 id39 id40 id41 id42"/>
+ </defs>
+ <defs class="EmbeddedBulletChars">
+  <g id="bullet-char-template-57356" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 580,1141 L 1163,571 580,0 -4,571 580,1141 Z"/>
+  </g>
+  <g id="bullet-char-template-57354" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 8,1128 L 1137,1128 1137,0 8,0 8,1128 Z"/>
+  </g>
+  <g id="bullet-char-template-10146" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 174,0 L 602,739 174,1481 1456,739 174,0 Z M 1358,739 L 309,1346 659,739 1358,739 Z"/>
+  </g>
+  <g id="bullet-char-template-10132" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 2015,739 L 1276,0 717,0 1260,543 174,543 174,936 1260,936 717,1481 1274,1481 2015,739 Z"/>
+  </g>
+  <g id="bullet-char-template-10007" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 0,-2 C -7,14 -16,27 -25,37 L 356,567 C 262,823 215,952 215,954 215,979 228,992 255,992 264,992 276,990 289,987 310,991 331,999 354,1012 L 381,999 492,748 772,1049 836,1024 860,1049 C 881,1039 901,1025 922,1006 886,937 835,863 770,784 769,783 710,716 594,584 L 774,223 C 774,196 753,168 711,139 L 727,119 C 717,90 699,76 672,76 641,76 570,178 457,381 L 164,-76 C 142,-110 111,-127 72,-127 30,-127 9,-110 8,-76 1,-67 -2,-52 -2,-32 -2,-23 -1,-13 0,-2 Z"/>
+  </g>
+  <g id="bullet-char-template-10004" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 285,-33 C 182,-33 111,30 74,156 52,228 41,333 41,471 41,549 55,616 82,672 116,743 169,778 240,778 293,778 328,747 346,684 L 369,508 C 377,444 397,411 428,410 L 1163,1116 C 1174,1127 1196,1133 1229,1133 1271,1133 1292,1118 1292,1087 L 1292,965 C 1292,929 1282,901 1262,881 L 442,47 C 390,-6 338,-33 285,-33 Z"/>
+  </g>
+  <g id="bullet-char-template-9679" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 813,0 C 632,0 489,54 383,161 276,268 223,411 223,592 223,773 276,916 383,1023 489,1130 632,1184 813,1184 992,1184 1136,1130 1245,1023 1353,916 1407,772 1407,592 1407,412 1353,268 1245,161 1136,54 992,0 813,0 Z"/>
+  </g>
+  <g id="bullet-char-template-8226" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 346,457 C 273,457 209,483 155,535 101,586 74,649 74,723 74,796 101,859 155,911 209,963 273,989 346,989 419,989 480,963 531,910 582,859 608,796 608,723 608,648 583,586 532,535 482,483 420,457 346,457 Z"/>
+  </g>
+  <g id="bullet-char-template-8211" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M -4,459 L 1135,459 1135,606 -4,606 -4,459 Z"/>
+  </g>
+  <g id="bullet-char-template-61548" transform="scale(0.00048828125,-0.00048828125)">
+   <path d="M 173,740 C 173,903 231,1043 346,1159 462,1274 601,1332 765,1332 928,1332 1067,1274 1183,1159 1299,1043 1357,903 1357,740 1357,577 1299,437 1183,322 1067,206 928,148 765,148 601,148 462,206 346,322 231,437 173,577 173,740 Z"/>
+  </g>
+ </defs>
+ <g>
+  <g id="id2" class="Master_Slide">
+   <g id="bg-id2" class="Background"/>
+   <g id="bo-id2" class="BackgroundObjects"/>
+  </g>
+ </g>
+ <g class="SlideGroup">
+  <g>
+   <g id="container-id1">
+    <g id="id1" class="Slide" clip-path="url(#presentation_clip_path)">
+     <g class="Page">
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id3">
+        <rect class="BoundingBox" stroke="none" fill="none" x="8999" y="1099" width="3604" height="3604"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 12601,2901 C 12601,3217 12518,3527 12360,3801 12202,4074 11974,4302 11701,4460 11427,4618 11117,4701 10801,4701 10484,4701 10174,4618 9900,4460 9627,4302 9399,4074 9241,3801 9083,3527 9000,3217 9000,2901 9000,2584 9083,2274 9241,2000 9399,1727 9627,1499 9900,1341 10174,1183 10484,1100 10800,1100 11117,1100 11427,1183 11701,1341 11974,1499 12202,1727 12360,2000 12518,2274 12601,2584 12601,2900 L 12601,2901 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 12601,2901 C 12601,3217 12518,3527 12360,3801 12202,4074 11974,4302 11701,4460 11427,4618 11117,4701 10801,4701 10484,4701 10174,4618 9900,4460 9627,4302 9399,4074 9241,3801 9083,3527 9000,3217 9000,2901 9000,2584 9083,2274 9241,2000 9399,1727 9627,1499 9900,1341 10174,1183 10484,1100 10800,1100 11117,1100 11427,1183 11701,1341 11974,1499 12202,1727 12360,2000 12518,2274 12601,2584 12601,2900 L 12601,2901 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="10129" y="3121"><tspan fill="rgb(0,0,0)" stroke="none">Start</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id4">
+        <rect class="BoundingBox" stroke="none" fill="none" x="6799" y="5399" width="7804" height="2404"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 10700,5400 L 14601,6600 10700,7801 6800,6600 10700,5400 10700,5400 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10700,5400 L 14601,6600 10700,7801 6800,6600 10700,5400 10700,5400 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="8009" y="6821"><tspan fill="rgb(0,0,0)" stroke="none">Combing Enabled?</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id5">
+        <rect class="BoundingBox" stroke="none" fill="none" x="1199" y="37199" width="4403" height="2116"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 3400,39300 L 1200,39300 1200,37200 5600,37200 5600,39300 3400,39300 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 3400,39300 L 1200,39300 1200,37200 5600,37200 5600,39300 3400,39300 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="2378" y="37760"><tspan fill="rgb(0,0,0)" stroke="none">Retract</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="2820" y="38471"><tspan fill="rgb(0,0,0)" stroke="none">Hop</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="1641" y="39182"><tspan fill="rgb(0,0,0)" stroke="none">No Combing</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.TextShape">
+       <g id="id6">
+        <rect class="BoundingBox" stroke="none" fill="none" x="4600" y="5600" width="1701" height="1001"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="4850" y="6301"><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.LineShape">
+       <g id="id7">
+        <rect class="BoundingBox" stroke="none" fill="none" x="2499" y="6599" width="4403" height="3"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 6900,6600 L 2500,6600"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.LineShape">
+       <g id="id8">
+        <rect class="BoundingBox" stroke="none" fill="none" x="2350" y="6599" width="301" height="30602"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 2500,6600 L 2500,36770"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 2500,37200 L 2650,36750 2350,36750 2500,37200 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id9">
+        <rect class="BoundingBox" stroke="none" fill="none" x="7699" y="9899" width="6104" height="2204"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 13801,11001 C 13801,11194 13660,11383 13392,11551 13125,11718 12739,11857 12276,11954 11812,12050 11286,12101 10751,12101 10215,12101 9689,12050 9225,11954 8762,11857 8376,11718 8109,11551 7841,11383 7700,11194 7700,11001 7700,10807 7841,10618 8109,10450 8376,10283 8762,10144 9225,10047 9689,9951 10215,9900 10750,9900 11286,9900 11812,9951 12276,10047 12739,10144 13125,10283 13392,10450 13660,10618 13801,10807 13801,11000 L 13801,11001 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 13801,11001 C 13801,11194 13660,11383 13392,11551 13125,11718 12739,11857 12276,11954 11812,12050 11286,12101 10751,12101 10215,12101 9689,12050 9225,11954 8762,11857 8376,11718 8109,11551 7841,11383 7700,11194 7700,11001 7700,10807 7841,10618 8109,10450 8376,10283 8762,10144 9225,10047 9689,9951 10215,9900 10750,9900 11286,9900 11812,9951 12276,10047 12739,10144 13125,10283 13392,10450 13660,10618 13801,10807 13801,11000 L 13801,11001 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9465" y="10865"><tspan fill="rgb(0,0,0)" stroke="none">Compute</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9484" y="11576"><tspan fill="rgb(0,0,0)" stroke="none">Combing</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id10">
+        <rect class="BoundingBox" stroke="none" fill="none" x="9497" y="7799" width="2436" height="2102"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10700,7800 L 10700,8851 10750,8851 10750,9470"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 10750,9900 L 10900,9450 10600,9450 10750,9900 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9497" y="9071"><tspan fill="rgb(0,0,0)" stroke="none">        </tspan><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id11">
+        <rect class="BoundingBox" stroke="none" fill="none" x="7399" y="14099" width="6704" height="3004"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 10750,14100 L 14101,15600 10750,17101 7400,15600 10750,14100 10750,14100 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,14100 L 14101,15600 10750,17101 7400,15600 10750,14100 10750,14100 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9006" y="15465"><tspan fill="rgb(0,0,0)" stroke="none">Shorter than</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="8902" y="16176"><tspan fill="rgb(0,0,0)" stroke="none">Nozzle Size?</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id12">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10749" y="14099" width="3" height="3"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,14100 L 10750,14100 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id13">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10600" y="12099" width="301" height="2002"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,12100 L 10750,13670"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 10750,14100 L 10900,13650 10600,13650 10750,14100 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id14">
+        <rect class="BoundingBox" stroke="none" fill="none" x="15799" y="37199" width="3903" height="2116"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 17750,39300 L 15800,39300 15800,37200 19700,37200 19700,39300 17750,39300 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 17750,39300 L 15800,39300 15800,37200 19700,37200 19700,39300 17750,39300 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="16235" y="37760"><tspan fill="rgb(0,0,0)" stroke="none">No Retract</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="16677" y="38471"><tspan fill="rgb(0,0,0)" stroke="none">No Hop</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="15991" y="39182"><tspan fill="rgb(0,0,0)" stroke="none">No Combing</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.TextShape">
+       <g id="id15">
+        <rect class="BoundingBox" stroke="none" fill="none" x="14700" y="14600" width="1701" height="1001"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="14950" y="15301"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id16">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10679" y="4699" width="290" height="702"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10800,4700 L 10800,5051 10781,5051"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 10700,5400 L 10968,5009 10679,4926 10700,5400 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id17">
+        <rect class="BoundingBox" stroke="none" fill="none" x="7499" y="17999" width="6503" height="3104"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 10750,18000 L 14000,19550 10750,21101 7500,19550 10750,18000 10750,18000 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,18000 L 14000,19550 10750,21101 7500,19550 10750,18000 10750,18000 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="8620" y="19771"><tspan fill="rgb(0,0,0)" stroke="none">Crosses walls?</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id18">
+        <rect class="BoundingBox" stroke="none" fill="none" x="9722" y="17099" width="2033" height="902"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,17100 L 10750,17570"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 10750,18000 L 10900,17550 10600,17550 10750,18000 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9723" y="17771"><tspan fill="rgb(0,0,0)" stroke="none">       </tspan><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id19">
+        <rect class="BoundingBox" stroke="none" fill="none" x="2899" y="20699" width="6004" height="3004"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 5900,20700 L 8901,22200 5900,23701 2900,22200 5900,20700 5900,20700 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 5900,20700 L 8901,22200 5900,23701 2900,22200 5900,20700 5900,20700 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="3648" y="22421"><tspan fill="rgb(0,0,0)" stroke="none">Z Hop enabled?</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id20">
+        <rect class="BoundingBox" stroke="none" fill="none" x="5750" y="19549" width="1752" height="1152"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 7500,19550 L 5900,19550 5900,20270"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 5900,20700 L 6050,20250 5750,20250 5900,20700 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="6184" y="20346"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id21">
+        <rect class="BoundingBox" stroke="none" fill="none" x="2899" y="22199" width="652" height="15002"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 2900,22200 L 2900,24600 3400,24600 3400,36770"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 3400,37200 L 3550,36750 3250,36750 3400,37200 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.TextShape">
+       <g id="id22">
+        <rect class="BoundingBox" stroke="none" fill="none" x="2900" y="23100" width="1701" height="1001"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="3150" y="23801"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id23">
+        <rect class="BoundingBox" stroke="none" fill="none" x="6099" y="37199" width="4203" height="2116"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 8200,39300 L 6100,39300 6100,37200 10300,37200 10300,39300 8200,39300 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 8200,39300 L 6100,39300 6100,37200 10300,37200 10300,39300 8200,39300 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="7178" y="37760"><tspan fill="rgb(0,0,0)" stroke="none">Retract</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="7127" y="38471"><tspan fill="rgb(0,0,0)" stroke="none">No Hop</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="6934" y="39182"><tspan fill="rgb(0,0,0)" stroke="none">Combing</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id24">
+        <rect class="BoundingBox" stroke="none" fill="none" x="5899" y="23699" width="2452" height="13502"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 5900,23700 L 5900,25100 8200,25100 8200,36770"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 8200,37200 L 8350,36750 8050,36750 8200,37200 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.TextShape">
+       <g id="id25">
+        <rect class="BoundingBox" stroke="none" fill="none" x="6100" y="24000" width="1401" height="1001"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="6350" y="24701"><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id26">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10799" y="20999" width="6503" height="3603"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 14050,21000 L 17300,22800 14050,24600 10800,22800 14050,21000 14050,21000 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14050,21000 L 17300,22800 14050,24600 10800,22800 14050,21000 14050,21000 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="12361" y="22665"><tspan fill="rgb(0,0,0)" stroke="none">Longer than</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="11954" y="23376"><tspan fill="rgb(0,0,0)" stroke="none">Max Distance?</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id27">
+        <rect class="BoundingBox" stroke="none" fill="none" x="13900" y="19549" width="301" height="1452"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14000,19550 L 14050,19550 14050,20570"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 14050,21000 L 14200,20550 13900,20550 14050,21000 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.LineShape">
+       <g id="id28">
+        <rect class="BoundingBox" stroke="none" fill="none" x="14099" y="15599" width="4703" height="3"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14100,15600 L 18800,15600"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.LineShape">
+       <g id="id29">
+        <rect class="BoundingBox" stroke="none" fill="none" x="18650" y="15599" width="301" height="21602"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 18800,15600 L 18800,36770"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 18800,37200 L 18950,36750 18650,36750 18800,37200 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id30">
+        <rect class="BoundingBox" stroke="none" fill="none" x="8050" y="22799" width="2752" height="14402"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10800,22800 L 8200,22800 8200,36770"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 8200,37200 L 8350,36750 8050,36750 8200,37200 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.TextShape">
+       <g id="id31">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10300" y="23100" width="1701" height="1001"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="10550" y="23801"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id32">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10599" y="26699" width="6804" height="2404"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 14000,26700 L 17401,27900 14000,29101 10600,27900 14000,26700 14000,26700 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14000,26700 L 17401,27900 14000,29101 10600,27900 14000,26700 14000,26700 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="12116" y="28121"><tspan fill="rgb(0,0,0)" stroke="none">Has detours?</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id33">
+        <rect class="BoundingBox" stroke="none" fill="none" x="12997" y="24599" width="2033" height="2102"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14050,24600 L 14050,25650 14000,25650 14000,26270"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 14000,26700 L 14150,26250 13850,26250 14000,26700 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="12998" y="25871"><tspan fill="rgb(0,0,0)" stroke="none">       </tspan><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id34">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10899" y="37199" width="4203" height="2116"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 13000,39300 L 10900,39300 10900,37200 15100,37200 15100,39300 13000,39300 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 13000,39300 L 10900,39300 10900,37200 15100,37200 15100,39300 13000,39300 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="11485" y="37760"><tspan fill="rgb(0,0,0)" stroke="none">No Retract</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="11927" y="38471"><tspan fill="rgb(0,0,0)" stroke="none">No Hop</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="11734" y="39182"><tspan fill="rgb(0,0,0)" stroke="none">Combing</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id35">
+        <rect class="BoundingBox" stroke="none" fill="none" x="17399" y="27899" width="502" height="9302"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 17400,27900 L 17600,27900 17600,33151 17750,33151 17750,36770"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 17750,37200 L 17900,36750 17600,36750 17750,37200 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.CustomShape">
+       <g id="id36">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10599" y="30599" width="6804" height="2804"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 14000,30600 L 17401,32000 14000,33401 10600,32000 14000,30600 14000,30600 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14000,30600 L 17401,32000 14000,33401 10600,32000 14000,30600 14000,30600 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="12186" y="31865"><tspan fill="rgb(0,0,0)" stroke="none">Limit support</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="12222" y="32576"><tspan fill="rgb(0,0,0)" stroke="none">Retractions?</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.TextShape">
+       <g id="id37">
+        <rect class="BoundingBox" stroke="none" fill="none" x="16100" y="28400" width="1801" height="1101"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="16350" y="29101"><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id38">
+        <rect class="BoundingBox" stroke="none" fill="none" x="12772" y="29099" width="2436" height="1502"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14000,29100 L 14000,30170"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 14000,30600 L 14150,30150 13850,30150 14000,30600 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="12772" y="30071"><tspan fill="rgb(0,0,0)" stroke="none">        </tspan><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id39">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10098" y="31999" width="3053" height="5202"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10600,32000 L 10099,32000 10099,34600 13000,34600 13000,36770"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 13000,37200 L 13150,36750 12850,36750 13000,37200 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.TextShape">
+       <g id="id40">
+        <rect class="BoundingBox" stroke="none" fill="none" x="10100" y="32500" width="2101" height="1101"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="10350" y="33201"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.ConnectorShape">
+       <g id="id41">
+        <rect class="BoundingBox" stroke="none" fill="none" x="13999" y="33399" width="3902" height="3802"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14000,33400 L 14000,35301 17750,35301 17750,36770"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 17750,37200 L 17900,36750 17600,36750 17750,37200 Z"/>
+       </g>
+      </g>
+      <g class="com.sun.star.drawing.TextShape">
+       <g id="id42">
+        <rect class="BoundingBox" stroke="none" fill="none" x="14000" y="33400" width="1901" height="1201"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="14250" y="34101"><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+       </g>
+      </g>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/docs/assets/retraction_combing_hop.svg
+++ b/docs/assets/retraction_combing_hop.svg
@@ -104,10 +104,10 @@
       </g>
       <g class="com.sun.star.drawing.CustomShape">
        <g id="id4">
-        <rect class="BoundingBox" stroke="none" fill="none" x="6799" y="5399" width="7804" height="2404"/>
-        <path fill="rgb(114,159,207)" stroke="none" d="M 10700,5400 L 14601,6600 10700,7801 6800,6600 10700,5400 10700,5400 Z"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 10700,5400 L 14601,6600 10700,7801 6800,6600 10700,5400 10700,5400 Z"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="8009" y="6821"><tspan fill="rgb(0,0,0)" stroke="none">Combing Enabled?</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="6799" y="9699" width="7804" height="2404"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 10700,9700 L 14601,10900 10700,12101 6800,10900 10700,9700 10700,9700 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10700,9700 L 14601,10900 10700,12101 6800,10900 10700,9700 10700,9700 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="8009" y="11121"><tspan fill="rgb(0,0,0)" stroke="none">Combing Enabled?</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.CustomShape">
@@ -120,58 +120,58 @@
       </g>
       <g class="com.sun.star.drawing.TextShape">
        <g id="id6">
-        <rect class="BoundingBox" stroke="none" fill="none" x="4600" y="5600" width="1701" height="1001"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="4850" y="6301"><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="4000" y="9800" width="1701" height="1001"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="4250" y="10501"><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.LineShape">
        <g id="id7">
-        <rect class="BoundingBox" stroke="none" fill="none" x="2499" y="6599" width="4403" height="3"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 6900,6600 L 2500,6600"/>
+        <rect class="BoundingBox" stroke="none" fill="none" x="2499" y="10899" width="4403" height="3"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 6900,10900 L 2500,10900"/>
        </g>
       </g>
       <g class="com.sun.star.drawing.LineShape">
        <g id="id8">
-        <rect class="BoundingBox" stroke="none" fill="none" x="2350" y="6599" width="301" height="30602"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 2500,6600 L 2500,36770"/>
+        <rect class="BoundingBox" stroke="none" fill="none" x="2350" y="10899" width="301" height="26302"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 2500,10900 L 2500,36770"/>
         <path fill="rgb(52,101,164)" stroke="none" d="M 2500,37200 L 2650,36750 2350,36750 2500,37200 Z"/>
        </g>
       </g>
       <g class="com.sun.star.drawing.CustomShape">
        <g id="id9">
-        <rect class="BoundingBox" stroke="none" fill="none" x="7699" y="9899" width="6104" height="2204"/>
-        <path fill="rgb(114,159,207)" stroke="none" d="M 13801,11001 C 13801,11194 13660,11383 13392,11551 13125,11718 12739,11857 12276,11954 11812,12050 11286,12101 10751,12101 10215,12101 9689,12050 9225,11954 8762,11857 8376,11718 8109,11551 7841,11383 7700,11194 7700,11001 7700,10807 7841,10618 8109,10450 8376,10283 8762,10144 9225,10047 9689,9951 10215,9900 10750,9900 11286,9900 11812,9951 12276,10047 12739,10144 13125,10283 13392,10450 13660,10618 13801,10807 13801,11000 L 13801,11001 Z"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 13801,11001 C 13801,11194 13660,11383 13392,11551 13125,11718 12739,11857 12276,11954 11812,12050 11286,12101 10751,12101 10215,12101 9689,12050 9225,11954 8762,11857 8376,11718 8109,11551 7841,11383 7700,11194 7700,11001 7700,10807 7841,10618 8109,10450 8376,10283 8762,10144 9225,10047 9689,9951 10215,9900 10750,9900 11286,9900 11812,9951 12276,10047 12739,10144 13125,10283 13392,10450 13660,10618 13801,10807 13801,11000 L 13801,11001 Z"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9465" y="10865"><tspan fill="rgb(0,0,0)" stroke="none">Compute</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9484" y="11576"><tspan fill="rgb(0,0,0)" stroke="none">Combing</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="7599" y="14299" width="6104" height="2204"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 13701,15401 C 13701,15594 13560,15783 13292,15951 13025,16118 12639,16257 12176,16354 11712,16450 11186,16501 10650,16501 10115,16501 9589,16450 9125,16354 8662,16257 8276,16118 8009,15951 7741,15783 7600,15594 7600,15401 7600,15207 7741,15018 8009,14850 8276,14683 8662,14544 9125,14447 9589,14351 10115,14300 10650,14300 11186,14300 11712,14351 12176,14447 12639,14544 13025,14683 13292,14850 13560,15018 13701,15207 13701,15400 L 13701,15401 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 13701,15401 C 13701,15594 13560,15783 13292,15951 13025,16118 12639,16257 12176,16354 11712,16450 11186,16501 10650,16501 10115,16501 9589,16450 9125,16354 8662,16257 8276,16118 8009,15951 7741,15783 7600,15594 7600,15401 7600,15207 7741,15018 8009,14850 8276,14683 8662,14544 9125,14447 9589,14351 10115,14300 10650,14300 11186,14300 11712,14351 12176,14447 12639,14544 13025,14683 13292,14850 13560,15018 13701,15207 13701,15400 L 13701,15401 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9365" y="15265"><tspan fill="rgb(0,0,0)" stroke="none">Compute</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9384" y="15976"><tspan fill="rgb(0,0,0)" stroke="none">Combing</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id10">
-        <rect class="BoundingBox" stroke="none" fill="none" x="9497" y="7799" width="2436" height="2102"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 10700,7800 L 10700,8851 10750,8851 10750,9470"/>
-        <path fill="rgb(52,101,164)" stroke="none" d="M 10750,9900 L 10900,9450 10600,9450 10750,9900 Z"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9497" y="9071"><tspan fill="rgb(0,0,0)" stroke="none">        </tspan><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="9447" y="12099" width="2436" height="2202"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10700,12100 L 10700,13201 10650,13201 10650,13870"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 10650,14300 L 10800,13850 10500,13850 10650,14300 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9447" y="13421"><tspan fill="rgb(0,0,0)" stroke="none">        </tspan><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.CustomShape">
        <g id="id11">
-        <rect class="BoundingBox" stroke="none" fill="none" x="7399" y="14099" width="6704" height="3004"/>
-        <path fill="rgb(114,159,207)" stroke="none" d="M 10750,14100 L 14101,15600 10750,17101 7400,15600 10750,14100 10750,14100 Z"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,14100 L 14101,15600 10750,17101 7400,15600 10750,14100 10750,14100 Z"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9006" y="15465"><tspan fill="rgb(0,0,0)" stroke="none">Shorter than</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="8902" y="16176"><tspan fill="rgb(0,0,0)" stroke="none">Nozzle Size?</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="7399" y="5799" width="6704" height="3004"/>
+        <path fill="rgb(114,159,207)" stroke="none" d="M 10750,5800 L 14101,7300 10750,8801 7400,7300 10750,5800 10750,5800 Z"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,5800 L 14101,7300 10750,8801 7400,7300 10750,5800 10750,5800 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9006" y="7165"><tspan fill="rgb(0,0,0)" stroke="none">Shorter than</tspan></tspan></tspan><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="8902" y="7876"><tspan fill="rgb(0,0,0)" stroke="none">Nozzle Size?</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id12">
-        <rect class="BoundingBox" stroke="none" fill="none" x="10749" y="14099" width="3" height="3"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,14100 L 10750,14100 Z"/>
+        <rect class="BoundingBox" stroke="none" fill="none" x="10749" y="5799" width="3" height="3"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,5800 L 10750,5800 Z"/>
        </g>
       </g>
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id13">
-        <rect class="BoundingBox" stroke="none" fill="none" x="10600" y="12099" width="301" height="2002"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,12100 L 10750,13670"/>
-        <path fill="rgb(52,101,164)" stroke="none" d="M 10750,14100 L 10900,13650 10600,13650 10750,14100 Z"/>
+        <rect class="BoundingBox" stroke="none" fill="none" x="10600" y="16499" width="301" height="1502"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10650,16500 L 10650,17251 10750,17251 10750,17570"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 10750,18000 L 10900,17550 10600,17550 10750,18000 Z"/>
        </g>
       </g>
       <g class="com.sun.star.drawing.CustomShape">
@@ -184,15 +184,15 @@
       </g>
       <g class="com.sun.star.drawing.TextShape">
        <g id="id15">
-        <rect class="BoundingBox" stroke="none" fill="none" x="14700" y="14600" width="1701" height="1001"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="14950" y="15301"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="16300" y="6000" width="1701" height="1001"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="16550" y="6701"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id16">
-        <rect class="BoundingBox" stroke="none" fill="none" x="10679" y="4699" width="290" height="702"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 10800,4700 L 10800,5051 10781,5051"/>
-        <path fill="rgb(52,101,164)" stroke="none" d="M 10700,5400 L 10968,5009 10679,4926 10700,5400 Z"/>
+        <rect class="BoundingBox" stroke="none" fill="none" x="10600" y="4699" width="301" height="1102"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10800,4700 L 10800,5251 10750,5251 10750,5370"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 10750,5800 L 10900,5350 10600,5350 10750,5800 Z"/>
        </g>
       </g>
       <g class="com.sun.star.drawing.CustomShape">
@@ -205,10 +205,10 @@
       </g>
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id18">
-        <rect class="BoundingBox" stroke="none" fill="none" x="9722" y="17099" width="2033" height="902"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,17100 L 10750,17570"/>
-        <path fill="rgb(52,101,164)" stroke="none" d="M 10750,18000 L 10900,17550 10600,17550 10750,18000 Z"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9723" y="17771"><tspan fill="rgb(0,0,0)" stroke="none">       </tspan><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="9697" y="8799" width="2033" height="902"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10750,8800 L 10750,9251 10700,9251 10700,9270"/>
+        <path fill="rgb(52,101,164)" stroke="none" d="M 10700,9700 L 10851,9250 10551,9250 10700,9700 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9698" y="9471"><tspan fill="rgb(0,0,0)" stroke="none">       </tspan><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.CustomShape">
@@ -271,21 +271,22 @@
       </g>
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id27">
-        <rect class="BoundingBox" stroke="none" fill="none" x="13900" y="19549" width="301" height="1452"/>
+        <rect class="BoundingBox" stroke="none" fill="none" x="12909" y="19549" width="2209" height="1452"/>
         <path fill="none" stroke="rgb(52,101,164)" d="M 14000,19550 L 14050,19550 14050,20570"/>
         <path fill="rgb(52,101,164)" stroke="none" d="M 14050,21000 L 14200,20550 13900,20550 14050,21000 Z"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="12909" y="20496"><tspan fill="rgb(0,0,0)" stroke="none">        </tspan><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.LineShape">
        <g id="id28">
-        <rect class="BoundingBox" stroke="none" fill="none" x="14099" y="15599" width="4703" height="3"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 14100,15600 L 18800,15600"/>
+        <rect class="BoundingBox" stroke="none" fill="none" x="13999" y="7299" width="4803" height="3"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14000,7300 L 18800,7300"/>
        </g>
       </g>
       <g class="com.sun.star.drawing.LineShape">
        <g id="id29">
-        <rect class="BoundingBox" stroke="none" fill="none" x="18650" y="15599" width="301" height="21602"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 18800,15600 L 18800,36770"/>
+        <rect class="BoundingBox" stroke="none" fill="none" x="18650" y="7299" width="301" height="29902"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 18800,7300 L 18800,36770"/>
         <path fill="rgb(52,101,164)" stroke="none" d="M 18800,37200 L 18950,36750 18650,36750 18800,37200 Z"/>
        </g>
       </g>
@@ -298,8 +299,8 @@
       </g>
       <g class="com.sun.star.drawing.TextShape">
        <g id="id31">
-        <rect class="BoundingBox" stroke="none" fill="none" x="10300" y="23100" width="1701" height="1001"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="10550" y="23801"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="9700" y="23000" width="1701" height="1001"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="9950" y="23701"><tspan fill="rgb(0,0,0)" stroke="none">Yes</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.CustomShape">
@@ -329,7 +330,7 @@
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id35">
         <rect class="BoundingBox" stroke="none" fill="none" x="17399" y="27899" width="502" height="9302"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 17400,27900 L 17600,27900 17600,33151 17750,33151 17750,36770"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 17400,27900 L 17800,27900 17800,33151 17750,33151 17750,36770"/>
         <path fill="rgb(52,101,164)" stroke="none" d="M 17750,37200 L 17900,36750 17600,36750 17750,37200 Z"/>
        </g>
       </g>
@@ -343,8 +344,8 @@
       </g>
       <g class="com.sun.star.drawing.TextShape">
        <g id="id37">
-        <rect class="BoundingBox" stroke="none" fill="none" x="16100" y="28400" width="1801" height="1101"/>
-        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="16350" y="29101"><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
+        <rect class="BoundingBox" stroke="none" fill="none" x="16600" y="28400" width="1801" height="1101"/>
+        <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="635px" font-weight="400"><tspan class="TextPosition" x="16850" y="29101"><tspan fill="rgb(0,0,0)" stroke="none">No</tspan></tspan></tspan></text>
        </g>
       </g>
       <g class="com.sun.star.drawing.ConnectorShape">
@@ -358,7 +359,7 @@
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id39">
         <rect class="BoundingBox" stroke="none" fill="none" x="10098" y="31999" width="3053" height="5202"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 10600,32000 L 10099,32000 10099,34600 13000,34600 13000,36770"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 10600,32000 L 10099,32000 10099,33600 13000,33600 13000,36770"/>
         <path fill="rgb(52,101,164)" stroke="none" d="M 13000,37200 L 13150,36750 12850,36750 13000,37200 Z"/>
        </g>
       </g>
@@ -371,7 +372,7 @@
       <g class="com.sun.star.drawing.ConnectorShape">
        <g id="id41">
         <rect class="BoundingBox" stroke="none" fill="none" x="13999" y="33399" width="3902" height="3802"/>
-        <path fill="none" stroke="rgb(52,101,164)" d="M 14000,33400 L 14000,35301 17750,35301 17750,36770"/>
+        <path fill="none" stroke="rgb(52,101,164)" d="M 14000,33400 L 14000,34400 17750,34400 17750,36770"/>
         <path fill="rgb(52,101,164)" stroke="none" d="M 17750,37200 L 17900,36750 17600,36750 17750,37200 Z"/>
        </g>
       </g>

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -431,10 +431,12 @@ GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
             }
             else //The combed path is shorter than retraction_combing_max_distance.
             {
-                if(comb_path.size() != 2 || comb_path[0] != *last_planned_position || comb_path[1] == p
-                        || !comb_paths.throughAir || comb_path.cross_boundary || !extruder->settings.get<bool>("limit_support_retractions"))
+                if(comb_path.size() != 2 || comb_path[0] != *last_planned_position || comb_path[1] != p) //If the combed path has any detours (not a straight line)...
                 {
-                    path->retract = retraction_enable;
+                    if(comb_paths.throughAir && !comb_path.cross_boundary && !extruder->settings.get<bool>("limit_support_retractions")) //If the combing goes through support and we limit support retractions...
+                    {
+                        path->retract = retraction_enable;
+                    }
                 }
             }
         }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -425,7 +425,7 @@ GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
                 last_point = comb_point;
             }
             const coord_t retract_threshold = extruder->settings.get<coord_t>("retraction_combing_max_distance");
-            if(path_length > retract_threshold) //If the combed path is longer than retraction_combing_max_distance...
+            if(retract_threshold != 0 && path_length > retract_threshold) //If the combed path is longer than retraction_combing_max_distance...
             {
                 path->retract = retraction_enable;
             }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -372,11 +372,18 @@ GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
     const ExtruderTrain* extruder = getLastPlannedExtruderTrain();
     const bool retraction_enable = extruder->settings.get<bool>("retraction_enable");
     const bool retraction_hop_enabled = retraction_enable && extruder->settings.get<bool>("retraction_hop_enabled");
+    bool bypass_combing = false;
 
     const coord_t maximum_travel_resolution = extruder->settings.get<coord_t>("meshfix_maximum_travel_resolution");
 
+    //Z hop after extruder switch?
     const bool is_first_travel_of_extruder_after_switch = extruder_plans.back().paths.size() == 1 && (extruder_plans.size() > 1 || last_extruder_previous_layer != getExtruder());
-    bool bypass_combing = is_first_travel_of_extruder_after_switch && extruder->settings.get<bool>("retraction_hop_after_extruder_switch");
+    if(is_first_travel_of_extruder_after_switch && extruder->settings.get<bool>("retraction_hop_after_extruder_switch"))
+    {
+        bypass_combing = true;
+        path->retract = true;
+        path->perform_z_hop = true;
+    }
 
     const bool is_first_travel_of_layer = !static_cast<bool>(last_planned_position);
     if(is_first_travel_of_layer)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -362,7 +362,7 @@ std::optional<std::pair<Point, bool>> LayerPlan::getFirstTravelDestinationState(
     return ret;
 }
 
-GCodePath& LayerPlan::addTravel(Point p, bool force_comb_retract)
+GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
 {
     const GCodePathConfig& travel_config = configs_storage.travel_config_per_extruder[getExtruder()];
     const RetractionConfig& retraction_config = storage.retraction_config_per_extruder[getExtruder()];
@@ -391,7 +391,7 @@ GCodePath& LayerPlan::addTravel(Point p, bool force_comb_retract)
         }
         forceNewPathStart(); // force a new travel path after this first bogus move
     }
-    else if (force_comb_retract && last_planned_position && !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))
+    else if (force_retract && last_planned_position && !shorterThen(*last_planned_position - p, retraction_config.retraction_min_travel_distance))
     {
         // path is not shorter than min travel distance, force a retraction
         path->retract = true;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -413,7 +413,12 @@ GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
         const coord_t max_distance_ignored = extruder->settings.get<coord_t>("machine_nozzle_tip_outer_diameter") / 2 * 2;
 
         const bool combed = comb->calc(*extruder, *last_planned_position, p, comb_paths, was_inside, is_inside, max_distance_ignored);
-        if(combed && comb_paths.size() == 1) //Combing consists of a single part, i.e. doesn't cross walls.
+        if(comb_paths.empty())
+        {
+            //Combed path was shorter than max_distance_ignored. Don't retract or comb.
+            bypass_combing = true;
+        }
+        else if(combed && comb_paths.size() == 1) //Combing consists of a single part, i.e. doesn't cross walls.
         {
             const CombPath& comb_path = comb_paths[0];
             //Compute total length of combing path.

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -450,17 +450,32 @@ public:
     }
 
     /*!
-     * Add a travel path to a certain point, retract if needed and when avoiding boundary crossings:
-     * avoiding obstacles and comb along the boundary of parts.
-     * 
-     * \warning For the first travel move in a layer this will result in a bogous travel move with no combing and no retraction
-     * This travel move needs to be fixed afterwards
-     * 
-     * \param p The point to travel to
-     * \param force_comb_retract Whether to force a retraction to occur when travelling to this point. (Only enforced when distance is larger than retraction_min_travel)
+     * Travel to a certain point, with all of the procedures necessary to do so.
+     *
+     * Additional procedures here are:
+     * - If retraction is forced, always retract.
+     * - If combing is enabled, try a combing move.
+     *   - If combing succeeds, i.e. there is a path to the destination
+     *     - If the combed path is longer than retraction_combing_max_distance
+     *       - Only retract (if enabled). Don't Z hop. Then follow coming path.
+     *     - If the combed path is shorter
+     *       - Travel the combing path without retraction.
+     *   - If combing fails, i.e. the destination is in a different part
+     *     - If Z hop is enabled
+     *       - Retract (if enabled) and make a straight travel move.
+     *     - If Z hop is disabled
+     *       - Retract (if enabled) and make a multi-part travel move.
+     * - If combing is disabled
+     *   - Retract (if enabled) and Z hop (if enabled) and make straight travel.
+     *
+     * The first travel move in a layer will result in a bogus travel move with
+     * no combing and no retraction. This travel move needs to be fixed
+     * afterwards.
+     * \param p The point to travel to.
+     * \param force_comb_retract Whether to force a retraction to occur.
      */
-    GCodePath& addTravel(Point p, bool force_comb_retract = false);
-    
+    GCodePath& addTravel(const Point p, const bool force_retract = false);
+
     /*!
      * Add a travel path to a certain point and retract if needed.
      * 

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -477,6 +477,8 @@ public:
      * - If combing is disabled
      *   - Retract (if enabled) and Z hop (if enabled) and make straight move.
      *
+     * \image svg ../docs/assets/retraction_combing_hop.svg
+     *
      * The first travel move in a layer will result in a bogus travel move with
      * no combing and no retraction. This travel move needs to be fixed
      * afterwards.

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -454,9 +454,9 @@ public:
      *
      * Additional procedures here are:
      * - If retraction is forced, always retract.
+     * - If the combed path is shorter than the outer diameter of the nozzle
+     *   - Travel directly without retraction or Z hop. Do not pass Go.
      * - If combing is enabled, try a combing move.
-     *   - If the combed path is shorter than the outer diameter of the nozzle
-     *     - Travel directly without retraction or Z hop.
      *   - If combing consists of a single part, i.e. doesn't cross walls
      *     - If the combed path is longer than retraction_combing_max_distance
      *       - Only retract (if enabled). Don't Z hop. Then follow coming path.

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -455,18 +455,25 @@ public:
      * Additional procedures here are:
      * - If retraction is forced, always retract.
      * - If combing is enabled, try a combing move.
-     *   - If combing succeeds, i.e. there is a path to the destination
+     *   - If combing consists of a single part, i.e. doesn't cross walls
      *     - If the combed path is longer than retraction_combing_max_distance
      *       - Only retract (if enabled). Don't Z hop. Then follow coming path.
-     *     - If the combed path is shorter
-     *       - Travel the combing path without retraction.
-     *   - If combing fails, i.e. the destination is in a different part
+     *     - If the combed path is shorter than retraction_combing_max_distance
+     *       - If the combed path has any detours (not straight line)
+     *         - If the combing goes through support and we limit support
+     *           retractions
+     *           - Travel the combing path without retraction or Z hop.
+     *         - Otherwise
+     *           - Only retract (if enabled). Don't Z hop. Follow coming path.
+     *       - If the combed path is straight (combing was unnecessary)
+     *         - Travel the combing path without retraction or Z hop.
+     *   - If combing consists of multiple parts, i.e. crosses walls
      *     - If Z hop is enabled
-     *       - Retract (if enabled) and make a straight travel move.
+     *       - Retract (if enabled) and Z hop and make a straight travel move.
      *     - If Z hop is disabled
-     *       - Retract (if enabled) and make a multi-part travel move.
+     *       - Retract (if enabled) and follow combing path.
      * - If combing is disabled
-     *   - Retract (if enabled) and Z hop (if enabled) and make straight travel.
+     *   - Retract (if enabled) and Z hop (if enabled) and make straight move.
      *
      * The first travel move in a layer will result in a bogus travel move with
      * no combing and no retraction. This travel move needs to be fixed

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -455,6 +455,8 @@ public:
      * Additional procedures here are:
      * - If retraction is forced, always retract.
      * - If combing is enabled, try a combing move.
+     *   - If the combed path is shorter than the outer diameter of the nozzle
+     *     - Travel directly without retraction or Z hop.
      *   - If combing consists of a single part, i.e. doesn't cross walls
      *     - If the combed path is longer than retraction_combing_max_distance
      *       - Only retract (if enabled). Don't Z hop. Then follow coming path.

--- a/src/pathPlanning/CombPaths.h
+++ b/src/pathPlanning/CombPaths.h
@@ -1,4 +1,6 @@
-/** Copyright (C) 2013 Ultimaker - Released under terms of the AGPLv3 License */
+//Copyright (c) 2019 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
 #ifndef PATH_PLANNING_COMB_PATHS_H
 #define PATH_PLANNING_COMB_PATHS_H
 
@@ -7,7 +9,7 @@
 namespace cura 
 {
 
-struct CombPaths : public  std::vector<CombPath> //!< A list of paths alternating between inside a part and outside a part
+struct CombPaths : public std::vector<CombPath> //!< A list of paths alternating between inside a part and outside a part
 {
     bool throughAir = false; //!< Whether the path is one which moves through air.
 }; 


### PR DESCRIPTION
Quite a big change. I hope I've documented everything well.

So currently, Z hops seem to be mostly broken. There are no Z hops to speak of except when switching extruders. Most profile authors seem to have accepted this but it's still printing okay. This change is intended to fix those again.

I've also restructured the travel move function in order to align it more with what is actually happening. This removes a bit of state, though some state still remains in the `bypass_combing` variable. However the big part here is that it's now aligned with what the decision tree is doing. I've documented the decision tree very well, both in the code documentation and with a diagram in the `docs` folder. Please see Github's rich diff in order to read the decision tree diagram.

This change comes with a change to the Cura profiles as well, which disables the Z hops for all profiles. The idea behind this is that it hasn't been working anyway so disabling the Z hop ensures that the behaviour is the same as what it used to be. That change is made in these two repositories:
* Cura: https://github.com/Ultimaker/Cura/pull/6595
* cura-private-data: https://github.com/Ultimaker/cura-private-data/pull/42 (not publicly accessible)

One additional behavioural change is that the "Z Hop for Extruder Switch" setting can now be enabled separately even if the normal Z hop setting is disabled.

Implements CURA-6860.