### PR TITLE
Automatically set the extruder number when using command line

### DIFF
--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -185,6 +185,11 @@ void CommandLine::sliceNext()
                                 slice.scene.extruders.emplace_back(slice.scene.extruders.size(), &slice.scene.settings);
                             }
                         }
+                        //If this was an extruder stack, make sure that the extruder_nr setting is correct.
+                        if (last_settings == &last_extruder->settings)
+                        {
+                            last_extruder->settings.add("extruder_nr", std::to_string(last_extruder->extruder_nr));
+                        }
                         break;
                     }
                     case 'e':
@@ -195,6 +200,7 @@ void CommandLine::sliceNext()
                             slice.scene.extruders.emplace_back(extruder_nr, &slice.scene.settings);
                         }
                         last_settings = &slice.scene.extruders[extruder_nr].settings;
+                        last_settings->add("extruder_nr", argument.substr(2));
                         last_extruder = &slice.scene.extruders[extruder_nr];
                         break;
                     }


### PR DESCRIPTION
So that you don't also need to specify extruder_nr. Makes things easier to type.

Fixes #1157.