### PR TITLE
Add support for Truncated Octahedron fill

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1571,7 +1571,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         }
         else
         {
-            gcode_layer.addLinesByOptimizer(infill_lines, mesh_config.infill_config[0], (pattern == EFillMethod::ZIG_ZAG) ? SpaceFillType::PolyLines : SpaceFillType::Lines, enable_travel_optimization
+            gcode_layer.addLinesByOptimizer(infill_lines, mesh_config.infill_config[0], (pattern == EFillMethod::ZIG_ZAG || pattern == EFillMethod::TRUNCATED_OCTAHEDRON) ? SpaceFillType::PolyLines : SpaceFillType::Lines, enable_travel_optimization
                 , /* wipe_dist = */ 0, /*float_ratio = */ 1.0, near_start_location);
         }
     }

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -19,6 +19,10 @@
 #include "utils/polygonUtils.h"
 #include "utils/UnionFind.h"
 
+#define SQRT2MUL(x) ((30547*(x))/21600)
+#define OCTSLEN(x) ((43200*(x))/73747)
+#define OCTDLEN(x) ((21600*(x))/30547)
+
 /*!
  * Function which returns the scanline_idx for a given x coordinate
  *
@@ -153,6 +157,10 @@ void Infill::_generate(Polygons& result_polygons, Polygons& result_lines, const 
     case EFillMethod::GYROID:
         generateGyroidInfill(result_lines);
         break;
+    case EFillMethod::TRUNCATED_OCTAHEDRON:
+        generateTroctInfill(result_polygons, fill_angle);
+        generateTroctInfill(result_polygons, fill_angle + 90);
+        break;
     default:
         logError("Fill pattern has unknown value.\n");
         break;
@@ -254,6 +262,133 @@ void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)
 void Infill::generateGyroidInfill(Polygons& result_lines)
 {
     GyroidInfill::generateTotalGyroidInfill(result_lines, zig_zaggify, outline_offset + infill_overlap, infill_line_width, line_distance, in_outline, z);
+}
+
+void Infill::generateTroctInfill(Polygons& result, const double& infill_rotation)
+{
+    int extrusionWidth = infill_line_width;
+    int lineSpacing = line_distance;
+    int infillOverlap = infill_overlap;
+    int posZ = z;
+
+    Polygons outline = in_outline.offset(extrusionWidth * infillOverlap / 100);
+    PointMatrix matrix(infill_rotation);
+    outline.applyMatrix(matrix);
+    AABB boundary(outline);
+
+    // ignore infill for areas smaller than line spacing
+    if ((abs(boundary.min.X - boundary.max.X) + abs(boundary.min.Y - boundary.max.Y)) < lineSpacing)
+    {
+        return;
+    }
+
+    // fix to normalise against diagonal infill
+    lineSpacing = lineSpacing * 2;
+
+    uint64_t Zscale = SQRT2MUL(lineSpacing);
+
+    int offset = abs(posZ % ((int)Zscale) - ((int)Zscale/2)) - (Zscale/4);
+    boundary.min.X = ((boundary.min.X / lineSpacing) - 1) * lineSpacing;
+    boundary.min.Y = ((boundary.min.Y / lineSpacing) - 1) * lineSpacing;
+
+    unsigned int lineCountX = (boundary.max.X - boundary.min.X + (lineSpacing - 1)) / lineSpacing;
+    unsigned int lineCountY = (boundary.max.Y - boundary.min.Y + (lineSpacing - 1)) / lineSpacing;
+    int rtMod = int(infill_rotation / 90) % 2;
+    // with an odd number of lines, sides need to be swapped around
+    if (rtMod == 1)
+    {
+        rtMod = (lineCountX + int(infill_rotation / 90)) % 2;
+    }
+
+    // draw non-horizontal walls of octohedrons
+    Polygons po;
+    PolygonRef p = po.newPoly();
+    for (unsigned int ly=0; ly < lineCountY;)
+    {
+        for (size_t it = 0; it < 2; ly++, it++)
+        {
+            int side = (2*((ly + it + rtMod) % 2) - 1);
+            int y = (ly * lineSpacing) + boundary.min.Y + lineSpacing / 2 - (offset/2 * side);
+            int x = boundary.min.X-(offset/2);
+            if (it == 1)
+            {
+                x = (lineCountX * (lineSpacing)) + boundary.min.X + lineSpacing / 2 - (offset/2);
+            }
+            p.add(Point(x,y));
+            for (unsigned int lx=0; lx < lineCountX; lx++)
+            {
+                if (it == 1)
+                {
+                    side = (2*((lx + ly + it + rtMod + lineCountX) % 2) - 1);
+                    y = (ly * lineSpacing) + boundary.min.Y + lineSpacing / 2 + (offset/2 * side);
+                    x = ((lineCountX - lx - 1) * lineSpacing) + boundary.min.X + lineSpacing / 2;
+                    p.add(Point(x+lineSpacing-abs(offset/2), y));
+                    p.add(Point(x+abs(offset/2), y));
+                }
+                else
+                {
+                    side = (2*((lx + ly + it + rtMod) % 2) - 1);
+                    y = (ly * lineSpacing) + boundary.min.Y + lineSpacing / 2 + (offset/2 * side);
+                    x = (lx * lineSpacing) + boundary.min.X + lineSpacing / 2;
+                    p.add(Point(x+abs(offset/2), y));
+                    p.add(Point(x+lineSpacing-abs(offset/2), y));
+                }
+            }
+            x = (lineCountX * lineSpacing) + boundary.min.X + lineSpacing / 2 - (offset/2);
+            if (it == 1)
+            {
+                x = boundary.min.X-(offset/2);
+            }
+            y = (ly * lineSpacing) + boundary.min.Y + lineSpacing / 2 - (offset/2 * side);
+            p.add(Point(x,y));
+        }
+    }
+    // Generate tops / bottoms of octohedrons
+    if (abs((abs(offset) - (int)Zscale/4)) < (extrusionWidth/2))
+    {
+        uint64_t startLine = (offset < 0) ? 0 : 1;
+        uint64_t coverWidth = OCTSLEN(lineSpacing);
+        std::vector<Point> points;
+        for (size_t xi = 0; xi < (lineCountX+1); xi++)
+        {
+            for (size_t yi = 0; yi < (lineCountY); yi += 2)
+            {
+                points.push_back(Point(boundary.min.X + OCTDLEN(lineSpacing) + (xi - startLine + rtMod) * lineSpacing, boundary.min.Y + OCTDLEN(lineSpacing) + (yi + (xi%2)) * lineSpacing + extrusionWidth/2));
+            }
+        }
+        uint64_t order = 0;
+        for (Point pp : points)
+        {
+            PolygonRef p = po.newPoly();
+            for (size_t yi = 0; yi <= coverWidth; yi += extrusionWidth)
+            {
+                if (order == 0)
+                {
+                    p.add(Point(pp.X, pp.Y + yi));
+                    p.add(Point(pp.X + coverWidth + extrusionWidth, pp.Y + yi));
+                }
+                else
+                {
+                    p.add(Point(pp.X + coverWidth + extrusionWidth, pp.Y + yi));
+                    p.add(Point(pp.X, pp.Y + yi));
+                }
+                order = (order + 1) % 2;
+            }
+        }
+    }
+    // intersect with outline polygon(s)
+    Polygons pi = po.intersection(outline);
+    // Hack to add intersection to result. There doesn't seem
+    // to be a direct way to do this
+    for (unsigned int polyNr=0; polyNr < pi.size(); polyNr++)
+    {
+        PolygonRef p = result.newPoly(); //  = result.newPoly()
+        for (unsigned int i=0; i < pi[polyNr].size(); i++)
+        {
+            Point p0 = pi[polyNr][i];
+            p.add(matrix.unapply(Point(p0.X,p0.Y)));
+        }
+    }
 }
 
 void Infill::generateConcentricInfill(Polygons& result, int inset_value)

--- a/src/infill.h
+++ b/src/infill.h
@@ -421,6 +421,14 @@ private:
      * \param[in/out] result_lines The lines to connect together.
      */
     void connectLines(Polygons& result_lines);
+
+    /*!
+     * Generate Truncated Octahedron infill pattern
+     * \param[out] result (output) The resulting lines
+     * \param[in] infill_rotation the angle the infill pattern is rotated through
+     */
+    void generateTroctInfill(Polygons& result, const double& infill_rotation);
+
 };
 
 }//namespace cura

--- a/src/settings/EnumSettings.h
+++ b/src/settings/EnumSettings.h
@@ -27,6 +27,7 @@ enum class EFillMethod
     CROSS,
     CROSS_3D,
     GYROID,
+    TRUNCATED_OCTAHEDRON,
     NONE  // NOTE: Should remain last! (May be used in testing to enumarate the enum.)
 };
 

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -333,6 +333,10 @@ template<> EFillMethod Settings::get<EFillMethod>(const std::string& key) const
     {
         return EFillMethod::GYROID;
     }
+    else if (value == "truncated_octahedron")
+    {
+        return EFillMethod::TRUNCATED_OCTAHEDRON;
+    }
     else //Default.
     {
         return EFillMethod::NONE;

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -193,8 +193,9 @@ namespace cura
          *    this can be considered a TODO for these testcases here, not in the methods themselves
          *    (these are; Cross, Cross-3D and Cubic-Subdivision)
          *  - Gyroid, since it doesn't handle the 100% infill and related cases well
+         *  - Truncated Octahedron, doesn't seem to handle these cases well either
          */
-        std::vector<EFillMethod> skip_methods = { EFillMethod::CROSS, EFillMethod::CROSS_3D, EFillMethod::CUBICSUBDIV, EFillMethod::GYROID };
+        std::vector<EFillMethod> skip_methods = { EFillMethod::CROSS, EFillMethod::CROSS_3D, EFillMethod::CUBICSUBDIV, EFillMethod::GYROID, EFillMethod::TRUNCATED_OCTAHEDRON };
 
         std::vector<EFillMethod> methods;
         for (int i_method = 0; i_method < static_cast<int>(EFillMethod::NONE); ++i_method)


### PR DESCRIPTION
This code was forward ported by me from the Lulzbot fork (based on 3.6.0). The original author is Victor Larchenko (@victor9999). 