### PR TITLE
4.4 - improved prime tower generation, no extra tool changes, no missing prime tower bands

### DIFF
--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -691,6 +691,13 @@ private:
      */
     void addPrimeTower(const SliceDataStorage& storage, LayerPlan& gcodeLayer, int prev_extruder) const;
     
+	/*!
+	* Add the prime tower gcode for missing paths
+	* \param [in] storage where the slice data is stored.
+	* \param gcodeLayer The initial planning of the gcode of the layer.
+	*/
+	void addPrimeTowerFillTheGap(const SliceDataStorage& storage, LayerPlan& gcodeLayer) const;
+
     /*!
      * Add the end gcode and set all temperatures to zero.
      */

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -85,6 +85,13 @@ public:
      * \param new_extruder The switched to extruder with which the prime tower paths should be generated.
      */
     void addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int prev_extruder, const int new_extruder) const;
+	
+	/*!
+	* Add path for the prime tower to the \p gcode_layer
+	* for polygon data of extruders that haven't been used in the current layer
+	* will use the current tool
+	*/
+	void addToGcodePlugTheGap(const SliceDataStorage& storage, LayerPlan& gcode_layer) const;
 
     /*!
      * \brief Subtract the prime tower from the support areas in storage.

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -104,7 +104,7 @@ void CommandLine::sliceNext()
 
     slice.scene.extruders.reserve(arguments.size() >> 1); //Allocate enough memory to prevent moves.
     slice.scene.extruders.emplace_back(0, &slice.scene.settings); //Always have one extruder.
-    ExtruderTrain& last_extruder = slice.scene.extruders[0];
+    ExtruderTrain* last_extruder = &slice.scene.extruders[0];
 
     for (size_t argument_index = 2; argument_index < arguments.size(); argument_index++)
     {
@@ -195,6 +195,7 @@ void CommandLine::sliceNext()
                             slice.scene.extruders.emplace_back(extruder_nr, &slice.scene.settings);
                         }
                         last_settings = &slice.scene.extruders[extruder_nr].settings;
+                        last_extruder = &slice.scene.extruders[extruder_nr];
                         break;
                     }
                     case 'l':
@@ -209,7 +210,7 @@ void CommandLine::sliceNext()
 
                         const FMatrix3x3 transformation = last_settings->get<FMatrix3x3>("mesh_rotation_matrix"); //The transformation applied to the model when loaded.
 
-                        if (!loadMeshIntoMeshGroup(&slice.scene.mesh_groups[mesh_group_index], argument.c_str(), transformation, last_extruder.settings))
+                        if (!loadMeshIntoMeshGroup(&slice.scene.mesh_groups[mesh_group_index], argument.c_str(), transformation, last_extruder->settings))
                         {
                             logError("Failed to load model: %s. (error number %d)\n", argument.c_str(), errno);
                             exit(1);

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -104,7 +104,7 @@ void CommandLine::sliceNext()
 
     slice.scene.extruders.reserve(arguments.size() >> 1); //Allocate enough memory to prevent moves.
     slice.scene.extruders.emplace_back(0, &slice.scene.settings); //Always have one extruder.
-    ExtruderTrain* last_extruder = &slice.scene.extruders[0];
+    ExtruderTrain& last_extruder = slice.scene.extruders[0];
 
     for (size_t argument_index = 2; argument_index < arguments.size(); argument_index++)
     {
@@ -195,7 +195,6 @@ void CommandLine::sliceNext()
                             slice.scene.extruders.emplace_back(extruder_nr, &slice.scene.settings);
                         }
                         last_settings = &slice.scene.extruders[extruder_nr].settings;
-                        last_extruder = &slice.scene.extruders[extruder_nr];
                         break;
                     }
                     case 'l':
@@ -210,7 +209,7 @@ void CommandLine::sliceNext()
 
                         const FMatrix3x3 transformation = last_settings->get<FMatrix3x3>("mesh_rotation_matrix"); //The transformation applied to the model when loaded.
 
-                        if (!loadMeshIntoMeshGroup(&slice.scene.mesh_groups[mesh_group_index], argument.c_str(), transformation, last_extruder->settings))
+                        if (!loadMeshIntoMeshGroup(&slice.scene.mesh_groups[mesh_group_index], argument.c_str(), transformation, last_extruder.settings))
                         {
                             logError("Failed to load model: %s. (error number %d)\n", argument.c_str(), errno);
                             exit(1);

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -13,7 +13,7 @@
 #include <cmath> // fabs
 #include <limits> // int64_t.min
 #include <list>
-
+#include <iterator>
 #include <initializer_list>
 
 #include "IntPoint.h"


### PR DESCRIPTION
Change on how the prime tower is generated in order to avoid skipping of printing of prime tower bands of unused extruders. Does not increase the number of tool changes while guaranteeing the prime  tower will be coherent and no printing 'in the air'

New strategy is :
- on tool change, slicer checks if previous extruder primed into the tower; if not add gcode to prime the tower with prevExtruder prior to the tool change (new behaviour)
- after the tool change, prime into the tower (current behaviour)
- at the end of layer processing, check which extruders haven't been primed in this layer; for each extruder that hasn't been primed, generate gcode for priming using currently active extruder

In this scenario - in example, 
```
layer #10, T0, T1 is active, T2, T3 is not active
- layer starts with T1 printing (T1 was last extruder in layer #9)
- T1->T0 is triggered
- [new behaviour] check if T1 primed in layer #10, it hasn't so generate gcode for priming into T1 prime tower band
- change T1->T0
- [current behaviour] check if T0 is primed, is not so generate gcode for priming into T0 prime tower band
- print with T0
...
...
- [new behaviour] end of layer processing, check which extruders haven't been primed -> [T2, T3] - for T2, T3, generate gcode for printing into the T2, T3 tower prime bands using current extruder settings/curren extruder [T0]
```
This guarantees all of the requested prime tower bands will be printed
No new tool changes are added

I have tested this in various configurations for my E3D toolchanger equiped with 4 toolheads - all was ok.