### PR TITLE
Wall Collapse

### DIFF
--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -40,6 +40,9 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
         part->print_outline = part->outline;
         return;
     }
+    
+    const coord_t wall_collapse_0 = settings.get<coord_t>("wall_collapse_0");
+    const coord_t wall_collapse_x = settings.get<coord_t>("wall_collapse_x");
 
     const coord_t wall_0_inset = settings.get<coord_t>("wall_0_inset");
     coord_t line_width_0 = settings.get<coord_t>("wall_line_width_0");
@@ -58,15 +61,15 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
         part->insets.push_back(Polygons());
         if (i == 0)
         {
-            part->insets[0] = part->outline.offset(-line_width_0 / 2 - wall_0_inset);
+            part->insets[0] = part->outline.offset(-line_width_0 / 2 - wall_0_inset - wall_collapse_0).offset(wall_collapse_0);
         }
         else if (i == 1)
         {
-            part->insets[1] = part->insets[0].offset(-line_width_0 / 2 + wall_0_inset - line_width_x / 2);
+            part->insets[1] = part->insets[0].offset(-line_width_0 / 2 + wall_0_inset - line_width_x / 2 - wall_collapse_x).offset(wall_collapse_x);
         }
         else
         {
-            part->insets[i] = part->insets[i - 1].offset(-line_width_x);
+            part->insets[i] = part->insets[i - 1].offset(-line_width_x - wall_collapse_x).offset(wall_collapse_x);
         }
 
         const size_t inset_part_count = part->insets[i].size();

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -54,7 +54,7 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
         const ExtruderTrain& train_wall_x = settings.get<ExtruderTrain&>("wall_x_extruder_nr");
         line_width_x *= train_wall_x.settings.get<Ratio>("initial_layer_line_width_factor");
     }
-
+    
     const bool recompute_outline_based_on_outer_wall = (settings.get<bool>("support_enable") || settings.get<bool>("support_tree_enable")) && !settings.get<bool>("fill_outline_gaps");
     for(size_t i = 0; i < inset_count; i++)
     {
@@ -83,15 +83,15 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
             Polygons alternative_inset;
             if (i == 0)
             {
-                alternative_inset = part->outline.offset(-(line_width_0 - try_smaller) / 2 - wall_0_inset);
+                alternative_inset = part->outline.offset(-(line_width_0 - try_smaller) / 2 - wall_0_inset - wall_collapse_0).offset(wall_collapse_0);
             }
             else if (i == 1)
             {
-                alternative_inset = part->insets[0].offset(-(line_width_0 - try_smaller) / 2 + wall_0_inset - line_width_x / 2);
+                alternative_inset = part->insets[0].offset(-(line_width_0 - try_smaller) / 2 + wall_0_inset - line_width_x / 2 - wall_collapse_x).offset(wall_collapse_x);
             }
             else
             {
-                alternative_inset = part->insets[i - 1].offset(-(line_width_x - try_smaller));
+                alternative_inset = part->insets[i - 1].offset(-(line_width_x - try_smaller) - wall_collapse_x).offset(wall_collapse_x);
             }
             if (alternative_inset.size() < inset_part_count - minimum_part_saving) //Significantly fewer parts (saves more than 3 parts).
             {


### PR DESCRIPTION
When a 3D model has thin/narrow parts the walls might not fit exactly. When the model is just wider than an even number of walls there is a space left: underfill; when the model is narrower than an even number of walls there is overfill.

What Cura currently does is to fill the underfill areas using some dense lines pattern, which is then combined into a single extrusion line with adaptive width. (Note that this combining algorithm fails quite often, currently!)
What Cura currently does to deal with the overfill is to compensate the overlap and extrude less on the second pass.

However, the compensation approach is limited. If the overlap gets above 75% of the line width, the second pass is reduces to less than 25% flow, which makes the extrusion unreliable.

Instead we can simply avoid such overfill, by performing a mathematical closure operation on the walls. If walls are too close to each other they collapse and are removed. The resulting gap is then handled as overfill and is filled using the Gaps Between Walls settings.

This PR makes the above possible. I would recommend setting the default value to something like half the line width, were it not for the buggy perimeter gap combine algorithm, which currently produces quite horrible output. See images below.

If you set the collapse distance to the line width, ideally the (currently buggy) combining code should produce an extrusion line up to twice the normal width, which is quite wide. Therefore setting it to 50% would be better, since it would only require lines of 150% the normal size. 

Because the current perimeter gap combining code is so buggy I left the default at 0, which means the default Cura behavior remains unchanged: The inter-perimeter gaps are filled using lines up to 100% the wall line width.

set to zero: (normal)
![image](https://user-images.githubusercontent.com/8895761/72887182-7b40cb80-3d0b-11ea-90d5-fa931cde8eaa.png)

Set to half line width:
![image](https://user-images.githubusercontent.com/8895761/72887112-5ba9a300-3d0b-11ea-91c3-83819296e0a4.png)

set to line width:
![image](https://user-images.githubusercontent.com/8895761/72887157-6f550980-3d0b-11ea-85da-63c7c510e917.png)

