### PR TITLE
Simplify each inset when generating concentric infill.

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -278,6 +278,7 @@ void Infill::generateConcentricInfill(Polygons& first_concentric_wall, Polygons&
     while (prev_inset->size() > 0)
     {
         new_inset = prev_inset->offset(-inset_value);
+        new_inset.simplify();
         result.add(new_inset);
         if (perimeter_gaps)
         {


### PR DESCRIPTION
When generating concentric infill, simplify each inset to stop glitches propogating. 

Fixes https://github.com/Ultimaker/Cura/issues/7040.
