### PR TITLE
Flow problem

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -278,6 +278,7 @@ void Infill::generateConcentricInfill(Polygons& first_concentric_wall, Polygons&
     while (prev_inset->size() > 0)
     {
         new_inset = prev_inset->offset(-inset_value);
+        new_inset.simplify();
         result.add(new_inset);
         if (perimeter_gaps)
         {

--- a/src/pathPlanning/GCodePath.cpp
+++ b/src/pathPlanning/GCodePath.cpp
@@ -31,7 +31,7 @@ bool GCodePath::isTravelPath() const
 
 double GCodePath::getExtrusionMM3perMM() const
 {
-    return flow * config->getExtrusionMM3perMM();
+    return flow * config->getExtrusionMM3perMM() * config->getFlowRatio();
 }
 
 coord_t GCodePath::getLineWidthForLayerView() const


### PR DESCRIPTION
Single-liner.

The feature specific flow was not applied to the actual gcode, while it was used for the layer view.

I have no idea why the code looked like this, but it seems to me to be an actual issue.

We should do 1 test print to see whether the feature specific flow settings used to not influence the actual flow and whether it is now fixed.