### PR TITLE
fix uninitialized Point variable

### DIFF
--- a/src/MergeInfillLines.cpp
+++ b/src/MergeInfillLines.cpp
@@ -72,7 +72,7 @@ MergeInfillLines::MergeInfillLines(ExtruderPlan& plan)
         }
         else
         {
-            average_first_path += first_path_start;
+            average_first_path = first_path_start;
             for (const Point& point : first_path.points)
             {
                 average_first_path += point;


### PR DESCRIPTION
I thought I found an uninitialized variable problem.

However, the default constructor of a point does initialize.
```
  IntPoint(cInt x = 0, cInt y = 0): X(x), Y(y) {};
```

I would still merge this for code clarity, though.