### PR TITLE
feat: minimum supporting area size

### DIFF
--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -165,18 +165,20 @@ public:
      * Get the all outlines of all layer parts in this layer.
      * 
      * \param external_polys_only Whether to only include the outermost outline of each layer part
+     * \param min_part_area The minimum area (mm^2) a part must have in order for it to be included in the result
      * \return A collection of all the outline polygons
      */
-    Polygons getOutlines(bool external_polys_only = false) const;
+    Polygons getOutlines(bool external_polys_only = false, double min_part_area = 0) const;
 
     /*!
      * Get the all outlines of all layer parts in this layer.
      * Add those polygons to @p result.
      * 
      * \param external_polys_only Whether to only include the outermost outline of each layer part
+     * \param min_part_area The minimum area (mm^2) a part must have in order for it to be included in the result
      * \param result The result: a collection of all the outline polygons
      */
-    void getOutlines(Polygons& result, bool external_polys_only = false) const;
+    void getOutlines(Polygons& result, bool external_polys_only = false, double min_part_area = 0) const;
 
     /*!
      * Collects the second wall of every part, or the outer wall if it has no second, or the outline, if it has no outer wall.
@@ -343,8 +345,9 @@ public:
      * outline.
      * \param external_polys_only Whether to disregard all hole polygons.
      * \param for_brim Whether the outline is to be used to construct the brim.
+     * \param min_part_area The minimum area (mm^2) a part must have in order for it to be included in the result
      */
-    Polygons getLayerOutlines(const LayerIndex layer_nr, const bool include_support, const bool include_prime_tower, const bool external_polys_only = false, const bool for_brim = false) const;
+    Polygons getLayerOutlines(const LayerIndex layer_nr, const bool include_support, const bool include_prime_tower, const bool external_polys_only = false, const bool for_brim = false, double min_part_area = 0) const;
 
     /*!
      * Get the extruders used.

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1248,12 +1248,14 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
     Polygons supportLayer_supportee = mesh.layers[layer_idx].getOutlines();
     constexpr bool no_support = false;
     constexpr bool no_prime_tower = false;
-    Polygons supportLayer_supporter = storage.getLayerOutlines(layer_idx-1, no_support, no_prime_tower);
+    const double min_supporting_model_area = mesh.settings.get<double>("min_supporting_model_area");
+    Polygons supportLayer_supporter = storage.getLayerOutlines(layer_idx-1, no_support, no_prime_tower, false, false, min_supporting_model_area);
 
     const coord_t layer_height = mesh.settings.get<coord_t>("layer_height");
     const AngleRadians support_angle = mesh.settings.get<AngleRadians>("support_angle");
     const double tan_angle = tan(support_angle) - 0.01;  //The X/Y component of the support angle. 0.01 to make 90 degrees work too.
     const coord_t max_dist_from_lower_layer = tan_angle * layer_height; //Maximum horizontal distance that can be bridged.
+
     Polygons supportLayer_supported =  supportLayer_supporter.offset(max_dist_from_lower_layer);
     Polygons basic_overhang = supportLayer_supportee.difference(supportLayer_supported);
 


### PR DESCRIPTION
Can be used to make point overhang more reliable, by supporting more of the downward hanging geometry.

Problem:
When the geometry has some downward pointing part, it may happen that the overhang is quit small.
When printing such a part on top of a tiny bit of support the printed part starts to wobble during printing, which eventually leads to spaghetti being printed.
It is not often that a model has such downward pointing geometry (perhaps 1% of all models), but *when* a model has such downward pointing geometry the print almost always fails - or at least shows defects.

Solution:
The solution we propose here is to consider geometry with a too small area as not being supported at all - regardless of the overhang angle. A layer part with an area smaller than the setting value is handled as if the overhang angle is 0*.

The fix of this PR fixes most of the pointy overhang problems using one simple setting. It's not a full proof solution, but it's very simple code, and it is very effective.

-------

*Results*

Without the setting:
![image](https://user-images.githubusercontent.com/8895761/74643751-8570b100-5175-11ea-87e5-b6e2dd49209c.png)

With setting set to 10 mm^2:
![image](https://user-images.githubusercontent.com/8895761/74643790-95889080-5175-11ea-919b-fed3e99a60aa.png)
closeup:
![image](https://user-images.githubusercontent.com/8895761/74643823-a6390680-5175-11ea-8099-536a550dc170.png)

