### PR TITLE
Fix crash when randomizing infill polygons

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1643,7 +1643,6 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             {
                 PolygonRef start_poly = infill_polygons[rand() % infill_polygons.size()];
                 near_start_location = start_poly[rand() % start_poly.size()];
-                std::cout << "Near start location: " << near_start_location->X << "," << near_start_location->Y << std::endl;
             }
         }
         if (!infill_polygons.empty())

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2019 Ultimaker B.V.
+//Copyright (c) 2020 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <cstring>
@@ -583,13 +583,13 @@ void LayerPlan::addPolygon(ConstPolygonRef polygon, int start_idx, const GCodePa
     }
 }
 
-void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePathConfig& config, WallOverlapComputation* wall_overlap_computation, const ZSeamConfig& z_seam_config, coord_t wall_0_wipe_dist, bool spiralize, const Ratio flow_ratio, bool always_retract, bool reverse_order)
+void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePathConfig& config, WallOverlapComputation* wall_overlap_computation, const ZSeamConfig& z_seam_config, coord_t wall_0_wipe_dist, bool spiralize, const Ratio flow_ratio, bool always_retract, bool reverse_order, std::optional<Point> start_near_location)
 {
     if (polygons.size() == 0)
     {
         return;
     }
-    PathOrderOptimizer orderOptimizer(getLastPlannedPositionOrStartingPosition(), z_seam_config);
+    PathOrderOptimizer orderOptimizer(start_near_location ? start_near_location.value() : getLastPlannedPositionOrStartingPosition(), z_seam_config);
     for (unsigned int poly_idx = 0; poly_idx < polygons.size(); poly_idx++)
     {
         orderOptimizer.addPolygon(polygons[poly_idx]);

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2020 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef LAYER_PLAN_H
@@ -523,23 +523,33 @@ public:
     /*!
      * Add polygons to the gcode with optimized order.
      * 
-     * When \p spiralize is true, each polygon will gradually increase from a z corresponding to this layer to the z corresponding to the next layer.
-     * Doing this for each polygon means there is a chance for the print head to crash into already printed parts,
-     * but doing it for the last polygon only would mean you are printing half of the layer in non-spiralize mode,
-     * while each layer starts with a different part.
-     * Two towers would result in alternating spiralize and non-spiralize layers.
+     * When \p spiralize is true, each polygon will gradually increase from a z
+     * corresponding to this layer to the z corresponding to the next layer.
+     * Doing this for each polygon means there is a chance for the print head to
+     * crash into already printed parts, but doing it for the last polygon only
+     * would mean you are printing half of the layer in non-spiralize mode,
+     * while each layer starts with a different part. Two towers would result in
+     * alternating spiralize and non-spiralize layers.
      * 
-     * \param polygons The polygons
-     * \param config The config with which to print the polygon lines
-     * \param wall_overlap_computation The wall overlap compensation calculator for each given segment (optionally nullptr)
-     * \param z_seam_config Optional configuration for z-seam
-     * \param wall_0_wipe_dist The distance to travel along each polygon after it has been laid down, in order to wipe the start and end of the wall together
-     * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over each polygon printed
-     * \param flow_ratio The ratio with which to multiply the extrusion amount
-     * \param always_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
-     * \param reverse_order Adds polygons in reverse order
+     * \param polygons The polygons.
+     * \param config The config with which to print the polygon lines.
+     * \param wall_overlap_computation The wall overlap compensation calculator
+     * for each given segment (optionally nullptr).
+     * \param z_seam_config Optional configuration for z-seam.
+     * \param wall_0_wipe_dist The distance to travel along each polygon after
+     * it has been laid down, in order to wipe the start and end of the wall
+     * together.
+     * \param spiralize Whether to gradually increase the z height from the
+     * normal layer height to the height of the next layer over each polygon
+     * printed.
+     * \param flow_ratio The ratio with which to multiply the extrusion amount.
+     * \param always_retract Whether to force a retraction when moving to the
+     * start of the polygon (used for outer walls).
+     * \param reverse_order Adds polygons in reverse order.
+     * \param start_near_location Start optimising the path near this location.
+     * If unset, this causes it to start near the last planned location.
      */
-    void addPolygonsByOptimizer(const Polygons& polygons, const GCodePathConfig& config, WallOverlapComputation* wall_overlap_computation = nullptr, const ZSeamConfig& z_seam_config = ZSeamConfig(), coord_t wall_0_wipe_dist = 0, bool spiralize = false, const Ratio flow_ratio = 1.0_r, bool always_retract = false, bool reverse_order = false);
+    void addPolygonsByOptimizer(const Polygons& polygons, const GCodePathConfig& config, WallOverlapComputation* wall_overlap_computation = nullptr, const ZSeamConfig& z_seam_config = ZSeamConfig(), coord_t wall_0_wipe_dist = 0, bool spiralize = false, const Ratio flow_ratio = 1.0_r, bool always_retract = false, bool reverse_order = false, const std::optional<Point> start_near_location = std::optional<Point>());
 
     /*!
      * Add a single line that is part of a wall to the gcode.


### PR DESCRIPTION
If you're printing infill lines it would randomize the starting line. However some infill patterns don't produce infill lines but infill polygons. This happens with the concentric pattern as well as when you're using the Infill Line Multiplier with an even number. Infill lines is empty then which would cause an arithmetic error when doing modulo 0 to confine the random number to the length of the array. Instead, if there are no lines, use a random polygon to start with.

Contributes to issue CURA-7229.

Fixes Ultimaker/Cura#6702.