### PR TITLE
Aggressively smooth polygons when multiplying infill lines.

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -201,11 +201,13 @@ void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)
             first_offset = outline.difference(first_offset);
         }
     }
+    first_offset.simplify(infill_line_width, infill_line_width);
     result.add(first_offset);
     Polygons reference_polygons = first_offset;
     for (size_t infill_line = 1; infill_line < infill_multiplier / 2; infill_line++) // 2 because we are making lines on both sides at the same time
     {
         Polygons extra_offset = reference_polygons.offset(-infill_line_width);
+        extra_offset.simplify(infill_line_width, infill_line_width);
         result.add(extra_offset);
         reference_polygons = std::move(extra_offset);
     }


### PR DESCRIPTION
This removes a lot of jaggies which looks nicer and reduces print time.

This makes a great different when using gyroid pattern. Here's a couple of images that show the difference. Notice the big change in predicted print time

Before this PR...
![Screenshot_2020-03-21_13-51-56](https://user-images.githubusercontent.com/585618/77229257-b8e39880-6b84-11ea-9331-4c0bec7eed99.png)

With this PR...
![Screenshot_2020-03-21_13-51-25](https://user-images.githubusercontent.com/585618/77229262-bd0fb600-6b84-11ea-9795-5bac105cfbfb.png)

I haven't seen any detrimental effect on the other infill patterns with this change.