### PR TITLE
CURA-7284 Fix sometimes crash on a skirt and no brim.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1042,6 +1042,11 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
         }
     }
 
+    if (skirt_brim.empty())
+    {
+        return;
+    }
+
     if (train.settings.get<bool>("brim_outside_only"))
     {
         gcode_layer.addTravel(skirt_brim.back().closestPointTo(start_close_to));
@@ -1062,16 +1067,23 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
                 inner_brim.add(polygon);
             }
         }
-        gcode_layer.addTravel(outer_brim.back().closestPointTo(start_close_to));
-        gcode_layer.addPolygonsByOptimizer(outer_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr]);
-        
-        //Add polygon in reverse order
-        const coord_t wall_0_wipe_dist = 0;
-        const bool spiralize = false;
-        const float flow_ratio = 1.0;
-        const bool always_retract = false;
-        const bool reverse_order = true;
-        gcode_layer.addPolygonsByOptimizer(inner_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr], nullptr, ZSeamConfig(), wall_0_wipe_dist, spiralize, flow_ratio, always_retract, reverse_order);
+
+        if (! outer_brim.empty())
+        {
+            gcode_layer.addTravel(outer_brim.back().closestPointTo(start_close_to));
+            gcode_layer.addPolygonsByOptimizer(outer_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr]);
+        }
+
+        if (! inner_brim.empty())
+        {
+            //Add polygon in reverse order
+            const coord_t wall_0_wipe_dist = 0;
+            const bool spiralize = false;
+            const float flow_ratio = 1.0;
+            const bool always_retract = false;
+            const bool reverse_order = true;
+            gcode_layer.addPolygonsByOptimizer(inner_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr], nullptr, ZSeamConfig(), wall_0_wipe_dist, spiralize, flow_ratio, always_retract, reverse_order);
+        }
     }
 }
 


### PR DESCRIPTION
Due to a previous fix within CURA-7284, the skirt_brim could be empty in the second half of the function, but since this wasn't previously possible, the code wasn't robust against that.