### PR TITLE
Simplify support areas as this can vastly reduce the line count.

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -690,8 +690,12 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage)
 
         generateSupportAreasForMesh(storage, *infill_settings, *roof_settings, *bottom_settings, mesh_idx, storage.print_layer_count, mesh_support_areas_per_layer);
         const double minimum_support_area = mesh.settings.get<double>("minimum_support_area");
+        const coord_t support_line_resolution = infill_settings->get<coord_t>("support_line_width") * 2;
+        const coord_t support_line_deviation = infill_settings->get<coord_t>("support_xy_distance") / 10;
         for (size_t layer_idx = 0; layer_idx < storage.print_layer_count; layer_idx++)
         {
+            mesh_support_areas_per_layer[layer_idx].simplify(support_line_resolution, support_line_deviation);
+
             if (minimum_support_area > 0.0)
             {
                 mesh_support_areas_per_layer[layer_idx].removeSmallAreas(minimum_support_area);


### PR DESCRIPTION
This provides a triple benefit of slicing quicker, reducing the gcode file size and avoiding
slowing the printer down due to the presence of many small line segments.

See https://community.ultimaker.com/topic/31734-very-slow-support-print-speed-around-object/ for a sample project that was greatly improved by this PR.

Without this PR, slicing that project produced 218044 lines of gcode. With this PR, it reduced to 121752 lines. That's about 45% reduction!
