### PR TITLE
Start skirt at point nearest to current position + print skirt from outer line inwards.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1028,18 +1028,25 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
         start_close_to = gcode_layer.getLastPlannedPositionOrStartingPosition();
     }
 
+    Polygons first_skirt_brim;
     Polygons skirt_brim;
     // Plan parts that need to be printed first: for example, skirt needs to be printed before support-brim.
     for (size_t i_part = 0; i_part < original_skirt_brim.size(); ++i_part)
     {
         if (i_part < storage.skirt_brim_max_locked_part_order[extruder_nr])
         {
-            gcode_layer.addPolygon(original_skirt_brim[i_part], 0, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr]);
+            first_skirt_brim.add(original_skirt_brim[i_part]);
         }
         else
         {
             skirt_brim.add(original_skirt_brim[i_part]);
         }
+    }
+
+    if (!first_skirt_brim.empty())
+    {
+        gcode_layer.addTravel(first_skirt_brim.back().closestPointTo(start_close_to));
+        gcode_layer.addPolygonsByOptimizer(first_skirt_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr]);
     }
 
     if (skirt_brim.empty())


### PR DESCRIPTION
It always used to print the skirt from the outer line inwards but recently that had
changed so I have reinstated the original behaviour.

These images show how with the PR the skirt is started at the point nearest the current location (0, 0)

Without this PR...

![Screenshot_2020-04-06_11-20-48](https://user-images.githubusercontent.com/585618/78548906-6b5c6200-77f9-11ea-81f7-701e9ad254a5.png)

With this PR...

![Screenshot_2020-04-06_11-21-27](https://user-images.githubusercontent.com/585618/78548865-597abf00-77f9-11ea-937d-6d1a79344ce8.png)
