### PR TITLE
Fix incorrect display of print time (issue #1233)

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1364,7 +1364,7 @@ void GCodeExport::finalize(const char* endCode)
     int64_t print_time = getSumTotalPrintTimes();
     int mat_0 = getTotalFilamentUsed(0);
     log("Print time (s): %d\n", print_time);
-    log("Print time (hr|min|s): %dh %dm %ds\n", print_time / 60 / 60, (print_time / 60) % 60, print_time % 60);
+    log("Print time (hr|min|s): %dh %dm %ds\n", int(print_time / 60 / 60), int((print_time / 60) % 60), int(print_time % 60));
     log("Filament (mm^3): %d\n", mat_0);
     for(int n=1; n<MAX_EXTRUDERS; n++)
         if (getTotalFilamentUsed(n) > 0)


### PR DESCRIPTION
This fixes the incorrect display of the print time (#1233). This is because the `sprintf` "%d" specifier cannot be used for `int64_t`.

Before:

```
Print time (s): 87813
Print time (hr|min|s): 24h 0m 23s
```

After:

```
Print time (s): 87813
Print time (hr|min|s): 24h 23m 33s
```