### PR TITLE
Fix edge case in moveInside

### DIFF
--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -238,7 +238,8 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
         bool projected_p_beyond_prev_segment = dot(p1 - p0, from - p0) >= vSize2(p1 - p0);
         for(const Point& p2 : poly)
         {   
-            // X = A + Normal( B - A ) * ((( B - A ) dot ( P - A )) / VSize( A - B ));
+            // X = A + Normal(B-A) * (((B-A) dot (P-A)) / VSize(B-A));
+            //   = A +       (B-A) *  ((B-A) dot (P-A)) / VSize2(B-A);
             // X = P projected on AB
             const Point& a = p1;
             const Point& b = p2;
@@ -251,8 +252,8 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
                 p1 = p2; //Skip only one of the points.
                 continue;
             }
-            int64_t ax_length2 = dot(ab, ap);
-            if (ax_length2 <= 0) // x is projected to before ab
+            int64_t dot_prod = dot(ab, ap);
+            if (dot_prod <= 0) // x is projected to before ab
             {
                 if (projected_p_beyond_prev_segment)
                 { //  case which looks like:   > .
@@ -282,7 +283,7 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
                     continue;
                 }
             }
-            else if (ax_length2 >= ab_length2) // x is projected to beyond ab
+            else if (dot_prod >= ab_length2) // x is projected to beyond ab
             {
                 projected_p_beyond_prev_segment = true;
                 p0 = p1;
@@ -292,7 +293,7 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
             else 
             { // x is projected to a point properly on the line segment (not onto a vertex). The case which looks like | .
                 projected_p_beyond_prev_segment = false;
-                Point x = a + ab * ax_length2 / ab_length2;
+                Point x = a + ab * dot_prod / ab_length2;
 
                 int64_t dist2 = vSize2(p - x);
                 if (dist2 < bestDist2)
@@ -359,7 +360,8 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
     bool projected_p_beyond_prev_segment = dot(p1 - p0, from - p0) >= vSize2(p1 - p0);
     for(const Point& p2 : polygon)
     {
-        // X = A + Normal( B - A ) * ((( B - A ) dot ( P - A )) / VSize( A - B ));
+        // X = A + Normal(B-A) * (((B-A) dot (P-A)) / VSize(B-A));
+        //   = A +       (B-A) *  ((B-A) dot (P-A)) / VSize2(B-A);
         // X = P projected on AB
         const Point& a = p1;
         const Point& b = p2;
@@ -372,8 +374,8 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
             p1 = p2; //Skip only one of the points.
             continue;
         }
-        int64_t ax_length2 = dot(ab, ap);
-        if (ax_length2 <= 0) // x is projected to before ab
+        int64_t dot_prod = dot(ab, ap);
+        if (dot_prod <= 0) // x is projected to before ab
         {
             if (projected_p_beyond_prev_segment)
             { //  case which looks like:   > .
@@ -405,7 +407,7 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
                 continue;
             }
         }
-        else if (ax_length2 >= ab_length2) // x is projected to beyond ab
+        else if (dot_prod >= ab_length2) // x is projected to beyond ab
         {
             projected_p_beyond_prev_segment = true;
             p0 = p1;
@@ -415,7 +417,7 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
         else
         { // x is projected to a point properly on the line segment (not onto a vertex). The case which looks like | .
             projected_p_beyond_prev_segment = false;
-            Point x = a + ab * ax_length2 / ab_length2;
+            Point x = a + ab * dot_prod / ab_length2;
 
             int64_t dist2 = vSize2(p - x);
             if (dist2 < bestDist2)

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -233,6 +233,8 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
             continue;
         Point p0 = poly[poly.size()-2];
         Point p1 = poly.back();
+        // because we compare with vSize2 here (no division by zero), we also need to compare by vSize2 inside the loop
+        // to avoid integer rounding edge cases
         bool projected_p_beyond_prev_segment = dot(p1 - p0, from - p0) >= vSize2(p1 - p0);
         for(const Point& p2 : poly)
         {   
@@ -243,14 +245,14 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
             const Point& p = from;
             Point ab = b - a;
             Point ap = p - a;
-            int64_t ab_length = vSize(ab);
-            if(ab_length <= 0) //A = B, i.e. the input polygon had two adjacent points on top of each other.
+            int64_t ab_length2 = vSize2(ab);
+            if(ab_length2 <= 0) //A = B, i.e. the input polygon had two adjacent points on top of each other.
             {
                 p1 = p2; //Skip only one of the points.
                 continue;
             }
-            int64_t ax_length = dot(ab, ap) / ab_length;
-            if (ax_length <= 0) // x is projected to before ab
+            int64_t ax_length2 = dot(ab, ap);
+            if (ax_length2 <= 0) // x is projected to before ab
             {
                 if (projected_p_beyond_prev_segment)
                 { //  case which looks like:   > .
@@ -280,7 +282,7 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
                     continue;
                 }
             }
-            else if (ax_length >= ab_length) // x is projected to beyond ab
+            else if (ax_length2 >= ab_length2) // x is projected to beyond ab
             {
                 projected_p_beyond_prev_segment = true;
                 p0 = p1;
@@ -290,7 +292,7 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
             else 
             { // x is projected to a point properly on the line segment (not onto a vertex). The case which looks like | .
                 projected_p_beyond_prev_segment = false;
-                Point x = a + ab * ax_length / ab_length;
+                Point x = a + ab * ax_length2 / ab_length2;
 
                 int64_t dist2 = vSize2(p - x);
                 if (dist2 < bestDist2)
@@ -352,6 +354,8 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
     }
     Point p0 = polygon[polygon.size() - 2];
     Point p1 = polygon.back();
+    // because we compare with vSize2 here (no division by zero), we also need to compare by vSize2 inside the loop
+    // to avoid integer rounding edge cases
     bool projected_p_beyond_prev_segment = dot(p1 - p0, from - p0) >= vSize2(p1 - p0);
     for(const Point& p2 : polygon)
     {
@@ -362,14 +366,14 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
         const Point& p = from;
         Point ab = b - a;
         Point ap = p - a;
-        int64_t ab_length = vSize(ab);
+        int64_t ab_length2 = vSize2(ab);
         if(ab_length <= 0) //A = B, i.e. the input polygon had two adjacent points on top of each other.
         {
             p1 = p2; //Skip only one of the points.
             continue;
         }
-        int64_t ax_length = dot(ab, ap) / ab_length;
-        if (ax_length <= 0) // x is projected to before ab
+        int64_t ax_length2 = dot(ab, ap);
+        if (ax_length2 <= 0) // x is projected to before ab
         {
             if (projected_p_beyond_prev_segment)
             { //  case which looks like:   > .
@@ -401,7 +405,7 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
                 continue;
             }
         }
-        else if (ax_length >= ab_length) // x is projected to beyond ab
+        else if (ax_length2 >= ab_length2) // x is projected to beyond ab
         {
             projected_p_beyond_prev_segment = true;
             p0 = p1;
@@ -411,7 +415,7 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
         else
         { // x is projected to a point properly on the line segment (not onto a vertex). The case which looks like | .
             projected_p_beyond_prev_segment = false;
-            Point x = a + ab * ax_length / ab_length;
+            Point x = a + ab * ax_length2 / ab_length2;
 
             int64_t dist2 = vSize2(p - x);
             if (dist2 < bestDist2)

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -367,7 +367,7 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
         Point ab = b - a;
         Point ap = p - a;
         int64_t ab_length2 = vSize2(ab);
-        if(ab_length <= 0) //A = B, i.e. the input polygon had two adjacent points on top of each other.
+        if(ab_length2 <= 0) //A = B, i.e. the input polygon had two adjacent points on top of each other.
         {
             p1 = p2; //Skip only one of the points.
             continue;


### PR DESCRIPTION
This fixes an edge case in the moveInside method:
The comparison `ax_length >= ab_length` MUST be the same for the points IN the loop and the check BEFORE the loop.

The edge case causing the issue:
Px is projected exactly onto the last line of the polygon => `projected_p_beyond_prev_segment` is initialized to `false`.
At the end of the loop, this last line is checked; but because in the loop, `ax_length` was divided by `ab_length`, this rounded up to the next integer, which means that inside the loop, Px is projected ONTO the last vertex (`projected_p_beyond_prev_segment = true`) and the loop ends without ever checking the last vertex.
This should resolve that issue.

I did not run proper tests on this yet, so please check carefully that it doesn't introduce any other bugs.
I'm planning to rewrite the moveInside in a more readable and less duplicated way, anyway; but that will take more time