### PR TITLE
Now cubicsubdiv infill pattern can be rotated.

### DIFF
--- a/src/infill/SubDivCube.cpp
+++ b/src/infill/SubDivCube.cpp
@@ -37,7 +37,10 @@ SubDivCube::~SubDivCube()
 void SubDivCube::precomputeOctree(SliceMeshStorage& mesh, const Point& infill_origin)
 {
     radius_addition = mesh.settings.get<coord_t>("sub_div_rad_add");
-    AngleRadians infill_angle = 45;
+
+    // if infill_angles is not empty use the first value, otherwise use 0
+    const std::vector<AngleDegrees> infill_angles = mesh.settings.get<std::vector<AngleDegrees>>("infill_angles");
+    const AngleDegrees infill_angle = (!infill_angles.empty()) ? infill_angles[0] : AngleDegrees(0);
 
     const coord_t furthest_dist_from_origin = std::sqrt(square(mesh.settings.get<coord_t>("machine_height")) + square(mesh.settings.get<coord_t>("machine_depth") / 2) + square(mesh.settings.get<coord_t>("machine_width") / 2));
     const coord_t max_side_length = furthest_dist_from_origin * 2;


### PR DESCRIPTION
Only uses first element from infill_angles.

This PR also fixes the regression that was introduced when the type of infill_angle was changed to AngleRadians.
