### PR TITLE
Cura 7318 ironing offsets with half a skin line width

### DIFF
--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -52,6 +52,11 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
         const float width_scale = (float)mesh.settings.get<coord_t>("layer_height") / mesh.settings.get<coord_t>("infill_sparse_thickness");
         ironing_inset += width_scale * line_width / 2;
     }
+    else if (pattern == EFillMethod::CONCENTRIC)
+    {
+        //Counteract the outline_offset increase that takes place when infill is generated for the concentric pattern
+        ironing_inset -= line_width / 2;
+    }
     const coord_t outline_offset = ironing_inset;
 
     Infill infill_generator(pattern, zig_zaggify_infill, connect_polygons, areas, outline_offset, line_width, line_spacing, infill_overlap, infill_multiplier, direction, layer.z - 10, shift);

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -44,18 +44,23 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
     constexpr coord_t infill_overlap = 0;
     constexpr int infill_multiplier = 1;
     constexpr coord_t shift = 0;
+    const Ratio ironing_flow = mesh.settings.get<Ratio>("ironing_flow");
 
     coord_t ironing_inset = -mesh.settings.get<coord_t>("ironing_inset");
     if (pattern == EFillMethod::ZIG_ZAG && ironing_inset == 0)
     {
         //Compensate for the outline_offset decrease that takes place when using the infill generator to generate ironing with the zigzag pattern
-        const float width_scale = (float)mesh.settings.get<coord_t>("layer_height") / mesh.settings.get<coord_t>("infill_sparse_thickness");
+        const Ratio width_scale = (float)mesh.settings.get<coord_t>("layer_height") / mesh.settings.get<coord_t>("infill_sparse_thickness");
         ironing_inset += width_scale * line_width / 2;
+        //Align the edge of the ironing line with the edge of the outer wall
+        ironing_inset -= ironing_flow * line_width / 2;
     }
     else if (pattern == EFillMethod::CONCENTRIC)
     {
         //Counteract the outline_offset increase that takes place when using the infill generator to generate ironing with the concentric pattern
-        ironing_inset -= line_width / 2;
+        ironing_inset += line_spacing - line_width / 2;
+        //Align the edge of the ironing line with the edge of the outer wall
+        ironing_inset -= ironing_flow * line_width / 2;
     }
     const coord_t outline_offset = ironing_inset;
 

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -48,13 +48,13 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
     coord_t ironing_inset = -mesh.settings.get<coord_t>("ironing_inset");
     if (pattern == EFillMethod::ZIG_ZAG && ironing_inset == 0)
     {
-        //Compensate for the outline_offset decrease that takes place when infill is generated for the zigzag pattern
+        //Compensate for the outline_offset decrease that takes place when using the infill generator to generate ironing with the zigzag pattern
         const float width_scale = (float)mesh.settings.get<coord_t>("layer_height") / mesh.settings.get<coord_t>("infill_sparse_thickness");
         ironing_inset += width_scale * line_width / 2;
     }
     else if (pattern == EFillMethod::CONCENTRIC)
     {
-        //Counteract the outline_offset increase that takes place when infill is generated for the concentric pattern
+        //Counteract the outline_offset increase that takes place when using the infill generator to generate ironing with the concentric pattern
         ironing_inset -= line_width / 2;
     }
     const coord_t outline_offset = ironing_inset;


### PR DESCRIPTION
Ironing is using the infill generator for the ironing path. The infill generator does not know that, so it generates "infill" taking into consideration the outer walls. As a result, despite the ironing inset at 0, the zigzag pattern was never reaching the outer wall while the concentric pattern was exceeding it. This PR fixes that by compensating for the outline_offsets before using the infill generator to generate the ironing path.