### PR TITLE
Add closing operation on inner walls.

### DIFF
--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -96,6 +96,9 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
             }
         }
 
+        // Closing operation and epsilon to prevent rounding errors from merging hole polygons to early:
+        part->insets[i] = part->insets[i].offset(line_width_x / 2).offset(1 - line_width_x / 2);
+
         //Finally optimize all the polygons. Every point removed saves time in the long run.
         part->insets[i].simplify();
         part->insets[i].removeDegenerateVerts();


### PR DESCRIPTION
This will prevent rounding errors from merging holes with each other too early. We might want to skip this and just wait until we get libArachne properly merged, which will _also_ solve this problem.
CURA-7424