### PR TITLE
CURA-7448 refactor temporary maps into fields

### DIFF
--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -660,7 +660,7 @@ void SkeletalTrapezoidation::generateTransitioningRibs()
 {
     // Store the upward edges to the transitions.
     // We only store the halfedge for which the distance_to_boundary is higher at the end than at the beginning.
-    temp_data_t<std::list<TransitionMiddle>> edge_transitions;
+    ptr_vector_t<std::list<TransitionMiddle>> edge_transitions;
 
     generateTransitionMids(edge_transitions);
 
@@ -674,7 +674,7 @@ void SkeletalTrapezoidation::generateTransitioningRibs()
  
     filterTransitionMids();
 
-    temp_data_t<std::list<TransitionEnd>> edge_transition_ends; // We only map the half edge in the upward direction. mapped items are not sorted
+    ptr_vector_t<std::list<TransitionEnd>> edge_transition_ends; // We only map the half edge in the upward direction. mapped items are not sorted
     generateTransitionEnds(edge_transition_ends);
 
     applyTransitions();
@@ -682,7 +682,7 @@ void SkeletalTrapezoidation::generateTransitioningRibs()
 }
 
 
-void SkeletalTrapezoidation::generateTransitionMids(temp_data_t<std::list<TransitionMiddle>>& edge_transitions)
+void SkeletalTrapezoidation::generateTransitionMids(ptr_vector_t<std::list<TransitionMiddle>>& edge_transitions)
 {
     for (edge_t& edge : graph.edges)
     {
@@ -934,7 +934,7 @@ bool SkeletalTrapezoidation::filterEndOfMarkingTransition(edge_t* edge_to_start,
     return should_dissolve;
 }
 
-void SkeletalTrapezoidation::generateTransitionEnds(temp_data_t<std::list<TransitionEnd>>& edge_transition_ends)
+void SkeletalTrapezoidation::generateTransitionEnds(ptr_vector_t<std::list<TransitionEnd>>& edge_transition_ends)
 {
     for (edge_t& edge : graph.edges)
     {
@@ -954,7 +954,7 @@ void SkeletalTrapezoidation::generateTransitionEnds(temp_data_t<std::list<Transi
     }
 }
 
-void SkeletalTrapezoidation::generateTransition(edge_t& edge, coord_t mid_pos, coord_t lower_bead_count, temp_data_t<std::list<TransitionEnd>>& edge_transition_ends)
+void SkeletalTrapezoidation::generateTransition(edge_t& edge, coord_t mid_pos, coord_t lower_bead_count, ptr_vector_t<std::list<TransitionEnd>>& edge_transition_ends)
 {
     Point a = edge.from->p;
     Point b = edge.to->p;
@@ -985,7 +985,7 @@ void SkeletalTrapezoidation::generateTransition(edge_t& edge, coord_t mid_pos, c
     }
 }
 
-bool SkeletalTrapezoidation::generateTransitionEnd(edge_t& edge, coord_t start_pos, coord_t end_pos, coord_t transition_half_length, float start_rest, float end_rest, coord_t lower_bead_count, temp_data_t<std::list<TransitionEnd>>& edge_transition_ends)
+bool SkeletalTrapezoidation::generateTransitionEnd(edge_t& edge, coord_t start_pos, coord_t end_pos, coord_t transition_half_length, float start_rest, float end_rest, coord_t lower_bead_count, ptr_vector_t<std::list<TransitionEnd>>& edge_transition_ends)
 {
     Point a = edge.from->p;
     Point b = edge.to->p;
@@ -1359,7 +1359,7 @@ void SkeletalTrapezoidation::generateSegments(std::vector<std::list<ExtrusionLin
 
     propagateBeadingsDownward(upward_quad_mids, node_to_beading);
     
-    temp_data_t<std::vector<ExtrusionJunction>> edge_junctions; // junctions ordered high R to low R
+    ptr_vector_t<std::vector<ExtrusionJunction>> edge_junctions; // junctions ordered high R to low R
     generateJunctions(node_to_beading, edge_junctions);
 
     connectJunctions(result_polylines_per_index);
@@ -1539,7 +1539,7 @@ SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beadin
     return ret;
 }
 
-void SkeletalTrapezoidation::generateJunctions(std::unordered_map<node_t*, BeadingPropagation>& node_to_beading, temp_data_t<std::vector<ExtrusionJunction>>& edge_junctions)
+void SkeletalTrapezoidation::generateJunctions(std::unordered_map<node_t*, BeadingPropagation>& node_to_beading, ptr_vector_t<std::vector<ExtrusionJunction>>& edge_junctions)
 {
     for (edge_t& edge_ : graph.edges)
     {

--- a/src/SkeletalTrapezoidation.h
+++ b/src/SkeletalTrapezoidation.h
@@ -56,7 +56,7 @@ class SkeletalTrapezoidation
     using TransitionEnd = SkeletalTrapezoidationEdge::TransitionEnd;
 
     template<typename T>
-    using temp_data_t = std::vector<std::shared_ptr<T>>;
+    using ptr_vector_t = std::vector<std::shared_ptr<T>>;
 
     float transitioning_angle; //!< How pointy a region should be before we apply the method. Equals 180* - limit_bisector_angle
     coord_t discretization_step_size; //!< approximate size of segments when parabolic VD edges get discretized (and vertex-vertex edges)
@@ -198,7 +198,7 @@ protected:
      */
     bool filterUnmarkedRegions(edge_t* to_edge, coord_t bead_count, coord_t traveled_dist, coord_t max_dist);
 
-    void generateTransitionMids(temp_data_t<std::list<TransitionMiddle>>& edge_transitions);
+    void generateTransitionMids(ptr_vector_t<std::list<TransitionMiddle>>& edge_transitions);
 
     void filterTransitionMids();
 
@@ -216,7 +216,7 @@ protected:
 
     bool filterEndOfMarkingTransition(edge_t* edge_to_start, coord_t traveled_dist, coord_t max_dist, coord_t replacing_bead_count);
 
-    void generateTransitionEnds(temp_data_t<std::list<TransitionEnd>>& edge_transition_ends);
+    void generateTransitionEnds(ptr_vector_t<std::list<TransitionEnd>>& edge_transition_ends);
 
     /*!
      * Also set the rest values at nodes in between the transition ends
@@ -228,7 +228,7 @@ protected:
     /*!
      * \param edge_to_transition_mids From the upward halfedges to their transitions mids
      */
-    void generateTransition(edge_t& edge, coord_t mid_R, coord_t transition_lower_bead_count, temp_data_t<std::list<TransitionEnd>>& edge_transition_ends);
+    void generateTransition(edge_t& edge, coord_t mid_R, coord_t transition_lower_bead_count, ptr_vector_t<std::list<TransitionEnd>>& edge_transition_ends);
 
     /*!
      * \p start_rest and \p end_rest refer to gap distances at the start and end pos in terms of ratios w.r.t. the inner bead width at the high end of the transition
@@ -238,7 +238,7 @@ protected:
      * 
      * \return whether the subgraph is going downward
      */
-    bool generateTransitionEnd(edge_t& edge, coord_t start_pos, coord_t end_pos, coord_t transition_half_length, float start_rest, float end_rest, coord_t transition_lower_bead_count, temp_data_t<std::list<TransitionEnd>>& edge_transition_ends);
+    bool generateTransitionEnd(edge_t& edge, coord_t start_pos, coord_t end_pos, coord_t transition_half_length, float start_rest, float end_rest, coord_t transition_lower_bead_count, ptr_vector_t<std::list<TransitionEnd>>& edge_transition_ends);
 
     bool isGoingDown(edge_t* outgoing, coord_t traveled_dist, coord_t transition_half_length, coord_t lower_bead_count) const;
 
@@ -301,7 +301,7 @@ protected:
      * generate junctions for each bone
      * \param edge_to_junctions junctions ordered high R to low R
      */
-    void generateJunctions(std::unordered_map<node_t*, BeadingPropagation>& node_to_beading, temp_data_t<std::vector<ExtrusionJunction>>& edge_junctions);
+    void generateJunctions(std::unordered_map<node_t*, BeadingPropagation>& node_to_beading, ptr_vector_t<std::vector<ExtrusionJunction>>& edge_junctions);
 
     /*!
      * connect junctions in each quad

--- a/src/SkeletalTrapezoidation.h
+++ b/src/SkeletalTrapezoidation.h
@@ -223,8 +223,6 @@ protected:
      */
     void applyTransitions();
 
-    //void filterMarkedLocalOptima(); // < -- function missing?
-
     void generateTransitioningRibs();
 
     /*!

--- a/src/SkeletalTrapezoidation.h
+++ b/src/SkeletalTrapezoidation.h
@@ -303,27 +303,20 @@ protected:
      * generate junctions for each bone
      * \param edge_to_junctions junctions ordered high R to low R
      */
-    void generateJunctions(std::unordered_map<node_t*, BeadingPropagation>& node_to_beading, std::unordered_map<edge_t*, std::vector<ExtrusionJunction>>& edge_to_junctions);
+    void generateJunctions(std::unordered_map<node_t*, BeadingPropagation>& node_to_beading, temp_data_t<std::vector<ExtrusionJunction>>& edge_junctions);
 
     /*!
      * connect junctions in each quad
      * \param edge_to_junctions junctions ordered high R to low R
      * \param[out] segments the generated segments
      */
-    void connectJunctions(std::unordered_map< arachne::SkeletalTrapezoidation::edge_t*, std::vector< arachne::ExtrusionJunction > >& edge_to_junctions, std::vector<std::list<ExtrusionLine>>& result_polylines_per_index);
+    void connectJunctions(std::vector<std::list<ExtrusionLine>>& result_polylines_per_index);
 
     /*!
      * Genrate small segments for local maxima where the beading would only result in a single bead
      * \param[out] segments the generated segments
      */
     void generateLocalMaximaSingleBeads(std::unordered_map< arachne::SkeletalTrapezoidation::node_t*, arachne::SkeletalTrapezoidation::BeadingPropagation >& node_to_beading, std::vector<std::list<ExtrusionLine>>& result_polylines_per_index);
-
-    /*!
-     * \p edge is assumed to point upward to higher R; otherwise take its twin
-     * 
-     * \param include_odd_start_junction Whether to leave out the first junction if it coincides with \p edge.from->p
-     */
-    const std::vector<ExtrusionJunction>& getJunctions(edge_t* edge, std::unordered_map<edge_t*, std::vector<ExtrusionJunction>>& edge_to_junctions);
 };
 
 } // namespace arachne

--- a/src/SkeletalTrapezoidationEdge.h
+++ b/src/SkeletalTrapezoidationEdge.h
@@ -1,8 +1,8 @@
 //Copyright (c) 2020 Ultimaker B.V.
 
 
-#ifndef VORONOI_QUADRILATERALIZATION_EDGE_H
-#define VORONOI_QUADRILATERALIZATION_EDGE_H
+#ifndef SKELETAL_TRAPEZOIDATION_EDGE_H
+#define SKELETAL_TRAPEZOIDATION_EDGE_H
 
 #include <memory> // smart pointers
 #include <list>
@@ -73,51 +73,51 @@ public:
 
     bool hasTransitions(bool ignore_empty = false) const
     {
-        return transitions_.use_count() > 0 && (ignore_empty || ! transitions_.lock()->empty());
+        return transitions.use_count() > 0 && (ignore_empty || ! transitions.lock()->empty());
     }
-    void initTransitions(std::shared_ptr<std::list<TransitionMiddle>> storage)
+    void setTransitions(std::shared_ptr<std::list<TransitionMiddle>> storage)
     {
-        transitions_ = storage;
+        transitions = storage;
     }
-    std::shared_ptr<std::list<TransitionMiddle>> transitions()
+    std::shared_ptr<std::list<TransitionMiddle>> getTransitions()
     {
-        return transitions_.lock();
+        return transitions.lock();
     }
 
     bool hasTransitionEnds(bool ignore_empty = false) const
     {
-        return transition_ends_.use_count() > 0 && (ignore_empty || ! transition_ends_.lock()->empty());
+        return transition_ends.use_count() > 0 && (ignore_empty || ! transition_ends.lock()->empty());
     }
-    void initTransitionEnds(std::shared_ptr<std::list<TransitionEnd>> storage)
+    void setTransitionEnds(std::shared_ptr<std::list<TransitionEnd>> storage)
     {
-        transition_ends_ = storage;
+        transition_ends = storage;
     }
-    std::shared_ptr<std::list<TransitionEnd>> transition_ends()
+    std::shared_ptr<std::list<TransitionEnd>> getTransitionEnds()
     {
-        return transition_ends_.lock();
+        return transition_ends.lock();
     }
 
     bool hasExtrusionJunctions(bool ignore_empty = false) const
     {
-        return extrusion_juntions_.use_count() > 0 && (ignore_empty || ! extrusion_juntions_.lock()->empty());
+        return extrusion_junctions.use_count() > 0 && (ignore_empty || ! extrusion_junctions.lock()->empty());
     }
-    void initExtrusionJunctions(std::shared_ptr<std::vector<ExtrusionJunction>> storage)
+    void setExtrusionJunctions(std::shared_ptr<std::vector<ExtrusionJunction>> storage)
     {
-        extrusion_juntions_ = storage;
+        extrusion_junctions = storage;
     }
-    std::shared_ptr<std::vector<ExtrusionJunction>> extrusion_juntions()
+    std::shared_ptr<std::vector<ExtrusionJunction>> getExtrusionJunctions()
     {
-        return extrusion_juntions_.lock();
+        return extrusion_junctions.lock();
     }
 
 private:
     int_least8_t is_marked; //! whether the edge is significant; whether the source segments have a sharp angle; -1 is unknown
 
-    std::weak_ptr<std::list<TransitionMiddle>> transitions_;
-    std::weak_ptr<std::list<TransitionEnd>> transition_ends_;
-    std::weak_ptr<std::vector<ExtrusionJunction>> extrusion_juntions_;
+    std::weak_ptr<std::list<TransitionMiddle>> transitions;
+    std::weak_ptr<std::list<TransitionEnd>> transition_ends;
+    std::weak_ptr<std::vector<ExtrusionJunction>> extrusion_junctions;
 };
 
 
 } // namespace arachne
-#endif // VORONOI_QUADRILATERALIZATION_EDGE_H
+#endif // SKELETAL_TRAPEZOIDATION_EDGE_H

--- a/src/SkeletalTrapezoidationEdge.h
+++ b/src/SkeletalTrapezoidationEdge.h
@@ -1,9 +1,11 @@
-//Copyright (c) 2019 Ultimaker B.V.
+//Copyright (c) 2020 Ultimaker B.V.
 
 
 #ifndef VORONOI_QUADRILATERALIZATION_EDGE_H
 #define VORONOI_QUADRILATERALIZATION_EDGE_H
 
+#include <memory> // smart pointers
+#include <list>
 
 namespace arachne
 {
@@ -12,7 +14,33 @@ namespace arachne
 class SkeletalTrapezoidationEdge
 {
     using type_t = int_least16_t;
+    using edge_t = SkeletalTrapezoidationEdge;
 public:
+    /*!
+     * Representing the location along an edge where the anchor position of a transition should be placed.
+     */
+    struct TransitionMiddle
+    {
+        coord_t pos; // Position along edge as measure from edge.from.p
+        coord_t lower_bead_count;
+        TransitionMiddle(coord_t pos, coord_t lower_bead_count)
+            : pos(pos), lower_bead_count(lower_bead_count)
+        {}
+    };
+
+    /*!
+     * Represents the location along an edge where the lower or upper end of a transition should be placed.
+     */
+    struct TransitionEnd
+    {
+        coord_t pos; // Position along edge as measure from edge.from.p, where the edge is always the half edge oriented from lower to higher R
+        coord_t lower_bead_count;
+        bool is_lower_end; // Whether this is the ed of the transition with lower bead count
+        TransitionEnd(coord_t pos, coord_t lower_bead_count, bool is_lower_end)
+            : pos(pos), lower_bead_count(lower_bead_count), is_lower_end(is_lower_end)
+        {}
+    };
+
     type_t type;
     static constexpr type_t NORMAL = 0; // from voronoi diagram
     static constexpr type_t EXTRA_VD = 1; // introduced to voronoi diagram in order to make the gMAT
@@ -39,11 +67,39 @@ public:
     {
         return is_marked >= 0;
     }
+
+    bool hasTransitions(bool ignore_empty = false) const
+    {
+        return transitions_.use_count() > 0 && (ignore_empty || ! transitions_.lock()->empty());
+    }
+    void initTransitions(std::shared_ptr<std::list<TransitionMiddle>> storage)
+    {
+        transitions_ = storage;
+    }
+    std::shared_ptr<std::list<TransitionMiddle>> transitions()
+    {
+        return transitions_.lock();
+    }
+
+    bool hasTransitionEnds(bool ignore_empty = false) const
+    {
+        return transition_ends_.use_count() > 0 && (ignore_empty || ! transition_ends_.lock()->empty());
+    }
+    void initTransitionEnds(std::shared_ptr<std::list<TransitionEnd>> storage)
+    {
+        transition_ends_ = storage;
+    }
+    std::shared_ptr<std::list<TransitionEnd>> transition_ends()
+    {
+        return transition_ends_.lock();
+    }
+
 private:
     int_least8_t is_marked; //! whether the edge is significant; whether the source segments have a sharp angle; -1 is unknown
+
+    std::weak_ptr<std::list<TransitionMiddle>> transitions_;
+    std::weak_ptr<std::list<TransitionEnd>> transition_ends_;
 };
-
-
 
 
 } // namespace arachne

--- a/src/SkeletalTrapezoidationEdge.h
+++ b/src/SkeletalTrapezoidationEdge.h
@@ -6,6 +6,9 @@
 
 #include <memory> // smart pointers
 #include <list>
+#include <vector>
+
+#include "utils/ExtrusionJunction.h"
 
 namespace arachne
 {
@@ -94,11 +97,25 @@ public:
         return transition_ends_.lock();
     }
 
+    bool hasExtrusionJunctions(bool ignore_empty = false) const
+    {
+        return extrusion_juntions_.use_count() > 0 && (ignore_empty || ! extrusion_juntions_.lock()->empty());
+    }
+    void initExtrusionJunctions(std::shared_ptr<std::vector<ExtrusionJunction>> storage)
+    {
+        extrusion_juntions_ = storage;
+    }
+    std::shared_ptr<std::vector<ExtrusionJunction>> extrusion_juntions()
+    {
+        return extrusion_juntions_.lock();
+    }
+
 private:
     int_least8_t is_marked; //! whether the edge is significant; whether the source segments have a sharp angle; -1 is unknown
 
     std::weak_ptr<std::list<TransitionMiddle>> transitions_;
     std::weak_ptr<std::list<TransitionEnd>> transition_ends_;
+    std::weak_ptr<std::vector<ExtrusionJunction>> extrusion_juntions_;
 };
 
 

--- a/src/SkeletalTrapezoidationJoint.h
+++ b/src/SkeletalTrapezoidationJoint.h
@@ -1,9 +1,12 @@
-//Copyright (c) 2019 Ultimaker B.V.
+//Copyright (c) 2020 Ultimaker B.V.
 
 
-#ifndef VORONOI_QUADRILATERALIZATION_JOINT_H
-#define VORONOI_QUADRILATERALIZATION_JOINT_H
+#ifndef SKELETAL_TRAPEZOIDATION_JOINT_H
+#define SKELETAL_TRAPEZOIDATION_JOINT_H
 
+#include <memory> // smart pointers
+
+#include "BeadingStrategy/BeadingStrategy.h"
 #include "utils/IntPoint.h"
 
 namespace arachne
@@ -12,7 +15,22 @@ namespace arachne
 
 class SkeletalTrapezoidationJoint
 {
+    using Beading = BeadingStrategy::Beading;
 public:
+    struct BeadingPropagation
+    {
+        Beading beading;
+        coord_t dist_to_bottom_source;
+        coord_t dist_from_top_source;
+        bool is_upward_propagated_only;
+        BeadingPropagation(const Beading& beading)
+            : beading(beading)
+            , dist_to_bottom_source(0)
+            , dist_from_top_source(0)
+            , is_upward_propagated_only(false)
+        {}
+    };
+
     coord_t distance_to_boundary;
     coord_t bead_count;
     float transition_ratio; //! The distance near the skeleton to leave free because this joint is in the middle of a transition, as a fraction of the inner bead width of the bead at the higher transition.
@@ -21,10 +39,24 @@ public:
     , bead_count(-1)
     , transition_ratio(0)
     {}
+
+    bool hasBeading() const
+    {
+        return beading.use_count() > 0;
+    }
+    void setBeading(std::shared_ptr<BeadingPropagation> storage)
+    {
+        beading = storage;
+    }
+    std::shared_ptr<BeadingPropagation> getBeading()
+    {
+        return beading.lock();
+    }
+
+private:
+
+    std::weak_ptr<BeadingPropagation> beading;
 };
 
-
-
-
 } // namespace arachne
-#endif // VORONOI_QUADRILATERALIZATION_JOINT_H
+#endif // SKELETAL_TRAPEZOIDATION_JOINT_H


### PR DESCRIPTION
SkeletalTrapezoidation used some structures that where determined should reside in SkeletalTrapezoidationEdge instead.

Uses smart pointers to make a weak reference in the edge, so that it's all cleaned when it should be, and it's semantically clear that the edge doesn't necessarily always have those fields.