### PR TITLE
BugFix GCode for bed temperature is now generated when changed

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1464,7 +1464,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     gcode.setFlowRateExtrusionSettings(mesh_group_settings.get<double>("flow_rate_max_extrusion_offset"), mesh_group_settings.get<Ratio>("flow_rate_extrusion_offset_factor")); //Offset is in mm.
 
-    if (layer_nr == 1 - static_cast<LayerIndex>(Raft::getTotalExtraLayers()) && mesh_group_settings.get<bool>("machine_heated_bed") && mesh_group_settings.get<Temperature>("material_bed_temperature") != 0)
+    if (is_initial_layer && !is_raft_layer && mesh_group_settings.get<bool>("machine_heated_bed") && mesh_group_settings.get<Temperature>("material_bed_temperature") != mesh_group_settings.get<Temperature>("material_bed_temperature_layer_0"))
     {
         constexpr bool wait = false;
         gcode.writeBedTemperatureCommand(mesh_group_settings.get<Temperature>("material_bed_temperature"), wait);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1464,7 +1464,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     gcode.setFlowRateExtrusionSettings(mesh_group_settings.get<double>("flow_rate_max_extrusion_offset"), mesh_group_settings.get<Ratio>("flow_rate_extrusion_offset_factor")); //Offset is in mm.
 
-    if (is_initial_layer && !is_raft_layer && mesh_group_settings.get<bool>("machine_heated_bed") && mesh_group_settings.get<Temperature>("material_bed_temperature") != mesh_group_settings.get<Temperature>("material_bed_temperature_layer_0"))
+    static LayerIndex layer_1 {1 - static_cast<LayerIndex>(Raft::getTotalExtraLayers())};
+    if (layer_nr == layer_1 && mesh_group_settings.get<bool>("machine_heated_bed") && mesh_group_settings.get<Temperature>("material_bed_temperature") != mesh_group_settings.get<Temperature>("material_bed_temperature_layer_0"))
     {
         constexpr bool wait = false;
         gcode.writeBedTemperatureCommand(mesh_group_settings.get<Temperature>("material_bed_temperature"), wait);


### PR DESCRIPTION
CURA-7442 mention that setting the build plate temperature to 0
and having a higher initial bed temperature doesn't actuate the
new bed temperature. By checking if the initial temperature
differs from the bed temperature.

Also changed the check if it is the first layer and not a raft.
Instanciation of LayerPlan allready creates two bools is_initial_layer
and is_raft_layer, here the raft::getTotalExtraLayers are allready
static_cast to check if those conditions apply. Checking two bools,
which is done now, requires less machine instructions then a:
compare, subtract and static_cast call