### PR TITLE
Don't reduce the infill outline offset unduly when infill_sparse_thickness < layer_height.

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -100,7 +100,7 @@ void Infill::_generate(Polygons& result_polygons, Polygons& result_lines, const 
 
     if (pattern == EFillMethod::ZIG_ZAG || (zig_zaggify && (pattern == EFillMethod::LINES || pattern == EFillMethod::TRIANGLES || pattern == EFillMethod::GRID || pattern == EFillMethod::CUBIC || pattern == EFillMethod::TETRAHEDRAL || pattern == EFillMethod::QUARTER_CUBIC || pattern == EFillMethod::TRIHEXAGON || pattern == EFillMethod::GYROID)))
     {
-        const float width_scale = (mesh) ? (float)mesh->settings.get<coord_t>("layer_height") / mesh->settings.get<coord_t>("infill_sparse_thickness") : 1;
+        const float width_scale = (mesh) ? std::min((float)mesh->settings.get<coord_t>("layer_height") / mesh->settings.get<coord_t>("infill_sparse_thickness"), 1.0f) : 1.0f;
         outline_offset -= width_scale * infill_line_width / 2; // the infill line zig zag connections must lie next to the border, not on it
     }
 


### PR DESCRIPTION

Does it even make sense for infill_sparse_thickness to be < layer_height? I don't know but
let's not get caught out if it is.

As discussed in https://github.com/Ultimaker/CuraEngine/issues/1265