### PR TITLE
Fix merging of skin areas on different layers for skin edge support.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1566,12 +1566,14 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         size_t skin_edge_support_layers = mesh.settings.get<size_t>("skin_edge_support_layers");
         if (skin_edge_support_layers > 0)
         {
-            Polygons skin_above;        // skin regions on the immediate layer above
-            Polygons skin_above_upper;  // skin regions on the 2nd and subsequent layers above
+            Polygons skin_above_combined;  // skin regions on the layers above combined with small gaps between
 
-            constexpr coord_t tiny_infill_offset = 10;
+            constexpr coord_t tiny_infill_offset = 20;
 
-            for (size_t i = 1; i <= skin_edge_support_layers; ++i)
+            // working from the highest layer downwards, combine the regions of skin on all the layers but don't let the regions merge together
+            // otherwise "terraced" skin regions on separate layers will look like a single region of unbroken skin
+
+            for (size_t i = skin_edge_support_layers; i > 0; --i)
             {
                 const size_t skin_layer_nr = gcode_layer.getLayerNr() + i;
                 if (skin_layer_nr < mesh.layers.size())
@@ -1580,30 +1582,87 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                     {
                         for (const SkinPart& skin_part : part.skin_parts)
                         {
-                            if (i == 1)
+                            if (skin_above_combined.size())
                             {
-                                skin_above.add(skin_part.outline);
+                                // does this skin part overlap with any of the skin parts on the layers above?
+                                Polygons overlap = skin_above_combined.intersection(skin_part.outline);
+                                if (overlap.size())
+                                {
+                                    // yes, it overlaps, need to leave a gap between this skin part and the others
+                                    if (i > 1)
+                                    {
+                                        // this layer is the 2nd or higher layer above the layer whose infill we're printing
+
+                                        // looking from the side, if the combined regions so far look like this...
+                                        //
+                                        //     ----------------------------------
+                                        //
+                                        // and the new skin part looks like this...
+                                        //
+                                        //             -------------------------------------
+                                        //
+                                        // the result should be like this...
+                                        //
+                                        //     ------- -------------------------- ----------
+
+                                        // expand the overlap region slightly to make a small gap
+                                        Polygons overlap_expanded = overlap.offset(tiny_infill_offset);
+                                        // subtract the expanded overlap region from the regions accumulated from higher layers
+                                        skin_above_combined = skin_above_combined.difference(overlap_expanded);
+                                        // subtract the expanded overlap region from this skin part and add the remainder to the overlap region
+                                        skin_above_combined.add(skin_part.outline.difference(overlap_expanded));
+                                        // and add the overlap area as well
+                                        skin_above_combined.add(overlap);
+                                    }
+                                    else
+                                    {
+                                        // this layer is the 1st layer above the layer whose infill we're printing
+
+                                        // add this layer's skin region without subtracting the overlap but still make a gap between this
+                                        // skin region and what has been accumulated so far
+                                        // we do this so that these skin region edges will definitely have infill walls below them
+
+                                        // looking from the side, if the combined regions so far look like this...
+                                        //
+                                        //     ----------------------------------
+                                        //
+                                        // and the new skin part looks like this...
+                                        //
+                                        //             -------------------------------------
+                                        //
+                                        // the result should be like this...
+                                        //
+                                        //     ------- -------------------------------------
+
+                                        skin_above_combined = skin_above_combined.difference(skin_part.outline.offset(tiny_infill_offset));
+                                        skin_above_combined.add(skin_part.outline);
+                                    }
+                                }
+                                else
+                                {
+                                    // no overlap
+                                    skin_above_combined.add(skin_part.outline);
+                                }
                             }
                             else
                             {
-                                // combine the regions of skin on all the layers from 2 upwards but don't let the regions merge together
-                                // otherwise "terraced" skin regions on separate layers will look like a single region of unbroken skin
-                                skin_above_upper.add(skin_part.outline.difference(skin_above_upper.offset(tiny_infill_offset)));
+                                // this is the first skin region we have looked at
+                                skin_above_combined.add(skin_part.outline);
                             }
                         }
                     }
                 }
             }
 
+            // the shrink/expand here is to remove regions of infill below skin that are narrower than the width of the infill walls
+            // otherwise the infill walls could merge and form a bump
+            Polygons infill_below_skin = skin_above_combined.intersection(in_outline).offset(-infill_line_width).offset(infill_line_width);
+
             constexpr double min_area_multiplier = 25;
             const double min_area = INT2MM(infill_line_width) * INT2MM(infill_line_width) * min_area_multiplier;
+            constexpr bool remove_small_holes_from_infill_below_skin = true;
 
-            Polygons infill_below_skin = skin_above.intersection(in_outline);
-            infill_below_skin.removeSmallAreas(min_area);
-
-            // combine the skin regions with a small gap between them
-            infill_below_skin.add(skin_above_upper.intersection(in_outline).difference(infill_below_skin.offset(tiny_infill_offset)));
-            infill_below_skin.removeSmallAreas(min_area);
+            infill_below_skin.removeSmallAreas(min_area, remove_small_holes_from_infill_below_skin);
 
             if (infill_below_skin.size())
             {
@@ -1616,7 +1675,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                     Polygons infill_not_below_skin = in_outline.difference(infill_below_skin);
                     infill_not_below_skin.removeSmallAreas(min_area);
 
-                    if (infill_not_below_skin.offset(-(infill_skin_overlap + tiny_infill_offset)).size())
+                    if (infill_not_below_skin.size())
                     {
                         constexpr Polygons* perimeter_gaps = nullptr;
                         constexpr bool connected_zigzags = false;


### PR DESCRIPTION
It now leaves a tiny gap between the areas when they are combined. Before, without the
gap, areas on different layers could merge together thus losing some skin edge support.

Fixes https://github.com/Ultimaker/Cura/issues/7792