### PR TITLE
Fix read STL file error

### DIFF
--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -195,7 +195,7 @@ bool loadMeshSTL_binary(Mesh* mesh, const char* filename, const FMatrix3x3& matr
 
 bool loadMeshSTL(Mesh* mesh, const char* filename, const FMatrix3x3& matrix)
 {
-    FILE* f = fopen(filename, "r");
+    FILE* f = fopen(filename, "rb");
     if (f == nullptr)
     {
         return false;


### PR DESCRIPTION
The ASCII value of a character may be decimal 26 (0x1A, \SUB, SUBSTITUTE) in a binary STL file.Opening a file in “r” mode may return an error