### PR TITLE
CURA-6465: Fix tree support intersecting the model

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -176,12 +176,12 @@ void TreeSupport::drawCircles(SliceDataStorage& storage, const std::vector<std::
             support_layer = support_layer.difference(floor_layer.offset(10)); //Subtract the support floor from the normal support.
         }
 
-        for (PolygonRef part : support_layer) //Convert every part into a PolygonsPart for the support.
+        std::vector<PolygonsPart> support_layer_parts = support_layer.splitIntoParts();
+        for (PolygonsPart& part : support_layer_parts) //Convert every part into a PolygonsPart for the support.
         {
-            PolygonsPart outline;
-            outline.add(part);
-            storage.support.supportLayers[layer_nr].support_infill_parts.emplace_back(outline, line_width, wall_count);
+            storage.support.supportLayers[layer_nr].support_infill_parts.emplace_back(part, line_width, wall_count);
         }
+
 #pragma omp critical (support_max_layer_nr)
         {
             if (!storage.support.supportLayers[layer_nr].support_infill_parts.empty() || !storage.support.supportLayers[layer_nr].support_roof.empty())


### PR DESCRIPTION
**The problem:** The generated tree branches were merging at some point while going up. When all of
them merged together, 1 big part was being created, which essentially had a hole in the middle
(which hole also contained the model itself). Because the Polygons were not split, the part and
its hole were considered as two individual parts leading the infill generator to produce infill
lines for the inside of BOTH those parts thus covering the entire area.

**The solution:** Calling the splitIntoParts on the support layer generates the necessary
PolyTree, which essentially marks the inside polygon as a hole, thus not generating infill for
that. Therefore, the support infill is only generated within the solid areas.

Fixes
* https://github.com/Ultimaker/Cura/issues/5223
* https://github.com/Ultimaker/Cura/issues/7240
* https://github.com/Ultimaker/Cura/issues/7105
* https://github.com/Ultimaker/Cura/issues/5940

CURA-6465