### PR TITLE
When using a shared heater, preserve other extruders' waited_for_temperature state.

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1202,7 +1202,12 @@ void GCodeExport::writeTemperatureCommand(const size_t extruder, const Temperatu
         {
             if (extruder_nr != extruder)
             {
-                extruder_attr[extruder_nr].waited_for_temperature = wait;
+                // only reset the other extruders' waited_for_temperature state when the new temperature
+                // is greater than the old temperature
+                if (wait || temperature > extruder_attr[extruder_nr].currentTemperature)
+                {
+                    extruder_attr[extruder_nr].waited_for_temperature = wait;
+                }
                 extruder_attr[extruder_nr].currentTemperature = temperature;
             }
         }


### PR DESCRIPTION
It was always resetting the other extruders' waited_for_temperature state when the current
temperature change wasn't going to wait but we only want to do that when the new
temperature is greater than the current temperature.

Discussed in https://community.ultimaker.com/topic/33196-eliminating-m109-calls-when-changing-toolsshared-heater/