### PR TITLE
Reimplement Outer Inset First when using Arachne

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1898,7 +1898,12 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
             processSpiralizedWall(storage, gcode_layer, mesh_config, part, mesh);
         }
     }
-    else if (false /* TODO! insetorderoptimizer will have to be rewritten! */ && InsetOrderOptimizer::optimizingInsetsIsWorthwhile(mesh, part))
+    else
+    {
+        InsetOrderOptimizer inset_order_optimizer(*this, storage, gcode_layer, mesh, extruder_nr, mesh_config, part, gcode_layer.getLayerNr());
+        return inset_order_optimizer.optimize();
+    }
+    if (false /* TODO! insetorderoptimizer will have to be rewritten! */ && InsetOrderOptimizer::optimizingInsetsIsWorthwhile(mesh, part))
     {
         InsetOrderOptimizer ioo(*this, storage, gcode_layer, mesh, extruder_nr, mesh_config, part, gcode_layer.getLayerNr());
         return ioo.processInsetsWithOptimizedOrdering();
@@ -1933,7 +1938,7 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
         }
         std::sort(ordered_insets.begin(), ordered_insets.end(), comparator);
 
-        //       - what to do with: compensate overlaps (0 and x)
+        //TODO: what to do with "compensate overlaps" (0 and x)
 
         constexpr float flow = 1.0;
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1899,8 +1899,9 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
     }
     else
     {
+        //Main case: Optimize the insets with the InsetOrderOptimizer.
         InsetOrderOptimizer inset_order_optimizer(*this, storage, gcode_layer, mesh, extruder_nr, mesh_config, part, gcode_layer.getLayerNr());
-        return inset_order_optimizer.optimize() || added_something;
+        added_something |= inset_order_optimizer.optimize();
     }
     return added_something;
 }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1737,7 +1737,6 @@ bool FffGcodeWriter::processInsets(const SliceDataStorage& storage, LayerPlan& g
     }
     const bool compensate_overlap_0 = mesh.settings.get<bool>("travel_compensate_overlapping_walls_0_enabled");
     const bool compensate_overlap_x = mesh.settings.get<bool>("travel_compensate_overlapping_walls_x_enabled");
-    const bool retract_before_outer_wall = mesh.settings.get<bool>("travel_retract_before_outer_wall");
 
     bool spiralize = false;
     if(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<bool>("magic_spiralize"))

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -43,6 +43,18 @@ InsetOrderOptimizer::InsetOrderOptimizer(const FffGcodeWriter& gcode_writer, con
 {
 }
 
+bool InsetOrderOptimizer::optimize()
+{
+    if (InsetOrderOptimizer::optimizingInsetsIsWorthWhile(mesh, part))
+    {
+        return processInsetsWithOptimizedOrdering();
+    }
+    else
+    {
+        return processInsetsIndexedOrdering();
+    }
+}
+
 void InsetOrderOptimizer::moveInside()
 {
     const coord_t outer_wall_line_width = mesh_config.inset0_config.getLineWidth();

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2020 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "ExtruderTrain.h"
@@ -24,6 +24,23 @@ static int findAdjacentEnclosingPoly(const ConstPolygonRef& enclosed_inset, cons
         }
     }
     return -1;
+}
+
+InsetOrderOptimizer::InsetOrderOptimizer(const FffGcodeWriter& gcode_writer, const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr) :
+    gcode_writer(gcode_writer),
+    storage(storage),
+    gcode_layer(gcode_layer),
+    mesh(mesh),
+    extruder_nr(extruder_nr),
+    mesh_config(mesh_config),
+    part(part),
+    layer_nr(layer_nr),
+    z_seam_config(mesh.settings.get<EZSeamType>("z_seam_type"), mesh.getZSeamHint(), mesh.settings.get<EZSeamCornerPrefType>("z_seam_corner")),
+    added_something(false),
+    retraction_region_calculated(false),
+    wall_overlapper_0(nullptr),
+    wall_overlapper_x(nullptr)
+{
 }
 
 void InsetOrderOptimizer::moveInside()

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -685,6 +685,8 @@ bool InsetOrderOptimizer::processInsetsWithOptimizedOrdering()
 
 bool InsetOrderOptimizer::optimizingInsetsIsWorthwhile(const SliceMeshStorage& mesh, const SliceLayerPart& part)
 {
+    return false; //TODO: The optimized inset order is broken due to libArachne.
+
     if (!mesh.settings.get<bool>("optimize_wall_printing_order"))
     {
         // optimization disabled

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -64,6 +64,16 @@ private:
     Polygons retraction_region; //After printing an outer wall, move into this region so that retractions do not leave visible blobs. Calculated lazily if needed (see retraction_region_calculated).
 
     /*!
+     * Print the insets in an order based on their inset index.
+     *
+     * For instance, it will first print all insets with index 0, then all
+     * insets with index 1, and so on. Which index to start from depends on the
+     * ``outer_inset_first`` setting.
+     * \return Whether this added anything to the layer plan or not.
+     */
+    bool processInsetsIndexedOrdering();
+
+    /*!
      * Generate the insets for the holes of a given layer part after optimizing the ordering.
      */
     void processHoleInsets();

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2020 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef INSET_ORDER_OPTIMIZER_H
@@ -18,32 +18,23 @@ class InsetOrderOptimizer
 {
 public:
     /*!
-     * Constructor for inset ordering optimizer
-     * \param gcode_writer The gcode_writer on whose behalf the inset order is being optimized
-     * \param storage where the slice data is stored
-     * \param gcode_layer The initial planning of the gcode of the layer
-     * \param mesh The mesh to be added to the layer plan
-     * \param extruder_nr The extruder for which to print all features of the mesh which should be printed with this extruder
-     * \param mesh_config the line config with which to print a print feature
-     * \param part The part for which to create gcode
-     * \param layer_nr The current layer number
+     * Constructor for inset ordering optimizer.
+     *
+     * This constructor gets basically all of the locals passed when it needs to
+     * optimise the order of insets.
+     * \param gcode_writer The FffGcodeWriter on whose behalf the inset order is
+     * being optimized.
+     * \param storage Read slice data from this storage.
+     * \param gcode_layer The layer where the resulting insets must be planned.
+     * \param mesh The mesh that these insets are part of.
+     * \param extruder_nr Which extruder to process. If an inset is not printed
+     * with this extruder, it will not be added to the plan.
+     * \param mesh_config The path configs for a single mesh, indicating the
+     * line widths, flows, speeds, etc to print this mesh with.
+     * \param part The part from which to read the previously generated insets.
+     * \param layer_nr The current layer number.
      */
-    InsetOrderOptimizer(const FffGcodeWriter& gcode_writer, const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr) :
-    gcode_writer(gcode_writer),
-    storage(storage),
-    gcode_layer(gcode_layer),
-    mesh(mesh),
-    extruder_nr(extruder_nr),
-    mesh_config(mesh_config),
-    part(part),
-    layer_nr(layer_nr),
-    z_seam_config(mesh.settings.get<EZSeamType>("z_seam_type"), mesh.getZSeamHint(), mesh.settings.get<EZSeamCornerPrefType>("z_seam_corner")),
-    added_something(false),
-    retraction_region_calculated(false),
-    wall_overlapper_0(nullptr),
-    wall_overlapper_x(nullptr)
-    {
-    }
+    InsetOrderOptimizer(const FffGcodeWriter& gcode_writer, const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr);
 private:
 
     const FffGcodeWriter& gcode_writer;

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -35,6 +35,16 @@ public:
      * \param layer_nr The current layer number.
      */
     InsetOrderOptimizer(const FffGcodeWriter& gcode_writer, const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr);
+
+    /*!
+     * Adds the insets to the given layer plan.
+     *
+     * The insets and the layer plan are passed to the constructor of this
+     * class, so this optimize function needs no additional information.
+     * \return Whether anything was added to the layer plan.
+     */
+    bool optimize();
+
 private:
 
     const FffGcodeWriter& gcode_writer;


### PR DESCRIPTION
The ordering of insets was completely lost. This re-introduces the basic ordering. When "Outer Inset First" is enabled, it should print from the outer wall inwards. When "Outer Inset First" is disabled, it should print from the inside out.

Some things related to this aren't working correctly yet, but are out of scope:
* Working CI (CURA-7565).
* Optimize Wall Printing Order setting (CURA-7557), although I moved some code into that class with this PR. The code that I moved in is supposed to work.
* Outer wall being printed as innermost wall and subsequently counting adjacent walls inwards too (CURA-7553).
* Order of outlines that have the same inset index (CURA-7558). Currently it's printing arbitrarily.

Some helpful notes for a reviewer:
* The `processInsets` function is largely unchanged except that I reversed the check for `wall_line_count > 0` to an early out, at the start of the function. This reduced the indentation, but Git doesn't seem to be able to match up the diffs correctly.
* The actual change to `processInsets` starts at line 1898 of the removed code, or line 1900 of the new code. The generation of the insets in correct order has been moved from `processInsets` to the new `InsetOrderOptimizer::processInsetsIndexedOrdering` function. The `InsetOrderOptimizer::optimize` function now chooses whether to optimize or not.
* The actually new part is really just the first half of `processInsetsIndexedOrdering` where it sorts the paths by inset.

This implements CURA-7554.