### PR TITLE
CURA-6684: Ignore the extra skin wall count in concentric

### DIFF
--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -354,7 +354,13 @@ void SkinInfillAreaComputation::generateSkinInsetsAndInnerSkinInfill(SliceLayerP
 {
     for (SkinPart& skin_part : part->skin_parts)
     {
-        generateSkinInsets(skin_part);
+        // Do not generate insets if the Bottom Pattern Initial Layer (for layer 0) and the Top/Bottom Layer Pattern
+        // (for the rest of the layers) are concentric
+        if ((layer_nr == 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern_0") != EFillMethod::CONCENTRIC)
+            || mesh.settings.get<EFillMethod>("top_bottom_pattern") != EFillMethod::CONCENTRIC)
+        {
+            generateSkinInsets(skin_part);
+        }
         generateInnerSkinInfill(skin_part);
     }
 }
@@ -501,6 +507,21 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
             }
             skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
             skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
+
+            // Insets have previously NOT been generated for any layer if the top/bottom pattern is concentric.
+            // In this case, we still want to generate insets for the roofing layers based on the extra skin wall count.
+            if (skin_part.roofing_fill.size() > 0
+                && ((layer_nr > 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC)))
+            {
+                // Generate skin insets and recalculate the inner and roofing infills, taking into account the 
+                // extra skin wall count (only for the roofing layers).
+                generateSkinInsets(skin_part);
+                skin_part.inner_infill.clear();
+                generateInnerSkinInfill(skin_part);
+                skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
+                skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
+                skin_part.inner_infill = skin_part.inner_infill.offset(-skin_inset_count * skin_line_width);
+            }
         }
     }
 }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -511,7 +511,7 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
             // Insets have previously NOT been generated for any layer if the top/bottom pattern is concentric.
             // In this case, we still want to generate insets for the roofing layers based on the extra skin wall count.
             if (skin_part.roofing_fill.size() > 0
-                && ((layer_nr > 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC)))
+                && (layer_nr > 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC))
             {
                 // Generate skin insets and recalculate the inner and roofing infills, taking into account the 
                 // extra skin wall count (only for the roofing layers).

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -357,7 +357,7 @@ void SkinInfillAreaComputation::generateSkinInsetsAndInnerSkinInfill(SliceLayerP
         // Do not generate insets if the Bottom Pattern Initial Layer (for layer 0) and the Top/Bottom Layer Pattern
         // (for the rest of the layers) are concentric
         if ((layer_nr == 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern_0") != EFillMethod::CONCENTRIC)
-            || mesh.settings.get<EFillMethod>("top_bottom_pattern") != EFillMethod::CONCENTRIC)
+            || (layer_nr > 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern") != EFillMethod::CONCENTRIC))
         {
             generateSkinInsets(skin_part);
         }
@@ -511,7 +511,7 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
             // Insets have previously NOT been generated for any layer if the top/bottom pattern is concentric.
             // In this case, we still want to generate insets for the roofing layers based on the extra skin wall count.
             if (skin_part.roofing_fill.size() > 0
-                && (layer_nr > 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC))
+                && (layer_nr > 0 && mesh.settings.get<EFillMethod>("roofing_pattern") != EFillMethod::CONCENTRIC))
             {
                 // Generate skin insets and recalculate the inner and roofing infills, taking into account the 
                 // extra skin wall count (only for the roofing layers).


### PR DESCRIPTION
When we set Top/Bottom Pattern or Bottom Pattern Initial Layer or Top Surface Pattern to concentric, 
the extra skin wall count setting doesn't have any effect. In such cases, no insets should be generated 
in the skin.

This commit deals with that by not generating insets for the layers where the pattern is concentric.
If the layer is a roofing layer, then if no insets have been generated previously, generate them
now, even if the Top Surface Skin Pattern is concentric, and take into account the Extra Skin Wall
Count to generate extra walls (if needed), as in this case the ESWC still has an effect (e.g. if the 
Top Surface Skin extruder is different than the normal print extruder).

Merge along with https://github.com/Ultimaker/Cura/pull/8045.

CURA-6684