### PR TITLE
Really force retraction before final travel move on layer if user wants it.

### DIFF
--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -101,7 +101,14 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
         const bool force_retract = extruder_settings.get<bool>("retract_at_layer_change") ||
           (mesh_group_settings.get<bool>("travel_retract_before_outer_wall") && (mesh_group_settings.get<bool>("outer_inset_first") || mesh_group_settings.get<size_t>("wall_line_count") == 1)); //Moving towards an outer wall.
         prev_layer->final_travel_z = newest_layer->z;
-        prev_layer->addTravel(first_location_new_layer, force_retract);
+        GCodePath &path = prev_layer->addTravel(first_location_new_layer, force_retract);
+        if (force_retract && !path.retract)
+        {
+            // addTravel() won't use retraction if the travel distance is less than retraction minimum travel setting
+            // so to avoid blobs when moving to the new layer height, which can occur if the z-axis speed is very slow,
+            // we force the path to use retraction
+            path.retract = true;
+        }
     }
 }
 


### PR DESCRIPTION
Before, it would omit the retraction if the travel distance was less than the retraction
min travel setting but this can cause blobs if the z-axis speed is very low so we make
sure that retraction will occur.

Note that the retraction will still not occur if the new layer starts at the same location
as the old layer ended as there is no final travel move in that situation.

Inspired by https://community.ultimaker.com/topic/33260-travel-retract-at-layer-change/