### PR TITLE
CURA_7547: Make TreeSupport deterministic

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -56,7 +56,7 @@ void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
         return;
     }
 
-    std::vector<std::unordered_set<Node*>> contact_nodes(storage.support.supportLayers.size()); //Generate empty layers to store the points in.
+    std::vector<std::vector<Node*>> contact_nodes(storage.support.supportLayers.size()); //Generate empty layers to store the points in.
     for (SliceMeshStorage& mesh : storage.meshes)
     {
         if (mesh.settings.get<bool>("support_tree_enable"))
@@ -84,7 +84,7 @@ void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
     storage.support.generated = true;
 }
 
-void TreeSupport::drawCircles(SliceDataStorage& storage, const std::vector<std::unordered_set<Node*>>& contact_nodes)
+void TreeSupport::drawCircles(SliceDataStorage& storage, const std::vector<std::vector<Node*>>& contact_nodes)
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     const coord_t branch_radius = mesh_group_settings.get<coord_t>("support_tree_branch_diameter") / 2;
@@ -201,7 +201,7 @@ void TreeSupport::drawCircles(SliceDataStorage& storage, const std::vector<std::
     }
 }
 
-void TreeSupport::dropNodes(std::vector<std::unordered_set<Node*>>& contact_nodes)
+void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     //Use Minimum Spanning Tree to connect the points on each layer and move them while dropping them down.
@@ -273,15 +273,16 @@ void TreeSupport::dropNodes(std::vector<std::unordered_set<Node*>>& contact_node
             }
             //Put it in the best one.
             nodes_per_part[closest_part + 1][node.position] = p_node; //Index + 1 because the 0th index is the outside part.
+
         }
         //Create a MST for every part.
         std::vector<MinimumSpanningTree> spanning_trees;
         for (const std::unordered_map<Point, Node*>& group : nodes_per_part)
         {
-            std::unordered_set<Point> points_to_buildplate;
+            std::vector<Point> points_to_buildplate;
             for (const std::pair<Point, Node*>& entry : group)
             {
-                points_to_buildplate.insert(entry.first); //Just the position of the node.
+                points_to_buildplate.emplace_back(entry.first); //Just the position of the node.
             }
             spanning_trees.emplace_back(points_to_buildplate);
         }
@@ -464,11 +465,16 @@ void TreeSupport::dropNodes(std::vector<std::unordered_set<Node*>>& contact_node
             Node* i_node = entry.second;
             for (size_t i_layer = entry.first; i_node != nullptr; ++i_layer, i_node = i_node->parent)
             {
-                contact_nodes[i_layer].erase(i_node);
-                to_free_node_set.insert(i_node);
-                for (Node* neighbour : i_node->merged_neighbours)
+                std::vector<Node*>::iterator to_erase = std::find(contact_nodes[i_layer].begin(), contact_nodes[i_layer].end(), i_node);
+                if (to_erase != contact_nodes[i_layer].end())
                 {
-                    unsupported_branch_leaves.push_front({i_layer, neighbour});
+                    delete *to_erase;
+                    contact_nodes[i_layer].erase(to_erase);
+                    to_free_node_set.insert(i_node);
+                    for (Node* neighbour : i_node->merged_neighbours)
+                    {
+                        unsupported_branch_leaves.push_front({ i_layer, neighbour });
+                    }
                 }
             }
         }
@@ -485,7 +491,7 @@ void TreeSupport::dropNodes(std::vector<std::unordered_set<Node*>>& contact_node
     to_free_node_set.clear();
 }
 
-void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vector<std::unordered_set<TreeSupport::Node*>>& contact_nodes)
+void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vector<std::vector<TreeSupport::Node*>>& contact_nodes)
 {
     const coord_t point_spread = mesh.settings.get<coord_t>("support_tree_branch_distance");
 
@@ -528,6 +534,7 @@ void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vecto
         }
     }
 
+
     const coord_t layer_height = mesh.settings.get<coord_t>("layer_height");
     const coord_t z_distance_top = mesh.settings.get<coord_t>("support_top_distance");
     const size_t z_distance_top_layers = round_up_divide(z_distance_top, layer_height) + 1; //Support must always be 1 layer below overhang.
@@ -568,7 +575,7 @@ void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vecto
                         constexpr size_t distance_to_top = 0;
                         constexpr bool to_buildplate = true;
                         Node* contact_node = new Node(candidate, distance_to_top, (layer_nr + z_distance_top_layers) % 2, support_roof_layers, to_buildplate, Node::NO_PARENT);
-                        contact_nodes[layer_nr].insert(contact_node);
+                        contact_nodes[layer_nr].emplace_back(contact_node);
                         added = true;
                     }
                 }
@@ -580,7 +587,7 @@ void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vecto
                 constexpr size_t distance_to_top = 0;
                 constexpr bool to_buildplate = true;
                 Node* contact_node = new Node(candidate, distance_to_top, layer_nr % 2, support_roof_layers, to_buildplate, Node::NO_PARENT);
-                contact_nodes[layer_nr].insert(contact_node);
+                contact_nodes[layer_nr].emplace_back(contact_node);
             }
         }
         for (const ConstPolygonRef overhang_part : overhang)
@@ -603,12 +610,12 @@ void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vecto
     }
 }
 
-void TreeSupport::insertDroppedNode(std::unordered_set<Node*>& nodes_layer, Node* p_node)
+void TreeSupport::insertDroppedNode(std::vector<Node*>& nodes_layer, Node* p_node)
 {
-    std::unordered_set<Node*>::iterator conflicting_node_it = nodes_layer.find(p_node);
+    std::vector<Node*>::iterator conflicting_node_it = std::find(nodes_layer.begin(), nodes_layer.end(), p_node);
     if (conflicting_node_it == nodes_layer.end()) //No conflict.
     {
-        nodes_layer.insert(p_node);
+        nodes_layer.emplace_back(p_node);
         return;
     }
 

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -307,7 +307,7 @@ private:
      * save the resulting support polygons to.
      * \param contact_nodes The nodes to draw as support.
      */
-    void drawCircles(SliceDataStorage& storage, const std::vector<std::unordered_set<Node*>>& contact_nodes);
+    void drawCircles(SliceDataStorage& storage, const std::vector<std::vector<Node*>>& contact_nodes);
 
     /*!
      * \brief Drops down the nodes of the tree support towards the build plate.
@@ -321,7 +321,7 @@ private:
      * dropped down. The nodes are dropped to lower layers inside the same
      * vector of layers.
      */
-    void dropNodes(std::vector<std::unordered_set<Node*>>& contact_nodes);
+    void dropNodes(std::vector<std::vector<Node*>>& contact_nodes);
 
     /*!
      * \brief Creates points where support contacts the model.
@@ -336,14 +336,14 @@ private:
      * \return For each layer, a list of points where the tree should connect
      * with the model.
      */
-    void generateContactPoints(const SliceMeshStorage& mesh, std::vector<std::unordered_set<Node*>>& contact_nodes);
+    void generateContactPoints(const SliceMeshStorage& mesh, std::vector<std::vector<Node*>>& contact_nodes);
 
     /*!
      * \brief Add a node to the next layer.
      *
      * If a node is already at that position in the layer, the nodes are merged.
      */
-    void insertDroppedNode(std::unordered_set<Node*>& nodes_layer, Node* node);
+    void insertDroppedNode(std::vector<Node*>& nodes_layer, Node* node);
 };
 
 }

--- a/src/utils/MinimumSpanningTree.cpp
+++ b/src/utils/MinimumSpanningTree.cpp
@@ -9,12 +9,12 @@
 namespace cura
 {
 
-MinimumSpanningTree::MinimumSpanningTree(std::unordered_set<Point> vertices) : adjacency_graph(prim(vertices))
+MinimumSpanningTree::MinimumSpanningTree(std::vector<Point> vertices) : adjacency_graph(prim(vertices))
 {
     //Just copy over the fields.
 }
 
-auto MinimumSpanningTree::prim(std::unordered_set<Point> vertices) const -> AdjacencyGraph_t
+auto MinimumSpanningTree::prim(std::vector<Point> vertices) const -> AdjacencyGraph_t
 {
     AdjacencyGraph_t result;
     if (vertices.empty())

--- a/src/utils/MinimumSpanningTree.h
+++ b/src/utils/MinimumSpanningTree.h
@@ -42,7 +42,7 @@ public:
     /*!
      * \brief Constructs a minimum spanning tree that spans all given vertices.
      */
-    MinimumSpanningTree(std::unordered_set<Point> vertices);
+    MinimumSpanningTree(std::vector<Point> vertices);
 
     /*!
      * \brief Gets the nodes that are adjacent to the specified node.
@@ -73,7 +73,7 @@ private:
      * \param vertices The vertices to span.
      * \return An adjacency graph with for each point one or more edges.
      */
-    AdjacencyGraph_t prim(std::unordered_set<Point> vertices) const;
+    AdjacencyGraph_t prim(std::vector<Point> vertices) const;
 };
 
 }

--- a/tests/utils/MinimumSpanningTreeTest.cpp
+++ b/tests/utils/MinimumSpanningTreeTest.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <vector>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "../src/utils/MinimumSpanningTree.h"
 
@@ -36,7 +35,7 @@ namespace cura
                 Point(12, 12),
                 Point(12, 13),
             };
-            std::unordered_set<Point> pts_set(pts.begin(), pts.end());
+            std::vector<Point> pts_set(pts.begin(), pts.end());
             p_mst = new MinimumSpanningTree(pts_set);
         }
 
@@ -52,7 +51,7 @@ namespace cura
 
     TEST(SimpleMinimumSpanningTreeTest, TestConstructEmpty)
     {
-        std::unordered_set<Point> vertices;
+        std::vector<Point> vertices;
         MinimumSpanningTree tree(vertices);
 
         ASSERT_TRUE(tree.leaves().empty()) << "Empty tree should be empty.";
@@ -61,7 +60,7 @@ namespace cura
     TEST(SimpleMinimumSpanningTreeTest, TestConstructOne)
     {
         const Point pt_a(1, 1);
-        std::unordered_set<Point> vertices = { pt_a };
+        std::vector<Point> vertices = { pt_a };
         MinimumSpanningTree tree(vertices);
 
         ASSERT_FALSE(tree.leaves().empty()) << "Tree with one point shouldn't have no vertices.";
@@ -76,7 +75,7 @@ namespace cura
         const Point pt_b(2, 2);
         const Point pt_c(3, 3);
         const Point pt_d(4, 4);
-        std::unordered_set<Point> vertices = { pt_a, pt_b, pt_c, pt_d };
+        std::vector<Point> vertices = { pt_a, pt_b, pt_c, pt_d };
         MinimumSpanningTree tree(vertices);
 
         std::vector<Point> adjacent;
@@ -103,7 +102,7 @@ namespace cura
         const Point pt_b(5, 2);
         const Point pt_c(2, 5);
         const Point pt_d(3, 3);
-        std::unordered_set<Point> vertices = { pt_a, pt_b, pt_c, pt_d };
+        std::vector<Point> vertices = { pt_a, pt_b, pt_c, pt_d };
         MinimumSpanningTree tree(vertices);
 
         std::vector<Point> leaves = tree.leaves();


### PR DESCRIPTION
Use vectors instead of unordered_sets for the contact_nodes.

In every slice, a different MinimumSpanningTree was generated every time due to the fact that
Prim's algorithm was receiving an unordered set of vertices, thus accessing the vertices in
different order, every time it was run. Now, since the contact points are generated in a grid,
they generally have the same distane between them. So, depending on which neighbour was found
first, the MST would generate different edges.
As the nodes move down, this difference becomes more and more apparent, because of the different
node merges, thus leading in an almost entirely different tree in every slice.

By converting the unordered sets into vectors, the vertices are accessed in the same order, so
the non-deterministic behaviour is eliminated.

The performance should be impacted slightly when there are unsupported branch leaves (since then
the TreeSupport is searching to find a specific node in a vector) or when the insertDropNode is
searching if a node already exists in the layer.

CURA-7547