### PR TITLE
Add gcode comments for skipped retractions

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -890,6 +890,7 @@ void GCodeExport::writeRetraction(const RetractionConfig& config, bool force, bo
     double retraction_diff_e_amount = old_retraction_e_amount - new_retraction_e_amount;
     if (std::abs(retraction_diff_e_amount) < 0.000001)
     {
+        writeComment("Retraction skipped - too small");
         return;
     }
 
@@ -904,11 +905,13 @@ void GCodeExport::writeRetraction(const RetractionConfig& config, bool force, bo
         }
         if (!force && config.retraction_count_max <= 0)
         {
+            writeComment("Retraction cancelled - retraction max <= 0");
             return;
         }
         if (!force && extruded_volume_at_previous_n_retractions.size() == config.retraction_count_max
             && current_extruded_volume < extruded_volume_at_previous_n_retractions.back() + config.retraction_extrusion_window * extr_attr.filament_area) 
         {
+            writeComment("Retraction cancelled - retraction max exceeded");
             return;
         }
         extruded_volume_at_previous_n_retractions.push_front(current_extruded_volume);

--- a/tests/GCodeExportTest.cpp
+++ b/tests/GCodeExportTest.cpp
@@ -448,7 +448,7 @@ TEST_F(GCodeExportTest, SwitchExtruderSimple)
     EXPECT_CALL(*mock_communication, sendCurrentPosition(testing::_));
     gcode.switchExtruder(1, no_retraction);
 
-    EXPECT_EQ(std::string("G92 E0\n;FIRST EXTRUDER END G-CODE!\nT1\nG92 E0\n;SECOND EXTRUDER START G-CODE!\n"), output.str());
+    EXPECT_EQ(std::string("G92 E0\n;FIRST EXTRUDER END G-CODE!\n; Retraction skipped - too small\nT1\nG92 E0\n;SECOND EXTRUDER START G-CODE!\n"), output.str());
 }
 
 TEST_F(GCodeExportTest, WriteZHopStartZero)

--- a/tests/GCodeExportTest.cpp
+++ b/tests/GCodeExportTest.cpp
@@ -448,7 +448,7 @@ TEST_F(GCodeExportTest, SwitchExtruderSimple)
     EXPECT_CALL(*mock_communication, sendCurrentPosition(testing::_));
     gcode.switchExtruder(1, no_retraction);
 
-    EXPECT_EQ(std::string("G92 E0\n;FIRST EXTRUDER END G-CODE!\n; Retraction skipped - too small\nT1\nG92 E0\n;SECOND EXTRUDER START G-CODE!\n"), output.str());
+    EXPECT_EQ(std::string("G92 E0\n;FIRST EXTRUDER END G-CODE!\n;Retraction skipped - too small\nT1\nG92 E0\n;SECOND EXTRUDER START G-CODE!\n"), output.str());
 }
 
 TEST_F(GCodeExportTest, WriteZHopStartZero)


### PR DESCRIPTION
I have not added a comment for the last condition that skips retraction because I have insufficient knowledge to know what is happening.

This PR is in support of issue https://github.com/Ultimaker/Cura/issues/8069 whereby we are finding it difficult to understand why a retraction is not happening sometimes on minimum layer lift.