### PR TITLE
CURA-7614: Fix missing skin infill in roofing layers

### DIFF
--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -473,57 +473,65 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
 void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
 {
     const size_t roofing_layer_count = mesh.settings.get<size_t>("roofing_layer_count");
-    const size_t wall_idx = std::min(size_t(2), mesh.settings.get<size_t>("wall_line_count"));
 
     for (SkinPart& skin_part : part.skin_parts)
     {
         Polygons roofing;
         if (roofing_layer_count > 0)
         {
-            Polygons no_air_above = getWalls(part, layer_nr + roofing_layer_count, wall_idx);
-            if (!no_small_gaps_heuristic)
-            {
-                for (int layer_nr_above = layer_nr + 1; layer_nr_above < layer_nr + roofing_layer_count; layer_nr_above++)
-                {
-                    Polygons outlines_above = getWalls(part, layer_nr_above, wall_idx);
-                    no_air_above = no_air_above.intersection(outlines_above);
-                }
-            }
-            if (layer_nr > 0)
-            {
-                // if the skin has air below it then cutting it into regions could cause a region
-                // to be wholely or partly above air and it may not be printable so restrict
-                // the regions that have air above (the visible regions) to not include any area that
-                // has air below (fixes https://github.com/Ultimaker/Cura/issues/2656)
-
-                // set air_below to the skin area for the current layer that has air below it
-                Polygons air_below = getWalls(part, layer_nr, wall_idx).difference(getWalls(part, layer_nr - 1, wall_idx));
-
-                if (!air_below.empty())
-                {
-                    // add the polygons that have air below to the no air above polygons
-                    no_air_above = no_air_above.unionPolygons(air_below);
-                }
-            }
+            Polygons no_air_above = generateNoAirAbove(part);
             skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
             skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
 
             // Insets have previously NOT been generated for any layer if the top/bottom pattern is concentric.
             // In this case, we still want to generate insets for the roofing layers based on the extra skin wall count.
             if (skin_part.roofing_fill.size() > 0
-                && (layer_nr > 0 && mesh.settings.get<EFillMethod>("roofing_pattern") != EFillMethod::CONCENTRIC))
+                && (layer_nr > 0 && mesh.settings.get<EFillMethod>("roofing_pattern") != EFillMethod::CONCENTRIC)
+                && (layer_nr > 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC))
             {
-                // Generate skin insets and recalculate the inner and roofing infills, taking into account the 
-                // extra skin wall count (only for the roofing layers).
+                // Generate skin insets, regenerate the no_air_above, and recalculate the inner and roofing infills, 
+                // taking into account the extra skin wall count (only for the roofing layers).
                 generateSkinInsets(skin_part);
-                skin_part.inner_infill.clear();
                 generateInnerSkinInfill(skin_part);
+                no_air_above = generateNoAirAbove(part);
                 skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
                 skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
-                skin_part.inner_infill = skin_part.inner_infill.offset(-skin_inset_count * skin_line_width);
             }
         }
     }
+}
+
+Polygons SkinInfillAreaComputation::generateNoAirAbove(SliceLayerPart& part)
+{
+    const size_t roofing_layer_count = mesh.settings.get<size_t>("roofing_layer_count");
+    const size_t wall_idx = std::min(size_t(2), mesh.settings.get<size_t>("wall_line_count"));
+
+    Polygons no_air_above = getWalls(part, layer_nr + roofing_layer_count, wall_idx);
+    if (!no_small_gaps_heuristic)
+    {
+        for (int layer_nr_above = layer_nr + 1; layer_nr_above < layer_nr + roofing_layer_count; layer_nr_above++)
+        {
+            Polygons outlines_above = getWalls(part, layer_nr_above, wall_idx);
+            no_air_above = no_air_above.intersection(outlines_above);
+        }
+    }
+    if (layer_nr > 0)
+    {
+        // if the skin has air below it then cutting it into regions could cause a region
+        // to be wholely or partly above air and it may not be printable so restrict
+        // the regions that have air above (the visible regions) to not include any area that
+        // has air below (fixes https://github.com/Ultimaker/Cura/issues/2656)
+
+        // set air_below to the skin area for the current layer that has air below it
+        Polygons air_below = getWalls(part, layer_nr, wall_idx).difference(getWalls(part, layer_nr - 1, wall_idx));
+
+        if (!air_below.empty())
+        {
+            // add the polygons that have air below to the no air above polygons
+            no_air_above = no_air_above.unionPolygons(air_below);
+        }
+    }
+    return no_air_above;
 }
 
 void SkinInfillAreaComputation::generateInfillSupport(SliceMeshStorage& mesh)

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -486,7 +486,7 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
             // Insets are NOT generated for any layer if the top/bottom pattern is concentric.
             // In this case, we still want to generate insets for the roofing layers based on the extra skin wall count,
             // if the roofing pattern is not concentric.
-            if (skin_part.roofing_fill.size() > 0 
+            if (!skin_part.roofing_fill.empty()
                 && layer_nr > 0
                 && mesh.settings.get<EFillMethod>("roofing_pattern") != EFillMethod::CONCENTRIC
                 && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC)
@@ -499,7 +499,7 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
             // On the contrary, unwanted insets are generated for roofing layers because of the non-concentric top/bottom pattern.
             // In such cases we want to clear the skin insets first and then regenerate the proper roofing fill and inner infill
             // in the concentric roofing_pattern.
-            else if (skin_part.roofing_fill.size() > 0
+            else if (!skin_part.roofing_fill.empty()
                     && layer_nr > 0 
                     && mesh.settings.get<EFillMethod>("roofing_pattern") == EFillMethod::CONCENTRIC
                     && mesh.settings.get<EFillMethod>("top_bottom_pattern") != EFillMethod::CONCENTRIC)

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -483,24 +483,42 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
             skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
             skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
 
-            // Insets have previously NOT been generated for any layer if the top/bottom pattern is concentric.
-            // In this case, we still want to generate insets for the roofing layers based on the extra skin wall count.
-            if (skin_part.roofing_fill.size() > 0
-                && (layer_nr > 0 && mesh.settings.get<EFillMethod>("roofing_pattern") != EFillMethod::CONCENTRIC)
-                && (layer_nr > 0 && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC))
+            // Insets are NOT generated for any layer if the top/bottom pattern is concentric.
+            // In this case, we still want to generate insets for the roofing layers based on the extra skin wall count,
+            // if the roofing pattern is not concentric.
+            if (skin_part.roofing_fill.size() > 0 
+                && layer_nr > 0
+                && mesh.settings.get<EFillMethod>("roofing_pattern") != EFillMethod::CONCENTRIC
+                && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC)
             {
                 // Generate skin insets, regenerate the no_air_above, and recalculate the inner and roofing infills, 
                 // taking into account the extra skin wall count (only for the roofing layers).
                 generateSkinInsets(skin_part);
-                generateInnerSkinInfill(skin_part);
-                no_air_above = generateNoAirAbove(part);
-                skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
-                skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
+                regenerateRoofingFillAndInnerInfill(part, skin_part);
+            }
+            // On the contrary, unwanted insets are generated for roofing layers because of the non-concentric top/bottom pattern.
+            // In such cases we want to clear the skin insets first and then regenerate the proper roofing fill and inner infill
+            // in the concentric roofing_pattern.
+            else if (skin_part.roofing_fill.size() > 0
+                    && layer_nr > 0 
+                    && mesh.settings.get<EFillMethod>("roofing_pattern") == EFillMethod::CONCENTRIC
+                    && mesh.settings.get<EFillMethod>("top_bottom_pattern") != EFillMethod::CONCENTRIC)
+            {
+                // Clear the skin insets for the roofing layers and regenerate the roofing fill and inner infill without taking into
+                // account the Extra Skin Wall Count.
+                skin_part.insets.clear();
+                regenerateRoofingFillAndInnerInfill(part, skin_part);
             }
         }
     }
 }
 
+/*
+ * This function is executed in a parallel region based on layer_nr.
+ * When modifying make sure any changes does not introduce data races.
+ *
+ * this function may only read the skin and infill from the *current* layer.
+ */
 Polygons SkinInfillAreaComputation::generateNoAirAbove(SliceLayerPart& part)
 {
     const size_t roofing_layer_count = mesh.settings.get<size_t>("roofing_layer_count");
@@ -532,6 +550,20 @@ Polygons SkinInfillAreaComputation::generateNoAirAbove(SliceLayerPart& part)
         }
     }
     return no_air_above;
+}
+
+/*
+ * This function is executed in a parallel region based on layer_nr.
+ * When modifying make sure any changes does not introduce data races.
+ *
+ * this function may only read/write the skin and infill from the *current* layer.
+ */
+void SkinInfillAreaComputation::regenerateRoofingFillAndInnerInfill(SliceLayerPart& part, SkinPart& skin_part)
+{
+    generateInnerSkinInfill(skin_part);
+    Polygons no_air_above = generateNoAirAbove(part);
+    skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
+    skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
 }
 
 void SkinInfillAreaComputation::generateInfillSupport(SliceMeshStorage& mesh)

--- a/src/skin.h
+++ b/src/skin.h
@@ -130,14 +130,14 @@ protected:
      * Remove the areas which are 'directly' under air from the \ref SkinPart::inner_infill and 
      * save them in the \ref SkinPart::roofing_fill of the \p part.
      * 
-     * \param[in,out] part Where to get the sSkinParts to get the outline info from and to store the roofing areas
+     * \param[in,out] part Where to get the SkinParts to get the outline info from and to store the roofing areas
      */
     void generateRoofing(SliceLayerPart& part);
 
     /*!
      * Helper function to calculate and return the areas which are 'directly' under air.
      *
-     * \param part Where to get the sSkinParts to get the outline info from
+     * \param part Where to get the SkinParts to get the outline info from
      */
     Polygons generateNoAirAbove(SliceLayerPart& part);
 
@@ -145,7 +145,7 @@ protected:
      * Helper function to recalculate the roofing fill and inner infill in roofing layers where the 
      * insets have to be changed.
      *
-     * \param part Where to get the sSkinParts to get the outline info from
+     * \param part Where to get the SkinParts to get the outline info from
      * \param skin_part The part where the skin outline information (input) is stored and
      * where the inner infill and roofing infill areas (output) is stored.
      */

--- a/src/skin.h
+++ b/src/skin.h
@@ -127,14 +127,29 @@ protected:
     void generateInfill(SliceLayerPart& part, const Polygons& skin);
 
     /*!
-     * Calculate the areas which are 'directly' under air,
-     * remove them from the \ref SkinPart::inner_infill and save them in the \ref SkinPart::roofing_fill of the \p part
+     * Remove the areas which are 'directly' under air from the \ref SkinPart::inner_infill and 
+     * save them in the \ref SkinPart::roofing_fill of the \p part.
      * 
      * \param[in,out] part Where to get the sSkinParts to get the outline info from and to store the roofing areas
      */
     void generateRoofing(SliceLayerPart& part);
 
+    /*!
+     * Helper function to calculate and return the areas which are 'directly' under air.
+     *
+     * \param part Where to get the sSkinParts to get the outline info from
+     */
     Polygons generateNoAirAbove(SliceLayerPart& part);
+
+    /*!
+     * Helper function to recalculate the roofing fill and inner infill in roofing layers where the 
+     * insets have to be changed.
+     *
+     * \param part Where to get the sSkinParts to get the outline info from
+     * \param skin_part The part where the skin outline information (input) is stored and
+     * where the inner infill and roofing infill areas (output) is stored.
+     */
+    void regenerateRoofingFillAndInnerInfill(SliceLayerPart& part, SkinPart& skin_part);
 
     /*!
      * Generate the skin insets and the inner infill area

--- a/src/skin.h
+++ b/src/skin.h
@@ -134,6 +134,8 @@ protected:
      */
     void generateRoofing(SliceLayerPart& part);
 
+    Polygons generateNoAirAbove(SliceLayerPart& part);
+
     /*!
      * Generate the skin insets and the inner infill area
      * 


### PR DESCRIPTION
The no_air_above depends on the insets so it has to be recalculated for the roofing layers
before regenerating the skin insets (when taking into account the extra skin wall count).

Fixes issue https://github.com/Ultimaker/CuraEngine/commit/f0b56479c97aad5b6e105e9f2df751186e7b4997#r40756573
introduced by https://github.com/Ultimaker/CuraEngine/pull/1287.

CURA-7614