### PR TITLE
CURA-7376 Remove gap-filling overlapping with libArachne

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1974,10 +1974,6 @@ bool FffGcodeWriter::processSkinAndPerimeterGaps(const SliceDataStorage& storage
     }
     bool added_something = false;
 
-    const bool fill_perimeter_gaps = mesh.settings.get<FillPerimeterGapMode>("fill_perimeter_gaps") != FillPerimeterGapMode::NOWHERE
-                            && !Application::getInstance().current_slice->scene.current_mesh_group->settings.get<bool>("magic_spiralize")
-                            && extruder_nr == wall_0_extruder_nr;
-
     PathOrderOptimizer<const SkinPart*> part_order_optimizer(gcode_layer.getLastPlannedPositionOrStartingPosition());
     for(const SkinPart& skin_part : part.skin_parts)
     {
@@ -1995,11 +1991,6 @@ bool FffGcodeWriter::processSkinAndPerimeterGaps(const SliceDataStorage& storage
             processSkinPart(storage, gcode_layer, mesh, extruder_nr, mesh_config, skin_part);
     }
 
-    if (fill_perimeter_gaps)
-    { // handle perimeter gaps of normal insets
-        assert(extruder_nr == wall_0_extruder_nr); // Should already be the case because of fill_perimeter_gaps check
-        processPerimeterGaps(storage, gcode_layer, mesh, extruder_nr, part.perimeter_gaps, mesh_config.perimeter_gap_config, added_something);
-    }
     return added_something;
 }
 

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -582,45 +582,6 @@ void FffPolygonGenerator::processPerimeterGaps(SliceDataStorage& storage)
             }
             for (SliceLayerPart& part : layer.parts)
             {
-                 // handle perimeter gaps of normal insets
-                int line_width = wall_line_width_0;
-                for (unsigned int inset_idx = 0; static_cast<int>(inset_idx) < static_cast<int>(part.insets.size()) - 1; inset_idx++)
-                {
-                    const Polygons outer = part.insets[inset_idx].offset(-1 * line_width / 2 - perimeter_gaps_extra_offset);
-                    line_width = wall_line_width_x;
-
-                    Polygons inner = part.insets[inset_idx + 1].offset(line_width / 2);
-                    part.perimeter_gaps.add(outer.difference(inner));
-                }
-
-                if (filter_out_tiny_gaps) {
-                    part.perimeter_gaps.removeSmallAreas(2 * INT2MM(wall_line_width_0) * INT2MM(wall_line_width_0)); // remove small outline gaps to reduce blobs on outside of model
-                }
-
-                // gap between inner wall and skin/infill
-                if (fill_gaps_between_inner_wall_and_skin_or_infill && part.insets.size() > 0)
-                {
-                    const Polygons outer = part.insets.back().offset(-1 * line_width / 2 - perimeter_gaps_extra_offset);
-
-                    // accumulate area of skin and infill that will be printed
-                    Polygons inner;
-                    for (const SkinPart& skin_part : part.skin_parts)
-                    {
-                        inner.add(skin_part.outline);
-                    }
-                    // for some reason the zig-zag and lines patterns behave differently and a narrow region that isn't filled with zig-zag pattern can be filled with
-                    // lines pattern so we only add the narrow region to the perimeter gaps when the pattern is zig-zag.
-                    if (((layer_nr == 0) ? mesh.settings.get<EFillMethod>("top_bottom_pattern_0") : mesh.settings.get<EFillMethod>("top_bottom_pattern")) == EFillMethod::ZIG_ZAG)
-                    {
-                        // remove skin areas that are narrower than skin_line_width as they won't get printed unless
-                        // we print them as a perimeter gap
-                        inner = inner.offset(-skin_line_width / 2).offset(skin_line_width / 2);
-                    }
-                    inner.add(part.infill_area);
-                    inner = inner.unionPolygons();
-                    part.perimeter_gaps.add(outer.difference(inner));
-                }
-
                 // add perimeter gaps for skin insets
                 for (SkinPart& skin_part : part.skin_parts)
                 {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -231,14 +231,8 @@ Polygons LayerPlan::computeCombBoundaryInside(const size_t max_inset)
                             inner = part.insets[num_insets - 1].offset(-10 - mesh.settings.get<coord_t>("wall_line_width_x") / 2);
                         }
 
-                        Polygons infill(part.infill_area);
-                        if (part.perimeter_gaps.size() > 0)
-                        {
-                            infill = infill.unionPolygons(part.perimeter_gaps.offset(10)); // ensure polygons overlap slightly
-                        }
-
                         // combine the wall combing region (outer - inner) with the infill (if any)
-                        comb_boundary.add(infill.unionPolygons(outer.difference(inner)));
+                        comb_boundary.add(part.infill_area.unionPolygons(outer.difference(inner)));
                     }
                 }
             }

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -259,10 +259,6 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr, const LayerIn
     {
         for (const SliceLayerPart& part : layer.parts)
         {
-            if (part.perimeter_gaps.size() > 0)
-            {
-                return true;
-            }
             for (const SkinPart& skin_part : part.skin_parts)
             {
                 if (skin_part.perimeter_gaps.size() > 0)

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -57,7 +57,6 @@ public:
     PolygonsPart outline;       //!< The outline is the first member that is filled, and it's filled with polygons that match a cross section of the 3D model. The first polygon is the outer boundary polygon and the rest are holes.
     Polygons print_outline; //!< An approximation to the outline of what's actually printed, based on the outer wall. Too small parts will be omitted compared to the outline.
     std::vector<Polygons> insets;         //!< The insets are generated with. The insets are also known as perimeters or the walls.
-    Polygons perimeter_gaps; //!< The gaps between consecutive walls and between the inner wall and outer skin inset
     Polygons outline_gaps; //!< The gaps between the outline of the mesh and the first wall. a.k.a. thin walls.
     std::vector<SkinPart> skin_parts;     //!< The skin parts which are filled for 100% with lines and/or insets.
 


### PR DESCRIPTION
removed the gap-filling that was now overlapping the current libArachne walls (previously needed in order to compensate for the fact that our walls weren't able to adjust width)