### PR TITLE
Don't throwaway last layer when slicing tolerance is exclusive.

### DIFF
--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -968,7 +968,6 @@ void Slicer::makePolygons(Mesh& mesh, SlicingTolerance slicing_tolerance, std::v
         {
             layers[layer_nr].polygons = layers[layer_nr].polygons.intersection(layers[layer_nr + 1].polygons);
         }
-        layers.back().polygons.clear();
         break;
     case SlicingTolerance::MIDDLE:
     default:


### PR DESCRIPTION
I can't see the benefit in throwing away the final layer when the slicing tolerance is exclusive so this PR retains the final layer. Perhaps the final layer should actually be a duplicate of the previous layer, i'm not sure about that.

Without this PR, a whole layer is missing...

![Screenshot_2020-08-17_11-46-03](https://user-images.githubusercontent.com/585618/90388214-6220b300-e07f-11ea-895c-2e1f050b399b.png)

With this PR, the layer is not missing but the outline is slight wrong compared to the previous layers....

![Screenshot_2020-08-17_11-46-44](https://user-images.githubusercontent.com/585618/90388406-a449f480-e07f-11ea-8827-f97a3d1bba4d.png)
