### PR TITLE
CURA-7713: Jump in tree support diameter causes failed print

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -343,12 +343,15 @@ void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
                         next_position = node.position + difference;
                     }
 
+                    Node* neighbour = nodes_per_part[group_index][neighbours[0]];
+                    size_t new_distance_to_top = std::max(node.distance_to_top, neighbour->distance_to_top) + 1;
+                    size_t new_support_roof_layers_below = std::max(node.support_roof_layers_below, neighbour->support_roof_layers_below) - 1;
+
                     const bool to_buildplate = !volumes_.getAvoidance(branch_radius_node, layer_nr - 1).inside(next_position);
-                    Node* next_node = new Node(next_position, node.distance_to_top + 1, node.skin_direction, node.support_roof_layers_below - 1, to_buildplate, p_node);
+                    Node* next_node = new Node(next_position, new_distance_to_top, node.skin_direction, new_support_roof_layers_below, to_buildplate, p_node);
                     insertDroppedNode(contact_nodes[layer_nr - 1], next_node); //Insert the node, resolving conflicts of the two colliding nodes.
 
-                    // Make sure the next pass doens't drop down either of these (since that already happened).
-                    Node* neighbour = nodes_per_part[group_index][neighbours[0]];
+                    // Make sure the next pass doesn't drop down either of these (since that already happened).
                     node.merged_neighbours.push_front(neighbour);
                     to_delete.insert(neighbour);
                     to_delete.insert(p_node);


### PR DESCRIPTION
When there were only two neighours left and they were about to be merged together, the distance
to top of the new node was selected based on which of the two neighbouring nodes the code was
going through first.

If the two nodes had a big difference between their distsance_to_top values, selecting one of the
two for the new node would sometimes select the max one (which is the correct), while in some cases
it would select the smaller one. This was entirely dependend on which node was being "looked at"
first.

When the min of the two was selected for the new node, the jump in the branch diameter happened,
since the branch diameter is affected by the distance_to_top of the node.

This commit PR that by correctly selecting the maximum distance_to_top between the two
neighbouring nodes.

Should fix https://github.com/Ultimaker/Cura/issues/7711

CURA-7713