### PR TITLE
Fix simplify leaving way too small line segments. 

### DIFF
--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -1089,7 +1089,7 @@ coord_t Slicer::interpolate(const coord_t x, const coord_t x0, const coord_t x1,
 {
     const coord_t dx_01 = x1 - x0;
     coord_t num = (y1 - y0) * (x - x0);
-    num += num > 0 ? dx_01 / 2 : -dx_01 / 2; // add in offset to round result
+    num += num > 0 ? dx_01 / 4 : -dx_01 / 4; // add in offset to round result
     return y0 + num / dx_01;
 }
 

--- a/src/utils/linearAlg2D.h
+++ b/src/utils/linearAlg2D.h
@@ -66,6 +66,33 @@ public:
                 
     }
 
+    static bool lineLineIntersection(Point a, Point b, Point c, Point d, Point& output)
+    {
+        // Line AB represented as a1x + b1y = c1
+        double a1 = b.Y - a.Y;
+        double b1 = a.X - b.X;
+        double c1 = a1*(a.X) + b1*(a.Y);
+
+        // Line CD represented as a2x + b2y = c2
+        double a2 = d.Y - c.Y;
+        double b2 = c.X - d.X;
+        double c2 = a2*(c.X)+ b2*(c.Y);
+
+        double determinant = a1 * b2 - a2 * b1;
+
+        if (determinant == 0)
+        {
+            // The lines are parallel
+            return false;
+        }
+        else
+        {
+            output.X = (b2 * c1 - b1 * c2) / determinant;
+            output.Y = (a1 * c2 - a2 * c1) / determinant;
+            return true;
+        }
+    }
+
     /*!
      * Find whether a point projected on a line segment would be projected to
      * - properly on the line : zero returned

--- a/src/utils/linearAlg2D.h
+++ b/src/utils/linearAlg2D.h
@@ -66,31 +66,30 @@ public:
                 
     }
 
-    static bool lineLineIntersection(Point a, Point b, Point c, Point d, Point& output)
+    static bool lineLineIntersection(const Point& a, const Point& b, const Point& c, const Point& d, Point& output)
     {
         // Line AB represented as a1x + b1y = c1
-        double a1 = b.Y - a.Y;
-        double b1 = a.X - b.X;
-        double c1 = a1*(a.X) + b1*(a.Y);
+        const double a1 = b.Y - a.Y;
+        const double b1 = a.X - b.X;
 
         // Line CD represented as a2x + b2y = c2
-        double a2 = d.Y - c.Y;
-        double b2 = c.X - d.X;
-        double c2 = a2*(c.X)+ b2*(c.Y);
+        const double a2 = d.Y - c.Y;
+        const double b2 = c.X - d.X;
 
-        double determinant = a1 * b2 - a2 * b1;
+        const double determinant = a1 * b2 - a2 * b1;
 
         if (determinant == 0)
         {
             // The lines are parallel
             return false;
         }
-        else
-        {
-            output.X = (b2 * c1 - b1 * c2) / determinant;
-            output.Y = (a1 * c2 - a2 * c1) / determinant;
-            return true;
-        }
+
+        const double c1 = a1 * (a.X) + b1 * (a.Y);
+        const double c2 = a2 * (c.X) + b2 * (c.Y);
+
+        output.X = (b2 * c1 - b1 * c2) / determinant;
+        output.Y = (a1 * c2 - a2 * c1) / determinant;
+        return true;
     }
 
     /*!

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -295,17 +295,17 @@ Polygons ConstPolygonRef::offset(int distance, ClipperLib::JoinType join_type, d
     return ret;
 }
 
-bool lineLineIntersection(Point A, Point B, Point C, Point D, Point* output)
+bool lineLineIntersection(Point a, Point b, Point c, Point d, Point& output)
 {
     // Line AB represented as a1x + b1y = c1
-    double a1 = B.Y - A.Y;
-    double b1 = A.X - B.X;
-    double c1 = a1*(A.X) + b1*(A.Y);
+    double a1 = b.Y - a.Y;
+    double b1 = a.X - b.X;
+    double c1 = a1*(a.X) + b1*(a.Y);
 
     // Line CD represented as a2x + b2y = c2
-    double a2 = D.Y - C.Y;
-    double b2 = C.X - D.X;
-    double c2 = a2*(C.X)+ b2*(C.Y);
+    double a2 = d.Y - c.Y;
+    double b2 = c.X - d.X;
+    double c2 = a2*(c.X)+ b2*(c.Y);
 
     double determinant = a1 * b2 - a2 * b1;
 
@@ -316,8 +316,8 @@ bool lineLineIntersection(Point A, Point B, Point C, Point D, Point* output)
     }
     else
     {
-        output->X = (b2 * c1 - b1 * c2) / determinant;
-        output->Y = (a1 * c2 - a2 * c1) / determinant;
+        output.X = (b2 * c1 - b1 * c2) / determinant;
+        output.Y = (a1 * c2 - a2 * c1) / determinant;
         return true;
     }
 }
@@ -413,7 +413,7 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                 // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.
                 // By taking the intersection of these two lines, we get a point that perseves the direction (so it makes the corner a bit more pointy)
                 Point intersection_point;
-                bool has_intersection = lineLineIntersection(previous_previous, previous, current, next, &intersection_point);
+                bool has_intersection = lineLineIntersection(previous_previous, previous, current, next, intersection_point);
                 
                 if (!has_intersection || LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared)
                 {

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -418,7 +418,7 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                 if(has_intersection)
                 {
                     // Find out if it is a degenerate intersection.
-                    if(vSize2(current - intersection_point) > allowed_error_distance_squared)
+                    if(LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared)
                     {
                         // The intersection is way to far away. Drop it. 
                         continue;

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -435,10 +435,6 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                     {
                         new_path.pop_back();
                     }
-                    else
-                    {
-                        continue;
-                    }
                 }
             }
             else

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -295,32 +295,7 @@ Polygons ConstPolygonRef::offset(int distance, ClipperLib::JoinType join_type, d
     return ret;
 }
 
-bool lineLineIntersection(Point a, Point b, Point c, Point d, Point& output)
-{
-    // Line AB represented as a1x + b1y = c1
-    double a1 = b.Y - a.Y;
-    double b1 = a.X - b.X;
-    double c1 = a1*(a.X) + b1*(a.Y);
 
-    // Line CD represented as a2x + b2y = c2
-    double a2 = d.Y - c.Y;
-    double b2 = c.X - d.X;
-    double c2 = a2*(c.X)+ b2*(c.Y);
-
-    double determinant = a1 * b2 - a2 * b1;
-
-    if (determinant == 0)
-    {
-        // The lines are parallel
-        return false;
-    }
-    else
-    {
-        output.X = (b2 * c1 - b1 * c2) / determinant;
-        output.Y = (a1 * c2 - a2 * c1) / determinant;
-        return true;
-    }
-}
 
 
 void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coord_t allowed_error_distance_squared)
@@ -413,7 +388,7 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                 // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.
                 // By taking the intersection of these two lines, we get a point that perseves the direction (so it makes the corner a bit more pointy)
                 Point intersection_point;
-                bool has_intersection = lineLineIntersection(previous_previous, previous, current, next, intersection_point);
+                bool has_intersection = LinearAlg2D::lineLineIntersection(previous_previous, previous, current, next, intersection_point);
                 
                 if (!has_intersection || LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared)
                 {

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -405,7 +405,7 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         }
   
         if (length2 < smallest_line_segment_squared
-            && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.) // removing the vertex doesn't introduce too much error.
+            && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.)
         {
             if(next_length2 > smallest_line_segment_squared)
             {

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -354,9 +354,8 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         const coord_t removed_area_next = current.X * next.Y - current.Y * next.X; // Twice the Shoelace formula for area of polygon per line segment.
         const coord_t negative_area_closing = next.X * previous.Y - next.Y * previous.X; // area between the origin and the short-cutting segment
         accumulated_area_removed += removed_area_next;
-        
+
         const coord_t length2 = vSize2(current - previous);
-        const coord_t next_length2 = vSize2(current - next);
 
         const coord_t area_removed_so_far = accumulated_area_removed + negative_area_closing; // close the shortcut area polygon
         const coord_t base_length_2 = vSize2(next - previous);
@@ -378,10 +377,11 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         {
             continue;
         }
-  
+
         if (length2 < smallest_line_segment_squared
             && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.)
         {
+            const coord_t next_length2 = vSize2(current - next);
             if (next_length2 > smallest_line_segment_squared)
             {
                 // Special case; The next line is long. If we were to remove this, it could happen that we get quite noticeable artifacts.
@@ -424,7 +424,6 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         previous = current; //Note that "previous" is only updated if we don't remove the vertex.
         new_path.push_back(current);
     }
-    
 
     *path = new_path;
 }

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -407,7 +407,7 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         if (length2 < smallest_line_segment_squared
             && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.)
         {
-            if(next_length2 > smallest_line_segment_squared)
+            if (next_length2 > smallest_line_segment_squared)
             {
                 // Special case; The next line is long. If we were to remove this, it could happen that we get quite noticeable artifacts.
                 // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -414,16 +414,13 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                 // By taking the intersection of these two lines, we get a point that perseves the direction (so it makes the corner a bit more pointy)
                 Point intersection_point;
                 bool has_intersection = lineLineIntersection(previous_previous, previous, current, next, &intersection_point);
-
-                if(has_intersection)
+                
+                if (!has_intersection || LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared)
                 {
-                    // Find out if it is a degenerate intersection.
-                    if(LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared)
-                    {
-                        // The intersection is way to far away. Drop it. 
-                        continue;
-                    }
-                    
+                    continue; // We coulnd't find a new place to combine the previous and current vertex, so remove the current vertex.
+                }
+                else
+                {
                     // New point seems like a valid one.
                     current = intersection_point;
                     
@@ -436,10 +433,6 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                     {
                         continue;
                     }
-                }
-                else
-                {
-                    continue; // We coulnd't find a new place for this, so remove the vertex.
                 }
             }
             else

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -417,7 +417,13 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                 
                 if (!has_intersection || LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared)
                 {
-                    continue; // We coulnd't find a new place to combine the previous and current vertex, so remove the current vertex.
+                    if(length2 < 25)
+                    {
+                        // We're allowed to always delete segments of less than 5 micron.
+                        continue;
+                    }
+                    // We can't find a better spot for it, but the size of the line is more than 5 micron.
+                    // So the only thing we can do here is leave it in...
                 }
                 else
                 {

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -352,7 +352,6 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         accumulated_area_removed += removed_area_next;
         
         const coord_t length2 = vSize2(current - previous);
-        const coord_t next_length2 = vSize2(current - next);
 
         const coord_t area_removed_so_far = accumulated_area_removed + negative_area_closing; // close the shortcut area polygon
         const coord_t base_length_2 = vSize2(next - previous);
@@ -372,7 +371,6 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         if ((height_2 <= 1 //Almost exactly colinear (barring rounding errors).
             && LinearAlg2D::getDist2FromLine(current, previous, next) <= 1) // make sure that height_2 is not small because of cancellation of positive and negative areas
             || (length2 < smallest_line_segment_squared
-                && next_length2 < smallest_line_segment_squared // Segments are small
                 && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.
         )
         {

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -449,15 +449,19 @@ public:
     /*! 
      * Removes consecutive line segments with same orientation and changes this polygon.
      * 
-     * Removes verts which are connected to line segments which are both too small.
-     * Removes verts which detour from a direct line from the previous and next vert by a too small amount.
+     * 1. Removes verts which are connected to line segments which are too small.
+     * 2. Removes verts which detour from a direct line from the previous and next vert by a too small amount.
+     * 3. Moves a vert when a small line segment is connected to a much longer one. in order to maintain the outline of the object.
+     * 4. Don't remove a vert when the impact on the outline of the object is too great.
      *
-     * Criteria:
-     * 1. Never remove a vertex if either of the connceted segments is larger than \p smallest_line_segment
-     * 2. Never remove a vertex if the distance between that vertex and the final resulting polygon would be higher than \p allowed_error_distance
-     * 3. Simplify uses a heuristic and doesn't neccesarily remove all removable vertices under the above criteria.
-     * 4. But simplify may never violate these criteria.
-     * 5. Unless the segments or the distance is smaller than the rounding error of 5 micron
+     * Note that the simplify is a best effort algorithm. It does not guarantee that no lines below the provided smallest_line_segment_squared are left.
+     *
+     * The following example (Two very long line segments (" & , respectively) that are connected by a very small line segment (i) is unsimplifable by this
+     * function, even though the actual area change of removing line segment i is very small. The reason for this is that in the case of long lines, even a small
+     * deviation from it's original direction is very noticeable in the final result, especially if the polygons above make a slightly different choice.
+     *
+     * """"""""""""""""""""""""""""""""i,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+
      * 
      * \param smallest_line_segment_squared maximal squared length of removed line segments
      * \param allowed_error_distance_squared The square of the distance of the middle point to the line segment of the consecutive and previous point for which the middle point is removed

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -903,9 +903,14 @@ public:
      * Criteria:
      * 1. Never remove a vertex if either of the connceted segments is larger than \p smallest_line_segment
      * 2. Never remove a vertex if the distance between that vertex and the final resulting polygon would be higher than \p allowed_error_distance
-     * 3. Simplify uses a heuristic and doesn't neccesarily remove all removable vertices under the above criteria.
-     * 4. But simplify may never violate these criteria.
-     * 5. Unless the segments or the distance is smaller than the rounding error of 5 micron
+     * 3. The direction of segments longer than \p smallest_line_segment always
+     * remains unaltered (but their end points may change if it is connected to
+     * a small segment)
+     *
+     * Simplify uses a heuristic and doesn't neccesarily remove all removable
+     * vertices under the above criteria, but simplify may never violate these
+     * criteria. Unless the segments or the distance is smaller than the
+     * rounding error of 5 micron.
      * 
      * Vertices which introduce an error of less than 5 microns are removed
      * anyway, even if the segments are longer than the smallest line segment.

--- a/tests/utils/PolygonTest.cpp
+++ b/tests/utils/PolygonTest.cpp
@@ -335,6 +335,14 @@ TEST_F(PolygonTest, simplifyLimitedError)
         // apply simplify iteratively for each point until nothing is simplifiable any more
         spiral_polygons.simplify(10000, max_height);
     }
+    
+    if (visualize)
+    {
+        SVG svg("output/simplifyLimitedError.svg", AABB(spiral_before));
+        svg.writePolygon(spiral_before);
+        svg.nextLayer();
+        svg.writePolygon(spiral, SVG::Color::RED);
+    }
 
     EXPECT_THAT(spiral.size(), testing::Eq(4)) << "Should simplify all spiral points except those connected to far away geometry.";
 }


### PR DESCRIPTION
https://github.com/Ultimaker/Cura/issues/8321

I've run some tests with this and it seems to resolve the issue reported.

**MezzerSealWithFix**
| Line length | Num segments |
| ------------- | ------------- |
| 1 | 60544 |
| 0.5 | 6256 |
| 0.1 | 686 |
| 0.05 | 32 |
| 0.01 | 32 |
| 0.005 | 32 |
| 0.001 | 32 |

**MezzerSealWithoutFix**
| Line length | Num segments |
| ------------- | ------------- |
| 1 | 92846 |
| 0.5 | 33547 |
| 0.1 | 5732 |
| 0.05 | 2359 |
| 0.01 | 719 |
| 0.005 | 579 |
| 0.001 | 0 |

**BenchyWithFix**
| Line length | Num segments |
| ------------- | ------------- |
| 1 | 120345 |
| 0.5 | 46781 |
| 0.1 | 2046 |
| 0.05 | 834 |
| 0.01 | 237 |
| 0.005 | 124 |
| 0.001 | 31 |

**BenchyWithoutFix**
| Line length | Num segments |
| ------------- | ------------- |
| 1 | 124375 |
| 0.5 | 50275 |
| 0.1 | 4015 |
| 0.05 | 2429 |
| 0.01 | 1596 |
| 0.005 | 1390 |
| 0.001 | 27 |

Benchy before:
![BenchyBowBeforeFix](https://user-images.githubusercontent.com/3922611/92724536-13f38c80-f36b-11ea-8114-a429ee3f2da6.png)

Benchy after:
![BenchyBowAfterFix](https://user-images.githubusercontent.com/3922611/92724533-135af600-f36b-11ea-97ef-cf595734f030.png)

CURA-7709