### PR TITLE
Fix infill multiplier not connected lines

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -201,14 +201,19 @@ void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)
         }
     }
     result.add(first_offset);
-    Polygons reference_polygons = first_offset;
-    for (size_t infill_line = 1; infill_line < infill_multiplier / 2; infill_line++) // 2 because we are making lines on both sides at the same time
+    if (infill_multiplier > 3)
     {
-        Polygons extra_offset = reference_polygons.offset(-infill_line_width);
-        result.add(extra_offset);
-        reference_polygons = std::move(extra_offset);
-    }
+        Polygons reference_polygons = first_offset;
+        const size_t multiplier = static_cast<size_t>(infill_multiplier / 2);
 
+        const int extra_offset = mirror_offset ? -infill_line_width : infill_line_width;
+        for (size_t infill_line = 1; infill_line < multiplier; ++infill_line)
+        {
+            Polygons extra_polys = reference_polygons.offset(extra_offset);
+            result.add(extra_polys);
+            reference_polygons = std::move(extra_polys);
+        }
+    }
     if (zig_zaggify)
     {
         result = result.intersection(outline);

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -187,9 +187,10 @@ void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)
 
     const Polygons outline = in_outline.offset(outline_offset);
 
+    // Get the first offset these are mirrored from the original center line
     Polygons result;
     Polygons first_offset;
-    { // calculate [first_offset]
+    {
         const Polygons first_offset_lines = result_lines.offsetPolyLine(offset); // make lines on both sides of the input lines
         const Polygons first_offset_polygons_inward = result_polygons.offset(-offset); // make lines on the inside of the input polygons
         const Polygons first_offset_polygons_outward = result_polygons.offset(offset); // make lines on the other side of the input polygons
@@ -201,6 +202,9 @@ void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)
         }
     }
     result.add(first_offset);
+
+    // Create the additional offsets from the first offsets, generated earlier, the direction of these offsets is
+    // depended on whether these lines should be connected or not.
     if (infill_multiplier > 3)
     {
         Polygons reference_polygons = first_offset;
@@ -219,6 +223,7 @@ void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)
         result = result.intersection(outline);
     }
 
+    // Remove the original center lines when there are an even number of lines required.
     if (!odd_multiplier)
     {
         result_polygons.clear();

--- a/src/infill.h
+++ b/src/infill.h
@@ -42,6 +42,7 @@ class Infill
     bool skip_some_zags;  //!< (ZigZag) Whether to skip some zags
     size_t zag_skip_count;  //!< (ZigZag) To skip one zag in every N if skip some zags is enabled
     coord_t pocket_size; //!< The size of the pockets at the intersections of the fractal in the cross 3d pattern
+    bool mirror_offset;
 
     static constexpr double one_over_sqrt_2 = 0.7071067811865475244008443621048490392848359376884740; //!< 1.0 / sqrt(2.0)
 public:
@@ -94,6 +95,7 @@ public:
     , skip_some_zags(skip_some_zags)
     , zag_skip_count(zag_skip_count)
     , pocket_size(pocket_size)
+    , mirror_offset(zig_zaggify)
     {
     }
 

--- a/src/infill.h
+++ b/src/infill.h
@@ -42,7 +42,7 @@ class Infill
     bool skip_some_zags;  //!< (ZigZag) Whether to skip some zags
     size_t zag_skip_count;  //!< (ZigZag) To skip one zag in every N if skip some zags is enabled
     coord_t pocket_size; //!< The size of the pockets at the intersections of the fractal in the cross 3d pattern
-    bool mirror_offset;
+    bool mirror_offset; //!< Indication in which offset direction the extra infill lines are made
 
     static constexpr double one_over_sqrt_2 = 0.7071067811865475244008443621048490392848359376884740; //!< 1.0 / sqrt(2.0)
 public:


### PR DESCRIPTION
When Connect Infill Lines was unchecked the multiplier didn't get the
correct number of offsets. A global flag was introduced mirror_offset
which ensures that the extra infill line offsets are generated in the
correct direction.
This is now only done for infill multiplier values higher then 3.