### PR TITLE
[CURA-7676] fix take outer wall width into account on only one side, not both

### DIFF
--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -15,6 +15,7 @@ CenterDeviationBeadingStrategy::Beading CenterDeviationBeadingStrategy::compute(
     {
         ret.bead_widths.emplace_back(thickness);
         ret.toolpath_locations.emplace_back(thickness / 2);
+        ret.left_over = 0;
     }
     else if (bead_count > 1)
     {

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -57,7 +57,7 @@ CenterDeviationBeadingStrategy::Beading CenterDeviationBeadingStrategy::compute(
 
 coord_t CenterDeviationBeadingStrategy::getOptimalThickness(coord_t bead_count) const
 {
-    return std::max(0LL, (bead_count - 2)) * optimal_width_inner + std::min(2LL, bead_count) * optimal_width_outer;
+    return std::max(0LL, (bead_count - 1)) * optimal_width_inner + std::min(1LL, bead_count) * optimal_width_outer;
 }
 
 coord_t CenterDeviationBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
@@ -75,7 +75,7 @@ coord_t CenterDeviationBeadingStrategy::getTransitionThickness(coord_t lower_bea
 coord_t CenterDeviationBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
     coord_t thickness_left = thickness;
-    coord_t naive_count = std::min(2LL, ((thickness / 2 + optimal_width_outer / 2) / optimal_width_outer) * 2);
+    coord_t naive_count = std::min(1LL, ((thickness / 2 + optimal_width_outer / 2) / optimal_width_outer) * 2);
     thickness_left -= naive_count * optimal_width_outer;
     if (thickness_left >= (optimal_width_inner / 2))
     {

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -30,20 +30,20 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
 
 coord_t DistributedBeadingStrategy::getOptimalThickness(coord_t bead_count) const
 {
-    return std::max(0LL, (bead_count - 2)) * optimal_width_inner + std::min(2LL, bead_count) * optimal_width_outer;
+    return std::max(0LL, (bead_count - 1)) * optimal_width_inner + std::min(1LL, bead_count) * optimal_width_outer;
 }
 
 coord_t DistributedBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
 {
     // TODO: doesnt take min and max width into account
     const coord_t optimal_thickness = this->getOptimalThickness(lower_bead_count);
-    return optimal_thickness + (optimal_thickness < 2 ? optimal_width_outer : optimal_width_inner) / 2;
+    return optimal_thickness + (optimal_thickness < 1 ? optimal_width_outer : optimal_width_inner) / 2;
 }
 
 coord_t DistributedBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
     coord_t thickness_left = thickness;
-    coord_t count = std::min(2LL, (thickness + optimal_width_outer / 2) / optimal_width_outer);
+    coord_t count = std::min(1LL, (thickness + optimal_width_outer / 2) / optimal_width_outer);
     thickness_left -= count * optimal_width_outer;
     if (thickness_left >= (optimal_width_inner / 2))
     {

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -19,10 +19,10 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
     }
     else if (bead_count > 1)
     {
-        const float widen_by = static_cast<float>(thickness) / (optimal_width_outer + optimal_width_inner * (bead_count));
+        const auto widen_by = static_cast<float>(thickness) / (optimal_width_outer + optimal_width_inner * (bead_count));
 
         // Outer wall:
-        const coord_t distributed_width_outer = static_cast<coord_t>(optimal_width_outer * widen_by);
+        const auto distributed_width_outer = static_cast<coord_t>(optimal_width_outer * widen_by);
         ret.bead_widths.emplace_back(distributed_width_outer);
         ret.toolpath_locations.emplace_back(distributed_width_outer / 2);
 

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -28,10 +28,10 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
         for (coord_t bead_idx = 1; bead_idx < bead_count; bead_idx++)
         {
             ret.bead_widths.emplace_back(distributed_width_inner);
-            ret.toolpath_locations.emplace_back(optimal_width_outer + (distributed_width_inner * (bead_idx - 1) * 2 + 1) / 2);
+            ret.toolpath_locations.emplace_back((optimal_width_outer - distributed_width_inner / 2) + distributed_width_inner * bead_idx);
         }
 
-        ret.left_over = std::max(0LL, thickness - (ret.toolpath_locations.back() + optimal_width_inner / 2));
+        ret.left_over = 0; // There should be nothing left over, as we've distributed the remaining space.
     }
     else
     {

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -11,14 +11,24 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
     Beading ret;
 
     ret.total_thickness = thickness;
-    if (bead_count > 0)
+    if (bead_count == 1)
     {
-        ret.bead_widths.resize(bead_count, thickness / bead_count);
-        for (coord_t bead_idx = 0; bead_idx < bead_count; bead_idx++)
+        ret.bead_widths.emplace_back(thickness);
+        ret.toolpath_locations.emplace_back(thickness / 2);
+    }
+    else if (bead_count > 1)
+    {
+        // Outer wall, always the same size:
+        ret.bead_widths.emplace_back(optimal_width_outer);
+        ret.toolpath_locations.emplace_back(optimal_width_outer / 2);
+
+        // Evenly distributed inner walls:
+        const coord_t distributed_width_inner = std::max(optimal_width_outer / 2, (thickness - optimal_width_outer) / (bead_count - 1));
+        for (coord_t bead_idx = 1; bead_idx < bead_count; bead_idx++)
         {
-            ret.toolpath_locations.emplace_back(thickness * (bead_idx * 2 + 1) / bead_count / 2);
+            ret.bead_widths.emplace_back(distributed_width_inner);
+            ret.toolpath_locations.emplace_back(optimal_width_outer + distributed_width_inner * ((bead_idx - 1) * 2 + 1) / 2);
         }
-        ret.left_over = 0;
     }
     else
     {

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -24,11 +24,11 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
         ret.toolpath_locations.emplace_back(optimal_width_outer / 2);
 
         // Evenly distributed inner walls:
-        const coord_t distributed_width_inner = std::max(optimal_width_outer / 2, (thickness - optimal_width_outer) / (bead_count - 1));
+        const coord_t distributed_width_inner = std::max(optimal_width_inner / 2, (thickness - optimal_width_outer) / (bead_count - 1));
         for (coord_t bead_idx = 1; bead_idx < bead_count; bead_idx++)
         {
             ret.bead_widths.emplace_back(distributed_width_inner);
-            ret.toolpath_locations.emplace_back(optimal_width_outer + distributed_width_inner * ((bead_idx - 1) * 2 + 1) / 2);
+            ret.toolpath_locations.emplace_back(optimal_width_outer + (distributed_width_inner * (bead_idx - 1) * 2 + 1) / 2);
         }
 
         ret.left_over = std::max(0LL, thickness - (ret.toolpath_locations.back() + optimal_width_inner / 2));

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -31,7 +31,7 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
             ret.toolpath_locations.emplace_back(optimal_width_outer + distributed_width_inner * ((bead_idx - 1) * 2 + 1) / 2);
         }
 
-        ret.left_over = 0;
+        ret.left_over = std::max(0LL, thickness - (ret.toolpath_locations.back() + optimal_width_inner / 2));
     }
     else
     {

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -15,6 +15,7 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
     {
         ret.bead_widths.emplace_back(thickness);
         ret.toolpath_locations.emplace_back(thickness / 2);
+        ret.left_over = 0;
     }
     else if (bead_count > 1)
     {
@@ -29,6 +30,8 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
             ret.bead_widths.emplace_back(distributed_width_inner);
             ret.toolpath_locations.emplace_back(optimal_width_outer + distributed_width_inner * ((bead_idx - 1) * 2 + 1) / 2);
         }
+
+        ret.left_over = 0;
     }
     else
     {

--- a/src/BeadingStrategy/InwardDistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/InwardDistributedBeadingStrategy.cpp
@@ -22,7 +22,7 @@ InwardDistributedBeadingStrategy::Beading InwardDistributedBeadingStrategy::comp
         const float widen_by = static_cast<float>(thickness) / (optimal_width_outer + optimal_width_inner * (bead_count));
 
         // Outer wall:
-        const coord_t distributed_width_outer = static_cast<coord_t>(optimal_width_outer * widen_by);
+        const auto distributed_width_outer = static_cast<coord_t>(optimal_width_outer * widen_by);
         ret.bead_widths.emplace_back(distributed_width_outer);
         ret.toolpath_locations.emplace_back(distributed_width_outer / 2);
 
@@ -31,11 +31,11 @@ InwardDistributedBeadingStrategy::Beading InwardDistributedBeadingStrategy::comp
         const coord_t to_be_divided = thickness - (distributed_width_outer + distributed_width_inner * (bead_count - 1));
 
         float total_weight = 0;
-        const float middle = static_cast<float>(bead_count - 2) / 2;
+        const auto middle = static_cast<float>(bead_count - 2) / 2.0f;
         
         auto getWeight = [middle, this](coord_t bead_idx)
         {
-            float dev_from_middle = (bead_idx - 1) - middle;
+            const float dev_from_middle = (bead_idx - 1) - middle;
             return std::max(0.0f, 1.0f - one_over_distribution_radius_squared * dev_from_middle * dev_from_middle);
         };
         

--- a/src/BeadingStrategy/InwardDistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/InwardDistributedBeadingStrategy.cpp
@@ -41,7 +41,7 @@ InwardDistributedBeadingStrategy::Beading InwardDistributedBeadingStrategy::comp
             }
             ret.bead_widths.emplace_back(width);
         }
-        ret.left_over = 0;
+        ret.left_over = std::max(0LL, thickness - (ret.toolpath_locations.back() + optimal_width_inner / 2));
     }
     else
     {

--- a/src/BeadingStrategy/InwardDistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/InwardDistributedBeadingStrategy.cpp
@@ -30,7 +30,7 @@ InwardDistributedBeadingStrategy::Beading InwardDistributedBeadingStrategy::comp
         
         for (coord_t bead_idx = 0; bead_idx < bead_count; bead_idx++)
         {
-            coord_t width = ((bead_idx == 0 || bead_idx == (bead_count - 1)) ? optimal_width_outer : optimal_width_inner) + to_be_divided * getWeight(bead_idx) / total_weight;
+            coord_t width = (bead_idx == 0 ? optimal_width_outer : optimal_width_inner) + to_be_divided * getWeight(bead_idx) / total_weight;
             if (bead_idx == 0)
             {
                 ret.toolpath_locations.emplace_back(width / 2);

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -122,7 +122,7 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
     }
 
     // Call on libArachne:
-    WallToolPaths wall_tool_paths(part->outline, line_width_0, inset_count, settings);
+    WallToolPaths wall_tool_paths(part->outline, line_width_0, line_width_x, inset_count, settings);
     part->wall_toolpaths = wall_tool_paths.generate();
 }
 


### PR DESCRIPTION
Already done at some places, but not completely followed through.

Turns out that in order to make this work completely (or at least the CURA-7676 internal ticket, I also had to fix the plain Distributed Case to _do_ take into account the outer wall after all.