### PR TITLE
CURA-7769: Fix Z-Seam being placed halfway through a straight wall

### DIFF
--- a/src/utils/LinearAlg2D.cpp
+++ b/src/utils/LinearAlg2D.cpp
@@ -9,8 +9,6 @@
 
 #include "IntPoint.h" // dot
 
-#define SQRT_LLONG_MAX_FLOOR 3037000499
-
 namespace cura 
 {
 
@@ -193,6 +191,8 @@ bool LinearAlg2D::lineSegmentsCollide(const Point& a_from_transformed, const Poi
 
 coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Point& b)
 {
+    constexpr coord_t SQRT_LLONG_MAX_FLOOR = 3037000499;
+
     //  x.......a------------b
     //  :
     //  :
@@ -202,7 +202,7 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
     const Point vap = p - a;
     const coord_t ab_size2 = vSize2(vab);
     const coord_t ap_size2 = vSize2(vap);
-    coord_t ax_size2, px_size2;
+    coord_t px_size2;
     if(ab_size2 == 0) //Line of 0 length. Assume it's a line perpendicular to the direction to p.
     {
         return ap_size2;
@@ -211,12 +211,12 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
     if (dott != 0 && abs(dott) > SQRT_LLONG_MAX_FLOOR)  // dott * dott will overflow so calculate ax_size2 via its square root
     {
         const coord_t ax_size = dott / sqrt(ab_size2);
-        ax_size2 = ax_size * ax_size;
+        const coord_t ax_size2 = ax_size * ax_size;
         px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
     }
     else
     {
-        ax_size2 = dott * dott / ab_size2;
+        const coord_t ax_size2 = dott * dott / ab_size2;
         px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
     }
     return px_size2;

--- a/src/utils/LinearAlg2D.cpp
+++ b/src/utils/LinearAlg2D.cpp
@@ -9,6 +9,8 @@
 
 #include "IntPoint.h" // dot
 
+#define SQRT_LLONG_MAX_FLOOR 3037000499
+
 namespace cura 
 {
 
@@ -200,13 +202,23 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
     const Point vap = p - a;
     const coord_t ab_size2 = vSize2(vab);
     const coord_t ap_size2 = vSize2(vap);
+    coord_t ax_size2, px_size2;
     if(ab_size2 == 0) //Line of 0 length. Assume it's a line perpendicular to the direction to p.
     {
         return ap_size2;
     }
     const coord_t dott = dot(vab, vap);
-    const coord_t ax_size2 = dott * dott / vSize2(vab);
-    const coord_t px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
+    if (dott != 0 && abs(dott) > SQRT_LLONG_MAX_FLOOR)  // dott * dott will overflow so calculate ax_size2 via its square root
+    {
+        const coord_t ax_size = dott / sqrt(ab_size2);
+        ax_size2 = ax_size * ax_size;
+        px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
+    }
+    else
+    {
+        ax_size2 = dott * dott / ab_size2;
+        px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
+    }
     return px_size2;
 }
 


### PR DESCRIPTION
This was caused by the fact that simplify would sometimes not remove a point from a 3-point straight line due to an overflow error. This in-turn lead to Z-Seam being able to select that point.

Overflow error in simplify:
If three points (a, p, b) form an almost straight line, simplify will remove the point p from the path. In order to detect that, simplify checks wheter the distance of p from ab is 0. When calculating that distance, an overflow error could occur, which would lead simplify to believe that the points are not actually in the same line, thus leaving p inside the path.

This is now fixed by checking first whether the error prone variable 'dott' exceeds the numerical limit of type coord_t (long long), i.e. if dott is greater than the square root of LLONG_MAX. If that's the case, then the function getDist2FromLine will calculate the square root of the necessary distance ax in order to avoid squaring dott.

CURA-7769