### PR TITLE
Remove intermediate vertexes in really long line segments

### DIFF
--- a/src/utils/LinearAlg2D.cpp
+++ b/src/utils/LinearAlg2D.cpp
@@ -219,7 +219,7 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
         }
         else
         {
-            px_size2 = LLONG_MAX;
+            px_size2 = std::numeric_limits<long long>::max();
         }
     }
     else

--- a/src/utils/LinearAlg2D.cpp
+++ b/src/utils/LinearAlg2D.cpp
@@ -197,7 +197,7 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
     //  :
     //  :
     //  p
-    // return px_size
+    // return px_size^2 (if there is no overflow)
     const Point vab = b - a;
     const Point vap = p - a;
     const coord_t ab_size2 = vSize2(vab);
@@ -208,11 +208,19 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
         return ap_size2;
     }
     const coord_t dott = dot(vab, vap);
-    if (dott != 0 && abs(dott) > SQRT_LLONG_MAX_FLOOR)  // dott * dott will overflow so calculate ax_size2 via its square root
-    {
-        const coord_t ax_size = dott / sqrt(ab_size2);
-        const coord_t ax_size2 = ax_size * ax_size;
-        px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
+    if (dott != 0 && abs(dott) > SQRT_LLONG_MAX_FLOOR)
+    { // dott * dott will overflow so calculate px_size2 via its square root
+        coord_t px_size = LinearAlg2D::getDistFromLine(p, a, b);
+        if (px_size <= SQRT_LLONG_MAX_FLOOR)
+        {
+            // Due to rounding and conversion errors, this multiplication may not be the exact value that would be
+            // produced via the dott product, but it should still be close enough
+            px_size2 = px_size * px_size;
+        }
+        else
+        {
+            px_size2 = LLONG_MAX;
+        }
     }
     else
     {
@@ -220,6 +228,26 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
         px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
     }
     return px_size2;
+}
+
+coord_t LinearAlg2D::getDistFromLine(const Point& p, const Point& a, const Point& b)
+{
+    //  x.......a------------b
+    //  :
+    //  :
+    //  p
+    // return px_size
+    const Point vab = b - a;
+    const Point vap = p - a;
+    const double ab_size = vSize(vab);
+    const coord_t ap_size = vSize(vap);
+    if(ab_size == 0) //Line of 0 length. Assume it's a line perpendicular to the direction to p.
+    {
+        return ap_size;
+    }
+    const coord_t area_times_two = abs((b.Y - a.Y) * p.X - (b.X - a.X) * p.Y + b.X * a.Y - b.Y * a.X);
+    const coord_t px_size = area_times_two / ab_size;
+    return px_size;
 }
 
 } // namespace cura

--- a/src/utils/linearAlg2D.h
+++ b/src/utils/linearAlg2D.h
@@ -353,6 +353,19 @@ public:
     static coord_t getDist2FromLine(const Point& p, const Point& a, const Point& b);
 
     /*!
+     * Get the distance from a point \p p to the line on which \p a and \p b lie.
+     * It calculates that distance via the area of the triangle (pab): dist=2*Area(pab)/size(ab).
+     * This approach is less overflow-prone but more computationally-expensive compared to
+     * calculating the distance via the dot product.
+     *
+     * \param p The point to measure the distance from.
+     * \param a One of the points through which the line goes.
+     * \param b One of the points through which the line goes.
+     * \return The distance between the point and the line, squared.
+     */
+    static coord_t getDistFromLine(const Point& p, const Point& a, const Point& b);
+
+    /*!
      * Check whether a corner is acute or obtuse.
      * 
      * This function is irrespective of the order between \p a and \p c;

--- a/src/utils/linearAlg2D.h
+++ b/src/utils/linearAlg2D.h
@@ -361,7 +361,7 @@ public:
      * \param p The point to measure the distance from.
      * \param a One of the points through which the line goes.
      * \param b One of the points through which the line goes.
-     * \return The distance between the point and the line, squared.
+     * \return The distance between the point and the line.
      */
     static coord_t getDistFromLine(const Point& p, const Point& a, const Point& b);
 

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -372,7 +372,7 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         //h^2 = L^2 / b^2     [factor the divisor]
         const coord_t height_2 = area_removed_so_far * area_removed_so_far / base_length_2;
         if ((height_2 <= 1 //Almost exactly colinear (barring rounding errors).
-            && LinearAlg2D::getDist2FromLine(current, previous, next) <= 1)) // make sure that height_2 is not small because of cancellation of positive and negative areas
+            && LinearAlg2D::getDistFromLine(current, previous, next) <= 1)) // make sure that height_2 is not small because of cancellation of positive and negative areas
         {
             continue;
         }


### PR DESCRIPTION
Due to rounding errors when calculating the sqrt(ab_size2), simplify was still leaving vertexes
that existed in very long line segments. To get around that issue, getDistFromLine is introduced
that calculates that distance following a different formula than the dot product. This way, it
avoids calculating the squares and square roots of enormous lines that would otherwise generate
overflow and rounding errors.

This getDistFromLine is now used inside simplify when deciding to remove this vertex, thus making
simplify less sensitive to overflows.

CURA-7769