### PR TITLE
Fill gaps between walls fills gaps between skin and infill

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1658,7 +1658,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 
             if (infill_below_skin.size())
             {
-                if (infill_below_skin.offset(-tiny_infill_offset).size())
+                if (!infill_below_skin.offset(-tiny_infill_offset).empty())
                 {
                     // there is infill below skin, is there also infill that isn't below skin?
                     Polygons infill_not_below_skin = in_outline.difference(infill_below_skin);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1658,10 +1658,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 
             if (infill_below_skin.size())
             {
-                // need to take skin/infill overlap that was added in SkinInfillAreaComputation::generateInfill() into account
-                const coord_t infill_skin_overlap = mesh.settings.get<coord_t>((part.insets.size() > 1) ? "wall_line_width_x" : "wall_line_width_0") / 2;
-
-                if (infill_below_skin.offset(-(infill_skin_overlap + tiny_infill_offset)).size())
+                if (infill_below_skin.offset(-tiny_infill_offset).size())
                 {
                     // there is infill below skin, is there also infill that isn't below skin?
                     Polygons infill_not_below_skin = in_outline.difference(infill_below_skin);

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -571,6 +571,7 @@ void FffPolygonGenerator::processPerimeterGaps(SliceDataStorage& storage)
             coord_t wall_line_width_0 = mesh.settings.get<coord_t>("wall_line_width_0");
             coord_t wall_line_width_x = mesh.settings.get<coord_t>("wall_line_width_x");
             coord_t skin_line_width = mesh.settings.get<coord_t>("skin_line_width");
+            coord_t infill_line_width = mesh.settings.get<coord_t>("infill_line_width");
             if (layer_nr == 0)
             {
                 const ExtruderTrain& train_wall_0 = mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr");
@@ -616,9 +617,13 @@ void FffPolygonGenerator::processPerimeterGaps(SliceDataStorage& storage)
                         // we print them as a perimeter gap
                         inner = inner.offset(-skin_line_width / 2).offset(skin_line_width / 2);
                     }
-                    inner.add(part.infill_area);
+                    inner.add(part.infill_area.offset(-infill_line_width / 2).offset(infill_line_width / 2));
                     inner = inner.unionPolygons();
                     part.perimeter_gaps.add(outer.difference(inner));
+
+                    if (filter_out_tiny_gaps) {
+                        part.perimeter_gaps.removeSmallAreas(2 * INT2MM(infill_line_width) * INT2MM(infill_line_width));
+                    }
                 }
 
                 // add perimeter gaps for skin insets

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -431,7 +431,7 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
     const size_t wall_line_count = mesh.settings.get<size_t>("wall_line_count");
     const coord_t infill_line_distance = mesh.settings.get<coord_t>("infill_line_distance");
 
-    coord_t offset_from_inner_wall = -infill_skin_overlap;
+    coord_t offset_from_inner_wall = -innermost_wall_line_width / 2;
     if (wall_line_count > 0)
     { // calculate offset_from_inner_wall
         coord_t extra_perimeter_offset = 0; // to align concentric polygons across layers
@@ -457,14 +457,13 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
                 }
             }
         }
-        offset_from_inner_wall += extra_perimeter_offset - innermost_wall_line_width / 2;
+        offset_from_inner_wall += extra_perimeter_offset;
     }
     Polygons infill = part.insets.back().offset(offset_from_inner_wall);
-
-    infill = infill.difference(skin.offset(infill_skin_overlap));
+    infill = infill.difference(skin);
     infill.removeSmallAreas(MIN_AREA_SIZE);
 
-    part.infill_area = infill.offset(infill_skin_overlap);
+    part.infill_area = infill;
 }
 
 /*

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -416,7 +416,7 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
     const size_t wall_line_count = mesh.settings.get<size_t>("wall_line_count");
     const coord_t infill_line_distance = mesh.settings.get<coord_t>("infill_line_distance");
 
-    coord_t offset_from_inner_wall = -innermost_wall_line_width / 2;
+    coord_t offset_from_inner_wall = 0;
     if (wall_line_count > 0)
     { // calculate offset_from_inner_wall
         coord_t extra_perimeter_offset = 0; // to align concentric polygons across layers
@@ -442,7 +442,7 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
                 }
             }
         }
-        offset_from_inner_wall += extra_perimeter_offset;
+        offset_from_inner_wall += extra_perimeter_offset - innermost_wall_line_width / 2;
     }
     Polygons infill = part.insets.back().offset(offset_from_inner_wall);
     infill = infill.difference(skin);

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -49,20 +49,6 @@ coord_t SkinInfillAreaComputation::getWallLineWidthX(const SliceMeshStorage& mes
     }
     return wall_line_width_x;
 }
-coord_t SkinInfillAreaComputation::getInfillSkinOverlap(const SliceMeshStorage& mesh, const LayerIndex& layer_nr, const coord_t& innermost_wall_line_width)
-{
-    coord_t infill_skin_overlap = 0;
-    { // compute infill_skin_overlap
-        const ExtruderTrain& train_infill = mesh.settings.get<ExtruderTrain&>("infill_extruder_nr");
-        const Ratio infill_line_width_factor = (layer_nr == 0) ? train_infill.settings.get<Ratio>("initial_layer_line_width_factor") : Ratio(1.0);
-        const bool infill_is_dense = mesh.settings.get<coord_t>("infill_line_distance") < mesh.settings.get<coord_t>("infill_line_width") * infill_line_width_factor + 10;
-        if (!infill_is_dense && mesh.settings.get<EFillMethod>("infill_pattern") != EFillMethod::CONCENTRIC)
-        {
-            infill_skin_overlap = innermost_wall_line_width / 2;
-        }
-    }
-    return infill_skin_overlap;
-}
 
 SkinInfillAreaComputation::SkinInfillAreaComputation(const LayerIndex& layer_nr, SliceMeshStorage& mesh, bool process_infill)
 : layer_nr(layer_nr)
@@ -75,7 +61,6 @@ SkinInfillAreaComputation::SkinInfillAreaComputation(const LayerIndex& layer_nr,
 , wall_line_width_0(getWallLineWidth0(mesh, layer_nr))
 , wall_line_width_x(getWallLineWidthX(mesh, layer_nr))
 , innermost_wall_line_width((wall_line_count == 1) ? wall_line_width_0 : wall_line_width_x)
-, infill_skin_overlap(getInfillSkinOverlap(mesh, layer_nr, innermost_wall_line_width))
 , skin_inset_count(mesh.settings.get<size_t>("skin_outline_count"))
 , no_small_gaps_heuristic(mesh.settings.get<bool>("skin_no_small_gaps_heuristic"))
 , process_infill(process_infill)

--- a/src/skin.h
+++ b/src/skin.h
@@ -186,7 +186,6 @@ protected:
     const coord_t wall_line_width_0; //!< The line width of the outer wall
     const coord_t wall_line_width_x; //!< The line width of the inner most wall
     const coord_t innermost_wall_line_width; //!< width of the innermost wall lines
-    const coord_t infill_skin_overlap; //!< overlap distance between infill and skin
     const size_t skin_inset_count; //!< The number of perimeters to surround the skin
     const bool no_small_gaps_heuristic; //!< A heuristic which assumes there will be no small gaps between bottom and top skin with a z size smaller than the skin size itself
     const bool process_infill; //!< Whether to process infill, i.e. whether there's a positive infill density or there are infill meshes modifying this mesh.
@@ -201,7 +200,6 @@ private:
     static coord_t getSkinLineWidth(const SliceMeshStorage& mesh, const LayerIndex& layer_nr); //!< Compute the skin line width, which might be different for the first layer.
     static coord_t getWallLineWidth0(const SliceMeshStorage& mesh, const LayerIndex& layer_nr); //!< Compute the outer wall line width, which might be different for the first layer
     static coord_t getWallLineWidthX(const SliceMeshStorage& mesh, const LayerIndex& layer_nr); //!< Compute the inner wall line widths, which might be different for the first layer
-    static coord_t getInfillSkinOverlap(const SliceMeshStorage& mesh, const LayerIndex& layer_nr, const coord_t& innermost_wall_line_width); //!< Compute the infill_skin_overlap
 
     /*!
      * Helper function to get the walls of each part which might intersect with \p part_here


### PR DESCRIPTION
This was caused due to a change done in https://github.com/Ultimaker/CuraEngine/pull/1284. Even though the change was fixing the original issue, small gaps were being generated between the infill and the skin walls due to the offsetted skin (as the offset can create discrepancies). 

![image](https://user-images.githubusercontent.com/19388042/98122395-d285e600-1eb0-11eb-9875-bf44a8bee3b5.png)

These gaps are the ones being filled by the small gap filling technique, even if there is no infill wall.

![image](https://user-images.githubusercontent.com/19388042/98122530-03661b00-1eb1-11eb-8636-934e41270a7f.png)



Upon further inspection of the original issue https://github.com/Ultimaker/Cura/issues/6571, it turns out that the infill-skin overlap was intentional and it was dependend on the inner wall line width, which is irrelevant. https://github.com/Ultimaker/CuraEngine/blob/e4acd35cd832fe170457b2ff7e10f671f65feb9c/src/skin.cpp#L61 
The bigger the inner wall width, the more the overlap. After giving it more thought, it seems that there is no reason for the infill and skin to overlap, since it is causing problems. Also there is no documentation as to why it was implemented like this in the first place.

Removing the infill-skin overlap fixes both the original problem https://github.com/Ultimaker/Cura/issues/6571 and the new issue https://github.com/Ultimaker/Cura/issues/8626.

CURA-7804