### PR TITLE
Cura 7115 gradual infill overextrusion

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1698,7 +1698,8 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         //Originally an area of 0.4*0.4*2 (2 line width squares) was found to be a good threshold for removal.
         //However we found that this doesn't scale well with polygons with larger circumference (https://github.com/Ultimaker/Cura/issues/3992).
         //Given that the original test worked for approximately 2x2cm models, this scaling by circumference should make it work for any size.
-        const double minimum_small_area = 0.4 * 0.4 * circumference / 40000;
+        constexpr double minimum_small_area_factor = 0.4 * 0.4 / 40000;
+        const double minimum_small_area = minimum_small_area_factor * circumference;
         
         // This is only for density infill, because after generating the infill might appear unnecessary infill on walls
         // especially on vertical surfaces

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1517,7 +1517,8 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     }
     const Point3 mesh_middle = mesh.bounding_box.getMiddle();
     const Point infill_origin(mesh_middle.x + mesh.settings.get<coord_t>("infill_offset_x"), mesh_middle.y + mesh.settings.get<coord_t>("infill_offset_y"));
-    for (unsigned int density_idx = part.infill_area_per_combine_per_density.size() - 1; (int)density_idx >= 0; density_idx--)
+    const size_t  last_idx = part.infill_area_per_combine_per_density.size() - 1;
+    for (size_t density_idx = last_idx; static_cast<int>(density_idx) >= 0; density_idx--)
     {
         int infill_line_distance_here = infill_line_distance << (density_idx + 1); // the highest density infill combines with the next to create a grid with density_factor 1
         int infill_shift = infill_line_distance_here / 2;
@@ -1535,7 +1536,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 // : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | |   > near top
 // >>>>>>>>"""""""""""""""""
 
-        if (density_idx == part.infill_area_per_combine_per_density.size() - 1 || pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D)
+        if (density_idx == last_idx || pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D)
         { // the least dense infill should fill up all remaining gaps
 // :       |       :       |       :       |       :       |       :  > furthest from top
 // :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |   :  > further from top
@@ -1716,16 +1717,14 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_provider, &mesh);
         if (zig_zaggify_infill)
         {
-            if (density_idx == part.infill_area_per_combine_per_density.size() - 1)
+            if (density_idx == last_idx)
             {
                 first_dense_lines = infill_lines;
                 infill_lines.clear();
             }
-            if (density_idx >= 0 && density_idx < part.infill_area_per_combine_per_density.size() - 1)
+            if (density_idx >= 0 && density_idx < last_idx)
             {
-                Polygons base =
-                    part.infill_area_per_combine_per_density[part.infill_area_per_combine_per_density.size() - 1][0];
-                Polygons tool = base.offset(-infill_line_width * 0.75);
+                Polygons tool = part.infill_area_per_combine_per_density[last_idx][0].offset(-infill_line_width * 0.75);
                 infill_lines.cut(tool);
             }
             if (density_idx == 0)

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1519,6 +1519,12 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     const size_t  last_idx = part.infill_area_per_combine_per_density.size() - 1;
     for (size_t density_idx = last_idx; static_cast<int>(density_idx) >= 0; density_idx--)
     {
+        // Only process dense areas when they're initialized
+        if (part.infill_area_per_combine_per_density[density_idx][0].empty())
+        {
+            continue;
+        }
+
         Polygons infill_lines_here;
         int infill_line_distance_here = infill_line_distance << (density_idx + 1); // the highest density infill combines with the next to create a grid with density_factor 1
         int infill_shift = infill_line_distance_here / 2;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1724,7 +1724,8 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             }
             if (density_idx >= 0 && density_idx < last_idx)
             {
-                Polygons tool = part.infill_area_per_combine_per_density[last_idx][0].offset(-infill_line_width * 0.75);
+                const int cut_offset = - static_cast<int>(infill_line_width) / 2 - 5;
+                Polygons tool = part.infill_area_per_combine_per_density[last_idx][0].offset(cut_offset);
                 infill_lines.cut(tool);
             }
             if (density_idx == 0)

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1714,20 +1714,24 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             , /*int zag_skip_count =*/ 0
             , mesh.settings.get<coord_t>("cross_infill_pocket_size"));
         infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_provider, &mesh);
-        if (density_idx == part.infill_area_per_combine_per_density.size() - 1)
+        if (zig_zaggify_infill)
         {
-            first_dense_lines = infill_lines;
-            infill_lines.clear();
-        }
-        if (density_idx >= 0 && density_idx < part.infill_area_per_combine_per_density.size() - 1)
-        {
-            Polygons base = part.infill_area_per_combine_per_density[part.infill_area_per_combine_per_density.size() - 1][0];
-            Polygons tool = base.offset(-infill_line_width*0.75);
-            infill_lines.cut(tool);
-        }
-        if (density_idx == 0)
-        {
-            infill_lines.add(first_dense_lines);
+            if (density_idx == part.infill_area_per_combine_per_density.size() - 1)
+            {
+                first_dense_lines = infill_lines;
+                infill_lines.clear();
+            }
+            if (density_idx >= 0 && density_idx < part.infill_area_per_combine_per_density.size() - 1)
+            {
+                Polygons base =
+                    part.infill_area_per_combine_per_density[part.infill_area_per_combine_per_density.size() - 1][0];
+                Polygons tool = base.offset(-infill_line_width * 0.75);
+                infill_lines.cut(tool);
+            }
+            if (density_idx == 0)
+            {
+                infill_lines.add(first_dense_lines);
+            }
         }
     }
     if (infill_lines.size() > 0 || infill_polygons.size() > 0)

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1652,7 +1652,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         infill_polygons.add(infill_polygons_here);
     }
 
-    if (!infill_lines.empty() || !infill_polygons.empty())
+    if (! infill_lines.empty() || ! infill_polygons.empty())
     {
         added_something = true;
         setExtruder_addPrime(storage, gcode_layer, extruder_nr);
@@ -1661,7 +1661,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         if (mesh.settings.get<bool>("infill_randomize_start_location"))
         {
             srand(gcode_layer.getLayerNr());
-            if(!infill_lines.empty())
+            if(! infill_lines.empty())
             {
                 near_start_location = infill_lines[rand() % infill_lines.size()][0];
             }
@@ -1671,7 +1671,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                 near_start_location = start_poly[rand() % start_poly.size()];
             }
         }
-        if (!infill_polygons.empty())
+        if (! infill_polygons.empty())
         {
             constexpr bool force_comb_retract = false;
             // start the infill polygons at the nearest vertex to the current location
@@ -1711,11 +1711,11 @@ bool FffGcodeWriter::partitionInfillBySkinAbove(Polygons& infill_below_skin, Pol
             {
                 for (const SkinPart& skin_part : part.skin_parts)
                 {
-                    if (!skin_above_combined.empty())
+                    if (! skin_above_combined.empty())
                     {
                         // does this skin part overlap with any of the skin parts on the layers above?
                         const Polygons overlap = skin_above_combined.intersection(skin_part.outline);
-                        if (!overlap.empty())
+                        if (! overlap.empty())
                         {
                             // yes, it overlaps, need to leave a gap between this skin part and the others
                             if (i > 1) // this layer is the 2nd or higher layer above the layer whose infill we're printing
@@ -1792,7 +1792,7 @@ bool FffGcodeWriter::partitionInfillBySkinAbove(Polygons& infill_below_skin, Pol
     const coord_t infill_skin_overlap = mesh.settings.get<coord_t>((part.insets.size() > 1) ? "wall_line_width_x" : "wall_line_width_0") / 2;
     const Polygons infill_below_skin_overlap = infill_below_skin.offset(-(infill_skin_overlap + tiny_infill_offset));
 
-    return !infill_below_skin_overlap.empty() && !infill_not_below_skin.empty();
+    return ! infill_below_skin_overlap.empty() && ! infill_not_below_skin.empty();
 }
 
 void FffGcodeWriter::processSpiralizedWall(const SliceDataStorage& storage, LayerPlan& gcode_layer, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, const SliceMeshStorage& mesh) const

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1520,14 +1520,26 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 
     auto get_cut_offset = [](const bool zig_zaggify, const coord_t line_width, const size_t line_count)
     {
-      if (zig_zaggify)
-      {
-          return - line_width / 2 - static_cast<coord_t>(line_count) * line_width - 5;
-      }
-      else
-      {
-          return - static_cast<coord_t>(line_count) * line_width;
-      }
+
+    };
+
+    auto cut_polygon = [](const Polygons& here, const Polygons& collection, const coord_t width)
+    {
+      Polygons result = here.breakApart();
+      Polygons tool = collection.intersection(collection.offset(-width/2));
+      tool.simplify();
+      result.cut(tool);
+      return result;
+    };
+
+    auto cut_lines = [](const Polygons& here, const Polygons& collection, const Polygons& below_skin, const bool zig_zaggify, const coord_t line_width, const size_t line_count)
+    {
+        Polygons result;
+        result.add(here);
+        const coord_t cut_offset = zig_zaggify ? - line_width / 2 - static_cast<coord_t>(line_count) * line_width - 5 : - static_cast<coord_t>(line_count) * line_width;
+        Polygons tool = below_skin.offset(static_cast<int>(cut_offset));
+        result.cut(collection.tubeShape(line_width, line_width).difference(collection));
+        return result;
     };
 
     Polygons sparse_in_outline = part.infill_area_per_combine_per_density[last_idx][0];
@@ -1611,12 +1623,14 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             infill_comp.generate(infill_polygons, infill_lines_here, mesh.cross_fill_provider, &mesh);
             if (density_idx < last_idx)
             {
-                const coord_t cut_offset =
-                    get_cut_offset(zig_zaggify_infill, infill_line_width, min_skin_below_wall_count);
-                Polygons tool = infill_below_skin.offset(static_cast<int>(cut_offset));
-                infill_lines_here.cut(tool);
+                infill_lines.add(cut_lines(infill_lines_here, sparse_in_outline, infill_below_skin, zig_zaggify_infill, infill_line_width, wall_line_count));
+                infill_polygons.add(cut_polygon(infill_polygons_here, infill_polygons, infill_line_width));
             }
-            infill_lines.add(infill_lines_here);
+            else
+            {
+                infill_lines.add(infill_lines_here);
+                infill_polygons.add(infill_polygons_here);
+            }
             // normal processing for the infill that isn't below skin
             in_outline = infill_not_below_skin;
             if (density_idx == last_idx)
@@ -1636,36 +1650,23 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         // especially on vertical surfaces
         in_outline.removeSmallAreas(minimum_small_area);
         const size_t wall_line_count_here = (density_idx < last_idx) ? 0 : wall_line_count;
-        
-        Infill infill_comp(pattern,
-                           zig_zaggify_infill,
-                           connect_polygons,
-                           in_outline,
-                           outline_offset,
-                           infill_line_width,
-                           infill_line_distance_here,
-                           infill_overlap,
-                           infill_multiplier,
-                           infill_angle,
-                           gcode_layer.z,
-                           infill_shift,
-                           wall_line_count_here,
-                           infill_origin,
-                           perimeter_gaps,
-                           connected_zigzags,
-                           use_endpieces,
-                           skip_some_zags,
-                           zag_skip_count,
-                           pocket_size);
+
+        Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, in_outline, outline_offset, infill_line_width,
+                           infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z,
+                           infill_shift, wall_line_count_here, infill_origin, perimeter_gaps, connected_zigzags,
+                           use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
         infill_comp.generate(infill_polygons_here, infill_lines_here, mesh.cross_fill_provider, &mesh);
+
         if (density_idx < last_idx)
         {
-            const coord_t cut_offset = get_cut_offset(zig_zaggify_infill, infill_line_width, wall_line_count);
-            Polygons tool = sparse_in_outline.offset(static_cast<int>(cut_offset));
-            infill_lines_here.cut(tool);
+            infill_lines.add(cut_lines(infill_lines_here, sparse_in_outline, infill_below_skin, zig_zaggify_infill, infill_line_width, wall_line_count));
+            infill_polygons.add(cut_polygon(infill_polygons_here, infill_polygons, infill_line_width));
         }
-        infill_lines.add(infill_lines_here);
-        infill_polygons.add(infill_polygons_here);
+        else
+        {
+            infill_lines.add(infill_lines_here);
+            infill_polygons.add(infill_polygons_here);
+        }
     }
 
     if (!infill_lines.empty() || !infill_polygons.empty())

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1658,18 +1658,18 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 
             infill_below_skin.removeSmallAreas(min_area, remove_small_holes_from_infill_below_skin);
 
-            if (infill_below_skin.size())
+            if (!infill_below_skin.empty())
             {
                 // need to take skin/infill overlap that was added in SkinInfillAreaComputation::generateInfill() into account
                 const coord_t infill_skin_overlap = mesh.settings.get<coord_t>((part.insets.size() > 1) ? "wall_line_width_x" : "wall_line_width_0") / 2;
 
-                if (infill_below_skin.offset(-(infill_skin_overlap + tiny_infill_offset)).size())
+                if (!infill_below_skin.offset(-(infill_skin_overlap + tiny_infill_offset)).empty())
                 {
                     // there is infill below skin, is there also infill that isn't below skin?
                     Polygons infill_not_below_skin = in_outline.difference(infill_below_skin);
                     infill_not_below_skin.removeSmallAreas(min_area);
 
-                    if (infill_not_below_skin.size())
+                    if (!infill_not_below_skin.empty())
                     {
                         constexpr Polygons* perimeter_gaps = nullptr;
                         constexpr bool connected_zigzags = false;
@@ -1733,7 +1733,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             }
         }
     }
-    if (infill_lines.size() > 0 || infill_polygons.size() > 0)
+    if (!infill_lines.empty() || !infill_polygons.empty())
     {
         added_something = true;
         setExtruder_addPrime(storage, gcode_layer, extruder_nr);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1705,15 +1705,28 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         // This is only for density infill, because after generating the infill might appear unnecessary infill on walls
         // especially on vertical surfaces
         in_outline.removeSmallAreas(minimum_small_area);
+        const size_t wall_line_count_here = (density_idx < last_idx) ? 0 : wall_line_count;
         
-        Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, in_outline, /*outline_offset =*/ 0
-            , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, wall_line_count, infill_origin
-            , /*Polygons* perimeter_gaps =*/ nullptr
-            , /*bool connected_zigzags =*/ false
-            , /*bool use_endpieces =*/ false
-            , /*bool skip_some_zags =*/ false
-            , /*int zag_skip_count =*/ 0
-            , mesh.settings.get<coord_t>("cross_infill_pocket_size"));
+        Infill infill_comp(pattern,
+                           zig_zaggify_infill,
+                           connect_polygons,
+                           in_outline,
+                           /*outline_offset =*/ 0,
+                           infill_line_width,
+                           infill_line_distance_here,
+                           infill_overlap,
+                           infill_multiplier,
+                           infill_angle,
+                           gcode_layer.z,
+                           infill_shift,
+                           wall_line_count_here,
+                           infill_origin,
+                           /*Polygons* perimeter_gaps =*/ nullptr,
+                           /*bool connected_zigzags =*/ false,
+                           /*bool use_endpieces =*/ false,
+                           /*bool skip_some_zags =*/ false,
+                           /*int zag_skip_count =*/ 0,
+                           mesh.settings.get<coord_t>("cross_infill_pocket_size"));
         infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_provider, &mesh);
         if (zig_zaggify_infill)
         {
@@ -1724,7 +1737,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             }
             if (density_idx >= 0 && density_idx < last_idx)
             {
-                const int cut_offset = - static_cast<int>(infill_line_width) / 2 - 5;
+                const int cut_offset = - static_cast<int>(infill_line_width) / 2 - wall_line_count * static_cast<int>(infill_line_width) - 5;
                 Polygons tool = part.infill_area_per_combine_per_density[last_idx][0].offset(cut_offset);
                 infill_lines.cut(tool);
             }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1517,6 +1517,25 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     const Point3 mesh_middle = mesh.bounding_box.getMiddle();
     const Point infill_origin(mesh_middle.x + mesh.settings.get<coord_t>("infill_offset_x"), mesh_middle.y + mesh.settings.get<coord_t>("infill_offset_y"));
     const size_t  last_idx = part.infill_area_per_combine_per_density.size() - 1;
+
+    auto get_cut_offset = [](const bool zig_zaggify, const coord_t line_width, const size_t line_count)
+    {
+      if (zig_zaggify)
+      {
+          return - line_width / 2 - static_cast<coord_t>(line_count) * line_width - 5;
+      }
+      else
+      {
+          return - static_cast<coord_t>(line_count) * line_width;
+      }
+    };
+
+    Polygons sparse_in_outline = part.infill_area_per_combine_per_density[last_idx][0];
+    Polygons skin_above_combined;  // skin regions on the layers above combined with small gaps between
+    Polygons infill_below_skin;
+    constexpr double min_area_multiplier = 25;
+    const double min_area = INT2MM(infill_line_width) * INT2MM(infill_line_width) * min_area_multiplier;
+
     for (size_t density_idx = last_idx; static_cast<int>(density_idx) >= 0; density_idx--)
     {
         // Only process dense areas when they're initialized
@@ -1526,6 +1545,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         }
 
         Polygons infill_lines_here;
+        Polygons infill_polygons_here;
         int infill_line_distance_here = infill_line_distance << (density_idx + 1); // the highest density infill combines with the next to create a grid with density_factor 1
         int infill_shift = infill_line_distance_here / 2;
         // infill shift explanation: [>]=shift ["]=line_dist
@@ -1566,103 +1586,101 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         size_t skin_edge_support_layers = mesh.settings.get<size_t>("skin_edge_support_layers");
         if (skin_edge_support_layers > 0)
         {
-            Polygons skin_above_combined;  // skin regions on the layers above combined with small gaps between
 
             constexpr coord_t tiny_infill_offset = 20;
 
             // working from the highest layer downwards, combine the regions of skin on all the layers but don't let the regions merge together
             // otherwise "terraced" skin regions on separate layers will look like a single region of unbroken skin
-
-            for (size_t i = skin_edge_support_layers; i > 0; --i)
+            if (density_idx == last_idx)
             {
-                const size_t skin_layer_nr = gcode_layer.getLayerNr() + i;
-                if (skin_layer_nr < mesh.layers.size())
+                for (size_t i = skin_edge_support_layers; i > 0; --i)
                 {
-                    for (const SliceLayerPart& part : mesh.layers[skin_layer_nr].parts)
+                    const size_t skin_layer_nr = gcode_layer.getLayerNr() + i;
+                    if (skin_layer_nr < mesh.layers.size())
                     {
-                        for (const SkinPart& skin_part : part.skin_parts)
+                        for (const SliceLayerPart& part : mesh.layers[skin_layer_nr].parts)
                         {
-                            if (skin_above_combined.size())
+                            for (const SkinPart& skin_part : part.skin_parts)
                             {
-                                // does this skin part overlap with any of the skin parts on the layers above?
-                                const Polygons overlap = skin_above_combined.intersection(skin_part.outline);
-                                if (overlap.size())
+                                if (skin_above_combined.size())
                                 {
-                                    // yes, it overlaps, need to leave a gap between this skin part and the others
-                                    if (i > 1)
+                                    // does this skin part overlap with any of the skin parts on the layers above?
+                                    const Polygons overlap = skin_above_combined.intersection(skin_part.outline);
+                                    if (overlap.size())
                                     {
-                                        // this layer is the 2nd or higher layer above the layer whose infill we're printing
+                                        // yes, it overlaps, need to leave a gap between this skin part and the others
+                                        if (i > 1)
+                                        {
+                                            // this layer is the 2nd or higher layer above the layer whose infill we're printing
 
-                                        // looking from the side, if the combined regions so far look like this...
-                                        //
-                                        //     ----------------------------------
-                                        //
-                                        // and the new skin part looks like this...
-                                        //
-                                        //             -------------------------------------
-                                        //
-                                        // the result should be like this...
-                                        //
-                                        //     ------- -------------------------- ----------
+                                            // looking from the side, if the combined regions so far look like this...
+                                            //
+                                            //     ----------------------------------
+                                            //
+                                            // and the new skin part looks like this...
+                                            //
+                                            //             -------------------------------------
+                                            //
+                                            // the result should be like this...
+                                            //
+                                            //     ------- -------------------------- ----------
 
-                                        // expand the overlap region slightly to make a small gap
-                                        const Polygons overlap_expanded = overlap.offset(tiny_infill_offset);
-                                        // subtract the expanded overlap region from the regions accumulated from higher layers
-                                        skin_above_combined = skin_above_combined.difference(overlap_expanded);
-                                        // subtract the expanded overlap region from this skin part and add the remainder to the overlap region
-                                        skin_above_combined.add(skin_part.outline.difference(overlap_expanded));
-                                        // and add the overlap area as well
-                                        skin_above_combined.add(overlap);
+                                            // expand the overlap region slightly to make a small gap
+                                            const Polygons overlap_expanded = overlap.offset(tiny_infill_offset);
+                                            // subtract the expanded overlap region from the regions accumulated from higher layers
+                                            skin_above_combined = skin_above_combined.difference(overlap_expanded);
+                                            // subtract the expanded overlap region from this skin part and add the remainder to the overlap region
+                                            skin_above_combined.add(skin_part.outline.difference(overlap_expanded));
+                                            // and add the overlap area as well
+                                            skin_above_combined.add(overlap);
+                                        }
+                                        else
+                                        {
+                                            // this layer is the 1st layer above the layer whose infill we're printing
+
+                                            // add this layer's skin region without subtracting the overlap but still make a gap between this skin region and what has been accumulated so far
+                                            // we do this so that these skin region edges will definitely have infill walls below them
+
+                                            // looking from the side, if the combined regions so far look like this...
+                                            //
+                                            //     ----------------------------------
+                                            //
+                                            // and the new skin part looks like this...
+                                            //
+                                            //             -------------------------------------
+                                            //
+                                            // the result should be like this...
+                                            //
+                                            //     ------- -------------------------------------
+
+                                            skin_above_combined = skin_above_combined.difference(
+                                                skin_part.outline.offset(tiny_infill_offset));
+                                            skin_above_combined.add(skin_part.outline);
+                                        }
                                     }
                                     else
                                     {
-                                        // this layer is the 1st layer above the layer whose infill we're printing
-
-                                        // add this layer's skin region without subtracting the overlap but still make a gap between this
-                                        // skin region and what has been accumulated so far
-                                        // we do this so that these skin region edges will definitely have infill walls below them
-
-                                        // looking from the side, if the combined regions so far look like this...
-                                        //
-                                        //     ----------------------------------
-                                        //
-                                        // and the new skin part looks like this...
-                                        //
-                                        //             -------------------------------------
-                                        //
-                                        // the result should be like this...
-                                        //
-                                        //     ------- -------------------------------------
-
-                                        skin_above_combined = skin_above_combined.difference(skin_part.outline.offset(tiny_infill_offset));
+                                        // no overlap
                                         skin_above_combined.add(skin_part.outline);
                                     }
                                 }
                                 else
                                 {
-                                    // no overlap
+                                    // this is the first skin region we have looked at
                                     skin_above_combined.add(skin_part.outline);
                                 }
-                            }
-                            else
-                            {
-                                // this is the first skin region we have looked at
-                                skin_above_combined.add(skin_part.outline);
                             }
                         }
                     }
                 }
+
+                // the shrink/expand here is to remove regions of infill below skin that are narrower than the width of the infill walls otherwise the infill walls could merge and form a bump
+                infill_below_skin =  skin_above_combined.intersection(in_outline).offset(-infill_line_width).offset(infill_line_width);
+
+                constexpr bool remove_small_holes_from_infill_below_skin = true;
+
+                infill_below_skin.removeSmallAreas(min_area, remove_small_holes_from_infill_below_skin);
             }
-
-            // the shrink/expand here is to remove regions of infill below skin that are narrower than the width of the infill walls
-            // otherwise the infill walls could merge and form a bump
-            Polygons infill_below_skin = skin_above_combined.intersection(in_outline).offset(-infill_line_width).offset(infill_line_width);
-
-            constexpr double min_area_multiplier = 25;
-            const double min_area = INT2MM(infill_line_width) * INT2MM(infill_line_width) * min_area_multiplier;
-            constexpr bool remove_small_holes_from_infill_below_skin = true;
-
-            infill_below_skin.removeSmallAreas(min_area, remove_small_holes_from_infill_below_skin);
 
             if (!infill_below_skin.empty())
             {
@@ -1684,18 +1702,42 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                         constexpr int zag_skip_count = 0;
 
                         // infill region with skin above has to have at least one infill wall line
-                        Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, infill_below_skin, /*outline_offset =*/ 0
-                            , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, std::max(1, (int)wall_line_count), infill_origin
-                            , perimeter_gaps
-                            , connected_zigzags
-                            , use_endpieces
-                            , skip_some_zags
-                            , zag_skip_count
-                            , mesh.settings.get<coord_t>("cross_infill_pocket_size"));
-                        infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_provider, &mesh);
-
+                        const size_t min_skin_below_wall_count = wall_line_count > 0 ? wall_line_count : 1;
+                        const size_t skin_below_wall_count = density_idx == last_idx ? min_skin_below_wall_count : 0;
+                        Infill infill_comp(pattern,
+                                           zig_zaggify_infill,
+                                           connect_polygons,
+                                           infill_below_skin,
+                                           /*outline_offset =*/ 0,
+                                           infill_line_width,
+                                           infill_line_distance_here,
+                                           infill_overlap,
+                                           infill_multiplier,
+                                           infill_angle,
+                                           gcode_layer.z,
+                                           infill_shift,
+                                           skin_below_wall_count,
+                                           infill_origin,
+                                           perimeter_gaps,
+                                           connected_zigzags,
+                                           use_endpieces,
+                                           skip_some_zags,
+                                           zag_skip_count,
+                                           mesh.settings.get<coord_t>("cross_infill_pocket_size"));
+                        infill_comp.generate(infill_polygons, infill_lines_here, mesh.cross_fill_provider, &mesh);
+                        if (density_idx < last_idx)
+                        {
+                            const coord_t cut_offset = get_cut_offset(zig_zaggify_infill, infill_line_width, min_skin_below_wall_count);
+                            Polygons tool = infill_below_skin.offset(static_cast<int>(cut_offset));
+                            infill_lines_here.cut(tool);
+                        }
+                        infill_lines.add(infill_lines_here);
                         // normal processing for the infill that isn't below skin
                         in_outline = infill_not_below_skin;
+                        if (density_idx == last_idx)
+                        {
+                            sparse_in_outline = infill_not_below_skin;
+                        }
                     }
                 }
             }
@@ -1733,22 +1775,11 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                            /*bool skip_some_zags =*/ false,
                            /*int zag_skip_count =*/ 0,
                            mesh.settings.get<coord_t>("cross_infill_pocket_size"));
-        infill_comp.generate(infill_polygons, infill_lines_here, mesh.cross_fill_provider, &mesh);
+        infill_comp.generate(infill_polygons_here, infill_lines_here, mesh.cross_fill_provider, &mesh);
         if (density_idx < last_idx)
         {
-            auto get_cut_offset = [](const bool zig_zaggify, const coord_t line_width, const size_t line_count)
-            {
-                if (zig_zaggify)
-                {
-                    return - line_width / 2 - static_cast<coord_t>(line_count) * line_width - 5;
-                }
-                else
-                {
-                    return - static_cast<coord_t>(line_count) * line_width;
-                }
-            };
             const coord_t cut_offset = get_cut_offset(zig_zaggify_infill, infill_line_width, wall_line_count);
-            Polygons tool = part.infill_area_per_combine_per_density[last_idx][0].offset(static_cast<int>(cut_offset));
+            Polygons tool = sparse_in_outline.offset(static_cast<int>(cut_offset));
             infill_lines_here.cut(tool);
         }
         infill_lines.add(infill_lines_here);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1490,8 +1490,8 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     {
         return false;
     }
-    const coord_t infill_line_distance = mesh.settings.get<coord_t>("infill_line_distance");
-    if (infill_line_distance == 0 || part.infill_area_per_combine_per_density[0].size() == 0)
+    const auto infill_line_distance = mesh.settings.get<coord_t>("infill_line_distance");
+    if (infill_line_distance == 0 || part.infill_area_per_combine_per_density[0].empty())
     {
         return false;
     }
@@ -1502,12 +1502,12 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     Polygons infill_polygons;
     Polygons infill_lines;
 
-    const EFillMethod pattern = mesh.settings.get<EFillMethod>("infill_pattern");
-    const bool zig_zaggify_infill = mesh.settings.get<bool>("zig_zaggify_infill") || pattern == EFillMethod::ZIG_ZAG;
-    const bool connect_polygons = mesh.settings.get<bool>("connect_infill_polygons");
-    const coord_t infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
-    const size_t infill_multiplier = mesh.settings.get<size_t>("infill_multiplier");
-    const size_t wall_line_count = mesh.settings.get<size_t>("infill_wall_line_count");
+    const auto pattern = mesh.settings.get<EFillMethod>("infill_pattern");
+    const auto zig_zaggify_infill = mesh.settings.get<bool>("zig_zaggify_infill") || pattern == EFillMethod::ZIG_ZAG;
+    const auto connect_polygons = mesh.settings.get<bool>("connect_infill_polygons");
+    const auto infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
+    const auto infill_multiplier = mesh.settings.get<size_t>("infill_multiplier");
+    const auto wall_line_count = mesh.settings.get<size_t>("infill_wall_line_count");
     AngleDegrees infill_angle = 45; //Original default. This will get updated to an element from mesh->infill_angles.
     if (mesh.infill_angles.size() > 0)
     {
@@ -1516,7 +1516,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     }
     const Point3 mesh_middle = mesh.bounding_box.getMiddle();
     const Point infill_origin(mesh_middle.x + mesh.settings.get<coord_t>("infill_offset_x"), mesh_middle.y + mesh.settings.get<coord_t>("infill_offset_y"));
-    const size_t  last_idx = part.infill_area_per_combine_per_density.size() - 1;
+    const size_t last_idx = part.infill_area_per_combine_per_density.size() - 1;
 
     auto get_cut_offset = [](const bool zig_zaggify, const coord_t line_width, const size_t line_count)
     {
@@ -1531,10 +1531,21 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     };
 
     Polygons sparse_in_outline = part.infill_area_per_combine_per_density[last_idx][0];
-    Polygons skin_above_combined;  // skin regions on the layers above combined with small gaps between
+
+    // if infill walls are required below the boundaries of skin regions above, partition the infill along the
+    // boundary edge
     Polygons infill_below_skin;
-    constexpr double min_area_multiplier = 25;
-    const double min_area = INT2MM(infill_line_width) * INT2MM(infill_line_width) * min_area_multiplier;
+    Polygons infill_not_below_skin;
+    const bool hasSkinEdgeSupport = partitionInfillBySkinAbove(infill_below_skin, infill_not_below_skin,
+                                                               gcode_layer, mesh, part, infill_line_width);
+    const auto skin_edge_support_layers = mesh.settings.get<size_t>("skin_edge_support_layers");
+    const auto pocket_size = mesh.settings.get<coord_t>("cross_infill_pocket_size");
+    constexpr coord_t outline_offset = 0;
+    constexpr Polygons* perimeter_gaps = nullptr;
+    constexpr bool connected_zigzags = false;
+    constexpr bool use_endpieces = false;
+    constexpr bool skip_some_zags = false;
+    constexpr int zag_skip_count = 0;
 
     for (size_t density_idx = last_idx; static_cast<int>(density_idx) >= 0; density_idx--)
     {
@@ -1546,199 +1557,76 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 
         Polygons infill_lines_here;
         Polygons infill_polygons_here;
-        int infill_line_distance_here = infill_line_distance << (density_idx + 1); // the highest density infill combines with the next to create a grid with density_factor 1
+
+        // the highest density infill combines with the next to create a grid with density_factor 1
+        int infill_line_distance_here = infill_line_distance << (density_idx + 1);
         int infill_shift = infill_line_distance_here / 2;
-        // infill shift explanation: [>]=shift ["]=line_dist
-// :       |       :       |       :       |       :       |         > furthest from top
-// :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |     > further from top
-// : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | |   > near top
-// >>"""""
-// :       |       :       |       :       |       :       |         > furthest from top
-// :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |     > further from top
-// : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | |   > near top
-// >>>>"""""""""
-// :       |       :       |       :       |       :       |         > furthest from top
-// :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |     > further from top
-// : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | |   > near top
-// >>>>>>>>"""""""""""""""""
+
+        /* infill shift explanation: [>]=shift ["]=line_dist
+
+         :       |       :       |       :       |       :       |         > furthest from top
+         :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |     > further from top
+         : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | |   > near top
+         >>"""""
+         :       |       :       |       :       |       :       |         > furthest from top
+         :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |     > further from top
+         : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | |   > near top
+         >>>>"""""""""
+         :       |       :       |       :       |       :       |         > furthest from top
+         :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |     > further from top
+         : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | |   > near top
+         >>>>>>>>"""""""""""""""""
+         */
 
         if (density_idx == last_idx || pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D)
         { // the least dense infill should fill up all remaining gaps
-// :       |       :       |       :       |       :       |       :  > furthest from top
-// :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |   :  > further from top
-// : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | | :  > near top
-//   .   .     .       .           .               .       .       .
-//   :   :     :       :           :               :       :       :
-//   `"""'     `"""""""'           `"""""""""""""""'       `"""""""'
-//                                                             ^   new line distance for lowest density infill
-//                                       ^ infill_line_distance_here for lowest density infill up till here
-//                 ^ middle density line dist
-//     ^   highest density line dist
-            
-            //All of that doesn't hold for the Cross patterns; they should just always be multiplied by 2 for every density index.
+        /*
+         :       |       :       |       :       |       :       |       :  > furthest from top
+         :   |   |   |   :   |   |   |   :   |   |   |   :   |   |   |   :  > further from top
+         : | | | | | | | : | | | | | | | : | | | | | | | : | | | | | | | :  > near top
+           .   .     .       .           .               .       .       .
+           :   :     :       :           :               :       :       :
+           `"""'     `"""""""'           `"""""""""""""""'       `"""""""'
+                                                                     ^   new line distance for lowest density infill
+                                               ^ infill_line_distance_here for lowest density infill up till here
+                         ^ middle density line dist
+             ^   highest density line dist
+        */
+
+            //All of that doesn't hold for the Cross patterns; they should just always be multiplied by 2.
             infill_line_distance_here /= 2;
         }
 
         Polygons in_outline = part.infill_area_per_combine_per_density[density_idx][0];
 
-        // if infill walls are required below the boundaries of skin regions above, partition the infill along the boundary edge
-
-        size_t skin_edge_support_layers = mesh.settings.get<size_t>("skin_edge_support_layers");
-        if (skin_edge_support_layers > 0)
+        if (hasSkinEdgeSupport)
         {
+            // need to take skin/infill overlap that was added in SkinInfillAreaComputation::generateInfill() into account
+            const auto infill_skin_overlap = mesh.settings.get<coord_t>((part.insets.size() > 1) ? "wall_line_width_x" : "wall_line_width_0") / 2;
 
-            constexpr coord_t tiny_infill_offset = 20;
-
-            // working from the highest layer downwards, combine the regions of skin on all the layers but don't let the regions merge together
-            // otherwise "terraced" skin regions on separate layers will look like a single region of unbroken skin
-            if (density_idx == last_idx)
+            if (!infill_not_below_skin.empty())
             {
-                for (size_t i = skin_edge_support_layers; i > 0; --i)
+                // infill region with skin above has to have at least one infill wall line
+                const size_t min_skin_below_wall_count = wall_line_count > 0 ? wall_line_count : 1;
+                const size_t skin_below_wall_count = density_idx == last_idx ? min_skin_below_wall_count : 0;
+                Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, infill_below_skin, outline_offset,
+                                   infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier,
+                                   infill_angle, gcode_layer.z, infill_shift, skin_below_wall_count, infill_origin,
+                                   perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count,
+                                   pocket_size);
+                infill_comp.generate(infill_polygons, infill_lines_here, mesh.cross_fill_provider, &mesh);
+                if (density_idx < last_idx)
                 {
-                    const size_t skin_layer_nr = gcode_layer.getLayerNr() + i;
-                    if (skin_layer_nr < mesh.layers.size())
-                    {
-                        for (const SliceLayerPart& part : mesh.layers[skin_layer_nr].parts)
-                        {
-                            for (const SkinPart& skin_part : part.skin_parts)
-                            {
-                                if (skin_above_combined.size())
-                                {
-                                    // does this skin part overlap with any of the skin parts on the layers above?
-                                    const Polygons overlap = skin_above_combined.intersection(skin_part.outline);
-                                    if (overlap.size())
-                                    {
-                                        // yes, it overlaps, need to leave a gap between this skin part and the others
-                                        if (i > 1)
-                                        {
-                                            // this layer is the 2nd or higher layer above the layer whose infill we're printing
-
-                                            // looking from the side, if the combined regions so far look like this...
-                                            //
-                                            //     ----------------------------------
-                                            //
-                                            // and the new skin part looks like this...
-                                            //
-                                            //             -------------------------------------
-                                            //
-                                            // the result should be like this...
-                                            //
-                                            //     ------- -------------------------- ----------
-
-                                            // expand the overlap region slightly to make a small gap
-                                            const Polygons overlap_expanded = overlap.offset(tiny_infill_offset);
-                                            // subtract the expanded overlap region from the regions accumulated from higher layers
-                                            skin_above_combined = skin_above_combined.difference(overlap_expanded);
-                                            // subtract the expanded overlap region from this skin part and add the remainder to the overlap region
-                                            skin_above_combined.add(skin_part.outline.difference(overlap_expanded));
-                                            // and add the overlap area as well
-                                            skin_above_combined.add(overlap);
-                                        }
-                                        else
-                                        {
-                                            // this layer is the 1st layer above the layer whose infill we're printing
-
-                                            // add this layer's skin region without subtracting the overlap but still make a gap between this skin region and what has been accumulated so far
-                                            // we do this so that these skin region edges will definitely have infill walls below them
-
-                                            // looking from the side, if the combined regions so far look like this...
-                                            //
-                                            //     ----------------------------------
-                                            //
-                                            // and the new skin part looks like this...
-                                            //
-                                            //             -------------------------------------
-                                            //
-                                            // the result should be like this...
-                                            //
-                                            //     ------- -------------------------------------
-
-                                            skin_above_combined = skin_above_combined.difference(
-                                                skin_part.outline.offset(tiny_infill_offset));
-                                            skin_above_combined.add(skin_part.outline);
-                                        }
-                                    }
-                                    else
-                                    {
-                                        // no overlap
-                                        skin_above_combined.add(skin_part.outline);
-                                    }
-                                }
-                                else
-                                {
-                                    // this is the first skin region we have looked at
-                                    skin_above_combined.add(skin_part.outline);
-                                }
-                            }
-                        }
-                    }
+                    const coord_t cut_offset = get_cut_offset(zig_zaggify_infill, infill_line_width, min_skin_below_wall_count);
+                    Polygons tool = infill_below_skin.offset(static_cast<int>(cut_offset));
+                    infill_lines_here.cut(tool);
                 }
-
-                // the shrink/expand here is to remove regions of infill below skin that are narrower than the width of the infill walls otherwise the infill walls could merge and form a bump
-                infill_below_skin =  skin_above_combined.intersection(in_outline).offset(-infill_line_width).offset(infill_line_width);
-
-                constexpr bool remove_small_holes_from_infill_below_skin = true;
-
-                infill_below_skin.removeSmallAreas(min_area, remove_small_holes_from_infill_below_skin);
-            }
-
-            if (!infill_below_skin.empty())
-            {
-                // need to take skin/infill overlap that was added in SkinInfillAreaComputation::generateInfill() into account
-                const coord_t infill_skin_overlap = mesh.settings.get<coord_t>((part.insets.size() > 1) ? "wall_line_width_x" : "wall_line_width_0") / 2;
-
-                if (!infill_below_skin.offset(-(infill_skin_overlap + tiny_infill_offset)).empty())
+                infill_lines.add(infill_lines_here);
+                // normal processing for the infill that isn't below skin
+                in_outline = infill_not_below_skin;
+                if (density_idx == last_idx)
                 {
-                    // there is infill below skin, is there also infill that isn't below skin?
-                    Polygons infill_not_below_skin = in_outline.difference(infill_below_skin);
-                    infill_not_below_skin.removeSmallAreas(min_area);
-
-                    if (!infill_not_below_skin.empty())
-                    {
-                        constexpr Polygons* perimeter_gaps = nullptr;
-                        constexpr bool connected_zigzags = false;
-                        constexpr bool use_endpieces = false;
-                        constexpr bool skip_some_zags = false;
-                        constexpr int zag_skip_count = 0;
-
-                        // infill region with skin above has to have at least one infill wall line
-                        const size_t min_skin_below_wall_count = wall_line_count > 0 ? wall_line_count : 1;
-                        const size_t skin_below_wall_count = density_idx == last_idx ? min_skin_below_wall_count : 0;
-                        Infill infill_comp(pattern,
-                                           zig_zaggify_infill,
-                                           connect_polygons,
-                                           infill_below_skin,
-                                           /*outline_offset =*/ 0,
-                                           infill_line_width,
-                                           infill_line_distance_here,
-                                           infill_overlap,
-                                           infill_multiplier,
-                                           infill_angle,
-                                           gcode_layer.z,
-                                           infill_shift,
-                                           skin_below_wall_count,
-                                           infill_origin,
-                                           perimeter_gaps,
-                                           connected_zigzags,
-                                           use_endpieces,
-                                           skip_some_zags,
-                                           zag_skip_count,
-                                           mesh.settings.get<coord_t>("cross_infill_pocket_size"));
-                        infill_comp.generate(infill_polygons, infill_lines_here, mesh.cross_fill_provider, &mesh);
-                        if (density_idx < last_idx)
-                        {
-                            const coord_t cut_offset = get_cut_offset(zig_zaggify_infill, infill_line_width, min_skin_below_wall_count);
-                            Polygons tool = infill_below_skin.offset(static_cast<int>(cut_offset));
-                            infill_lines_here.cut(tool);
-                        }
-                        infill_lines.add(infill_lines_here);
-                        // normal processing for the infill that isn't below skin
-                        in_outline = infill_not_below_skin;
-                        if (density_idx == last_idx)
-                        {
-                            sparse_in_outline = infill_not_below_skin;
-                        }
-                    }
+                    sparse_in_outline = infill_not_below_skin;
                 }
             }
         }
@@ -1759,7 +1647,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                            zig_zaggify_infill,
                            connect_polygons,
                            in_outline,
-                           /*outline_offset =*/ 0,
+                           outline_offset,
                            infill_line_width,
                            infill_line_distance_here,
                            infill_overlap,
@@ -1769,12 +1657,12 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                            infill_shift,
                            wall_line_count_here,
                            infill_origin,
-                           /*Polygons* perimeter_gaps =*/ nullptr,
-                           /*bool connected_zigzags =*/ false,
-                           /*bool use_endpieces =*/ false,
-                           /*bool skip_some_zags =*/ false,
-                           /*int zag_skip_count =*/ 0,
-                           mesh.settings.get<coord_t>("cross_infill_pocket_size"));
+                           perimeter_gaps,
+                           connected_zigzags,
+                           use_endpieces,
+                           skip_some_zags,
+                           zag_skip_count,
+                           pocket_size);
         infill_comp.generate(infill_polygons_here, infill_lines_here, mesh.cross_fill_provider, &mesh);
         if (density_idx < last_idx)
         {
@@ -1783,7 +1671,9 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             infill_lines_here.cut(tool);
         }
         infill_lines.add(infill_lines_here);
+        infill_polygons.add(infill_polygons_here);
     }
+
     if (!infill_lines.empty() || !infill_polygons.empty())
     {
         added_something = true;
@@ -1823,6 +1713,110 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         }
     }
     return added_something;
+}
+
+bool FffGcodeWriter::partitionInfillBySkinAbove(Polygons& infill_below_skin, Polygons& infill_not_below_skin, const LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const SliceLayerPart& part, const coord_t infill_line_width)
+{
+    constexpr coord_t tiny_infill_offset = 20;
+    const auto skin_edge_support_layers = mesh.settings.get<size_t>("skin_edge_support_layers");
+    if (skin_edge_support_layers == 0)
+    {
+        return false;
+    }
+    Polygons skin_above_combined;  // skin regions on the layers above combined with small gaps between
+
+    // working from the highest layer downwards, combine the regions of skin on all the layers
+    // but don't let the regions merge together
+    // otherwise "terraced" skin regions on separate layers will look like a single region of unbroken skin
+    for (size_t i = skin_edge_support_layers; i > 0; --i)
+    {
+        const size_t skin_layer_nr = gcode_layer.getLayerNr() + i;
+        if (skin_layer_nr < mesh.layers.size())
+        {
+            for (const SliceLayerPart& part : mesh.layers[skin_layer_nr].parts)
+            {
+                for (const SkinPart& skin_part : part.skin_parts)
+                {
+                    if (!skin_above_combined.empty())
+                    {
+                        // does this skin part overlap with any of the skin parts on the layers above?
+                        const Polygons overlap = skin_above_combined.intersection(skin_part.outline);
+                        if (!overlap.empty())
+                        {
+                            // yes, it overlaps, need to leave a gap between this skin part and the others
+                            if (i > 1) // this layer is the 2nd or higher layer above the layer whose infill we're printing
+                            {
+                                // looking from the side, if the combined regions so far look like this...
+                                //
+                                //     ----------------------------------
+                                //
+                                // and the new skin part looks like this...
+                                //
+                                //             -------------------------------------
+                                //
+                                // the result should be like this...
+                                //
+                                //     ------- -------------------------- ----------
+
+                                // expand the overlap region slightly to make a small gap
+                                const Polygons overlap_expanded = overlap.offset(tiny_infill_offset);
+                                // subtract the expanded overlap region from the regions accumulated from higher layers
+                                skin_above_combined = skin_above_combined.difference(overlap_expanded);
+                                // subtract the expanded overlap region from this skin part and add the remainder to the overlap region
+                                skin_above_combined.add(skin_part.outline.difference(overlap_expanded));
+                                // and add the overlap area as well
+                                skin_above_combined.add(overlap);
+                            }
+                            else // this layer is the 1st layer above the layer whose infill we're printing
+                            {
+                                // add this layer's skin region without subtracting the overlap but still make a gap between this skin region and what has been accumulated so far
+                                // we do this so that these skin region edges will definitely have infill walls below them
+
+                                // looking from the side, if the combined regions so far look like this...
+                                //
+                                //     ----------------------------------
+                                //
+                                // and the new skin part looks like this...
+                                //
+                                //             -------------------------------------
+                                //
+                                // the result should be like this...
+                                //
+                                //     ------- -------------------------------------
+
+                                skin_above_combined = skin_above_combined.difference(
+                                    skin_part.outline.offset(tiny_infill_offset));
+                                skin_above_combined.add(skin_part.outline);
+                            }
+                        }
+                        else // no overlap
+                        {
+                            skin_above_combined.add(skin_part.outline);
+                        }
+                    }
+                    else // this is the first skin region we have looked at
+                    {
+                        skin_above_combined.add(skin_part.outline);
+                    }
+                }
+            }
+        }
+
+        // the shrink/expand here is to remove regions of infill below skin that are narrower than the width of the infill walls otherwise the infill walls could merge and form a bump
+        Polygons first = part.infill_area_per_combine_per_density.back().front();
+        infill_below_skin =  skin_above_combined.intersection(first).offset(-infill_line_width).offset(infill_line_width);
+
+        constexpr bool remove_small_holes_from_infill_below_skin = true;
+        constexpr double min_area_multiplier = 25;
+        const double min_area = INT2MM(infill_line_width) * INT2MM(infill_line_width) * min_area_multiplier;
+        infill_below_skin.removeSmallAreas(min_area, remove_small_holes_from_infill_below_skin);
+
+        // need to take skin/infill overlap that was added in SkinInfillAreaComputation::generateInfill() into account
+        const coord_t infill_skin_overlap = mesh.settings.get<coord_t>((part.insets.size() > 1) ? "wall_line_width_x" : "wall_line_width_0") / 2;
+
+        return !infill_below_skin.empty()
+               && !infill_below_skin.offset(-(infill_skin_overlap + tiny_infill_offset)).empty();
+    }
 }
 
 void FffGcodeWriter::processSpiralizedWall(const SliceDataStorage& storage, LayerPlan& gcode_layer, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, const SliceMeshStorage& mesh) const

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -715,9 +715,23 @@ private:
      */
     unsigned int findSpiralizedLayerSeamVertexIndex(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const int layer_nr, const int last_layer_nr);
 
-    static bool partitionInfillBySkinAbove(Polygons& infill_below_skin, Polygons& infill_not_below_skin,
-                                           const LayerPlan& gcode_layer, const SliceMeshStorage& mesh,
-                                           const SliceLayerPart& part, coord_t infill_line_width) ;
+    /*!
+     * Partition the Infill regions by the skin at N layers above.
+     *
+     * When skind edge support layers is set this function will check N layers above the infill layer to see if there is
+     * skin above. If this skin needs to be supported by a wall it will return true else it returns false. The Infill
+     * outline of the Sparse density layer is partitioned into two polygons, either below the skin regions or outside
+     * of the skin region.
+     *
+     * \param infill_below_skin [out] Polygons with infill below the skin
+     * \param infill_not_below_skin [out] Polygons with infill outside of skin regions above
+     * \param gcode_layer The initial planning of the gcode of the layer
+     * \param mesh the mesh containing the layer of interest
+     * \param part \param part The part for which to create gcode
+     * \param infill_line_width line width of the infill
+     * \return true if there needs to be a skin edge support wall in this layer, otherwise false
+     */
+    static bool partitionInfillBySkinAbove(Polygons& infill_below_skin, Polygons& infill_not_below_skin, const LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const SliceLayerPart& part, coord_t infill_line_width) ;
 };
 
 }//namespace cura

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -717,7 +717,7 @@ private:
 
     static bool partitionInfillBySkinAbove(Polygons& infill_below_skin, Polygons& infill_not_below_skin,
                                            const LayerPlan& gcode_layer, const SliceMeshStorage& mesh,
-                                           const SliceLayerPart& part, const coord_t infill_line_width);
+                                           const SliceLayerPart& part, coord_t infill_line_width) ;
 };
 
 }//namespace cura

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -718,7 +718,7 @@ private:
     /*!
      * Partition the Infill regions by the skin at N layers above.
      *
-     * When skind edge support layers is set this function will check N layers above the infill layer to see if there is
+     * When skin edge support layers is set this function will check N layers above the infill layer to see if there is
      * skin above. If this skin needs to be supported by a wall it will return true else it returns false. The Infill
      * outline of the Sparse density layer is partitioned into two polygons, either below the skin regions or outside
      * of the skin region.

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -432,6 +432,8 @@ private:
      */
     bool processSingleLayerInfill(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part) const;
 
+
+
     /*!
      * Generate the insets for the walls of a given layer part.
      * \param[in] storage where the slice data is stored.
@@ -712,6 +714,10 @@ private:
      * \return layer seam vertex index
      */
     unsigned int findSpiralizedLayerSeamVertexIndex(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const int layer_nr, const int last_layer_nr);
+
+    static bool partitionInfillBySkinAbove(Polygons& infill_below_skin, Polygons& infill_not_below_skin,
+                                           const LayerPlan& gcode_layer, const SliceMeshStorage& mesh,
+                                           const SliceLayerPart& part, const coord_t infill_line_width);
 };
 
 }//namespace cura

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -358,7 +358,7 @@ void Infill::generateCubicSubDivInfill(Polygons& result, const SliceMeshStorage&
 {
     Polygons uncropped;
     mesh.base_subdiv_cube->generateSubdivisionLines(z, uncropped);
-    addLineSegmentsInfill(result, uncropped);
+    result = uncropped.cut(in_outline.offset(infill_overlap));
 }
 
 void Infill::generateCrossInfill(const SierpinskiFillProvider& cross_fill_provider, Polygons& result_polygons, Polygons& result_lines)
@@ -399,18 +399,6 @@ void Infill::generateCrossInfill(const SierpinskiFillProvider& cross_fill_provid
                 result_lines.addLine(poly_line[point_idx - 1], poly_line[point_idx]);
             }
         }
-    }
-}
-
-void Infill::addLineSegmentsInfill(Polygons& result, Polygons& input)
-{
-    ClipperLib::PolyTree interior_segments_tree;
-    in_outline.offset(infill_overlap).lineSegmentIntersection(input, interior_segments_tree);
-    ClipperLib::Paths interior_segments;
-    ClipperLib::OpenPathsFromPolyTree(interior_segments_tree, interior_segments);
-    for (size_t idx = 0; idx < interior_segments.size(); idx++)
-    {
-        result.addLine(interior_segments[idx][0], interior_segments[idx][1]);
     }
 }
 

--- a/src/infill.h
+++ b/src/infill.h
@@ -319,13 +319,6 @@ private:
     void addLineInfill(Polygons& result, const PointMatrix& rotation_matrix, const int scanline_min_idx, const int line_distance, const AABB boundary, std::vector<std::vector<coord_t>>& cut_list, coord_t total_shift);
 
     /*!
-     * Crop line segments by the infill polygon using Clipper
-     * \param[out] result (output) The resulting lines
-     * \param input The line segments to be cropped
-     */
-    void addLineSegmentsInfill(Polygons& result, Polygons& input);
-
-    /*!
      * generate lines within the area of \p in_outline, at regular intervals of \p line_distance
      * 
      * idea:

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -630,11 +630,11 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
 
         for (SliceLayerPart& part : layer.parts)
         {
-            assert(part.infill_area_per_combine_per_density.size() == 0 && "infill_area_per_combine_per_density is supposed to be uninitialized");
+            assert((part.infill_area_per_combine_per_density.empty() && "infill_area_per_combine_per_density is supposed to be uninitialized"));
 
             const Polygons& infill_area = part.getOwnInfillArea();
 
-            if (infill_area.size() == 0 || layer_idx < min_layer || layer_idx > max_layer)
+            if (infill_area.empty() || layer_idx < min_layer || layer_idx > max_layer)
             { // initialize infill_area_per_combine_per_density empty
                 part.infill_area_per_combine_per_density.emplace_back(); // create a new infill_area_per_combine
                 part.infill_area_per_combine_per_density.back().emplace_back(); // put empty infill area in the newly constructed infill_area_per_combine
@@ -666,7 +666,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
                     }
                     less_dense_infill = less_dense_infill.intersection(relevent_upper_polygons);
                 }
-                if (less_dense_infill.size() == 0)
+                if (less_dense_infill.empty())
                 {
                     break;
                 }
@@ -680,7 +680,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
             std::vector<Polygons>& infill_area_per_combine_current_density = part.infill_area_per_combine_per_density.back();
             infill_area_per_combine_current_density.push_back(infill_area);
             part.infill_area_own = nullptr; // clear infill_area_own, it's not needed any more.
-            assert(part.infill_area_per_combine_per_density.size() != 0 && "infill_area_per_combine_per_density is now initialized");
+            assert(!part.infill_area_per_combine_per_density.empty() && "infill_area_per_combine_per_density is now initialized");
         }
     }
 }

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -249,6 +249,20 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines) const
     return ret;
 }
 
+Polygons& Polygons::cut(const Polygons& tool)
+{
+    ClipperLib::PolyTree interior_segments_tree;
+    tool.lineSegmentIntersection(*this, interior_segments_tree);
+    ClipperLib::Paths interior_segments;
+    ClipperLib::OpenPathsFromPolyTree(interior_segments_tree, interior_segments);
+    this->clear();
+    for (const std::vector<ClipperLib::IntPoint>& interior_segment : interior_segments)
+    {
+        this->addLine(interior_segment[0], interior_segment[1]);
+    }
+    return *this;
+}
+
 coord_t Polygons::polyLineLength() const
 {
     coord_t length = 0;

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -263,21 +263,6 @@ Polygons& Polygons::cut(const Polygons& tool)
     return *this;
 }
 
-Polygons Polygons::breakApart() const
-{
-    Polygons result;
-    for (const auto& poly : *this)
-    {
-        Polygons part;
-        for (size_t i = 1; i < poly.size(); ++i)
-        {
-            part.addLine(poly[i - 1], poly[i]);
-        }
-        result.add(part);
-    }
-    return result;
-}
-
 coord_t Polygons::polyLineLength() const
 {
     coord_t length = 0;

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -263,6 +263,21 @@ Polygons& Polygons::cut(const Polygons& tool)
     return *this;
 }
 
+Polygons Polygons::breakApart() const
+{
+    Polygons result;
+    for (const auto& poly : *this)
+    {
+        Polygons part;
+        for (size_t i = 1; i < poly.size(); ++i)
+        {
+            part.addLine(poly[i - 1], poly[i]);
+        }
+        result.add(part);
+    }
+    return result;
+}
+
 coord_t Polygons::polyLineLength() const
 {
     coord_t length = 0;

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -781,6 +781,13 @@ public:
         clipper.AddPaths(other.paths, ClipperLib::ptSubject, false);
         clipper.Execute(ClipperLib::ctIntersection, segment_tree);
     }
+
+    /*!
+     * Cut this polygon using an other polygon as a tool
+     * \param tool a closed polygon serving as boundary
+     */
+    Polygons& cut(const Polygons& tool);
+
     Polygons xorPolygons(const Polygons& other) const
     {
         Polygons ret;

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -788,8 +788,6 @@ public:
      */
     Polygons& cut(const Polygons& tool);
 
-    Polygons breakApart() const;
-
     Polygons xorPolygons(const Polygons& other) const
     {
         Polygons ret;

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -788,6 +788,8 @@ public:
      */
     Polygons& cut(const Polygons& tool);
 
+    Polygons breakApart() const;
+
     Polygons xorPolygons(const Polygons& other) const
     {
         Polygons ret;


### PR DESCRIPTION
Coupled with PR ultimaker/cura#8693

This PR fixes the over extrusion caused when gradual infill areas overlap and connected infill lines is checked.
The spare density infill area will be connected lines, while the denser density area are only connected at the borders where the areas overlap, not adjacent to walls. This will result in unconnected lines but it is mathematically not possible to connect these line structures in such away that there will be a single motion along the complete infill lines. 

Fixes CURA-7115