### PR TITLE
Fix polyline chaining

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,7 @@ set(engine_SRCS # Except main.cpp.
 
 # List of tests. For each test there must be a file tests/${NAME}.cpp.
 set(engine_TEST
+    ClipperTest
     GCodeExportTest
     InfillTest
     LayerPlanTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ set(engine_SRCS # Except main.cpp.
     src/utils/PolygonProximityLinker.cpp
     src/utils/polygonUtils.cpp
     src/utils/polygon.cpp
+    src/utils/PolylineStitcher.cpp
     src/utils/ProximityPointLink.cpp
     src/utils/SVG.cpp
     src/utils/socket.cpp

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1269,18 +1269,7 @@ void FffGcodeWriter::addMeshOpenPolyLinesToGCode(const SliceMeshStorage& mesh, c
 {
     const SliceLayer* layer = &mesh.layers[gcode_layer.getLayerNr()];
     
-    Polygons lines;
-    for(ConstPolygonRef polyline : layer->openPolyLines)
-    {
-        for(unsigned int point_idx = 1; point_idx<polyline.size(); point_idx++)
-        {
-            Polygon p;
-            p.add(polyline[point_idx-1]);
-            p.add(polyline[point_idx]);
-            lines.add(p);
-        }
-    }
-    gcode_layer.addLinesByOptimizer(lines, mesh_config.inset0_config, SpaceFillType::PolyLines);
+    gcode_layer.addLinesByOptimizer(layer->openPolyLines, mesh_config.inset0_config, SpaceFillType::PolyLines);
 }
 
 void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, LayerPlan& gcode_layer) const

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1112,7 +1112,6 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathCon
             }
 
             // Don't wipe if next starting point is very near
-            // TODO: remove this condition once all polylines are properly chained
             if (wipe && (order_idx < orderOptimizer.polyOrder.size() - 1))
             {
                 const unsigned int next_poly_idx = orderOptimizer.polyOrder[order_idx + 1];

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -716,11 +716,8 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const SliceMeshSto
 
             // determine which segments of the line are bridges
 
-            Polygon line_poly;
-            line_poly.add(p0);
-            line_poly.add(p1);
             Polygons line_polys;
-            line_polys.add(line_poly);
+            line_polys.addLine(p0, p1);
             line_polys = bridge_wall_mask.intersectionPolyLines(line_polys);
 
             // line_polys now contains the wall lines that need to be printed using bridge_config
@@ -837,11 +834,8 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const SliceMeshStor
 
                     // determine which segments of the line are bridges
 
-                    Polygon line_poly;
-                    line_poly.add(p0);
-                    line_poly.add(p1);
                     Polygons line_polys;
-                    line_polys.add(line_poly);
+                    line_polys.addLine(p0, p1);
                     line_polys = bridge_wall_mask.intersectionPolyLines(line_polys);
 
                     while (line_polys.size() > 0)

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -393,14 +393,7 @@ void Infill::generateCrossInfill(const SierpinskiFillProvider& cross_fill_provid
 
 void Infill::addLineSegmentsInfill(Polygons& result, Polygons& input)
 {
-    ClipperLib::PolyTree interior_segments_tree;
-    in_outline.offset(infill_overlap).lineSegmentIntersection(input, interior_segments_tree);
-    ClipperLib::Paths interior_segments;
-    ClipperLib::OpenPathsFromPolyTree(interior_segments_tree, interior_segments);
-    for (size_t idx = 0; idx < interior_segments.size(); idx++)
-    {
-        result.addLine(interior_segments[idx][0], interior_segments[idx][1]);
-    }
+    result.add(in_outline.offset(infill_overlap).intersectionPolyLines(input));
 }
 
 void Infill::addLineInfill(Polygons& result, const PointMatrix& rotation_matrix, const int scanline_min_idx, const int line_distance, const AABB boundary, std::vector<std::vector<coord_t>>& cut_list, coord_t shift)

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -17,6 +17,7 @@
 #include "utils/logoutput.h"
 #include "utils/PolygonConnector.h"
 #include "utils/polygonUtils.h"
+#include "utils/PolylineStitcher.h"
 #include "utils/UnionFind.h"
 
 /*!
@@ -168,6 +169,14 @@ void Infill::_generate(Polygons& result_polygons, Polygons& result_lines, const 
         connectLines(result_lines);
     }
     crossings_on_line.clear();
+
+    if (zig_zaggify ||
+        pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D || pattern == EFillMethod::CUBICSUBDIV || pattern == EFillMethod::GYROID || pattern == EFillMethod::ZIG_ZAG)
+    { // don't stich for non-zig-zagged line infill types
+        Polygons stiched_lines;
+        PolylineStitcher::stitch(result_lines, stiched_lines, result_polygons, infill_line_width);
+        result_lines = stiched_lines;
+    }
 }
 
 void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -249,9 +249,9 @@ void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)
             }
             poly.add(poly[0]);
         }
-        Polygons polylines = outline.intersectionPolyLines(result_polygons);
-        result_lines.add(polylines);
-        result_polygons.clear(); // the output should only contain polylines
+        Polygons polylines = outline.intersectionPolyLines(result_polygons.splitPolygonsIntoSegments());
+        result_polygons.clear();
+        PolylineStitcher::stitch(polylines, result_lines, result_polygons, infill_line_width);
     }
 }
 
@@ -385,15 +385,17 @@ void Infill::generateCrossInfill(const SierpinskiFillProvider& cross_fill_provid
 
         Polygons cross_pattern_polygons;
         cross_pattern_polygons.add(cross_pattern_polygon);
-        Polygons poly_lines = outline.intersectionPolyLines(cross_pattern_polygons);
-
-        result_lines.add(poly_lines);
+        Polygons poly_lines = outline.intersectionPolyLines(cross_pattern_polygons.splitPolygonsIntoSegments());
+        PolylineStitcher::stitch(poly_lines, result_lines, result_polygons, infill_line_width);
     }
 }
 
 void Infill::addLineSegmentsInfill(Polygons& result, Polygons& input)
 {
-    result.add(in_outline.offset(infill_overlap).intersectionPolyLines(input));
+    Polygons polylines = in_outline.offset(infill_overlap).intersectionPolyLines(input);
+    Polygons result_polygons;
+    PolylineStitcher::stitch(polylines, result, result_polygons, infill_line_width);
+    assert(result_polygons.empty());
 }
 
 void Infill::addLineInfill(Polygons& result, const PointMatrix& rotation_matrix, const int scanline_min_idx, const int line_distance, const AABB boundary, std::vector<std::vector<coord_t>>& cut_list, coord_t shift)

--- a/src/infill/GyroidInfill.cpp
+++ b/src/infill/GyroidInfill.cpp
@@ -335,10 +335,7 @@ void GyroidInfill::generateTotalGyroidInfill(Polygons& result_lines, bool zig_za
 
                         if (chain_index != connector_start_chain_index && connected_to[(point_index + 1) % 2][chain_index] != connector_start_chain_index)
                         {
-                            for (unsigned pi = 1; pi < connector_points.size(); ++pi)
-                            {
-                                result.addLine(connector_points[pi - 1], connector_points[pi]);
-                            }
+                            result.add(connector_points);
                             drawing = false;
                             connector_points.clear();
                             // remember the connection
@@ -389,15 +386,9 @@ void GyroidInfill::generateTotalGyroidInfill(Polygons& result_lines, bool zig_za
             {
                 // output the connector line segments from the last chain to the first point in the outline
                 connector_points.push_back(outline_poly[0]);
-                for (unsigned pi = 1; pi < connector_points.size(); ++pi)
-                {
-                    result.addLine(connector_points[pi - 1], connector_points[pi]);
-                }
+                result.add(connector_points);
                 // output the connector line segments from the first point in the outline to the first chain
-                for (unsigned pi = 1; pi < path_to_first_chain.size(); ++pi)
-                {
-                    result.addLine(path_to_first_chain[pi - 1], path_to_first_chain[pi]);
-                }
+                result.add(path_to_first_chain);
             }
 
             if (chain_ends_remaining < 1)

--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -8,6 +8,7 @@
 #include "settings/Settings.h"
 #include "progress/Progress.h"
 
+#include "utils/PolylineStitcher.h"
 #include "utils/SVG.h" // debug output
 
 /*
@@ -26,7 +27,7 @@ namespace cura {
 
 void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, SlicerLayer* layer)
 {
-    storageLayer.openPolyLines = layer->openPolylines;
+    PolylineStitcher::stitch(layer->openPolylines, storageLayer.openPolyLines, layer->polygons, settings.get<coord_t>("wall_line_width_0"));
 
     const bool union_all_remove_holes = settings.get<bool>("meshfix_union_all_remove_holes");
     if (union_all_remove_holes)

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -235,7 +235,7 @@ static inline bool pointsAreCoincident(const Point& a, const Point& b)
 */
 void LineOrderOptimizer::optimize(bool find_chains)
 {
-    const int grid_size = 100; // the size of the cells in the hash grid. TODO
+    const coord_t grid_size = 100_mu; // the size of the cells in the hash grid. TODO
     SparsePointGridInclusive<unsigned int> line_bucket_grid(grid_size);
     // NOTE: Keep this vector fixed-size, it replaces an (non-standard, sized at runtime) array:
     std::vector<bool> picked(polygons.size(), false);

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -235,7 +235,7 @@ static inline bool pointsAreCoincident(const Point& a, const Point& b)
 */
 void LineOrderOptimizer::optimize(bool find_chains)
 {
-    const int grid_size = 2000; // the size of the cells in the hash grid. TODO
+    const int grid_size = 100; // the size of the cells in the hash grid. TODO
     SparsePointGridInclusive<unsigned int> line_bucket_grid(grid_size);
     // NOTE: Keep this vector fixed-size, it replaces an (non-standard, sized at runtime) array:
     std::vector<bool> picked(polygons.size(), false);

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -124,12 +124,10 @@ public:
 
     /*!
      * Do the optimization
-     *
-     * \param find_chains Whether to determine when lines are chained together (i.e. zigzag infill)
-     *
-     * \return The squared travel distance between the two points
+     * 
+     * sets #polyStart and #polyOrder
      */
-    void optimize(bool find_chains = true); //!< sets #polyStart and #polyOrder
+    void optimize();
 
 private:
     /*!

--- a/src/utils/Coord_t.h
+++ b/src/utils/Coord_t.h
@@ -13,6 +13,8 @@ namespace cura
 
 using coord_t = ClipperLib::cInt;
 
+static inline coord_t operator "" _mu(unsigned long long i) { return i; };
+
 #define INT2MM(n) (static_cast<double>(n) / 1000.0)
 #define INT2MM2(n) (static_cast<double>(n) / 1000000.0)
 #define MM2INT(n) (static_cast<coord_t>((n) * 1000 + 0.5 * (((n) > 0) - ((n) < 0))))

--- a/src/utils/PolygonsPointIndex.h
+++ b/src/utils/PolygonsPointIndex.h
@@ -135,6 +135,35 @@ public:
 };
 
 
+
+/*!
+ * Locator to extract a line segment out of a \ref PolygonsPointIndex
+ */
+struct PolygonsPointIndexSegmentLocator
+{
+    std::pair<Point, Point> operator()(const PolygonsPointIndex& val) const
+    {
+        ConstPolygonRef poly = (*val.polygons)[val.poly_idx];
+        Point start = poly[val.point_idx];
+        unsigned int next_point_idx = (val.point_idx + 1) % poly.size();
+        Point end = poly[next_point_idx];
+        return std::pair<Point, Point>(start, end);
+    }
+};
+
+
+
+/*!
+ * Locator of a \ref PolygonsPointIndex
+ */
+struct PolygonsPointIndexLocator
+{
+    Point operator()(const PolygonsPointIndex& val) const
+    {
+        return val.p();
+    }
+};
+
 }//namespace cura
 
 namespace std

--- a/src/utils/PolylineStitcher.cpp
+++ b/src/utils/PolylineStitcher.cpp
@@ -104,14 +104,24 @@ void PolylineStitcher::stitch(const Polygons& lines, Polygons& result_lines, Pol
                 }
                 
 
+                coord_t segment_dist = vSize(chain.back() - closest.p());
+                assert(segment_dist <= max_stitch_distance + 10);
                 if (closest.point_idx == 0)
                 {
-                    assert(vSize(chain.back() - *closest.getPolygon().begin()) <= max_stitch_distance + 10);
-                    chain.insert(chain.end(), closest.getPolygon().begin(), closest.getPolygon().end());
+                    auto start_pos = closest.getPolygon().begin();
+                    if (segment_dist < snap_distance)
+                    {
+                        ++start_pos;
+                    }
+                    chain.insert(chain.end(), start_pos, closest.getPolygon().end());
                 }
                 else
                 {
-                    assert(vSize(chain.back() - *closest.getPolygon().rbegin()) <= max_stitch_distance + 10);
+                    auto start_pos = closest.getPolygon().rbegin();
+                    if (segment_dist < snap_distance)
+                    {
+                        ++start_pos;
+                    }
                     chain.insert(chain.end(), closest.getPolygon().rbegin(), closest.getPolygon().rend());
                 }
                 assert( ! processed[closest.poly_idx]);

--- a/src/utils/PolylineStitcher.cpp
+++ b/src/utils/PolylineStitcher.cpp
@@ -1,0 +1,137 @@
+//Copyright (c) 2020 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include "PolylineStitcher.h"
+#include "SparsePointGrid.h"
+#include "PolygonsPointIndex.h"
+
+#include "SymmetricPair.h"
+#include <unordered_set>
+#include <cassert>
+
+namespace cura
+{
+
+
+void PolylineStitcher::stitch(const Polygons& lines, Polygons& result_lines, Polygons& result_polygons, coord_t max_stitch_distance, coord_t snap_distance)
+{
+    if (lines.empty())
+    {
+        return;
+    }
+
+    SparsePointGrid<PolygonsPointIndex, PolygonsPointIndexLocator> grid(max_stitch_distance, lines.size() * 2);
+    
+    // populate grid
+    for (size_t line_idx = 0; line_idx < lines.size(); line_idx++)
+    {
+        ConstPolygonRef line = lines[line_idx];
+        grid.insert(PolygonsPointIndex(&lines, line_idx, 0));
+        grid.insert(PolygonsPointIndex(&lines, line_idx, line.size() - 1));
+    }
+    
+    std::vector<bool> processed(lines.size(), false);
+    
+    for (size_t line_idx = 0; line_idx < lines.size(); line_idx++)
+    {
+        if (processed[line_idx])
+        {
+            continue;
+        }
+        processed[line_idx] = true;
+        ConstPolygonRef line = lines[line_idx];
+        
+        Polygon chain = line;
+        bool closest_is_closing_polygon = false;
+        for (bool go_in_reverse_direction : { false, true })
+        {
+            if (go_in_reverse_direction)
+            { // try extending chain in the other direction
+                chain.reverse();
+            }
+            
+            while (true)
+            {
+                Point from = chain.back();
+                
+                PolygonsPointIndex closest;
+                coord_t closest_distance = std::numeric_limits<coord_t>::max();
+                grid.processNearby(from, max_stitch_distance, 
+                    std::function<bool (const PolygonsPointIndex&)> (
+                        [from, &chain, &closest, &closest_is_closing_polygon, &closest_distance, &processed, max_stitch_distance, snap_distance](const PolygonsPointIndex& nearby)->bool
+                    {
+                        bool is_closing_segment = false;
+                        coord_t dist = vSize(nearby.p() - from);
+                        if (dist > max_stitch_distance)
+                        {
+                            return true; // keep looking
+                        }
+                        if (nearby.p() == chain.front())
+                        {
+                            if (chain.polylineLength() + dist < 3 * max_stitch_distance // prevent closing of small poly, cause it might be able to continue making a larger polyline
+                                || chain.size() <= 2) // don't make 2 vert polygons
+                            {
+                                return true; // look for a better next line
+                            }
+                            is_closing_segment = true;
+                            dist += 10; // prefer continuing polyline over closing a polygon; avoids closed zigzags from being printed separately
+                            // continue to see if closing segment is also the closest 
+                            // there might be a segment smaller than [max_stitch_distance] which closes the polygon better
+                        }
+                        else if (processed[nearby.poly_idx])
+                        { // it was already moved to output
+                            return true; // keep looking for a connection
+                        }
+                        if (dist < closest_distance)
+                        {
+                            closest_distance = dist;
+                            closest = nearby;
+                            closest_is_closing_polygon = is_closing_segment;
+                        }
+                        if (dist < snap_distance)
+                        { // we have found a good enough next line
+                            return false; // stop looking for alternatives
+                        }
+                        return true; // keep processing elements 
+                    })
+                );
+                
+                if (!closest.initialized()          // we couldn't find any next line 
+                    || closest_is_closing_polygon   // we closed the polygon
+                )
+                {
+                    break;
+                }
+                
+
+                if (closest.point_idx == 0)
+                {
+                    assert(vSize(chain.back() - *closest.getPolygon().begin()) <= max_stitch_distance + 10);
+                    chain.insert(chain.end(), closest.getPolygon().begin(), closest.getPolygon().end());
+                }
+                else
+                {
+                    assert(vSize(chain.back() - *closest.getPolygon().rbegin()) <= max_stitch_distance + 10);
+                    chain.insert(chain.end(), closest.getPolygon().rbegin(), closest.getPolygon().rend());
+                }
+                assert( ! processed[closest.poly_idx]);
+                processed[closest.poly_idx] = true;
+            }
+            if (closest_is_closing_polygon)
+            {
+                break; // don't consider reverse direction
+            }
+        }
+        if (closest_is_closing_polygon)
+        {
+            result_polygons.add(chain);
+        }
+        else
+        {
+            result_lines.add(chain);
+        }
+    }
+}
+
+}//namespace cura
+

--- a/src/utils/PolylineStitcher.h
+++ b/src/utils/PolylineStitcher.h
@@ -17,10 +17,8 @@ class PolylineStitcher
 public:
     /*!
      * Stitch together the separate \p lines into \p result_lines and if they can be closed into \p result_polygons.
-     * Only introduce new segments shorter than \p max_stitch_distance,
-     * but always try to make the shortest segment possible,
-     * unless the segment is smaller than \p snap_distance.
-     * When the first connection smaller than \p snap_distance is found no other nearby connections will be considered.
+     * Only introduce new segments shorter than \p max_stitch_distance, and larger then \p snap_distance
+     * but always try to take the shortest connection possible.
      * 
      * Only stitch polylines into closed polygons if they are larger than 3 * \p max_stitch_distance,
      * in order to prevent small segments to accidentally get closed into a polygon.

--- a/src/utils/PolylineStitcher.h
+++ b/src/utils/PolylineStitcher.h
@@ -1,0 +1,36 @@
+//Copyright (c) 2020 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef UTILS_POLYLINE_STITCHER_H
+#define UTILS_POLYLINE_STITCHER_H
+
+#include "polygon.h"
+
+namespace cura
+{
+
+/*!
+ * Class for stitching polylines into longer polylines or into polygons
+ */
+class PolylineStitcher
+{
+public:
+    /*!
+     * Stitch together the separate \p lines into \p result_lines and if they can be closed into \p result_polygons.
+     * Only introduce new segments shorter than \p max_stitch_distance,
+     * but always try to make the shortest segment possible,
+     * unless the segment is smaller than \p snap_distance.
+     * When the first connection smaller than \p snap_distance is found no other nearby connections will be considered.
+     * 
+     * Only stitch polylines into closed polygons if they are larger than 3 * \p max_stitch_distance,
+     * in order to prevent small segments to accidentally get closed into a polygon.
+     * 
+     * \note Resulting polylines and polygons are added onto the existing containers, so you can directly output onto a polygons container with existing polygons in it.
+     * Hewever, you shouldn't call this function with the same parameter in \p lines as \p result_lines, because that would duplicate (some of) the polylines.
+     */
+    static void stitch(const Polygons& lines, Polygons& result_lines, Polygons& result_polygons, coord_t max_stitch_distance = MM2INT(0.1), coord_t snap_distance = 10);
+};
+
+}//namespace cura
+#endif//UTILS_POLYLINE_STITCHER_H
+

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -252,15 +252,9 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines) const
 coord_t Polygons::polyLineLength() const
 {
     coord_t length = 0;
-    for (unsigned int poly_idx = 0; poly_idx < paths.size(); poly_idx++)
+    for (ConstPolygonRef poly : *this)
     {
-        Point p0 = paths[poly_idx][0];
-        for (unsigned int point_idx = 1; point_idx < paths[poly_idx].size(); point_idx++)
-        {
-            Point p1 = paths[poly_idx][point_idx];
-            length += vSize(p0 - p1);
-            p0 = p1;
-        }
+        length += poly.polylineLength();
     }
     return length;
 }

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -245,7 +245,7 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines) const
     clipper.AddPaths(paths, ClipperLib::ptClip, true);
     clipper.Execute(ClipperLib::ctIntersection, result);
     Polygons ret;
-    ret.addPolyTreeNodeRecursive(result);
+    ClipperLib::OpenPathsFromPolyTree(result, ret.paths);
     return ret;
 }
 
@@ -561,19 +561,8 @@ void Polygons::removeSmallAreas(const double min_area_size, const bool remove_ho
 Polygons Polygons::toPolygons(ClipperLib::PolyTree& poly_tree)
 {
     Polygons ret;
-    ret.addPolyTreeNodeRecursive(poly_tree);
+    ClipperLib::PolyTreeToPaths(poly_tree, ret.paths);
     return ret;
-}
-
-
-void Polygons::addPolyTreeNodeRecursive(const ClipperLib::PolyNode& node)
-{
-    for (int outer_poly_idx = 0; outer_poly_idx < node.ChildCount(); outer_poly_idx++)
-    {
-        ClipperLib::PolyNode* child = node.Childs[outer_poly_idx];
-        paths.push_back(child->Contour);
-        addPolyTreeNodeRecursive(*child);
-    }
 }
 
 bool ConstPolygonRef::smooth_corner_complex(const Point p1, ListPolyIt& p0_it, ListPolyIt& p2_it, const int64_t shortcut_length)

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -249,6 +249,34 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines) const
     return ret;
 }
 
+void Polygons::splitPolylinesIntoSegments(Polygons& result) const
+{
+    for (ConstPolygonRef poly : *this)
+    {
+        poly.splitPolylineIntoSegments(result);
+    }
+}
+Polygons Polygons::splitPolylinesIntoSegments() const
+{
+    Polygons ret;
+    splitPolylinesIntoSegments(ret);
+    return ret;
+}
+
+void Polygons::splitPolygonsIntoSegments(Polygons& result) const
+{
+    for (ConstPolygonRef poly : *this)
+    {
+        poly.splitPolygonIntoSegments(result);
+    }
+}
+Polygons Polygons::splitPolygonsIntoSegments() const
+{
+    Polygons ret;
+    splitPolygonsIntoSegments(ret);
+    return ret;
+}
+
 coord_t Polygons::polyLineLength() const
 {
     coord_t length = 0;
@@ -996,6 +1024,39 @@ Polygons Polygons::smooth_outward(const AngleDegrees max_angle, int shortcut_len
     return ret;
 }
 
+
+
+
+void ConstPolygonRef::splitPolylineIntoSegments(Polygons& result) const 
+{
+    Point last = front();
+    for (size_t idx = 1; idx < size(); idx++)
+    {
+        Point p = (*this)[idx];
+        result.addLine(last, p);
+        last = p;
+    }
+}
+
+Polygons ConstPolygonRef::splitPolylineIntoSegments() const 
+{
+    Polygons ret;
+    splitPolylineIntoSegments(ret);
+    return ret;
+}
+
+void ConstPolygonRef::splitPolygonIntoSegments(Polygons& result) const
+{
+    splitPolylineIntoSegments(result);
+    result.addLine(back(), front());
+}
+
+Polygons ConstPolygonRef::splitPolygonIntoSegments() const 
+{
+    Polygons ret;
+    splitPolygonIntoSegments(ret);
+    return ret;
+}
 
 void ConstPolygonRef::smooth(int remove_length, PolygonRef result) const
 {

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -160,6 +160,20 @@ public:
         return length;
     }
 
+    /*!
+     * Split these poly line objects into several line segment objects consisting of only two verts
+     * and store them in the \p result
+     */
+    void splitPolylineIntoSegments(Polygons& result) const;
+    Polygons splitPolylineIntoSegments() const;
+
+    /*!
+     * Split these polygon objects into several line segment objects consisting of only two verts
+     * and store them in the \p result
+     */
+    void splitPolygonIntoSegments(Polygons& result) const;
+    Polygons splitPolygonIntoSegments() const;
+
     bool shorterThan(const coord_t check_length) const;
 
     Point min() const
@@ -812,6 +826,20 @@ public:
      * Intersect polylines with this area Polygons object.
      */
     Polygons intersectionPolyLines(const Polygons& polylines) const;
+
+    /*!
+     * Split this poly line object into several line segment objects
+     * and store them in the \p result
+     */
+    void splitPolylinesIntoSegments(Polygons& result) const;
+    Polygons splitPolylinesIntoSegments() const;
+
+    /*!
+     * Split this polygon object into several line segment objects
+     * and store them in the \p result
+     */
+    void splitPolygonsIntoSegments(Polygons& result) const;
+    Polygons splitPolygonsIntoSegments() const;
 
     Polygons xorPolygons(const Polygons& other) const
     {

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -104,6 +104,16 @@ public:
         return path->end();
     }
 
+    ClipperLib::Path::const_reverse_iterator rbegin() const
+    {
+        return path->rbegin();
+    }
+
+    ClipperLib::Path::const_reverse_iterator rend() const
+    {
+        return path->rend();
+    }
+
     ClipperLib::Path::const_reference front() const
     {
         return path->front();
@@ -372,6 +382,12 @@ public:
     void reserve(size_t min_size)
     {
         path->reserve(min_size);
+    }
+
+    template <class iterator>
+    ClipperLib::Path::iterator insert(ClipperLib::Path::const_iterator pos, iterator first, iterator last)
+    {
+        return path->insert(pos, first, last);
     }
 
     PolygonRef& operator=(const ConstPolygonRef& other) =delete; // polygon assignment is expensive and probably not what you want when you use the assignment operator

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -813,18 +813,6 @@ public:
      */
     Polygons intersectionPolyLines(const Polygons& polylines) const;
 
-    /*!
-     * Clips input line segments by this Polygons.
-     * \param other Input line segments to be cropped
-     * \param segment_tree the resulting interior line segments
-     */
-    void lineSegmentIntersection(const Polygons& other, ClipperLib::PolyTree& segment_tree) const
-    {
-        ClipperLib::Clipper clipper(clipper_init);
-        clipper.AddPaths(paths, ClipperLib::ptClip, true);
-        clipper.AddPaths(other.paths, ClipperLib::ptSubject, false);
-        clipper.Execute(ClipperLib::ctIntersection, segment_tree);
-    }
     Polygons xorPolygons(const Polygons& other) const
     {
         Polygons ret;
@@ -1024,11 +1012,6 @@ private:
     void removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, const bool remove_holes, Polygons& ret) const;
     void splitIntoParts_processPolyTreeNode(ClipperLib::PolyNode* node, std::vector<PolygonsPart>& ret) const;
 
-    /*!
-     * Convert a node from a ClipperLib::PolyTree and add it to a Polygons object,
-     * which uses ClipperLib::Paths instead of ClipperLib::PolyTree
-     */
-    void addPolyTreeNodeRecursive(const ClipperLib::PolyNode& node);
 public:
     /*!
      * Split up the polygons into groups according to the even-odd rule.

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -104,6 +104,11 @@ public:
         return path->end();
     }
 
+    ClipperLib::Path::const_reference front() const
+    {
+        return path->front();
+    }
+
     ClipperLib::Path::const_reference back() const
     {
         return path->back();
@@ -127,11 +132,16 @@ public:
 
     Polygons offset(int distance, ClipperLib::JoinType joinType = ClipperLib::jtMiter, double miter_limit = 1.2) const;
 
-    int64_t polygonLength() const
+    coord_t polygonLength() const
     {
-        int64_t length = 0;
-        Point p0 = (*path)[path->size()-1];
-        for(unsigned int n=0; n<path->size(); n++)
+        return polylineLength() + vSize(path->front() - path->back());
+    }
+
+    coord_t polylineLength() const
+    {
+        coord_t length = 0;
+        Point p0 = path->front();
+        for (unsigned int n = 1; n < path->size(); n++)
         {
             Point p1 = (*path)[n];
             length += vSize(p0 - p1);
@@ -389,6 +399,11 @@ public:
     ClipperLib::Path::iterator end()
     {
         return path->end();
+    }
+
+    ClipperLib::Path::reference front()
+    {
+        return path->front();
     }
 
     ClipperLib::Path::reference back()
@@ -704,6 +719,14 @@ public:
     {
         paths.emplace_back();
         return PolygonRef(paths.back());
+    }
+    PolygonRef front()
+    {
+        return PolygonRef(paths.front());
+    }
+    ConstPolygonRef front() const
+    {
+        return ConstPolygonRef(paths.front());
     }
     PolygonRef back()
     {
@@ -1123,15 +1146,9 @@ public:
     coord_t polygonLength() const
     {
         coord_t length = 0;
-        for(unsigned int i=0; i<paths.size(); i++)
+        for (ConstPolygonRef poly : *this)
         {
-            Point p0 = paths[i][paths[i].size()-1];
-            for(unsigned int n=0; n<paths[i].size(); n++)
-            {
-                Point p1 = paths[i][n];
-                length += vSize(p0 - p1);
-                p0 = p1;
-            }
+            length += poly.polygonLength();
         }
         return length;
     }

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -641,6 +641,11 @@ public:
         return paths.size();
     }
 
+    void set(const ClipperLib::Paths& new_paths)
+    {
+        paths = new_paths;
+    }
+
     /*!
      * Convenience function to check if the polygon has no points.
      *

--- a/src/utils/polygonUtils.h
+++ b/src/utils/polygonUtils.h
@@ -85,21 +85,6 @@ struct GivenDistPoint
     int pos; //!< Index to the first point in the polygon of the line segment on which the result was found
 };
 
-/*!
- * Locator to extract a line segment out of a \ref PolygonsPointIndex
- */
-struct PolygonsPointIndexSegmentLocator
-{
-    std::pair<Point, Point> operator()(const PolygonsPointIndex& val) const
-    {
-        ConstPolygonRef poly = (*val.polygons)[val.poly_idx];
-        Point start = poly[val.point_idx];
-        unsigned int next_point_idx = (val.point_idx + 1) % poly.size();
-        Point end = poly[next_point_idx];
-        return std::pair<Point, Point>(start, end);
-    }
-};
-
 typedef SparseLineGrid<PolygonsPointIndex, PolygonsPointIndexSegmentLocator> LocToLineGrid;
 
 class PolygonUtils 

--- a/tests/ClipperTest.cpp
+++ b/tests/ClipperTest.cpp
@@ -3,10 +3,12 @@
 
 #include <gtest/gtest.h>
 
-#include "../src/utils/polygon.h"
+#include "clipper.hpp"
+#include <math.h>
 
 // #define TEST_INFILL_SVG_OUTPUT
 #ifdef TEST_INFILL_SVG_OUTPUT
+#include "../src/utils/polygon.h"
 #include <cstdlib>
 #include "../src/utils/SVG.h"
 #endif //TEST_INFILL_SVG_OUTPUT
@@ -17,7 +19,13 @@ namespace cura
 class ClipperTest : public testing::Test
 {
 public:
+    using Paths = ClipperLib::Paths;
+    using Path = ClipperLib::Path;
+    using coord_t = ClipperLib::cInt;
+    using Point = ClipperLib::IntPoint;
 
+    std::vector<Paths> all_outlines;
+    std::vector<Paths> all_polylines;
 
     ClipperTest()
     {
@@ -25,110 +33,123 @@ public:
 
     void SetUp()
     {
+        
+        {
+            all_outlines.emplace_back();
+            all_outlines.back().emplace_back();
+            Path& outline = all_outlines.back().back();
+            outline.emplace_back(1100, 500);
+            outline.emplace_back(500, 500);
+            outline.emplace_back(500, 400);
+            outline.emplace_back(1100, 400);
+            
+            all_polylines.emplace_back();
+            all_polylines.back().emplace_back();
+            Path& polyline = all_polylines.back().back();
+            polyline.emplace_back(1075, 425);
+            polyline.emplace_back(672, 425 );
+            polyline.emplace_back(651, 425 );
+            polyline.emplace_back(595, 424 );
+            polyline.emplace_back(617, 437 );
+        }
+        {
+            all_outlines.emplace_back();
+            all_outlines.back().emplace_back();
+            Path& outline = all_outlines.back().back();
+            outline.emplace_back(1000, 1100);
+            outline.emplace_back(300, 1100);
+            outline.emplace_back(200, 1000);
+            outline.emplace_back(1000, 1000);
+            
+            all_polylines.emplace_back();
+            all_polylines.back().emplace_back();
+            Path& polyline = all_polylines.back().back();
+            polyline.emplace_back(992, 1050);
+            polyline.emplace_back(617, 1049);
+            polyline.emplace_back(660, 1074);
+            polyline.emplace_back(617, 1049);
+            polyline.emplace_back(582, 1049);
+            polyline.emplace_back(538, 1074);
+        }
     }
 
     void TearDown()
     {
     }
+    
+    static Paths intersectPolylines(const Paths& outlines, const Paths& polylines);
+
+    static coord_t sq(coord_t i) { return i*i; };
+
+    static coord_t calculateLength(const Paths& polylines);
+
+    static void outputSVG(const Paths& outlines, const Paths& polylines, const Paths& intersected, const char* filename);
 };
 
-TEST_F(ClipperTest, PolylinesTest)
+ClipperTest::Paths ClipperTest::intersectPolylines(const Paths& outlines, const Paths& polylines)
 {
-
-    auto sq = [](int i) { return i*i; };
-    
-    ClipperLib::Paths outlines;
-    {
-        outlines.emplace_back();
-        ClipperLib::Path& outline = outlines.back();
-        outline.emplace_back(1100, 500);
-        outline.emplace_back(500, 500);
-        outline.emplace_back(500, 400);
-        outline.emplace_back(1100, 400);
-        
-//         outline.emplace_back(1000, 1100);
-//         outline.emplace_back(300, 1100);
-//         outline.emplace_back(200, 1000);
-//         outline.emplace_back(1000, 1000);
-    }
-    
-    ClipperLib::Paths polylines;
-    {
-        polylines.emplace_back();
-        ClipperLib::Path& polyline = polylines.back();
-        polyline.emplace_back(1075, 425);
-        polyline.emplace_back(672, 425 );
-        polyline.emplace_back(651, 425 );
-        polyline.emplace_back(595, 424 );
-        polyline.emplace_back(617, 437 );
-        // old ^
-        
-        
-//         polyline.emplace_back(992, 1050);
-//         polyline.emplace_back(617, 1049);
-//         polyline.emplace_back(660, 1074);
-//         polyline.emplace_back(617, 1049);
-//         polyline.emplace_back(582, 1049);
-//         polyline.emplace_back(538, 1074);
-    }
     ClipperLib::PolyTree result_tree;
     ClipperLib::Clipper clipper(0);
     clipper.AddPaths(polylines, ClipperLib::ptSubject, false);
     clipper.AddPaths(outlines, ClipperLib::ptClip, true);
     clipper.Execute(ClipperLib::ctIntersection, result_tree);
-    ClipperLib::Paths result;
+    Paths result;
     ClipperLib::PolyTreeToPaths(result_tree, result);
-
-    coord_t original_polyline_length = 0;
-    for (ClipperLib::Path path : polylines)
-    {
-        Point* last = nullptr;
-        for (Point& p : path)
-        {
-            if (last)
-            {
-                original_polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
-            }
-            last = &p;
-        }
-    }
-
-    coord_t intersected_polyline_length = 0;
-    for (ClipperLib::Path path : result)
-    {
-        Point* last = nullptr;
-        for (Point& p : path)
-        {
-            if (last)
-            {
-                intersected_polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
-            }
-            last = &p;
-        }
-    }
-
-    
-    
-#ifdef TEST_INFILL_SVG_OUTPUT
-    {
-        Polygons outs;
-        outs.paths = outlines;
-        Polygons lines;
-        lines.paths = polylines;
-        Polygons lines_after;
-        lines_after.paths = result;
-        SVG svg("/tmp/problem.svg", AABB(outs));
-        svg.writePolygons(outs, SVG::Color::BLACK);
-        svg.nextLayer();
-        svg.writePolylines(lines_after, SVG::Color::RED);
-        svg.nextLayer();
-        svg.writePolylines(lines, SVG::Color::GREEN);
-    }
-#endif // TEST_INFILL_SVG_OUTPUT
-    
-    
-    assert(intersected_polyline_length == original_polyline_length);
+    return result;
 }
+
+ClipperTest::coord_t ClipperTest::calculateLength(const Paths& polylines)
+{
+    coord_t polyline_length = 0;
+    for (const Path& path : polylines)
+    {
+        const Point* last = nullptr;
+        for (const Point& p : path)
+        {
+            if (last)
+            {
+                polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
+            }
+            last = &p;
+        }
+    }
+    return polyline_length;
+}
+
+
+TEST_F(ClipperTest, PolylinesTest1)
+{
+    Paths intersected = intersectPolylines(all_outlines[0], all_polylines[0]);
+    outputSVG(all_outlines[0], all_polylines[0], intersected, "/tmp/clipper_test_0");
+    ASSERT_EQ(calculateLength(intersected), calculateLength(all_polylines[0]));
+}
+
+TEST_F(ClipperTest, PolylinesTest2)
+{
+    Paths intersected = intersectPolylines(all_outlines[1], all_polylines[1]);
+    outputSVG(all_outlines[1], all_polylines[1], intersected, "/tmp/clipper_test_1");
+    ASSERT_EQ(calculateLength(intersected), calculateLength(all_polylines[1]));
+}
+
+    
+    
+void ClipperTest::outputSVG(const Paths& outlines, const Paths& polylines, const Paths& intersected, const char* filename)
+{
+#ifdef TEST_INFILL_SVG_OUTPUT
+    Polygons outs;
+    outs.set(outlines);
+    Polygons lines;
+    lines.set(polylines);
+    Polygons lines_after;
+    lines_after.set(intersected);
+    SVG svg(filename, AABB(outs));
+    svg.writePolygons(outs, SVG::Color::BLACK);
+    svg.nextLayer();
+    svg.writePolylines(lines_after, SVG::Color::RED);
+    svg.nextLayer();
+    svg.writePolylines(lines, SVG::Color::GREEN);
+#endif // TEST_INFILL_SVG_OUTPUT
+}    
 
 
 } //namespace cura

--- a/tests/ClipperTest.cpp
+++ b/tests/ClipperTest.cpp
@@ -1,0 +1,134 @@
+//Copyright (c) 2020 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include <gtest/gtest.h>
+
+#include "../src/utils/polygon.h"
+
+// #define TEST_INFILL_SVG_OUTPUT
+#ifdef TEST_INFILL_SVG_OUTPUT
+#include <cstdlib>
+#include "../src/utils/SVG.h"
+#endif //TEST_INFILL_SVG_OUTPUT
+
+namespace cura
+{
+
+class ClipperTest : public testing::Test
+{
+public:
+
+
+    ClipperTest()
+    {
+    }
+
+    void SetUp()
+    {
+    }
+
+    void TearDown()
+    {
+    }
+};
+
+TEST_F(ClipperTest, PolylinesTest)
+{
+
+    auto sq = [](int i) { return i*i; };
+    
+    ClipperLib::Paths outlines;
+    {
+        outlines.emplace_back();
+        ClipperLib::Path& outline = outlines.back();
+        outline.emplace_back(1100, 500);
+        outline.emplace_back(500, 500);
+        outline.emplace_back(500, 400);
+        outline.emplace_back(1100, 400);
+        
+//         outline.emplace_back(1000, 1100);
+//         outline.emplace_back(300, 1100);
+//         outline.emplace_back(200, 1000);
+//         outline.emplace_back(1000, 1000);
+    }
+    
+    ClipperLib::Paths polylines;
+    {
+        polylines.emplace_back();
+        ClipperLib::Path& polyline = polylines.back();
+        polyline.emplace_back(1075, 425);
+        polyline.emplace_back(672, 425 );
+        polyline.emplace_back(651, 425 );
+        polyline.emplace_back(595, 424 );
+        polyline.emplace_back(617, 437 );
+        // old ^
+        
+        
+//         polyline.emplace_back(992, 1050);
+//         polyline.emplace_back(617, 1049);
+//         polyline.emplace_back(660, 1074);
+//         polyline.emplace_back(617, 1049);
+//         polyline.emplace_back(582, 1049);
+//         polyline.emplace_back(538, 1074);
+    }
+    ClipperLib::PolyTree result_tree;
+    ClipperLib::Clipper clipper(0);
+    clipper.AddPaths(polylines, ClipperLib::ptSubject, false);
+    clipper.AddPaths(outlines, ClipperLib::ptClip, true);
+    clipper.Execute(ClipperLib::ctIntersection, result_tree);
+    ClipperLib::Paths result;
+    ClipperLib::PolyTreeToPaths(result_tree, result);
+
+    coord_t original_polyline_length = 0;
+    for (ClipperLib::Path path : polylines)
+    {
+        Point* last = nullptr;
+        for (Point& p : path)
+        {
+            if (last)
+            {
+                original_polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
+            }
+            last = &p;
+        }
+    }
+
+    coord_t intersected_polyline_length = 0;
+    for (ClipperLib::Path path : result)
+    {
+        Point* last = nullptr;
+        for (Point& p : path)
+        {
+            if (last)
+            {
+                intersected_polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
+            }
+            last = &p;
+        }
+    }
+
+    
+    
+#ifdef TEST_INFILL_SVG_OUTPUT
+    {
+        Polygons outs;
+        outs.paths = outlines;
+        Polygons lines;
+        lines.paths = polylines;
+        Polygons lines_after;
+        lines_after.paths = result;
+        SVG svg("/tmp/problem.svg", AABB(outs));
+        svg.writePolygons(outs, SVG::Color::BLACK);
+        svg.nextLayer();
+        svg.writePolylines(lines_after, SVG::Color::RED);
+        svg.nextLayer();
+        svg.writePolylines(lines, SVG::Color::GREEN);
+    }
+#endif // TEST_INFILL_SVG_OUTPUT
+    
+    
+    assert(intersected_polyline_length == original_polyline_length);
+}
+
+
+} //namespace cura

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -257,7 +257,10 @@ namespace cura
 
         const Polygons padded_shape_outline = params.outline_polygons.offset(infill_line_width / 2);
         ASSERT_EQ(padded_shape_outline.intersectionPolyLines(params.result_lines.splitPolylinesIntoSegments()).polyLineLength(), params.result_lines.polyLineLength()) << "Infill (lines) should not be outside target polygon.";
-        ASSERT_EQ(params.result_polygons.difference(padded_shape_outline).area(), 0) << "Infill (polys) should not be outside target polygon.";
+        Polygons result_polygon_lines = params.result_polygons;
+        for (PolygonRef poly : result_polygon_lines)
+            poly.add(poly.front());
+        ASSERT_EQ(padded_shape_outline.intersectionPolyLines(result_polygon_lines.splitPolylinesIntoSegments()).polyLineLength(), result_polygon_lines.polyLineLength()) << "Infill (lines) should not be outside target polygon.";
     }
 
 } //namespace cura

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -138,8 +138,10 @@ namespace cura
 
         SVG svgFile(filename.c_str(), aabb);
         svgFile.writePolygons(params.outline_polygons , SVG::Color::BLUE);
-        svgFile.writePolygons(params.result_lines, SVG::Color::RED);
-        svgFile.writePolygons(params.result_polygons, SVG::Color::RED);
+        svgFile.nextLayer();
+        svgFile.writePolylines(params.result_lines, SVG::Color::RED);
+        svgFile.nextLayer();
+        svgFile.writePolygons(params.result_polygons, SVG::Color::MAGENTA);
         // Note: SVG writes 'itself' when the object is destroyed.
     }
 #endif //TEST_INFILL_SVG_OUTPUT

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -244,10 +244,16 @@ namespace cura
         writeTestcaseSVG(params);
 #endif //TEST_INFILL_SVG_OUTPUT
 
+        double worst_case_zig_zag_added_area = 0;
+        if (params.params.zig_zagify || params.params.pattern == EFillMethod::ZIG_ZAG)
+        {
+            worst_case_zig_zag_added_area = params.outline_polygons.polygonLength() * infill_line_width;
+        }
+        
         const double min_available_area = std::abs(params.outline_polygons.offset(-params.params.line_distance / 2).area());
-        const double max_available_area = std::abs(params.outline_polygons.offset( params.params.line_distance / 2).area());
+        const double max_available_area = std::abs(params.outline_polygons.offset( params.params.line_distance / 2).area()) + worst_case_zig_zag_added_area;
         const double min_expected_infill_area = (min_available_area * infill_line_width) / params.params.line_distance;
-        const double max_expected_infill_area = (max_available_area * infill_line_width) / params.params.line_distance;
+        const double max_expected_infill_area = (max_available_area * infill_line_width) / params.params.line_distance + worst_case_zig_zag_added_area;
 
         const double out_infill_area = ((params.result_polygons.polygonLength() + params.result_lines.polyLineLength()) * infill_line_width) / getPatternMultiplier(params.params.pattern);
 

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -256,7 +256,7 @@ namespace cura
         ASSERT_LT((coord_t)out_infill_area, (coord_t)max_expected_infill_area) << "Infill area should be less than the maximum area to be covered.";
 
         const Polygons padded_shape_outline = params.outline_polygons.offset(infill_line_width / 2);
-        ASSERT_EQ(padded_shape_outline.intersectionPolyLines(params.result_lines).polyLineLength(), params.result_lines.polyLineLength()) << "Infill (lines) should not be outside target polygon.";
+        ASSERT_EQ(padded_shape_outline.intersectionPolyLines(params.result_lines.splitPolylinesIntoSegments()).polyLineLength(), params.result_lines.polyLineLength()) << "Infill (lines) should not be outside target polygon.";
         ASSERT_EQ(params.result_polygons.difference(padded_shape_outline).area(), 0) << "Infill (polys) should not be outside target polygon.";
     }
 


### PR DESCRIPTION
TL;DR: This PR solves a bug with the print order of open polylines (infill and surface mode), and it enhances the performance of the engine.

The old code used to have an arbitrary constraint that polylines should always be split up into short straight segments per polyline. This was because the Cura 2014 code used to use the same order optimizer for both lines and polygons, and only disambiguated between the two by checking whether the length of the poly was 2 or more than 2. In the meantime the order optimizer for lines and polygons has been pulled apart, so there is no reason to have a constraint on polylines that they should always be single line segments.

I've now refactored some of the algorithms dealing with polylines, so that we are able to directly move polylines into the result. This saves on half of the RAM used to store the points of the polylines and it saves on computation time, because the separated segments don't need to be rejoined anymore at the order optimizer stage.

Surface mode @ PR:
![image](https://user-images.githubusercontent.com/8895761/98537588-c1aaeb00-2289-11eb-8749-617a4618055a.png)
time elapsed: 1 second

surface mode @ current master :
![image](https://user-images.githubusercontent.com/8895761/98537674-e69f5e00-2289-11eb-9f6d-1c067a066f79.png)
![image](https://user-images.githubusercontent.com/8895761/98537898-40078d00-228a-11eb-8937-16f9196271fe.png)
time elapsed: 1 second

[UM3_open_mesh_surface_mode_x4.3mf.rename.zip](https://github.com/Ultimaker/CuraEngine/files/5510210/UM3_open_mesh_surface_mode_x4.3mf.rename.zip)

PS:
This PR used to include a fix for the infill wipe distance, but that would require quite a bit more work to get it to actually work bugless, so I've removed that from this PR. After merging this PR it should be considered whether we would want to make a separate function `Polygons PolygonUtils::chainPolylines(const Polygons& polylines)`, so that `LayerPlan::addLinesByOptimizer` can apply the wipe distance always at the end of a polyline, without risking that the end of a polyline is the start of the next polyline.

