### PR TITLE
fix surface mode modifier meshes

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -946,9 +946,10 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, LayerIn
             {
                 const SliceMeshStorage& mesh = storage.meshes[mesh_idx];
                 const PathConfigStorage::MeshPathConfigs& mesh_config = gcode_layer.configs_storage.mesh_configs[mesh_idx];
-                if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") == ESurfaceMode::SURFACE)
+                if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") == ESurfaceMode::SURFACE
+                    && extruder_nr == mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr // mesh surface mode should always only be printed with the outer wall extruder!
+                )
                 {
-                    assert(extruder_nr == mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr && "mesh surface mode should always only be printed with the outer wall extruder!");
                     addMeshLayerToGCode_meshSurfaceMode(storage, mesh, mesh_config, gcode_layer);
                 }
                 else

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -652,11 +652,31 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
 {
     size_t mesh_idx = mesh_order[mesh_order_idx];
     SliceMeshStorage& mesh = storage.meshes[mesh_idx];
+    coord_t surface_line_width = mesh.settings.get<coord_t>("wall_line_width_0");
+
     mesh.layer_nr_max_filled_layer = -1;
     for (LayerIndex layer_idx = 0; layer_idx < static_cast<LayerIndex>(mesh.layers.size()); layer_idx++)
     {
         SliceLayer& layer = mesh.layers[layer_idx];
+
+        if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") == ESurfaceMode::SURFACE)
+        {
+            // break up polygons into polylines
+            // they have to be polylines, because they might break up further when doing the cutting
+            Polygons outline_polylines;
+            for (SliceLayerPart& part : layer.parts)
+            {
+                for (PolygonRef poly : part.outline)
+                {
+                    layer.openPolyLines.add(poly);
+                    layer.openPolyLines.back().add(layer.openPolyLines.back()[0]); // add the segment which closes the polygon
+                }
+            }
+            layer.parts.clear();
+        }
+
         std::vector<PolygonsPart> new_parts;
+        Polygons new_polylines;
 
         for (const size_t other_mesh_idx : mesh_order)
         { // limit the infill mesh's outline to within the infill of all meshes with lower order
@@ -672,9 +692,11 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
 
             SliceLayer& other_layer = other_mesh.layers[layer_idx];
 
-            for (SliceLayerPart& part : layer.parts)
+            for (SliceLayerPart& other_part : other_layer.parts)
             {
-                for (SliceLayerPart& other_part : other_layer.parts)
+                if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::SURFACE)
+                {
+                    for (SliceLayerPart& part : layer.parts)
                     { // limit the outline of each part of this infill mesh to the infill of parts of the other mesh with lower infill mesh order
                         if (!part.boundaryBox.hit(other_part.boundaryBox))
                         { // early out
@@ -700,6 +722,14 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
                         // note: don't change the part.infill_area, because we change the structure of that area, while the basic area in which infill is printed remains the same
                         //       the infill area remains the same for combing
                     }
+                }
+                if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
+                {
+                    const Polygons& own_infill_area = other_part.getOwnInfillArea();
+                    Polygons cut_lines = own_infill_area.intersectionPolyLines(layer.openPolyLines);
+                    new_polylines.add(cut_lines);
+                    other_part.infill_area_own = other_part.getOwnInfillArea().difference(layer.openPolyLines.offsetPolyLine(surface_line_width / 2));
+                }
             }
         }
 
@@ -709,6 +739,12 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
             layer.parts.emplace_back();
             layer.parts.back().outline = part;
             layer.parts.back().boundaryBox.calculate(part);
+        }
+        // TODO: reclose surface mode polygons which weren't cut up into broken polylines; and make LayerParts for them
+
+        if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
+        {
+            layer.openPolyLines = new_polylines;
         }
 
         if (layer.parts.size() > 0 || (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL && layer.openPolyLines.size() > 0) )

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -675,31 +675,31 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
             for (SliceLayerPart& part : layer.parts)
             {
                 for (SliceLayerPart& other_part : other_layer.parts)
-                { // limit the outline of each part of this infill mesh to the infill of parts of the other mesh with lower infill mesh order
-                    if (!part.boundaryBox.hit(other_part.boundaryBox))
-                    { // early out
-                        continue;
-                    }
-                    Polygons new_outline = part.outline.intersection(other_part.getOwnInfillArea());
-                    if (new_outline.size() == 1)
-                    { // we don't have to call splitIntoParts, because a single polygon can only be a single part
-                        PolygonsPart outline_part_here;
-                        outline_part_here.add(new_outline[0]);
-                        new_parts.push_back(outline_part_here);
-                    }
-                    else if (new_outline.size() > 1)
-                    { // we don't know whether it's a multitude of parts because of newly introduced holes, or because the polygon has been split up
-                        std::vector<PolygonsPart> new_parts_here = new_outline.splitIntoParts();
-                        for (PolygonsPart& new_part_here : new_parts_here)
-                        {
-                            new_parts.push_back(new_part_here);
+                    { // limit the outline of each part of this infill mesh to the infill of parts of the other mesh with lower infill mesh order
+                        if (!part.boundaryBox.hit(other_part.boundaryBox))
+                        { // early out
+                            continue;
                         }
+                        Polygons new_outline = part.outline.intersection(other_part.getOwnInfillArea());
+                        if (new_outline.size() == 1)
+                        { // we don't have to call splitIntoParts, because a single polygon can only be a single part
+                            PolygonsPart outline_part_here;
+                            outline_part_here.add(new_outline[0]);
+                            new_parts.push_back(outline_part_here);
+                        }
+                        else if (new_outline.size() > 1)
+                        { // we don't know whether it's a multitude of parts because of newly introduced holes, or because the polygon has been split up
+                            std::vector<PolygonsPart> new_parts_here = new_outline.splitIntoParts();
+                            for (PolygonsPart& new_part_here : new_parts_here)
+                            {
+                                new_parts.push_back(new_part_here);
+                            }
+                        }
+                        // change the infill area of the non-infill mesh which is to be filled with e.g. lines
+                        other_part.infill_area_own = other_part.getOwnInfillArea().difference(part.outline);
+                        // note: don't change the part.infill_area, because we change the structure of that area, while the basic area in which infill is printed remains the same
+                        //       the infill area remains the same for combing
                     }
-                    // change the infill area of the non-infill mesh which is to be filled with e.g. lines
-                    other_part.infill_area_own = other_part.getOwnInfillArea().difference(part.outline);
-                    // note: don't change the part.infill_area, because we change the structure of that area, while the basic area in which infill is printed remains the same
-                    //       the infill area remains the same for combing
-                }
             }
         }
 

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -200,6 +200,11 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr) const
             return false;
         }
     }
+    if (settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL
+        && settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr == extruder_nr)
+    {
+        return true;
+    }
     if (settings.get<size_t>("wall_line_count") > 0 && settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr == extruder_nr)
     {
         return true;
@@ -283,6 +288,13 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr, const LayerIn
                 return true;
             }
         }
+    }
+    if (settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL
+        && settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr == extruder_nr
+        && layer.openPolyLines.size() > 0
+    )
+    {
+        return true;
     }
     if ((settings.get<size_t>("wall_line_count") > 1 || settings.get<bool>("alternate_extra_perimeter")) && settings.get<ExtruderTrain&>("wall_x_extruder_nr").extruder_nr == extruder_nr)
     {


### PR DESCRIPTION
Apply modifier mesh functionality (cuttinf mesh or infill mesh) to surface mode as well.

Here are some results from this PR.

Cutting mesh:
Wood grain example:
![image](https://user-images.githubusercontent.com/8895761/98659827-d39d9400-2344-11eb-8842-98bf7b07fa3a.png)

Surface mode both:
![image](https://user-images.githubusercontent.com/8895761/98660409-8ec62d00-2345-11eb-944a-c0bae2eb7de5.png)
![image](https://user-images.githubusercontent.com/8895761/98660426-95ed3b00-2345-11eb-929b-bb8717eeefb6.png)

Infill mesh:
![image](https://user-images.githubusercontent.com/8895761/98667873-4f9cd980-234f-11eb-9e71-518dd9b830b6.png)

Surface mode both:
![image](https://user-images.githubusercontent.com/8895761/98663066-e4500900-2348-11eb-87aa-5eb465ebf88a.png)


[pyramid_surface_mode_modifier_mesh.3mf.rename.zip](https://github.com/Ultimaker/CuraEngine/files/5516655/pyramid_surface_mode_modifier_mesh.3mf.rename.zip)

[UM3_wood_grain.svg_5mm.3mf.rename.zip](https://github.com/Ultimaker/CuraEngine/files/5516656/UM3_wood_grain.svg_5mm.3mf.rename.zip)
