### PR TITLE
Fix polyline handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,7 @@ set(engine_SRCS # Except main.cpp.
 
 # List of tests. For each test there must be a file tests/${NAME}.cpp.
 set(engine_TEST
+    ClipperTest
     GCodeExportTest
     InfillTest
     LayerPlanTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ set(engine_SRCS # Except main.cpp.
     src/utils/PolygonProximityLinker.cpp
     src/utils/polygonUtils.cpp
     src/utils/polygon.cpp
+    src/utils/PolylineStitcher.cpp
     src/utils/ProximityPointLink.cpp
     src/utils/SVG.cpp
     src/utils/socket.cpp

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -946,9 +946,10 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, LayerIn
             {
                 const SliceMeshStorage& mesh = storage.meshes[mesh_idx];
                 const PathConfigStorage::MeshPathConfigs& mesh_config = gcode_layer.configs_storage.mesh_configs[mesh_idx];
-                if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") == ESurfaceMode::SURFACE)
+                if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") == ESurfaceMode::SURFACE
+                    && extruder_nr == mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr // mesh surface mode should always only be printed with the outer wall extruder!
+                )
                 {
-                    assert(extruder_nr == mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr && "mesh surface mode should always only be printed with the outer wall extruder!");
                     addMeshLayerToGCode_meshSurfaceMode(storage, mesh, mesh_config, gcode_layer);
                 }
                 else

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1269,18 +1269,7 @@ void FffGcodeWriter::addMeshOpenPolyLinesToGCode(const SliceMeshStorage& mesh, c
 {
     const SliceLayer* layer = &mesh.layers[gcode_layer.getLayerNr()];
     
-    Polygons lines;
-    for(ConstPolygonRef polyline : layer->openPolyLines)
-    {
-        for(unsigned int point_idx = 1; point_idx<polyline.size(); point_idx++)
-        {
-            Polygon p;
-            p.add(polyline[point_idx-1]);
-            p.add(polyline[point_idx]);
-            lines.add(p);
-        }
-    }
-    gcode_layer.addLinesByOptimizer(lines, mesh_config.inset0_config, SpaceFillType::PolyLines);
+    gcode_layer.addLinesByOptimizer(layer->openPolyLines, mesh_config.inset0_config, SpaceFillType::PolyLines);
 }
 
 void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, LayerPlan& gcode_layer) const

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -651,6 +651,9 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
     constexpr double fill_overlap = 0; // raft line shouldn't be expanded - there is no boundary polygon printed
     constexpr int infill_multiplier = 1; // rafts use single lines
     constexpr int extra_infill_shift = 0;
+    coord_t max_resolution = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr").settings.get<coord_t>("meshfix_maximum_resolution");
+    coord_t max_deviation = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr").settings.get<coord_t>("meshfix_maximum_deviation");
+
     Polygons raft_polygons; // should remain empty, since we only have the lines pattern for the raft...
     std::optional<Point> last_planned_position = std::optional<Point>();
 
@@ -698,6 +701,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Infill infill_comp(
             EFillMethod::LINES, zig_zaggify_infill, connect_polygons, wall, offset_from_poly_outline, gcode_layer.configs_storage.raft_base_config.getLineWidth(), train.settings.get<coord_t>("raft_base_line_spacing"),
             fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
+            max_resolution, max_deviation,
             wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
             );
         infill_comp.generate(raft_polygons, raftLines);
@@ -759,6 +763,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Infill infill_comp(
             EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, offset_from_poly_outline, infill_outline_width, train.settings.get<coord_t>("raft_interface_line_spacing"),
             fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
+            max_resolution, max_deviation,
             wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
             );
         infill_comp.generate(raft_polygons, raftLines);
@@ -816,6 +821,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         Infill infill_comp(
             EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, offset_from_poly_outline, infill_outline_width, train.settings.get<coord_t>("raft_surface_line_spacing"),
             fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
+            max_resolution, max_deviation,
             wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
             );
         infill_comp.generate(raft_polygons, raft_lines);
@@ -1404,7 +1410,8 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
     {
         return false;
     }
-
+    coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
+    coord_t max_deviation = mesh.settings.get<coord_t>("meshfix_maximum_deviation");
     const coord_t infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
     AngleDegrees infill_angle = 45; //Original default. This will get updated to an element from mesh->infill_angles.
     if (!mesh.infill_angles.empty())
@@ -1444,7 +1451,9 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
             constexpr size_t zag_skip_count = 0;
 
             Infill infill_comp(infill_pattern, zig_zaggify_infill, connect_polygons, part.infill_area_per_combine_per_density[density_idx][combine_idx], /*outline_offset =*/ 0
-                , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, wall_line_count, infill_origin
+                , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift
+                , max_resolution, max_deviation
+                , wall_line_count, infill_origin
                 , perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count
                 , mesh.settings.get<coord_t>("cross_infill_pocket_size"));
             infill_comp.generate(infill_polygons, infill_lines, mesh.cross_fill_provider, &mesh);
@@ -1498,6 +1507,8 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     const coord_t infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
     const size_t infill_multiplier = mesh.settings.get<size_t>("infill_multiplier");
     const size_t wall_line_count = mesh.settings.get<size_t>("infill_wall_line_count");
+    coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
+    coord_t max_deviation = mesh.settings.get<coord_t>("meshfix_maximum_deviation");
     AngleDegrees infill_angle = 45; //Original default. This will get updated to an element from mesh->infill_angles.
     if (mesh.infill_angles.size() > 0)
     {
@@ -1667,7 +1678,9 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 
                         // infill region with skin above has to have at least one infill wall line
                         Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, infill_below_skin, /*outline_offset =*/ 0
-                            , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, std::max(1, (int)wall_line_count), infill_origin
+                            , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift
+                            , max_resolution, max_deviation
+                            , std::max(1, (int)wall_line_count), infill_origin
                             , perimeter_gaps
                             , connected_zigzags
                             , use_endpieces
@@ -1694,7 +1707,9 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         in_outline.removeSmallAreas(minimum_small_area);
         
         Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, in_outline, /*outline_offset =*/ 0
-            , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, wall_line_count, infill_origin
+            , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift
+            , max_resolution, max_deviation
+            , wall_line_count, infill_origin
             , /*Polygons* perimeter_gaps =*/ nullptr
             , /*bool connected_zigzags =*/ false
             , /*bool use_endpieces =*/ false
@@ -2073,10 +2088,13 @@ void FffGcodeWriter::processOutlineGaps(const SliceDataStorage& storage, LayerPl
     constexpr bool skip_some_zags = false;
     constexpr int zag_skip_count = 0;
     constexpr coord_t pocket_size = 0;
+    coord_t max_resolution = 10; // we dont need to simplify line based infill
+    coord_t max_deviation = 5;
 
     Infill infill_comp(
-        EFillMethod::LINES, zig_zaggify_infill, connect_polygons, part.outline_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, outline_gap_overlap, infill_multiplier, skin_angle, gcode_layer.z, extra_infill_shift,
-        wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
+        EFillMethod::LINES, zig_zaggify_infill, connect_polygons, part.outline_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, outline_gap_overlap, infill_multiplier, skin_angle, gcode_layer.z, extra_infill_shift
+        , max_resolution, max_deviation
+        , wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
         );
     infill_comp.generate(gap_polygons, gap_lines);
 
@@ -2387,6 +2405,8 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage, La
     constexpr coord_t offset_from_inner_skin_infill = 0;
     const bool zig_zaggify_infill = pattern == EFillMethod::ZIG_ZAG;
     const bool connect_polygons = mesh.settings.get<bool>("connect_skin_polygons");
+    coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
+    coord_t max_deviation = mesh.settings.get<coord_t>("meshfix_maximum_deviation");
     const Point infill_origin;
     constexpr bool connected_zigzags = false;
     constexpr bool use_endpieces = true;
@@ -2395,7 +2415,9 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage, La
     constexpr coord_t pocket_size = 0;
 
     Infill infill_comp(
-        pattern, zig_zaggify_infill, connect_polygons, area, offset_from_inner_skin_infill, config.getLineWidth(), config.getLineWidth() / skin_density, skin_overlap, infill_multiplier, skin_angle, gcode_layer.z, extra_infill_shift, wall_line_count, infill_origin, perimeter_gaps_output,
+        pattern, zig_zaggify_infill, connect_polygons, area, offset_from_inner_skin_infill, config.getLineWidth(), config.getLineWidth() / skin_density, skin_overlap, infill_multiplier, skin_angle, gcode_layer.z, extra_infill_shift
+        , max_resolution, max_deviation
+        , wall_line_count, infill_origin, perimeter_gaps_output,
         connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
         );
     infill_comp.generate(skin_polygons, skin_lines);
@@ -2459,10 +2481,13 @@ void FffGcodeWriter::processPerimeterGaps(const SliceDataStorage& storage, Layer
     constexpr bool skip_some_zags = false;
     constexpr int zag_skip_count = 0;
     constexpr coord_t pocket_size = 0;
+    coord_t max_resolution = 10; // we don't need to simplify line based infill
+    coord_t max_deviation = 5;
 
     Infill infill_comp(
-        EFillMethod::LINES, zig_zaggify_infill, connect_polygons, perimeter_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, skin_overlap, infill_multiplier, perimeter_gaps_angle, gcode_layer.z, extra_infill_shift,
-        wall_line_count, infill_origin, perimeter_gaps_polyons, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
+        EFillMethod::LINES, zig_zaggify_infill, connect_polygons, perimeter_gaps, offset, perimeter_gaps_line_width, perimeter_gaps_line_width, skin_overlap, infill_multiplier, perimeter_gaps_angle, gcode_layer.z, extra_infill_shift
+        , max_resolution, max_deviation
+        , wall_line_count, infill_origin, perimeter_gaps_polyons, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
     infill_comp.generate(gap_polygons, gap_lines);
     if (gap_lines.size() > 0)
     {
@@ -2558,6 +2583,8 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
     }
     constexpr size_t infill_multiplier = 1; // there is no frontend setting for this (yet)
     constexpr size_t wall_line_count = 0;
+    coord_t max_resolution = infill_extruder.settings.get<coord_t>("meshfix_maximum_resolution");
+    coord_t max_deviation = infill_extruder.settings.get<coord_t>("meshfix_maximum_deviation");
     coord_t default_support_line_width = infill_extruder.settings.get<coord_t>("support_line_width");
     if (gcode_layer.getLayerNr() == 0 && mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::RAFT)
     {
@@ -2648,7 +2675,9 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                 constexpr coord_t pocket_size = 0;
 
                 Infill infill_comp(support_pattern, zig_zaggify_infill, connect_polygons, support_area_offset > 0 ? support_area_with_offset : support_area, offset_from_outline, support_line_width,
-                                   support_line_distance_here, current_support_infill_overlap, infill_multiplier, support_infill_angle, gcode_layer.z, support_shift, wall_line_count, infill_origin,
+                                   support_line_distance_here, current_support_infill_overlap, infill_multiplier, support_infill_angle, gcode_layer.z, support_shift
+                                   , max_resolution, max_deviation
+                                   , wall_line_count, infill_origin,
                                    perimeter_gaps, infill_extruder.settings.get<bool>("support_connect_zigzags"), use_endpieces,
                                    skip_some_zags, zag_skip_count, pocket_size);
                 infill_comp.generate(support_polygons, support_lines, storage.support.cross_fill_provider);
@@ -2717,6 +2746,8 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, Lay
     constexpr bool skip_some_zags = false;
     constexpr size_t zag_skip_count = 0;
     constexpr coord_t pocket_size = 0;
+    const coord_t max_resolution = roof_extruder.settings.get<coord_t>("meshfix_maximum_resolution");
+    const coord_t max_deviation = roof_extruder.settings.get<coord_t>("meshfix_maximum_deviation");
 
     coord_t support_roof_line_distance = roof_extruder.settings.get<coord_t>("support_roof_line_distance");
     const coord_t support_roof_line_width = roof_extruder.settings.get<coord_t>("support_roof_line_width");
@@ -2736,8 +2767,9 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, Lay
 
     Infill roof_computation(
         pattern, zig_zaggify_infill, connect_polygons, infill_outline, outline_offset, gcode_layer.configs_storage.support_roof_config.getLineWidth(),
-        support_roof_line_distance, support_roof_overlap, infill_multiplier, fill_angle, gcode_layer.z, extra_infill_shift,
-        wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
+        support_roof_line_distance, support_roof_overlap, infill_multiplier, fill_angle, gcode_layer.z, extra_infill_shift
+        , max_resolution, max_deviation
+        , wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
         );
     Polygons roof_polygons;
     Polygons roof_lines;
@@ -2799,12 +2831,15 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
     constexpr bool skip_some_zags = false;
     constexpr int zag_skip_count = 0;
     constexpr coord_t pocket_size = 0;
+    const coord_t max_resolution = bottom_extruder.settings.get<coord_t>("meshfix_maximum_resolution");
+    const coord_t max_deviation = bottom_extruder.settings.get<coord_t>("meshfix_maximum_deviation");
 
     const coord_t support_bottom_line_distance = bottom_extruder.settings.get<coord_t>("support_bottom_line_distance"); // note: no need to apply initial line width factor; support bottoms cannot exist on the first layer
     Infill bottom_computation(
         pattern, zig_zaggify_infill, connect_polygons, support_layer.support_bottom, outline_offset, gcode_layer.configs_storage.support_bottom_config.getLineWidth(),
-        support_bottom_line_distance, support_bottom_overlap, infill_multiplier, fill_angle, gcode_layer.z, extra_infill_shift,
-        wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
+        support_bottom_line_distance, support_bottom_overlap, infill_multiplier, fill_angle, gcode_layer.z, extra_infill_shift
+        , max_resolution, max_deviation
+        , wall_line_count, infill_origin, perimeter_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
         );
     Polygons bottom_polygons;
     Polygons bottom_lines;

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -652,11 +652,31 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
 {
     size_t mesh_idx = mesh_order[mesh_order_idx];
     SliceMeshStorage& mesh = storage.meshes[mesh_idx];
+    coord_t surface_line_width = mesh.settings.get<coord_t>("wall_line_width_0");
+
     mesh.layer_nr_max_filled_layer = -1;
     for (LayerIndex layer_idx = 0; layer_idx < static_cast<LayerIndex>(mesh.layers.size()); layer_idx++)
     {
         SliceLayer& layer = mesh.layers[layer_idx];
+
+        if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") == ESurfaceMode::SURFACE)
+        {
+            // break up polygons into polylines
+            // they have to be polylines, because they might break up further when doing the cutting
+            Polygons outline_polylines;
+            for (SliceLayerPart& part : layer.parts)
+            {
+                for (PolygonRef poly : part.outline)
+                {
+                    layer.openPolyLines.add(poly);
+                    layer.openPolyLines.back().add(layer.openPolyLines.back()[0]); // add the segment which closes the polygon
+                }
+            }
+            layer.parts.clear();
+        }
+
         std::vector<PolygonsPart> new_parts;
+        Polygons new_polylines;
 
         for (const size_t other_mesh_idx : mesh_order)
         { // limit the infill mesh's outline to within the infill of all meshes with lower order
@@ -672,9 +692,11 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
 
             SliceLayer& other_layer = other_mesh.layers[layer_idx];
 
-            for (SliceLayerPart& part : layer.parts)
+            for (SliceLayerPart& other_part : other_layer.parts)
             {
-                for (SliceLayerPart& other_part : other_layer.parts)
+                if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::SURFACE)
+                {
+                    for (SliceLayerPart& part : layer.parts)
                     { // limit the outline of each part of this infill mesh to the infill of parts of the other mesh with lower infill mesh order
                         if (!part.boundaryBox.hit(other_part.boundaryBox))
                         { // early out
@@ -700,6 +722,14 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
                         // note: don't change the part.infill_area, because we change the structure of that area, while the basic area in which infill is printed remains the same
                         //       the infill area remains the same for combing
                     }
+                }
+                if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
+                {
+                    const Polygons& own_infill_area = other_part.getOwnInfillArea();
+                    Polygons cut_lines = own_infill_area.intersectionPolyLines(layer.openPolyLines);
+                    new_polylines.add(cut_lines);
+                    other_part.infill_area_own = other_part.getOwnInfillArea().difference(layer.openPolyLines.offsetPolyLine(surface_line_width / 2));
+                }
             }
         }
 
@@ -709,6 +739,12 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
             layer.parts.emplace_back();
             layer.parts.back().outline = part;
             layer.parts.back().boundaryBox.calculate(part);
+        }
+        // TODO: reclose surface mode polygons which weren't cut up into broken polylines; and make LayerParts for them
+
+        if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
+        {
+            layer.openPolyLines = new_polylines;
         }
 
         if (layer.parts.size() > 0 || (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL && layer.openPolyLines.size() > 0) )

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -675,31 +675,31 @@ void FffPolygonGenerator::processInfillMesh(SliceDataStorage& storage, const siz
             for (SliceLayerPart& part : layer.parts)
             {
                 for (SliceLayerPart& other_part : other_layer.parts)
-                { // limit the outline of each part of this infill mesh to the infill of parts of the other mesh with lower infill mesh order
-                    if (!part.boundaryBox.hit(other_part.boundaryBox))
-                    { // early out
-                        continue;
-                    }
-                    Polygons new_outline = part.outline.intersection(other_part.getOwnInfillArea());
-                    if (new_outline.size() == 1)
-                    { // we don't have to call splitIntoParts, because a single polygon can only be a single part
-                        PolygonsPart outline_part_here;
-                        outline_part_here.add(new_outline[0]);
-                        new_parts.push_back(outline_part_here);
-                    }
-                    else if (new_outline.size() > 1)
-                    { // we don't know whether it's a multitude of parts because of newly introduced holes, or because the polygon has been split up
-                        std::vector<PolygonsPart> new_parts_here = new_outline.splitIntoParts();
-                        for (PolygonsPart& new_part_here : new_parts_here)
-                        {
-                            new_parts.push_back(new_part_here);
+                    { // limit the outline of each part of this infill mesh to the infill of parts of the other mesh with lower infill mesh order
+                        if (!part.boundaryBox.hit(other_part.boundaryBox))
+                        { // early out
+                            continue;
                         }
+                        Polygons new_outline = part.outline.intersection(other_part.getOwnInfillArea());
+                        if (new_outline.size() == 1)
+                        { // we don't have to call splitIntoParts, because a single polygon can only be a single part
+                            PolygonsPart outline_part_here;
+                            outline_part_here.add(new_outline[0]);
+                            new_parts.push_back(outline_part_here);
+                        }
+                        else if (new_outline.size() > 1)
+                        { // we don't know whether it's a multitude of parts because of newly introduced holes, or because the polygon has been split up
+                            std::vector<PolygonsPart> new_parts_here = new_outline.splitIntoParts();
+                            for (PolygonsPart& new_part_here : new_parts_here)
+                            {
+                                new_parts.push_back(new_part_here);
+                            }
+                        }
+                        // change the infill area of the non-infill mesh which is to be filled with e.g. lines
+                        other_part.infill_area_own = other_part.getOwnInfillArea().difference(part.outline);
+                        // note: don't change the part.infill_area, because we change the structure of that area, while the basic area in which infill is printed remains the same
+                        //       the infill area remains the same for combing
                     }
-                    // change the infill area of the non-infill mesh which is to be filled with e.g. lines
-                    other_part.infill_area_own = other_part.getOwnInfillArea().difference(part.outline);
-                    // note: don't change the part.infill_area, because we change the structure of that area, while the basic area in which infill is printed remains the same
-                    //       the infill area remains the same for combing
-                }
             }
         }
 

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1112,7 +1112,6 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathCon
             }
 
             // Don't wipe if next starting point is very near
-            // TODO: remove this condition once all polylines are properly chained
             if (wipe && (order_idx < orderOptimizer.polyOrder.size() - 1))
             {
                 const unsigned int next_poly_idx = orderOptimizer.polyOrder[order_idx + 1];

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -716,11 +716,8 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const SliceMeshSto
 
             // determine which segments of the line are bridges
 
-            Polygon line_poly;
-            line_poly.add(p0);
-            line_poly.add(p1);
             Polygons line_polys;
-            line_polys.add(line_poly);
+            line_polys.addLine(p0, p1);
             line_polys = bridge_wall_mask.intersectionPolyLines(line_polys);
 
             // line_polys now contains the wall lines that need to be printed using bridge_config
@@ -837,11 +834,8 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const SliceMeshStor
 
                     // determine which segments of the line are bridges
 
-                    Polygon line_poly;
-                    line_poly.add(p0);
-                    line_poly.add(p1);
                     Polygons line_polys;
-                    line_polys.add(line_poly);
+                    line_polys.addLine(p0, p1);
                     line_polys = bridge_wall_mask.intersectionPolyLines(line_polys);
 
                     while (line_polys.size() > 0)

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -56,6 +56,8 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
     constexpr coord_t infill_overlap = 0;
     constexpr int infill_multiplier = 1;
     constexpr coord_t shift = 0;
+    const coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
+    const coord_t max_deviation = mesh.settings.get<coord_t>("meshfix_maximum_deviation");
     const Ratio ironing_flow = mesh.settings.get<Ratio>("ironing_flow");
 
     coord_t ironing_inset = -mesh.settings.get<coord_t>("ironing_inset");
@@ -76,7 +78,7 @@ bool TopSurface::ironing(const SliceMeshStorage& mesh, const GCodePathConfig& li
     }
     const coord_t outline_offset = ironing_inset;
 
-    Infill infill_generator(pattern, zig_zaggify_infill, connect_polygons, areas, outline_offset, line_width, line_spacing, infill_overlap, infill_multiplier, direction, layer.z - 10, shift);
+    Infill infill_generator(pattern, zig_zaggify_infill, connect_polygons, areas, outline_offset, line_width, line_spacing, infill_overlap, infill_multiplier, direction, layer.z - 10, shift, max_resolution, max_deviation);
     Polygons ironing_polygons;
     Polygons ironing_lines;
     infill_generator.generate(ironing_polygons, ironing_lines);

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -177,6 +177,7 @@ void Infill::_generate(Polygons& result_polygons, Polygons& result_lines, const 
         PolylineStitcher::stitch(result_lines, stiched_lines, result_polygons, infill_line_width);
         result_lines = stiched_lines;
     }
+    result_lines.simplifyPolylines(max_resolution, max_deviation);
 }
 
 void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -393,14 +393,7 @@ void Infill::generateCrossInfill(const SierpinskiFillProvider& cross_fill_provid
 
 void Infill::addLineSegmentsInfill(Polygons& result, Polygons& input)
 {
-    ClipperLib::PolyTree interior_segments_tree;
-    in_outline.offset(infill_overlap).lineSegmentIntersection(input, interior_segments_tree);
-    ClipperLib::Paths interior_segments;
-    ClipperLib::OpenPathsFromPolyTree(interior_segments_tree, interior_segments);
-    for (size_t idx = 0; idx < interior_segments.size(); idx++)
-    {
-        result.addLine(interior_segments[idx][0], interior_segments[idx][1]);
-    }
+    result.add(in_outline.offset(infill_overlap).intersectionPolyLines(input));
 }
 
 void Infill::addLineInfill(Polygons& result, const PointMatrix& rotation_matrix, const int scanline_min_idx, const int line_distance, const AABB boundary, std::vector<std::vector<coord_t>>& cut_list, coord_t shift)

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -17,6 +17,7 @@
 #include "utils/logoutput.h"
 #include "utils/PolygonConnector.h"
 #include "utils/polygonUtils.h"
+#include "utils/PolylineStitcher.h"
 #include "utils/UnionFind.h"
 
 /*!
@@ -168,6 +169,14 @@ void Infill::_generate(Polygons& result_polygons, Polygons& result_lines, const 
         connectLines(result_lines);
     }
     crossings_on_line.clear();
+
+    if (zig_zaggify ||
+        pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D || pattern == EFillMethod::CUBICSUBDIV || pattern == EFillMethod::GYROID || pattern == EFillMethod::ZIG_ZAG)
+    { // don't stich for non-zig-zagged line infill types
+        Polygons stiched_lines;
+        PolylineStitcher::stitch(result_lines, stiched_lines, result_polygons, infill_line_width);
+        result_lines = stiched_lines;
+    }
 }
 
 void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -249,9 +249,9 @@ void Infill::multiplyInfill(Polygons& result_polygons, Polygons& result_lines)
             }
             poly.add(poly[0]);
         }
-        Polygons polylines = outline.intersectionPolyLines(result_polygons);
-        result_lines.add(polylines);
-        result_polygons.clear(); // the output should only contain polylines
+        Polygons polylines = outline.intersectionPolyLines(result_polygons.splitPolygonsIntoSegments());
+        result_polygons.clear();
+        PolylineStitcher::stitch(polylines, result_lines, result_polygons, infill_line_width);
     }
 }
 
@@ -385,15 +385,17 @@ void Infill::generateCrossInfill(const SierpinskiFillProvider& cross_fill_provid
 
         Polygons cross_pattern_polygons;
         cross_pattern_polygons.add(cross_pattern_polygon);
-        Polygons poly_lines = outline.intersectionPolyLines(cross_pattern_polygons);
-
-        result_lines.add(poly_lines);
+        Polygons poly_lines = outline.intersectionPolyLines(cross_pattern_polygons.splitPolygonsIntoSegments());
+        PolylineStitcher::stitch(poly_lines, result_lines, result_polygons, infill_line_width);
     }
 }
 
 void Infill::addLineSegmentsInfill(Polygons& result, Polygons& input)
 {
-    result.add(in_outline.offset(infill_overlap).intersectionPolyLines(input));
+    Polygons polylines = in_outline.offset(infill_overlap).intersectionPolyLines(input);
+    Polygons result_polygons;
+    PolylineStitcher::stitch(polylines, result, result_polygons, infill_line_width);
+    assert(result_polygons.empty());
 }
 
 void Infill::addLineInfill(Polygons& result, const PointMatrix& rotation_matrix, const int scanline_min_idx, const int line_distance, const AABB boundary, std::vector<std::vector<coord_t>>& cut_list, coord_t shift)

--- a/src/infill.h
+++ b/src/infill.h
@@ -34,6 +34,8 @@ class Infill
     AngleDegrees fill_angle; //!< for linear infill types: the angle of the infill lines (or the angle of the grid)
     coord_t z; //!< height of the layer for which we generate infill
     coord_t shift; //!< shift of the scanlines in the direction perpendicular to the fill_angle
+    coord_t max_resolution; //!< Min feature size of the output
+    coord_t max_deviation; //!< Max deviation fro the original poly when enforcing max_resolution
     size_t wall_line_count; //!< Number of walls to generate at the boundary of the infill region, spaced \ref infill_line_width apart
     const Point infill_origin; //!< origin of the infill pattern
     Polygons* perimeter_gaps; //!< (optional output) The areas in between consecutive insets when Concentric infill is used.
@@ -66,6 +68,8 @@ public:
         , AngleDegrees fill_angle
         , coord_t z
         , coord_t shift
+        , coord_t max_resolution
+        , coord_t max_deviation
         , size_t wall_line_count = 0
         , const Point& infill_origin = Point()
         , Polygons* perimeter_gaps = nullptr
@@ -87,6 +91,8 @@ public:
     , fill_angle(fill_angle)
     , z(z)
     , shift(shift)
+    , max_resolution(max_resolution)
+    , max_deviation(max_deviation)
     , wall_line_count(wall_line_count)
     , infill_origin(infill_origin)
     , perimeter_gaps(perimeter_gaps)

--- a/src/infill/GyroidInfill.cpp
+++ b/src/infill/GyroidInfill.cpp
@@ -335,10 +335,7 @@ void GyroidInfill::generateTotalGyroidInfill(Polygons& result_lines, bool zig_za
 
                         if (chain_index != connector_start_chain_index && connected_to[(point_index + 1) % 2][chain_index] != connector_start_chain_index)
                         {
-                            for (unsigned pi = 1; pi < connector_points.size(); ++pi)
-                            {
-                                result.addLine(connector_points[pi - 1], connector_points[pi]);
-                            }
+                            result.add(connector_points);
                             drawing = false;
                             connector_points.clear();
                             // remember the connection
@@ -389,15 +386,9 @@ void GyroidInfill::generateTotalGyroidInfill(Polygons& result_lines, bool zig_za
             {
                 // output the connector line segments from the last chain to the first point in the outline
                 connector_points.push_back(outline_poly[0]);
-                for (unsigned pi = 1; pi < connector_points.size(); ++pi)
-                {
-                    result.addLine(connector_points[pi - 1], connector_points[pi]);
-                }
+                result.add(connector_points);
                 // output the connector line segments from the first point in the outline to the first chain
-                for (unsigned pi = 1; pi < path_to_first_chain.size(); ++pi)
-                {
-                    result.addLine(path_to_first_chain[pi - 1], path_to_first_chain[pi]);
-                }
+                result.add(path_to_first_chain);
             }
 
             if (chain_ends_remaining < 1)

--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -8,6 +8,7 @@
 #include "settings/Settings.h"
 #include "progress/Progress.h"
 
+#include "utils/PolylineStitcher.h"
 #include "utils/SVG.h" // debug output
 
 /*
@@ -26,7 +27,7 @@ namespace cura {
 
 void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, SlicerLayer* layer)
 {
-    storageLayer.openPolyLines = layer->openPolylines;
+    PolylineStitcher::stitch(layer->openPolylines, storageLayer.openPolyLines, layer->polygons, settings.get<coord_t>("wall_line_width_0"));
     
     const coord_t maximum_resolution = settings.get<coord_t>("meshfix_maximum_resolution");
     const coord_t maximum_deviation = settings.get<coord_t>("meshfix_maximum_deviation");

--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -27,6 +27,10 @@ namespace cura {
 void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, SlicerLayer* layer)
 {
     storageLayer.openPolyLines = layer->openPolylines;
+    
+    const coord_t maximum_resolution = settings.get<coord_t>("meshfix_maximum_resolution");
+    const coord_t maximum_deviation = settings.get<coord_t>("meshfix_maximum_deviation");
+    storageLayer.openPolyLines.simplifyPolylines(maximum_resolution, maximum_deviation);
 
     const bool union_all_remove_holes = settings.get<bool>("meshfix_union_all_remove_holes");
     if (union_all_remove_holes)

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -235,7 +235,7 @@ static inline bool pointsAreCoincident(const Point& a, const Point& b)
 */
 void LineOrderOptimizer::optimize(bool find_chains)
 {
-    const int grid_size = 100; // the size of the cells in the hash grid. TODO
+    const coord_t grid_size = 100_mu; // the size of the cells in the hash grid. TODO
     SparsePointGridInclusive<unsigned int> line_bucket_grid(grid_size);
     // NOTE: Keep this vector fixed-size, it replaces an (non-standard, sized at runtime) array:
     std::vector<bool> picked(polygons.size(), false);

--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -235,7 +235,7 @@ static inline bool pointsAreCoincident(const Point& a, const Point& b)
 */
 void LineOrderOptimizer::optimize(bool find_chains)
 {
-    const int grid_size = 2000; // the size of the cells in the hash grid. TODO
+    const int grid_size = 100; // the size of the cells in the hash grid. TODO
     SparsePointGridInclusive<unsigned int> line_bucket_grid(grid_size);
     // NOTE: Keep this vector fixed-size, it replaces an (non-standard, sized at runtime) array:
     std::vector<bool> picked(polygons.size(), false);

--- a/src/pathOrderOptimizer.h
+++ b/src/pathOrderOptimizer.h
@@ -124,12 +124,10 @@ public:
 
     /*!
      * Do the optimization
-     *
-     * \param find_chains Whether to determine when lines are chained together (i.e. zigzag infill)
-     *
-     * \return The squared travel distance between the two points
+     * 
+     * sets #polyStart and #polyOrder
      */
-    void optimize(bool find_chains = true); //!< sets #polyStart and #polyOrder
+    void optimize();
 
 private:
     /*!

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -200,6 +200,11 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr) const
             return false;
         }
     }
+    if (settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL
+        && settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr == extruder_nr)
+    {
+        return true;
+    }
     if (settings.get<size_t>("wall_line_count") > 0 && settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr == extruder_nr)
     {
         return true;
@@ -283,6 +288,13 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr, const LayerIn
                 return true;
             }
         }
+    }
+    if (settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL
+        && settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr == extruder_nr
+        && layer.openPolyLines.size() > 0
+    )
+    {
+        return true;
     }
     if ((settings.get<size_t>("wall_line_count") > 1 || settings.get<bool>("alternate_extra_perimeter")) && settings.get<ExtruderTrain&>("wall_x_extruder_nr").extruder_nr == extruder_nr)
     {

--- a/src/utils/Coord_t.h
+++ b/src/utils/Coord_t.h
@@ -13,6 +13,8 @@ namespace cura
 
 using coord_t = ClipperLib::cInt;
 
+static inline coord_t operator "" _mu(unsigned long long i) { return i; };
+
 #define INT2MM(n) (static_cast<double>(n) / 1000.0)
 #define INT2MM2(n) (static_cast<double>(n) / 1000000.0)
 #define MM2INT(n) (static_cast<coord_t>((n) * 1000 + 0.5 * (((n) > 0) - ((n) < 0))))

--- a/src/utils/PolygonsPointIndex.h
+++ b/src/utils/PolygonsPointIndex.h
@@ -135,6 +135,35 @@ public:
 };
 
 
+
+/*!
+ * Locator to extract a line segment out of a \ref PolygonsPointIndex
+ */
+struct PolygonsPointIndexSegmentLocator
+{
+    std::pair<Point, Point> operator()(const PolygonsPointIndex& val) const
+    {
+        ConstPolygonRef poly = (*val.polygons)[val.poly_idx];
+        Point start = poly[val.point_idx];
+        unsigned int next_point_idx = (val.point_idx + 1) % poly.size();
+        Point end = poly[next_point_idx];
+        return std::pair<Point, Point>(start, end);
+    }
+};
+
+
+
+/*!
+ * Locator of a \ref PolygonsPointIndex
+ */
+struct PolygonsPointIndexLocator
+{
+    Point operator()(const PolygonsPointIndex& val) const
+    {
+        return val.p();
+    }
+};
+
 }//namespace cura
 
 namespace std

--- a/src/utils/PolylineStitcher.cpp
+++ b/src/utils/PolylineStitcher.cpp
@@ -104,14 +104,24 @@ void PolylineStitcher::stitch(const Polygons& lines, Polygons& result_lines, Pol
                 }
                 
 
+                coord_t segment_dist = vSize(chain.back() - closest.p());
+                assert(segment_dist <= max_stitch_distance + 10);
                 if (closest.point_idx == 0)
                 {
-                    assert(vSize(chain.back() - *closest.getPolygon().begin()) <= max_stitch_distance + 10);
-                    chain.insert(chain.end(), closest.getPolygon().begin(), closest.getPolygon().end());
+                    auto start_pos = closest.getPolygon().begin();
+                    if (segment_dist < snap_distance)
+                    {
+                        ++start_pos;
+                    }
+                    chain.insert(chain.end(), start_pos, closest.getPolygon().end());
                 }
                 else
                 {
-                    assert(vSize(chain.back() - *closest.getPolygon().rbegin()) <= max_stitch_distance + 10);
+                    auto start_pos = closest.getPolygon().rbegin();
+                    if (segment_dist < snap_distance)
+                    {
+                        ++start_pos;
+                    }
                     chain.insert(chain.end(), closest.getPolygon().rbegin(), closest.getPolygon().rend());
                 }
                 assert( ! processed[closest.poly_idx]);

--- a/src/utils/PolylineStitcher.cpp
+++ b/src/utils/PolylineStitcher.cpp
@@ -1,0 +1,137 @@
+//Copyright (c) 2020 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include "PolylineStitcher.h"
+#include "SparsePointGrid.h"
+#include "PolygonsPointIndex.h"
+
+#include "SymmetricPair.h"
+#include <unordered_set>
+#include <cassert>
+
+namespace cura
+{
+
+
+void PolylineStitcher::stitch(const Polygons& lines, Polygons& result_lines, Polygons& result_polygons, coord_t max_stitch_distance, coord_t snap_distance)
+{
+    if (lines.empty())
+    {
+        return;
+    }
+
+    SparsePointGrid<PolygonsPointIndex, PolygonsPointIndexLocator> grid(max_stitch_distance, lines.size() * 2);
+    
+    // populate grid
+    for (size_t line_idx = 0; line_idx < lines.size(); line_idx++)
+    {
+        ConstPolygonRef line = lines[line_idx];
+        grid.insert(PolygonsPointIndex(&lines, line_idx, 0));
+        grid.insert(PolygonsPointIndex(&lines, line_idx, line.size() - 1));
+    }
+    
+    std::vector<bool> processed(lines.size(), false);
+    
+    for (size_t line_idx = 0; line_idx < lines.size(); line_idx++)
+    {
+        if (processed[line_idx])
+        {
+            continue;
+        }
+        processed[line_idx] = true;
+        ConstPolygonRef line = lines[line_idx];
+        
+        Polygon chain = line;
+        bool closest_is_closing_polygon = false;
+        for (bool go_in_reverse_direction : { false, true })
+        {
+            if (go_in_reverse_direction)
+            { // try extending chain in the other direction
+                chain.reverse();
+            }
+            
+            while (true)
+            {
+                Point from = chain.back();
+                
+                PolygonsPointIndex closest;
+                coord_t closest_distance = std::numeric_limits<coord_t>::max();
+                grid.processNearby(from, max_stitch_distance, 
+                    std::function<bool (const PolygonsPointIndex&)> (
+                        [from, &chain, &closest, &closest_is_closing_polygon, &closest_distance, &processed, max_stitch_distance, snap_distance](const PolygonsPointIndex& nearby)->bool
+                    {
+                        bool is_closing_segment = false;
+                        coord_t dist = vSize(nearby.p() - from);
+                        if (dist > max_stitch_distance)
+                        {
+                            return true; // keep looking
+                        }
+                        if (nearby.p() == chain.front())
+                        {
+                            if (chain.polylineLength() + dist < 3 * max_stitch_distance // prevent closing of small poly, cause it might be able to continue making a larger polyline
+                                || chain.size() <= 2) // don't make 2 vert polygons
+                            {
+                                return true; // look for a better next line
+                            }
+                            is_closing_segment = true;
+                            dist += 10; // prefer continuing polyline over closing a polygon; avoids closed zigzags from being printed separately
+                            // continue to see if closing segment is also the closest 
+                            // there might be a segment smaller than [max_stitch_distance] which closes the polygon better
+                        }
+                        else if (processed[nearby.poly_idx])
+                        { // it was already moved to output
+                            return true; // keep looking for a connection
+                        }
+                        if (dist < closest_distance)
+                        {
+                            closest_distance = dist;
+                            closest = nearby;
+                            closest_is_closing_polygon = is_closing_segment;
+                        }
+                        if (dist < snap_distance)
+                        { // we have found a good enough next line
+                            return false; // stop looking for alternatives
+                        }
+                        return true; // keep processing elements 
+                    })
+                );
+                
+                if (!closest.initialized()          // we couldn't find any next line 
+                    || closest_is_closing_polygon   // we closed the polygon
+                )
+                {
+                    break;
+                }
+                
+
+                if (closest.point_idx == 0)
+                {
+                    assert(vSize(chain.back() - *closest.getPolygon().begin()) <= max_stitch_distance + 10);
+                    chain.insert(chain.end(), closest.getPolygon().begin(), closest.getPolygon().end());
+                }
+                else
+                {
+                    assert(vSize(chain.back() - *closest.getPolygon().rbegin()) <= max_stitch_distance + 10);
+                    chain.insert(chain.end(), closest.getPolygon().rbegin(), closest.getPolygon().rend());
+                }
+                assert( ! processed[closest.poly_idx]);
+                processed[closest.poly_idx] = true;
+            }
+            if (closest_is_closing_polygon)
+            {
+                break; // don't consider reverse direction
+            }
+        }
+        if (closest_is_closing_polygon)
+        {
+            result_polygons.add(chain);
+        }
+        else
+        {
+            result_lines.add(chain);
+        }
+    }
+}
+
+}//namespace cura
+

--- a/src/utils/PolylineStitcher.h
+++ b/src/utils/PolylineStitcher.h
@@ -17,10 +17,8 @@ class PolylineStitcher
 public:
     /*!
      * Stitch together the separate \p lines into \p result_lines and if they can be closed into \p result_polygons.
-     * Only introduce new segments shorter than \p max_stitch_distance,
-     * but always try to make the shortest segment possible,
-     * unless the segment is smaller than \p snap_distance.
-     * When the first connection smaller than \p snap_distance is found no other nearby connections will be considered.
+     * Only introduce new segments shorter than \p max_stitch_distance, and larger then \p snap_distance
+     * but always try to take the shortest connection possible.
      * 
      * Only stitch polylines into closed polygons if they are larger than 3 * \p max_stitch_distance,
      * in order to prevent small segments to accidentally get closed into a polygon.

--- a/src/utils/PolylineStitcher.h
+++ b/src/utils/PolylineStitcher.h
@@ -1,0 +1,36 @@
+//Copyright (c) 2020 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef UTILS_POLYLINE_STITCHER_H
+#define UTILS_POLYLINE_STITCHER_H
+
+#include "polygon.h"
+
+namespace cura
+{
+
+/*!
+ * Class for stitching polylines into longer polylines or into polygons
+ */
+class PolylineStitcher
+{
+public:
+    /*!
+     * Stitch together the separate \p lines into \p result_lines and if they can be closed into \p result_polygons.
+     * Only introduce new segments shorter than \p max_stitch_distance,
+     * but always try to make the shortest segment possible,
+     * unless the segment is smaller than \p snap_distance.
+     * When the first connection smaller than \p snap_distance is found no other nearby connections will be considered.
+     * 
+     * Only stitch polylines into closed polygons if they are larger than 3 * \p max_stitch_distance,
+     * in order to prevent small segments to accidentally get closed into a polygon.
+     * 
+     * \note Resulting polylines and polygons are added onto the existing containers, so you can directly output onto a polygons container with existing polygons in it.
+     * Hewever, you shouldn't call this function with the same parameter in \p lines as \p result_lines, because that would duplicate (some of) the polylines.
+     */
+    static void stitch(const Polygons& lines, Polygons& result_lines, Polygons& result_polygons, coord_t max_stitch_distance = MM2INT(0.1), coord_t snap_distance = 10);
+};
+
+}//namespace cura
+#endif//UTILS_POLYLINE_STITCHER_H
+

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -366,73 +366,73 @@ void PolygonRef::_simplify(const coord_t smallest_line_segment_squared, const co
 
         if (!processing_polylines || (point_idx != 0 && point_idx + 1 != size()))
         { // bypass all checks for deleting a vertex when processing the start or end of a polyline
-        const coord_t length2 = vSize2(current - previous);
-        if (length2 < 25)
-        {
-            // We're allowed to always delete segments of less than 5 micron.
-            continue;
-        }
-
-        const coord_t area_removed_so_far = accumulated_area_removed + negative_area_closing; // close the shortcut area polygon
-        const coord_t base_length_2 = vSize2(next - previous);
-
-        if (base_length_2 == 0) //Two line segments form a line back and forth with no area.
-        {
-            continue; //Remove the vertex.
-        }
-        //We want to check if the height of the triangle formed by previous, current and next vertices is less than allowed_error_distance_squared.
-        //1/2 L = A           [actual area is half of the computed shoelace value] // Shoelace formula is .5*(...) , but we simplify the computation and take out the .5
-        //A = 1/2 * b * h     [triangle area formula]
-        //L = b * h           [apply above two and take out the 1/2]
-        //h = L / b           [divide by b]
-        //h^2 = (L / b)^2     [square it]
-        //h^2 = L^2 / b^2     [factor the divisor]
-        const coord_t height_2 = area_removed_so_far * area_removed_so_far / base_length_2;
-        if ((height_2 <= 1 //Almost exactly colinear (barring rounding errors).
-            && LinearAlg2D::getDistFromLine(current, previous, next) <= 1)) // make sure that height_2 is not small because of cancellation of positive and negative areas
-        {
-            continue;
-        }
-
-        if (length2 < smallest_line_segment_squared
-            && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.)
-        {
-            const coord_t next_length2 = vSize2(current - next);
-            if (next_length2 > smallest_line_segment_squared)
+            const coord_t length2 = vSize2(current - previous);
+            if (length2 < 25)
             {
-                // Special case; The next line is long. If we were to remove this, it could happen that we get quite noticeable artifacts.
-                // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.
-                // By taking the intersection of these two lines, we get a point that preserves the direction (so it makes the corner a bit more pointy).
-                // We just need to be sure that the intersection point does not introduce an artifact itself.
-                Point intersection_point;
-                bool has_intersection = LinearAlg2D::lineLineIntersection(previous_previous, previous, current, next, intersection_point);
-                if (!has_intersection
-                    || LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared
-                    || vSize2(intersection_point - previous) > smallest_line_segment_squared  // The intersection point is way too far from the 'previous'
-                    || vSize2(intersection_point - next) > smallest_line_segment_squared)     // and 'next' points, so it shouldn't replace 'current'
-                {
-                    // We can't find a better spot for it, but the size of the line is more than 5 micron.
-                    // So the only thing we can do here is leave it in...
-                }
-                else
-                {
-                    // New point seems like a valid one.
-                    current = intersection_point;
-                    // If there was a previous point added, remove it.
-                    if (!new_path.empty()
-                        && (!processing_polylines || new_path.size() > 1) // never delete the first point of a polyline
-                    )
-                    {
-                        new_path.pop_back();
-                        previous = previous_previous;
-                    }
-                }
+                // We're allowed to always delete segments of less than 5 micron.
+                continue;
             }
-            else
+
+            const coord_t area_removed_so_far = accumulated_area_removed + negative_area_closing; // close the shortcut area polygon
+            const coord_t base_length_2 = vSize2(next - previous);
+
+            if (base_length_2 == 0) //Two line segments form a line back and forth with no area.
             {
                 continue; //Remove the vertex.
             }
-        }
+            //We want to check if the height of the triangle formed by previous, current and next vertices is less than allowed_error_distance_squared.
+            //1/2 L = A           [actual area is half of the computed shoelace value] // Shoelace formula is .5*(...) , but we simplify the computation and take out the .5
+            //A = 1/2 * b * h     [triangle area formula]
+            //L = b * h           [apply above two and take out the 1/2]
+            //h = L / b           [divide by b]
+            //h^2 = (L / b)^2     [square it]
+            //h^2 = L^2 / b^2     [factor the divisor]
+            const coord_t height_2 = area_removed_so_far * area_removed_so_far / base_length_2;
+            if ((height_2 <= 1 //Almost exactly colinear (barring rounding errors).
+                && LinearAlg2D::getDistFromLine(current, previous, next) <= 1)) // make sure that height_2 is not small because of cancellation of positive and negative areas
+            {
+                continue;
+            }
+
+            if (length2 < smallest_line_segment_squared
+                && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.)
+            {
+                const coord_t next_length2 = vSize2(current - next);
+                if (next_length2 > smallest_line_segment_squared)
+                {
+                    // Special case; The next line is long. If we were to remove this, it could happen that we get quite noticeable artifacts.
+                    // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.
+                    // By taking the intersection of these two lines, we get a point that preserves the direction (so it makes the corner a bit more pointy).
+                    // We just need to be sure that the intersection point does not introduce an artifact itself.
+                    Point intersection_point;
+                    bool has_intersection = LinearAlg2D::lineLineIntersection(previous_previous, previous, current, next, intersection_point);
+                    if (!has_intersection
+                        || LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared
+                        || vSize2(intersection_point - previous) > smallest_line_segment_squared  // The intersection point is way too far from the 'previous'
+                        || vSize2(intersection_point - next) > smallest_line_segment_squared)     // and 'next' points, so it shouldn't replace 'current'
+                    {
+                        // We can't find a better spot for it, but the size of the line is more than 5 micron.
+                        // So the only thing we can do here is leave it in...
+                    }
+                    else
+                    {
+                        // New point seems like a valid one.
+                        current = intersection_point;
+                        // If there was a previous point added, remove it.
+                        if (!new_path.empty()
+                            && (!processing_polylines || new_path.size() > 1) // never delete the first point of a polyline
+                        )
+                        {
+                            new_path.pop_back();
+                            previous = previous_previous;
+                        }
+                    }
+                }
+                else
+                {
+                    continue; //Remove the vertex.
+                }
+            }
         }
         //Don't remove the vertex.
         accumulated_area_removed = removed_area_next; // so that in the next iteration it's the area between the origin, [previous] and [current]

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -252,15 +252,9 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines) const
 coord_t Polygons::polyLineLength() const
 {
     coord_t length = 0;
-    for (unsigned int poly_idx = 0; poly_idx < paths.size(); poly_idx++)
+    for (ConstPolygonRef poly : *this)
     {
-        Point p0 = paths[poly_idx][0];
-        for (unsigned int point_idx = 1; point_idx < paths[poly_idx].size(); point_idx++)
-        {
-            Point p1 = paths[poly_idx][point_idx];
-            length += vSize(p0 - p1);
-            p0 = p1;
-        }
+        length += poly.polylineLength();
     }
     return length;
 }

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -249,6 +249,34 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines) const
     return ret;
 }
 
+void Polygons::splitPolylinesIntoSegments(Polygons& result) const
+{
+    for (ConstPolygonRef poly : *this)
+    {
+        poly.splitPolylineIntoSegments(result);
+    }
+}
+Polygons Polygons::splitPolylinesIntoSegments() const
+{
+    Polygons ret;
+    splitPolylinesIntoSegments(ret);
+    return ret;
+}
+
+void Polygons::splitPolygonsIntoSegments(Polygons& result) const
+{
+    for (ConstPolygonRef poly : *this)
+    {
+        poly.splitPolygonIntoSegments(result);
+    }
+}
+Polygons Polygons::splitPolygonsIntoSegments() const
+{
+    Polygons ret;
+    splitPolygonsIntoSegments(ret);
+    return ret;
+}
+
 coord_t Polygons::polyLineLength() const
 {
     coord_t length = 0;
@@ -1020,6 +1048,39 @@ Polygons Polygons::smooth_outward(const AngleDegrees max_angle, int shortcut_len
     return ret;
 }
 
+
+
+
+void ConstPolygonRef::splitPolylineIntoSegments(Polygons& result) const 
+{
+    Point last = front();
+    for (size_t idx = 1; idx < size(); idx++)
+    {
+        Point p = (*this)[idx];
+        result.addLine(last, p);
+        last = p;
+    }
+}
+
+Polygons ConstPolygonRef::splitPolylineIntoSegments() const 
+{
+    Polygons ret;
+    splitPolylineIntoSegments(ret);
+    return ret;
+}
+
+void ConstPolygonRef::splitPolygonIntoSegments(Polygons& result) const
+{
+    splitPolylineIntoSegments(result);
+    result.addLine(back(), front());
+}
+
+Polygons ConstPolygonRef::splitPolygonIntoSegments() const 
+{
+    Polygons ret;
+    splitPolygonIntoSegments(ret);
+    return ret;
+}
 
 void ConstPolygonRef::smooth(int remove_length, PolygonRef result) const
 {

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -245,7 +245,7 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines) const
     clipper.AddPaths(paths, ClipperLib::ptClip, true);
     clipper.Execute(ClipperLib::ctIntersection, result);
     Polygons ret;
-    ret.addPolyTreeNodeRecursive(result);
+    ClipperLib::OpenPathsFromPolyTree(result, ret.paths);
     return ret;
 }
 
@@ -585,19 +585,8 @@ void Polygons::removeSmallAreas(const double min_area_size, const bool remove_ho
 Polygons Polygons::toPolygons(ClipperLib::PolyTree& poly_tree)
 {
     Polygons ret;
-    ret.addPolyTreeNodeRecursive(poly_tree);
+    ClipperLib::PolyTreeToPaths(poly_tree, ret.paths);
     return ret;
-}
-
-
-void Polygons::addPolyTreeNodeRecursive(const ClipperLib::PolyNode& node)
-{
-    for (int outer_poly_idx = 0; outer_poly_idx < node.ChildCount(); outer_poly_idx++)
-    {
-        ClipperLib::PolyNode* child = node.Childs[outer_poly_idx];
-        paths.push_back(child->Contour);
-        addPolyTreeNodeRecursive(*child);
-    }
 }
 
 bool ConstPolygonRef::smooth_corner_complex(const Point p1, ListPolyIt& p0_it, ListPolyIt& p2_it, const int64_t shortcut_length)

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -839,6 +839,9 @@ public:
 
     /*!
      * Intersect polylines with this area Polygons object.
+     * 
+     * \warning Should never be called on polylines which have several collinear segments.
+     * Call \ref splitPolylinesIntoSegments first!
      */
     Polygons intersectionPolyLines(const Polygons& polylines) const;
 

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -828,18 +828,6 @@ public:
      */
     Polygons intersectionPolyLines(const Polygons& polylines) const;
 
-    /*!
-     * Clips input line segments by this Polygons.
-     * \param other Input line segments to be cropped
-     * \param segment_tree the resulting interior line segments
-     */
-    void lineSegmentIntersection(const Polygons& other, ClipperLib::PolyTree& segment_tree) const
-    {
-        ClipperLib::Clipper clipper(clipper_init);
-        clipper.AddPaths(paths, ClipperLib::ptClip, true);
-        clipper.AddPaths(other.paths, ClipperLib::ptSubject, false);
-        clipper.Execute(ClipperLib::ctIntersection, segment_tree);
-    }
     Polygons xorPolygons(const Polygons& other) const
     {
         Polygons ret;
@@ -1050,11 +1038,6 @@ private:
     void removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, const bool remove_holes, Polygons& ret) const;
     void splitIntoParts_processPolyTreeNode(ClipperLib::PolyNode* node, std::vector<PolygonsPart>& ret) const;
 
-    /*!
-     * Convert a node from a ClipperLib::PolyTree and add it to a Polygons object,
-     * which uses ClipperLib::Paths instead of ClipperLib::PolyTree
-     */
-    void addPolyTreeNodeRecursive(const ClipperLib::PolyNode& node);
 public:
     /*!
      * Split up the polygons into groups according to the even-odd rule.

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -104,6 +104,16 @@ public:
         return path->end();
     }
 
+    ClipperLib::Path::const_reverse_iterator rbegin() const
+    {
+        return path->rbegin();
+    }
+
+    ClipperLib::Path::const_reverse_iterator rend() const
+    {
+        return path->rend();
+    }
+
     ClipperLib::Path::const_reference front() const
     {
         return path->front();
@@ -374,6 +384,12 @@ public:
     void reserve(size_t min_size)
     {
         path->reserve(min_size);
+    }
+
+    template <class iterator>
+    ClipperLib::Path::iterator insert(ClipperLib::Path::const_iterator pos, iterator first, iterator last)
+    {
+        return path->insert(pos, first, last);
     }
 
     PolygonRef& operator=(const ConstPolygonRef& other) =delete; // polygon assignment is expensive and probably not what you want when you use the assignment operator

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -656,6 +656,11 @@ public:
         return paths.size();
     }
 
+    void set(const ClipperLib::Paths& new_paths)
+    {
+        paths = new_paths;
+    }
+
     /*!
      * Convenience function to check if the polygon has no points.
      *

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -104,6 +104,11 @@ public:
         return path->end();
     }
 
+    ClipperLib::Path::const_reference front() const
+    {
+        return path->front();
+    }
+
     ClipperLib::Path::const_reference back() const
     {
         return path->back();
@@ -127,11 +132,16 @@ public:
 
     Polygons offset(int distance, ClipperLib::JoinType joinType = ClipperLib::jtMiter, double miter_limit = 1.2) const;
 
-    int64_t polygonLength() const
+    coord_t polygonLength() const
     {
-        int64_t length = 0;
-        Point p0 = (*path)[path->size()-1];
-        for(unsigned int n=0; n<path->size(); n++)
+        return polylineLength() + vSize(path->front() - path->back());
+    }
+
+    coord_t polylineLength() const
+    {
+        coord_t length = 0;
+        Point p0 = path->front();
+        for (unsigned int n = 1; n < path->size(); n++)
         {
             Point p1 = (*path)[n];
             length += vSize(p0 - p1);
@@ -391,6 +401,11 @@ public:
     ClipperLib::Path::iterator end()
     {
         return path->end();
+    }
+
+    ClipperLib::Path::reference front()
+    {
+        return path->front();
     }
 
     ClipperLib::Path::reference back()
@@ -719,6 +734,14 @@ public:
     {
         paths.emplace_back();
         return PolygonRef(paths.back());
+    }
+    PolygonRef front()
+    {
+        return PolygonRef(paths.front());
+    }
+    ConstPolygonRef front() const
+    {
+        return ConstPolygonRef(paths.front());
     }
     PolygonRef back()
     {
@@ -1149,15 +1172,9 @@ public:
     coord_t polygonLength() const
     {
         coord_t length = 0;
-        for(unsigned int i=0; i<paths.size(); i++)
+        for (ConstPolygonRef poly : *this)
         {
-            Point p0 = paths[i][paths[i].size()-1];
-            for(unsigned int n=0; n<paths[i].size(); n++)
-            {
-                Point p1 = paths[i][n];
-                length += vSize(p0 - p1);
-                p0 = p1;
-            }
+            length += poly.polygonLength();
         }
         return length;
     }

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -160,6 +160,20 @@ public:
         return length;
     }
 
+    /*!
+     * Split these poly line objects into several line segment objects consisting of only two verts
+     * and store them in the \p result
+     */
+    void splitPolylineIntoSegments(Polygons& result) const;
+    Polygons splitPolylineIntoSegments() const;
+
+    /*!
+     * Split these polygon objects into several line segment objects consisting of only two verts
+     * and store them in the \p result
+     */
+    void splitPolygonIntoSegments(Polygons& result) const;
+    Polygons splitPolygonIntoSegments() const;
+
     bool shorterThan(const coord_t check_length) const;
 
     Point min() const
@@ -827,6 +841,20 @@ public:
      * Intersect polylines with this area Polygons object.
      */
     Polygons intersectionPolyLines(const Polygons& polylines) const;
+
+    /*!
+     * Split this poly line object into several line segment objects
+     * and store them in the \p result
+     */
+    void splitPolylinesIntoSegments(Polygons& result) const;
+    Polygons splitPolylinesIntoSegments() const;
+
+    /*!
+     * Split this polygon object into several line segment objects
+     * and store them in the \p result
+     */
+    void splitPolygonsIntoSegments(Polygons& result) const;
+    Polygons splitPolygonsIntoSegments() const;
 
     Polygons xorPolygons(const Polygons& other) const
     {

--- a/src/utils/polygonUtils.h
+++ b/src/utils/polygonUtils.h
@@ -85,21 +85,6 @@ struct GivenDistPoint
     int pos; //!< Index to the first point in the polygon of the line segment on which the result was found
 };
 
-/*!
- * Locator to extract a line segment out of a \ref PolygonsPointIndex
- */
-struct PolygonsPointIndexSegmentLocator
-{
-    std::pair<Point, Point> operator()(const PolygonsPointIndex& val) const
-    {
-        ConstPolygonRef poly = (*val.polygons)[val.poly_idx];
-        Point start = poly[val.point_idx];
-        unsigned int next_point_idx = (val.point_idx + 1) % poly.size();
-        Point end = poly[next_point_idx];
-        return std::pair<Point, Point>(start, end);
-    }
-};
-
 typedef SparseLineGrid<PolygonsPointIndex, PolygonsPointIndexSegmentLocator> LocToLineGrid;
 
 class PolygonUtils 

--- a/tests/ClipperTest.cpp
+++ b/tests/ClipperTest.cpp
@@ -3,10 +3,12 @@
 
 #include <gtest/gtest.h>
 
-#include "../src/utils/polygon.h"
+#include "clipper.hpp"
+#include <math.h>
 
 // #define TEST_INFILL_SVG_OUTPUT
 #ifdef TEST_INFILL_SVG_OUTPUT
+#include "../src/utils/polygon.h"
 #include <cstdlib>
 #include "../src/utils/SVG.h"
 #endif //TEST_INFILL_SVG_OUTPUT
@@ -17,7 +19,13 @@ namespace cura
 class ClipperTest : public testing::Test
 {
 public:
+    using Paths = ClipperLib::Paths;
+    using Path = ClipperLib::Path;
+    using coord_t = ClipperLib::cInt;
+    using Point = ClipperLib::IntPoint;
 
+    std::vector<Paths> all_outlines;
+    std::vector<Paths> all_polylines;
 
     ClipperTest()
     {
@@ -25,110 +33,123 @@ public:
 
     void SetUp()
     {
+        
+        {
+            all_outlines.emplace_back();
+            all_outlines.back().emplace_back();
+            Path& outline = all_outlines.back().back();
+            outline.emplace_back(1100, 500);
+            outline.emplace_back(500, 500);
+            outline.emplace_back(500, 400);
+            outline.emplace_back(1100, 400);
+            
+            all_polylines.emplace_back();
+            all_polylines.back().emplace_back();
+            Path& polyline = all_polylines.back().back();
+            polyline.emplace_back(1075, 425);
+            polyline.emplace_back(672, 425 );
+            polyline.emplace_back(651, 425 );
+            polyline.emplace_back(595, 424 );
+            polyline.emplace_back(617, 437 );
+        }
+        {
+            all_outlines.emplace_back();
+            all_outlines.back().emplace_back();
+            Path& outline = all_outlines.back().back();
+            outline.emplace_back(1000, 1100);
+            outline.emplace_back(300, 1100);
+            outline.emplace_back(200, 1000);
+            outline.emplace_back(1000, 1000);
+            
+            all_polylines.emplace_back();
+            all_polylines.back().emplace_back();
+            Path& polyline = all_polylines.back().back();
+            polyline.emplace_back(992, 1050);
+            polyline.emplace_back(617, 1049);
+            polyline.emplace_back(660, 1074);
+            polyline.emplace_back(617, 1049);
+            polyline.emplace_back(582, 1049);
+            polyline.emplace_back(538, 1074);
+        }
     }
 
     void TearDown()
     {
     }
+    
+    static Paths intersectPolylines(const Paths& outlines, const Paths& polylines);
+
+    static coord_t sq(coord_t i) { return i*i; };
+
+    static coord_t calculateLength(const Paths& polylines);
+
+    static void outputSVG(const Paths& outlines, const Paths& polylines, const Paths& intersected, const char* filename);
 };
 
-TEST_F(ClipperTest, PolylinesTest)
+ClipperTest::Paths ClipperTest::intersectPolylines(const Paths& outlines, const Paths& polylines)
 {
-
-    auto sq = [](int i) { return i*i; };
-    
-    ClipperLib::Paths outlines;
-    {
-        outlines.emplace_back();
-        ClipperLib::Path& outline = outlines.back();
-        outline.emplace_back(1100, 500);
-        outline.emplace_back(500, 500);
-        outline.emplace_back(500, 400);
-        outline.emplace_back(1100, 400);
-        
-//         outline.emplace_back(1000, 1100);
-//         outline.emplace_back(300, 1100);
-//         outline.emplace_back(200, 1000);
-//         outline.emplace_back(1000, 1000);
-    }
-    
-    ClipperLib::Paths polylines;
-    {
-        polylines.emplace_back();
-        ClipperLib::Path& polyline = polylines.back();
-        polyline.emplace_back(1075, 425);
-        polyline.emplace_back(672, 425 );
-        polyline.emplace_back(651, 425 );
-        polyline.emplace_back(595, 424 );
-        polyline.emplace_back(617, 437 );
-        // old ^
-        
-        
-//         polyline.emplace_back(992, 1050);
-//         polyline.emplace_back(617, 1049);
-//         polyline.emplace_back(660, 1074);
-//         polyline.emplace_back(617, 1049);
-//         polyline.emplace_back(582, 1049);
-//         polyline.emplace_back(538, 1074);
-    }
     ClipperLib::PolyTree result_tree;
     ClipperLib::Clipper clipper(0);
     clipper.AddPaths(polylines, ClipperLib::ptSubject, false);
     clipper.AddPaths(outlines, ClipperLib::ptClip, true);
     clipper.Execute(ClipperLib::ctIntersection, result_tree);
-    ClipperLib::Paths result;
+    Paths result;
     ClipperLib::PolyTreeToPaths(result_tree, result);
-
-    coord_t original_polyline_length = 0;
-    for (ClipperLib::Path path : polylines)
-    {
-        Point* last = nullptr;
-        for (Point& p : path)
-        {
-            if (last)
-            {
-                original_polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
-            }
-            last = &p;
-        }
-    }
-
-    coord_t intersected_polyline_length = 0;
-    for (ClipperLib::Path path : result)
-    {
-        Point* last = nullptr;
-        for (Point& p : path)
-        {
-            if (last)
-            {
-                intersected_polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
-            }
-            last = &p;
-        }
-    }
-
-    
-    
-#ifdef TEST_INFILL_SVG_OUTPUT
-    {
-        Polygons outs;
-        outs.paths = outlines;
-        Polygons lines;
-        lines.paths = polylines;
-        Polygons lines_after;
-        lines_after.paths = result;
-        SVG svg("/tmp/problem.svg", AABB(outs));
-        svg.writePolygons(outs, SVG::Color::BLACK);
-        svg.nextLayer();
-        svg.writePolylines(lines_after, SVG::Color::RED);
-        svg.nextLayer();
-        svg.writePolylines(lines, SVG::Color::GREEN);
-    }
-#endif // TEST_INFILL_SVG_OUTPUT
-    
-    
-    assert(intersected_polyline_length == original_polyline_length);
+    return result;
 }
+
+ClipperTest::coord_t ClipperTest::calculateLength(const Paths& polylines)
+{
+    coord_t polyline_length = 0;
+    for (const Path& path : polylines)
+    {
+        const Point* last = nullptr;
+        for (const Point& p : path)
+        {
+            if (last)
+            {
+                polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
+            }
+            last = &p;
+        }
+    }
+    return polyline_length;
+}
+
+
+TEST_F(ClipperTest, PolylinesTest1)
+{
+    Paths intersected = intersectPolylines(all_outlines[0], all_polylines[0]);
+    outputSVG(all_outlines[0], all_polylines[0], intersected, "/tmp/clipper_test_0");
+    ASSERT_EQ(calculateLength(intersected), calculateLength(all_polylines[0]));
+}
+
+TEST_F(ClipperTest, PolylinesTest2)
+{
+    Paths intersected = intersectPolylines(all_outlines[1], all_polylines[1]);
+    outputSVG(all_outlines[1], all_polylines[1], intersected, "/tmp/clipper_test_1");
+    ASSERT_EQ(calculateLength(intersected), calculateLength(all_polylines[1]));
+}
+
+    
+    
+void ClipperTest::outputSVG(const Paths& outlines, const Paths& polylines, const Paths& intersected, const char* filename)
+{
+#ifdef TEST_INFILL_SVG_OUTPUT
+    Polygons outs;
+    outs.set(outlines);
+    Polygons lines;
+    lines.set(polylines);
+    Polygons lines_after;
+    lines_after.set(intersected);
+    SVG svg(filename, AABB(outs));
+    svg.writePolygons(outs, SVG::Color::BLACK);
+    svg.nextLayer();
+    svg.writePolylines(lines_after, SVG::Color::RED);
+    svg.nextLayer();
+    svg.writePolylines(lines, SVG::Color::GREEN);
+#endif // TEST_INFILL_SVG_OUTPUT
+}    
 
 
 } //namespace cura

--- a/tests/ClipperTest.cpp
+++ b/tests/ClipperTest.cpp
@@ -1,0 +1,134 @@
+//Copyright (c) 2020 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include <gtest/gtest.h>
+
+#include "../src/utils/polygon.h"
+
+// #define TEST_INFILL_SVG_OUTPUT
+#ifdef TEST_INFILL_SVG_OUTPUT
+#include <cstdlib>
+#include "../src/utils/SVG.h"
+#endif //TEST_INFILL_SVG_OUTPUT
+
+namespace cura
+{
+
+class ClipperTest : public testing::Test
+{
+public:
+
+
+    ClipperTest()
+    {
+    }
+
+    void SetUp()
+    {
+    }
+
+    void TearDown()
+    {
+    }
+};
+
+TEST_F(ClipperTest, PolylinesTest)
+{
+
+    auto sq = [](int i) { return i*i; };
+    
+    ClipperLib::Paths outlines;
+    {
+        outlines.emplace_back();
+        ClipperLib::Path& outline = outlines.back();
+        outline.emplace_back(1100, 500);
+        outline.emplace_back(500, 500);
+        outline.emplace_back(500, 400);
+        outline.emplace_back(1100, 400);
+        
+//         outline.emplace_back(1000, 1100);
+//         outline.emplace_back(300, 1100);
+//         outline.emplace_back(200, 1000);
+//         outline.emplace_back(1000, 1000);
+    }
+    
+    ClipperLib::Paths polylines;
+    {
+        polylines.emplace_back();
+        ClipperLib::Path& polyline = polylines.back();
+        polyline.emplace_back(1075, 425);
+        polyline.emplace_back(672, 425 );
+        polyline.emplace_back(651, 425 );
+        polyline.emplace_back(595, 424 );
+        polyline.emplace_back(617, 437 );
+        // old ^
+        
+        
+//         polyline.emplace_back(992, 1050);
+//         polyline.emplace_back(617, 1049);
+//         polyline.emplace_back(660, 1074);
+//         polyline.emplace_back(617, 1049);
+//         polyline.emplace_back(582, 1049);
+//         polyline.emplace_back(538, 1074);
+    }
+    ClipperLib::PolyTree result_tree;
+    ClipperLib::Clipper clipper(0);
+    clipper.AddPaths(polylines, ClipperLib::ptSubject, false);
+    clipper.AddPaths(outlines, ClipperLib::ptClip, true);
+    clipper.Execute(ClipperLib::ctIntersection, result_tree);
+    ClipperLib::Paths result;
+    ClipperLib::PolyTreeToPaths(result_tree, result);
+
+    coord_t original_polyline_length = 0;
+    for (ClipperLib::Path path : polylines)
+    {
+        Point* last = nullptr;
+        for (Point& p : path)
+        {
+            if (last)
+            {
+                original_polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
+            }
+            last = &p;
+        }
+    }
+
+    coord_t intersected_polyline_length = 0;
+    for (ClipperLib::Path path : result)
+    {
+        Point* last = nullptr;
+        for (Point& p : path)
+        {
+            if (last)
+            {
+                intersected_polyline_length += std::sqrt(sq(p.X - last->X) + sq(p.Y - last->Y));
+            }
+            last = &p;
+        }
+    }
+
+    
+    
+#ifdef TEST_INFILL_SVG_OUTPUT
+    {
+        Polygons outs;
+        outs.paths = outlines;
+        Polygons lines;
+        lines.paths = polylines;
+        Polygons lines_after;
+        lines_after.paths = result;
+        SVG svg("/tmp/problem.svg", AABB(outs));
+        svg.writePolygons(outs, SVG::Color::BLACK);
+        svg.nextLayer();
+        svg.writePolylines(lines_after, SVG::Color::RED);
+        svg.nextLayer();
+        svg.writePolylines(lines, SVG::Color::GREEN);
+    }
+#endif // TEST_INFILL_SVG_OUTPUT
+    
+    
+    assert(intersected_polyline_length == original_polyline_length);
+}
+
+
+} //namespace cura

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -116,6 +116,8 @@ namespace cura
     const AngleDegrees fill_angle = 0.;
     constexpr coord_t z = 100; // Future improvement: Also take an uneven layer, so we get the alternate.
     constexpr coord_t shift = 0;
+    constexpr coord_t max_resolution = 10;
+    constexpr coord_t max_deviation = 5;
     const std::vector<std::string> polygon_filenames =
     {
         "../tests/resources/polygon_concave.txt",
@@ -166,7 +168,9 @@ namespace cura
             infill_multiplier,
             fill_angle,
             z,
-            shift
+            shift,
+            max_resolution,
+            max_deviation
         ); // There are some optional parameters, but these will do for now (future improvement?).
 
         Polygons result_polygons;

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -258,7 +258,10 @@ namespace cura
 
         const Polygons padded_shape_outline = params.outline_polygons.offset(infill_line_width / 2);
         ASSERT_EQ(padded_shape_outline.intersectionPolyLines(params.result_lines.splitPolylinesIntoSegments()).polyLineLength(), params.result_lines.polyLineLength()) << "Infill (lines) should not be outside target polygon.";
-        ASSERT_EQ(params.result_polygons.difference(padded_shape_outline).area(), 0) << "Infill (polys) should not be outside target polygon.";
+        Polygons result_polygon_lines = params.result_polygons;
+        for (PolygonRef poly : result_polygon_lines)
+            poly.add(poly.front());
+        ASSERT_EQ(padded_shape_outline.intersectionPolyLines(result_polygon_lines.splitPolylinesIntoSegments()).polyLineLength(), result_polygon_lines.polyLineLength()) << "Infill (lines) should not be outside target polygon.";
     }
 
 } //namespace cura

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -245,10 +245,16 @@ namespace cura
         ASSERT_TRUE(params.valid) << params.fail_reason;
         ASSERT_FALSE(params.result_polygons.empty() && params.result_lines.empty()) << "Infill should have been generated.";
 
+        double worst_case_zig_zag_added_area = 0;
+        if (params.params.zig_zagify || params.params.pattern == EFillMethod::ZIG_ZAG)
+        {
+            worst_case_zig_zag_added_area = params.outline_polygons.polygonLength() * infill_line_width;
+        }
+        
         const double min_available_area = std::abs(params.outline_polygons.offset(-params.params.line_distance / 2).area());
-        const double max_available_area = std::abs(params.outline_polygons.offset( params.params.line_distance / 2).area());
+        const double max_available_area = std::abs(params.outline_polygons.offset( params.params.line_distance / 2).area()) + worst_case_zig_zag_added_area;
         const double min_expected_infill_area = (min_available_area * infill_line_width) / params.params.line_distance;
-        const double max_expected_infill_area = (max_available_area * infill_line_width) / params.params.line_distance;
+        const double max_expected_infill_area = (max_available_area * infill_line_width) / params.params.line_distance + worst_case_zig_zag_added_area;
 
         const double out_infill_area = ((params.result_polygons.polygonLength() + params.result_lines.polyLineLength()) * infill_line_width) / getPatternMultiplier(params.params.pattern);
 

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -138,8 +138,10 @@ namespace cura
 
         SVG svgFile(filename.c_str(), aabb);
         svgFile.writePolygons(params.outline_polygons , SVG::Color::BLUE);
-        svgFile.writePolygons(params.result_lines, SVG::Color::RED);
-        svgFile.writePolygons(params.result_polygons, SVG::Color::RED);
+        svgFile.nextLayer();
+        svgFile.writePolylines(params.result_lines, SVG::Color::RED);
+        svgFile.nextLayer();
+        svgFile.writePolygons(params.result_polygons, SVG::Color::MAGENTA);
         // Note: SVG writes 'itself' when the object is destroyed.
     }
 #endif //TEST_INFILL_SVG_OUTPUT
@@ -235,12 +237,13 @@ namespace cura
     TEST_P(InfillTest, TestInfillSanity)
     {
         InfillTestParameters params = GetParam();
-        ASSERT_TRUE(params.valid) << params.fail_reason;
-        ASSERT_FALSE(params.result_polygons.empty() && params.result_lines.empty()) << "Infill should have been generated.";
 
 #ifdef TEST_INFILL_SVG_OUTPUT
         writeTestcaseSVG(params);
 #endif //TEST_INFILL_SVG_OUTPUT
+
+        ASSERT_TRUE(params.valid) << params.fail_reason;
+        ASSERT_FALSE(params.result_polygons.empty() && params.result_lines.empty()) << "Infill should have been generated.";
 
         const double min_available_area = std::abs(params.outline_polygons.offset(-params.params.line_distance / 2).area());
         const double max_available_area = std::abs(params.outline_polygons.offset( params.params.line_distance / 2).area());

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -257,7 +257,7 @@ namespace cura
         ASSERT_LT((coord_t)out_infill_area, (coord_t)max_expected_infill_area) << "Infill area should be less than the maximum area to be covered.";
 
         const Polygons padded_shape_outline = params.outline_polygons.offset(infill_line_width / 2);
-        ASSERT_EQ(padded_shape_outline.intersectionPolyLines(params.result_lines).polyLineLength(), params.result_lines.polyLineLength()) << "Infill (lines) should not be outside target polygon.";
+        ASSERT_EQ(padded_shape_outline.intersectionPolyLines(params.result_lines.splitPolylinesIntoSegments()).polyLineLength(), params.result_lines.polyLineLength()) << "Infill (lines) should not be outside target polygon.";
         ASSERT_EQ(params.result_polygons.difference(padded_shape_outline).area(), 0) << "Infill (polys) should not be outside target polygon.";
     }
 


### PR DESCRIPTION
This PR combines the past few PRs of mine which ar all related to processing polylines.
This concerns polylines in surface mode, but also for all infill patterns.

- the simplify() function is edited so that it can also process polylines
- the pathOrderOptimizer is extended so that it can handle polylines of size > 2
- in various places in the engine we make use of this by actually generating polylines instead of immediately cutting them up into 2 vert segments
- a PolylineStitcher class is introduced which further stitches together polylines into chains
- the chaining functionality which used to be inside pathOrderOptimizer is removed
- simplification is now applied in between chaining and order optimization
- the infill unit test has various bugs fixed
- a new test case showing a bug in clipper is added (which currently **always fails**)
- the modifier mesh functionality has also been applied to surface mode meshes - making it *possible to design and test an infill pattern outside of Cura*

As such this PR has the following advantages:
- surface mode for high poly models can now be printed without constant stuttering
- surface mode doesn't start somewhere in the middle of a polyline anymore, which would leave blobs in the middle of curved surfaces
- connected infill also doesn't start somewhere in the middle of a polyline anymore. I can recall a bug which caused the connections to be printed in the wrong directions sometimes (see below), but I'm not sure that failure mode is still present.
- surface mode meshes can now be used as infill, meaning that people (both internal and external) can more easily prototype a novel infill pattern - without actually implementing it.
- for some models the computation time is considerably reduced (9%)
- for some models the print time is also reduced. (`simplifyPolylines()` removes verts, which removes the need to slow down for a corner there. )
- fixed an issue where surface mode meshes would be printed twice

PS: the zigzag order bug I recall: Left infill line is printed first, right one last.
![image](https://user-images.githubusercontent.com/8895761/100085061-dcfe2480-2e4b-11eb-975a-7083d7b8e7e6.png)
