### PR TITLE
CURA-7876: Disable fuzzy skin in libArachne

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -659,7 +659,7 @@ void FffPolygonGenerator::processDerivedWallsSkinInfill(SliceMeshStorage& mesh)
     SkinInfillAreaComputation::combineInfillLayers(mesh);
 
     // fuzzy skin
-    if (mesh.settings.get<bool>("magic_fuzzy_skin_enabled"))
+    if (mesh.settings.get<bool>("magic_fuzzy_skin_enabled") && false) //TODO make fuzzy skin work with libArachne (CURA-7887) and then re-enable it
     {
         processFuzzyWalls(mesh);
     }
@@ -981,7 +981,7 @@ void FffPolygonGenerator::processPlatformAdhesion(SliceDataStorage& storage)
 
 
 void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
-{
+{//TODO make fuzzy skin work with libArachne (CURA-7887)
     if (mesh.settings.get<size_t>("wall_line_count") == 0)
     {
         return;
@@ -997,7 +997,8 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
         for (SliceLayerPart& part : layer.parts)
         {
             Polygons results;
-            Polygons& skin = (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") == ESurfaceMode::SURFACE)? part.outline : part.insets[0];
+//            Polygons& skin = (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") == ESurfaceMode::SURFACE)? part.outline : part.insets[0]; insets no longer used in libArachne
+            Polygons& skin = part.outline;
             for (PolygonRef poly : skin)
             {
                 if (mesh.settings.get<bool>("magic_fuzzy_skin_outside_only") && poly.area() < 0)


### PR DESCRIPTION
Fuzzy skin will be re-enabled when it is made to work with the new wall_toolpaths.
Until then it will be disabled.

Contributes to CURA-7678 via CURA-7876