### PR TITLE
Replaced insets usage in PathOrderOptimizer for wall_toolpaths

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1299,7 +1299,7 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
 
     const SliceLayer& layer = mesh.layers[gcode_layer.getLayerNr()];
 
-    if (layer.parts.size() == 0)
+    if (layer.parts.empty())
     {
         return;
     }

--- a/src/PathOrderOptimizer.cpp
+++ b/src/PathOrderOptimizer.cpp
@@ -30,9 +30,25 @@ ConstPolygonRef PathOrderOptimizer<const SkinPart*>::getVertexData(const SkinPar
 template<>
 ConstPolygonRef PathOrderOptimizer<const SliceLayerPart*>::getVertexData(const SliceLayerPart* path)
 {
-    if(!path->insets.empty())
+    if(!path->wall_toolpaths.empty())
     {
-        return path->insets[0][0];
+        cached_vertices.emplace_back();
+        Polygon& poly = cached_vertices.back();
+        for (const VariableWidthLines& lines : path->wall_toolpaths)
+        {
+            for (const ExtrusionLine& line : lines)
+            {
+                if (line.inset_idx != 0)
+                {
+                    continue;
+                }
+                for (const ExtrusionJunction& junction : line.junctions)
+                {
+                    poly.add(junction.p);
+                }
+            }
+        }
+        return ConstPolygonRef(poly);
     }
     else
     {


### PR DESCRIPTION
Add mesh layer to GCode used the outer inset to order the paths. This is now done by the outer walls.

Contributes to CURA-7678 and CURA-7881