### PR TITLE
CURA-7884: Remove outline gaps

### DIFF
--- a/src/FffPolygonGenerator.h
+++ b/src/FffPolygonGenerator.h
@@ -81,14 +81,6 @@ private:
     void processBasicWallsSkinInfill(SliceDataStorage& storage, const size_t mesh_order_idx, const std::vector<size_t>& mesh_order, ProgressStageEstimator& inset_skin_progress_estimate);
 
     /*!
-     * Generate areas for the gaps between outer wall and the outline where the first wall doesn't fit.
-     * These areas should be filled with a skin-like pattern, so that these skin lines get combined into one line with gradual changing width.
-     * 
-     * \param[in,out] storage fetches the SliceLayerPart::insets and SliceLayerPart::outline and generates the outline_gaps in SliceLayerPart
-     */
-    void processOutlineGaps(SliceDataStorage& storage);
-
-    /*!
      * Process the mesh to be an infill mesh: limit all outlines to within the infill of normal meshes and subtract their volume from the infill of those meshes
      * 
      * \param storage Input and Output parameter: fetches the outline information (see SliceLayerPart::outline) and generates the other reachable field of the \p storage

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -268,18 +268,6 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr, const LayerIn
             }
         }
     }
-    if (settings.get<bool>("fill_outline_gaps")
-        && settings.get<size_t>("wall_line_count") > 0
-        && settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr == extruder_nr)
-    {
-        for (const SliceLayerPart& part : layer.parts)
-        {
-            if (part.outline_gaps.size() > 0)
-            {
-                return true;
-            }
-        }
-    }
     if ((settings.get<size_t>("wall_line_count") > 1 || settings.get<bool>("alternate_extra_perimeter")) && settings.get<ExtruderTrain&>("wall_x_extruder_nr").extruder_nr == extruder_nr)
     {
         for (const SliceLayerPart& part : layer.parts)

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -50,6 +50,24 @@ const Polygons& SliceLayerPart::getOwnInfillArea() const
     }
 }
 
+bool SliceLayerPart::hasWallAtInsetIndex(size_t inset_idx) const
+{
+    if(!wall_toolpaths.empty())
+    {
+        for (const VariableWidthLines& lines : wall_toolpaths)
+        {
+            for (const ExtrusionLine& line : lines)
+            {
+                if (line.inset_idx == inset_idx)
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 SliceLayer::~SliceLayer()
 {
 }
@@ -240,7 +258,7 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr, const LayerIn
     {
         for (const SliceLayerPart& part : layer.parts)
         {
-            if ((!part.wall_toolpaths.empty() && !part.wall_toolpaths[0].empty()) || (!part.spiral_insets.empty() && !part.spiral_insets[0].empty()))
+            if ((!part.wall_toolpaths.empty() && part.hasWallAtInsetIndex(0)) || (!part.spiral_insets.empty() && !part.spiral_insets[0].empty()))
             {
                 return true;
             }
@@ -272,7 +290,7 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr, const LayerIn
     {
         for (const SliceLayerPart& part : layer.parts)
         {
-            if (part.wall_toolpaths.size() > 1 && !part.wall_toolpaths[1].empty())
+            if (!part.wall_toolpaths.empty() && part.hasWallAtInsetIndex(1))
             {
                 return true;
             }

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -58,7 +58,6 @@ public:
     std::vector<Polygons> insets;         //!< The insets are generated with. The insets are also known as perimeters or the walls.
     std::vector<Polygons> spiral_insets;         //!< Outer insets used in spiralize mode.
     Polygons inner_area; //The area of the outline, minus the walls. This will be filled with either skin or infill.
-    Polygons outline_gaps; //!< The gaps between the outline of the mesh and the first wall. a.k.a. thin walls.
     std::vector<SkinPart> skin_parts;     //!< The skin parts which are filled for 100% with lines and/or insets.
 
     VariableWidthPaths wall_toolpaths;  //!< toolpaths for walls, will replace(?) the insets

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -140,6 +140,13 @@ public:
      * \return the own infill area
      */
     const Polygons& getOwnInfillArea() const;
+
+    /*!
+     * Searches whether the part has any walls in the specified inset index
+     * \param inset_idx The index of the wall
+     * \return true if there is at least one ExtrusionLine at the specified wall index, false otherwise
+     */
+    bool hasWallAtInsetIndex(size_t inset_idx) const;
 };
 
 /*!


### PR DESCRIPTION
LibArachne, contrary to the insets, handles the outline gaps through the widening beading strategy.
Therefore, there is no need any more to process them individually, as there will be no gaps left
when "Print Thin Walls" is enabled and the widening beading takes over.

This PR removes the whole outline_gaps for that reason. It also fixes the part that checks whether a 
wall at a specific inset index exists inside the libArachne-generated wall_toolpaths.

Contributes to CURA-7678 via CURA-7884