### PR TITLE
Cura 7880 remove inset usage from pathorderoptimizer

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1299,7 +1299,7 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
 
     const SliceLayer& layer = mesh.layers[gcode_layer.getLayerNr()];
 
-    if (layer.parts.size() == 0)
+    if (layer.parts.empty())
     {
         return;
     }

--- a/src/PathOrderOptimizer.cpp
+++ b/src/PathOrderOptimizer.cpp
@@ -30,9 +30,25 @@ ConstPolygonRef PathOrderOptimizer<const SkinPart*>::getVertexData(const SkinPar
 template<>
 ConstPolygonRef PathOrderOptimizer<const SliceLayerPart*>::getVertexData(const SliceLayerPart* path)
 {
-    if(!path->insets.empty())
+    if(!path->wall_toolpaths.empty())
     {
-        return path->insets[0][0];
+        cached_vertices.emplace_back();
+        Polygon& poly = cached_vertices.back();
+        for (const VariableWidthLines& lines : path->wall_toolpaths)
+        {
+            for (const ExtrusionLine& line : lines)
+            {
+                if (line.inset_idx != 0)
+                {
+                    continue;
+                }
+                for (const ExtrusionJunction& junction : line.junctions)
+                {
+                    poly.add(junction.p);
+                }
+            }
+        }
+        return ConstPolygonRef(poly);
     }
     else
     {

--- a/src/PathOrderOptimizer.cpp
+++ b/src/PathOrderOptimizer.cpp
@@ -31,28 +31,7 @@ ConstPolygonRef PathOrderOptimizer<const SkinPart*>::getVertexData(const SkinPar
 template<>
 ConstPolygonRef PathOrderOptimizer<const SliceLayerPart*>::getVertexData(const SliceLayerPart* path)
 {
-    if(!path->wall_toolpaths.empty())
-    {
-        Polygons poly;
-        // Assuming the first wall tool path is always the outer wall
-        VariableWidthPaths outer_wall { path->wall_toolpaths.front() };
-
-        // Half the minimum wall line width, should be the minimum required stitch distance
-        const coord_t stitch_distance = std::min_element(outer_wall.back().cbegin(), outer_wall.back().cend(),
-                                       [](const ExtrusionLine& l, const ExtrusionLine& r)
-                                       {
-                                           return l.getWidth() < r.getWidth();
-                                       })->getWidth() / 2;
-
-        // Stitch the outer_wall contour to a polygon and store it in the cached vertices
-        WallToolPaths::stitchContours(outer_wall, stitch_distance, poly);
-        cached_vertices.emplace_back(poly.back());
-        return ConstPolygonRef(cached_vertices.back());
-    }
-    else
-    {
-        return path->outline.outerPolygon();
-    }
+    return path->outline.outerPolygon();
 }
 
 template<>

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -79,6 +79,11 @@ const VariableWidthPaths& WallToolPaths::generate()
     simplifyToolPaths(toolpaths, settings);
 
     removeEmptyToolPaths(toolpaths);
+    assert(std::is_sorted(toolpaths.cbegin(), toolpaths.cend(),
+                          [](const VariableWidthLines& l, const VariableWidthLines& r)
+                          {
+                              return l.front().inset_idx < r.front().inset_idx;
+                          }) && "WallToolPaths should be sorted from the outer 0th to inner_walls");
     toolpaths_generated = true;
     return toolpaths;
 }
@@ -166,7 +171,7 @@ bool WallToolPaths::removeEmptyToolPaths(VariableWidthPaths& toolpaths)
     return toolpaths.empty();
 }
 
-void WallToolPaths::stitchContours(const VariableWidthPaths& input, const coord_t stitch_distance, Polygons& output) const
+void WallToolPaths::stitchContours(const VariableWidthPaths& input, const coord_t stitch_distance, Polygons& output)
 {
     //Create a bucket grid to find endpoints that are close together.
     struct ExtrusionLineStartLocator

--- a/src/WallToolPaths.h
+++ b/src/WallToolPaths.h
@@ -75,7 +75,6 @@ public:
      */
     static bool removeEmptyToolPaths(VariableWidthPaths& toolpaths);
 
-protected:
     /*!
      * Stitches toolpaths together to form contours.
      *
@@ -90,8 +89,9 @@ protected:
      * stitched together. An additional line segment will bridge the gap.
      * \param output Where to store the output polygons.
      */
-    void stitchContours(const VariableWidthPaths& input, const coord_t stitch_distance, Polygons& output) const;
+    static void stitchContours(const VariableWidthPaths& input, const coord_t stitch_distance, Polygons& output) ;
 
+protected:
     /*!
      * Simplifies the variable-width toolpaths by calling the simplify on every line in the toolpath using the provided
      * settings.

--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -23,6 +23,11 @@ coord_t ExtrusionLine::getLength() const
     return len;
 }
 
+coord_t ExtrusionLine::getWidth() const
+{
+    return junctions.front().w;
+}
+
 void ExtrusionLine::appendJunctionsTo(LineJunctions& result) const
 {
     result.insert(result.end(), junctions.begin(), junctions.end());

--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -1,6 +1,8 @@
 //Copyright (c) 2020 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
+#include <algorithm>
+
 #include "ExtrusionLine.h"
 #include "linearAlg2D.h"
 
@@ -23,9 +25,13 @@ coord_t ExtrusionLine::getLength() const
     return len;
 }
 
-coord_t ExtrusionLine::getWidth() const
+coord_t ExtrusionLine::getMinimalWidth() const
 {
-    return junctions.front().w;
+    return std::min_element(junctions.cbegin(), junctions.cend(),
+                            [](const ExtrusionJunction& l, const ExtrusionJunction& r)
+                            {
+                                return l.w < r.w;
+                            })->w;
 }
 
 void ExtrusionLine::appendJunctionsTo(LineJunctions& result) const

--- a/src/utils/ExtrusionLine.h
+++ b/src/utils/ExtrusionLine.h
@@ -61,6 +61,11 @@ struct ExtrusionLine
     coord_t getLength() const;
 
     /*!
+     * Get the width of this path
+     */
+    coord_t getWidth() const;
+
+    /*!
      * Export the included junctions as vector.
      */
     void appendJunctionsTo(LineJunctions& result) const;

--- a/src/utils/ExtrusionLine.h
+++ b/src/utils/ExtrusionLine.h
@@ -61,9 +61,9 @@ struct ExtrusionLine
     coord_t getLength() const;
 
     /*!
-     * Get the width of this path
+     * Get the minimal width of this path
      */
-    coord_t getWidth() const;
+    coord_t getMinimalWidth() const;
 
     /*!
      * Export the included junctions as vector.


### PR DESCRIPTION
The original idea, was to return a stitched Polygon from the outer wall toolpath.
This is an expensive operation. After a short discussion with
@Ghostkeeper we came to the conclusion that this level of accuracy isn't
 needed. It now returns just the outerPolygon.

Three remnants of commit 79a0abb are kept:
We are often assuming that the outer wall_toolpath is the 0th index of
the generated wall_toolpaths after generation, an assert was added, to
check if that is indeed the case.

The stitchContours function is made static and exposed to public,
since this is typically a function that will be used to obtain the
polygon contour of an wall_toolpath in other scenario's. Exposing this
doesn't hurt i.m.o. and will help in the future.

Exposing the width of the ExtrusionLine by taking the width of the first
junction (assuming all junctions have the same width in a line) is also
a valuable addition i.m.o.