### PR TITLE
Implement new specialised settings for variable line width

### DIFF
--- a/src/BeadingStrategy/BeadingStrategyFactory.cpp
+++ b/src/BeadingStrategy/BeadingStrategyFactory.cpp
@@ -54,15 +54,15 @@ coord_t get_weighted_average(const coord_t preferred_bead_width_outer, const coo
     return preferred_bead_width_outer;
 }
 
-BeadingStrategy* BeadingStrategyFactory::makeStrategy(const StrategyType type, const coord_t preferred_bead_width_outer, const coord_t preferred_bead_width_inner, const coord_t preferred_transition_length, const float transitioning_angle, const bool print_thin_walls, const coord_t min_bead_width, const coord_t min_feature_size, const coord_t max_bead_count)
+BeadingStrategy* BeadingStrategyFactory::makeStrategy(const StrategyType type, const coord_t preferred_bead_width_outer, const coord_t preferred_bead_width_inner, const coord_t preferred_transition_length, const float transitioning_angle, const bool print_thin_walls, const coord_t min_bead_width, const coord_t min_feature_size, const Ratio wall_transition_threshold, const coord_t max_bead_count)
 {
     const coord_t bar_preferred_wall_width = get_weighted_average(preferred_bead_width_outer, preferred_bead_width_inner, max_bead_count);
     BeadingStrategy* ret = nullptr;
     switch (type)
     {
-        case StrategyType::Center:             ret = new CenterDeviationBeadingStrategy(bar_preferred_wall_width, transitioning_angle);       break;
-        case StrategyType::Distributed:        ret = new DistributedBeadingStrategy(bar_preferred_wall_width, preferred_transition_length, transitioning_angle);     break;
-        case StrategyType::InwardDistributed:  ret = new InwardDistributedBeadingStrategy(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, inward_distributed_center_size);  break;
+        case StrategyType::Center:             ret = new CenterDeviationBeadingStrategy(bar_preferred_wall_width, transitioning_angle, wall_transition_threshold);       break;
+        case StrategyType::Distributed:        ret = new DistributedBeadingStrategy(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, wall_transition_threshold);     break;
+        case StrategyType::InwardDistributed:  ret = new InwardDistributedBeadingStrategy(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, wall_transition_threshold, inward_distributed_center_size);  break;
         default:
             logError("Cannot make strategy!\n");
             return nullptr;

--- a/src/BeadingStrategy/BeadingStrategyFactory.h
+++ b/src/BeadingStrategy/BeadingStrategyFactory.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include "../settings/types/Ratio.h"
 #include "../utils/optional.h"  // until the move to C++17
 
 #include "BeadingStrategy.h"
@@ -39,6 +40,7 @@ public:
         const bool print_thin_walls = false,
         const coord_t min_bead_width = 0,
         const coord_t min_feature_size = 0,
+        const Ratio wall_transition_thresold = 0.5_r,
         const coord_t max_bead_count = 0);
 };
 

--- a/src/BeadingStrategy/BeadingStrategyFactory.h
+++ b/src/BeadingStrategy/BeadingStrategyFactory.h
@@ -34,7 +34,7 @@ public:
     static BeadingStrategy* makeStrategy(const StrategyType type,
         const coord_t preferred_bead_width_outer = MM2INT(0.5),
         const coord_t preferred_bead_width_inner = MM2INT(0.5),
-        const coord_t preferred_transition_length = 400,
+        const coord_t preferred_transition_length = MM2INT(0.4),
         const float transitioning_angle = M_PI_4,
         const bool print_thin_walls = false,
         const coord_t min_bead_width = 0,

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
@@ -25,7 +25,7 @@ public:
     CenterDeviationBeadingStrategy(const coord_t pref_bead_width, const AngleRadians transitioning_angle, const Ratio wall_transition_threshold)
     : BeadingStrategy(pref_bead_width, pref_bead_width / 2, transitioning_angle)
     , overfill_bound(pref_bead_width * (1.0f - wall_transition_threshold))
-    , underfill_bound(pref_bead_width * (1.0f / wall_transition_threshold - 1.0f))
+    , underfill_bound(pref_bead_width * (1.0f - (wall_transition_threshold * 0.95f)))
     {
         name = "CenterDeviationBeadingStrategy";
     }

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
@@ -5,6 +5,7 @@
 #ifndef CENTER_DEVIATION_BEADING_STRATEGY_H
 #define CENTER_DEVIATION_BEADING_STRATEGY_H
 
+#include "../settings/types/Ratio.h" //For the wall transition threshold.
 #include "BeadingStrategy.h"
 
 namespace cura
@@ -21,10 +22,10 @@ class CenterDeviationBeadingStrategy : public BeadingStrategy
     coord_t overfill_bound; // Amount of overfill before the two innermost beads are replaced by a single in the middle.
     coord_t underfill_bound; // Amount of underfil before a single bead in the middle is placed
 public:
-    CenterDeviationBeadingStrategy(const coord_t pref_bead_width, float transitioning_angle, float min_diameter = 0.8, float max_diameter = 1.25)
+    CenterDeviationBeadingStrategy(const coord_t pref_bead_width, const AngleRadians transitioning_angle, const Ratio wall_transition_threshold)
     : BeadingStrategy(pref_bead_width, pref_bead_width / 2, transitioning_angle)
-    , overfill_bound(pref_bead_width * (1.0f - min_diameter))
-    , underfill_bound(pref_bead_width * (max_diameter - 1.0f))
+    , overfill_bound(pref_bead_width * (1.0f - wall_transition_threshold))
+    , underfill_bound(pref_bead_width * (1.0f / wall_transition_threshold - 1.0f))
     {
         name = "CenterDeviationBeadingStrategy";
     }

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -35,7 +35,7 @@ namespace cura
 
     coord_t DistributedBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
     {
-        return lower_bead_count * optimal_width + optimal_width / 2; // TODO: doesnt take min and max width into account
+        return lower_bead_count * optimal_width + optimal_width * wall_transition_threshold;
     }
 
     coord_t DistributedBeadingStrategy::getOptimalBeadCount(coord_t thickness) const

--- a/src/BeadingStrategy/DistributedBeadingStrategy.h
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.h
@@ -4,6 +4,7 @@
 #ifndef DISTRIBUTED_BEADING_STRATEGY_H
 #define DISTRIBUTED_BEADING_STRATEGY_H
 
+#include "../settings/types/Ratio.h" //For the wall transition threshold.
 #include "BeadingStrategy.h"
 
 namespace cura
@@ -16,9 +17,17 @@ namespace cura
  */
 class DistributedBeadingStrategy : public BeadingStrategy
 {
+private:
+    /*!
+     * Threshold line width at which it will use fewer, wider lines instead of
+     * reducing the line width further.
+     */
+    Ratio wall_transition_threshold;
+
 public:
-    DistributedBeadingStrategy(const coord_t optimal_width, coord_t default_transition_length, float transitioning_angle)
+    DistributedBeadingStrategy(const coord_t optimal_width, const coord_t default_transition_length, const AngleRadians transitioning_angle, const Ratio wall_transition_threshold)
     : BeadingStrategy(optimal_width, default_transition_length, transitioning_angle)
+    , wall_transition_threshold(wall_transition_threshold)
     {
         name = "DistributedBeadingStrategy";
     }

--- a/src/BeadingStrategy/InwardDistributedBeadingStrategy.h
+++ b/src/BeadingStrategy/InwardDistributedBeadingStrategy.h
@@ -25,8 +25,8 @@ public:
     /*!
      * \param distribution_radius the radius (in number of beads) over which to distribute the discrepancy between the feature size and the optimal thickness
      */
-    InwardDistributedBeadingStrategy(const coord_t optimal_width, coord_t default_transition_length, float transitioning_angle, float distribution_radius)
-    : DistributedBeadingStrategy(optimal_width, default_transition_length, transitioning_angle)
+    InwardDistributedBeadingStrategy(const coord_t optimal_width, const coord_t default_transition_length, const AngleRadians transitioning_angle, const Ratio wall_transition_threshold, const float distribution_radius)
+    : DistributedBeadingStrategy(optimal_width, default_transition_length, transitioning_angle, wall_transition_threshold)
     , one_over_distribution_radius_squared(1.0f / distribution_radius * 1.0f / distribution_radius)
     {
         name = "InwardDistributedBeadingStrategy";

--- a/src/SkeletalTrapezoidation.h
+++ b/src/SkeletalTrapezoidation.h
@@ -98,9 +98,9 @@ public:
     SkeletalTrapezoidation(const Polygons& polys, 
                            const BeadingStrategy& beading_strategy,
                            AngleRadians transitioning_angle
-    , coord_t discretization_step_size = 200
-    , coord_t transition_filter_dist = 1000
-    , coord_t beading_propagation_transition_dist = 400);
+    , coord_t discretization_step_size = MM2INT(0.8)
+    , coord_t transition_filter_dist = MM2INT(1)
+    , coord_t beading_propagation_transition_dist = MM2INT(0.4));
 
     /*!
      * A skeletal graph through the polygons that we need to fill with beads.

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -67,10 +67,11 @@ const VariableWidthPaths& WallToolPaths::generate()
     if (prepared_outline.area() > 0)
     {
         const coord_t wall_transition_length = settings.get<coord_t>("wall_transition_length");
+        const Ratio wall_transition_threshold = settings.get<Ratio>("wall_transition_threshold");
         const size_t max_bead_count = 2 * inset_count;
         const auto beading_strat = std::unique_ptr<BeadingStrategy>(BeadingStrategyFactory::makeStrategy(
             strategy_type, bead_width_0, bead_width_x, wall_transition_length, transitioning_angle, print_thin_walls, min_bead_width,
-            min_feature_size, max_bead_count));
+            min_feature_size, wall_transition_threshold, max_bead_count));
         const coord_t transition_filter_dist = settings.get<coord_t>("wall_transition_filter_distance");
         SkeletalTrapezoidation wall_maker(prepared_outline, *beading_strat, beading_strat->transitioning_angle, discretization_step_size, transition_filter_dist, wall_transition_length);
         wall_maker.generateToolpaths(toolpaths);

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -72,7 +72,7 @@ const VariableWidthPaths& WallToolPaths::generate()
             strategy_type, bead_width_0, bead_width_x, wall_transition_length, transitioning_angle, print_thin_walls, min_bead_width,
             min_feature_size, max_bead_count));
         const coord_t transition_filter_dist = settings.get<coord_t>("wall_transition_filter_distance");
-        SkeletalTrapezoidation wall_maker(prepared_outline, *beading_strat, beading_strat->transitioning_angle, discretization_step_size, transition_filter_dist);
+        SkeletalTrapezoidation wall_maker(prepared_outline, *beading_strat, beading_strat->transitioning_angle, discretization_step_size, transition_filter_dist, wall_transition_length);
         wall_maker.generateToolpaths(toolpaths);
         computeInnerContour();
     }

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -71,7 +71,7 @@ const VariableWidthPaths& WallToolPaths::generate()
         const auto beading_strat = std::unique_ptr<BeadingStrategy>(BeadingStrategyFactory::makeStrategy(
             strategy_type, bead_width_0, bead_width_x, wall_transition_length, transitioning_angle, print_thin_walls, min_bead_width,
             min_feature_size, max_bead_count));
-        const coord_t transition_filter_dist = beading_strat->optimal_width * 5;
+        const coord_t transition_filter_dist = settings.get<coord_t>("wall_transition_filter_distance");
         SkeletalTrapezoidation wall_maker(prepared_outline, *beading_strat, beading_strat->transitioning_angle, discretization_step_size, transition_filter_dist);
         wall_maker.generateToolpaths(toolpaths);
         computeInnerContour();

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -52,7 +52,7 @@ const VariableWidthPaths& WallToolPaths::generate()
     constexpr coord_t smallest_segment = 50;
     constexpr coord_t allowed_distance = 50;
     constexpr coord_t epsilon_offset = (allowed_distance / 2) - 1;
-    constexpr float transitioning_angle = 0.5;
+    const AngleRadians transitioning_angle = settings.get<AngleRadians>("wall_transition_angle");
     constexpr coord_t discretization_step_size = 200;
 
     // Simplify outline for boost::voronoi consumption. Absolutely no self intersections or near-self intersections allowed:

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -53,7 +53,7 @@ const VariableWidthPaths& WallToolPaths::generate()
     constexpr coord_t allowed_distance = 50;
     constexpr coord_t epsilon_offset = (allowed_distance / 2) - 1;
     const AngleRadians transitioning_angle = settings.get<AngleRadians>("wall_transition_angle");
-    constexpr coord_t discretization_step_size = 200;
+    constexpr coord_t discretization_step_size = MM2INT(0.8);
 
     // Simplify outline for boost::voronoi consumption. Absolutely no self intersections or near-self intersections allowed:
     // TODO: Open question: Does this indeed fix all (or all-but-one-in-a-million) cases for manifold but otherwise possibly complex polygons?

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -14,7 +14,6 @@
 
 namespace cura
 {
-constexpr coord_t transition_length_multiplier = 2;
 
 WallToolPaths::WallToolPaths(const Polygons& outline, const coord_t nominal_bead_width, const size_t inset_count,
                              const Settings& settings)
@@ -27,7 +26,6 @@ WallToolPaths::WallToolPaths(const Polygons& outline, const coord_t nominal_bead
     , min_feature_size(settings.get<coord_t>("min_feature_size"))
     , min_bead_width(settings.get<coord_t>("min_bead_width"))
     , small_area_length(INT2MM(static_cast<double>(nominal_bead_width) / 2))
-    , transition_length(transition_length_multiplier * nominal_bead_width)
     , toolpaths_generated(false)
     , settings(settings)
 {
@@ -44,7 +42,6 @@ WallToolPaths::WallToolPaths(const Polygons& outline, const coord_t bead_width_0
     , min_feature_size(settings.get<coord_t>("min_feature_size"))
     , min_bead_width(settings.get<coord_t>("min_bead_width"))
     , small_area_length(INT2MM(static_cast<double>(bead_width_0) / 2))
-    , transition_length(transition_length_multiplier * bead_width_0)
     , toolpaths_generated(false)
     , settings(settings)
 {
@@ -69,9 +66,10 @@ const VariableWidthPaths& WallToolPaths::generate()
 
     if (prepared_outline.area() > 0)
     {
+        const coord_t wall_transition_length = settings.get<coord_t>("wall_transition_length");
         const size_t max_bead_count = 2 * inset_count;
         const auto beading_strat = std::unique_ptr<BeadingStrategy>(BeadingStrategyFactory::makeStrategy(
-            strategy_type, bead_width_0, bead_width_x, transition_length, transitioning_angle, print_thin_walls, min_bead_width,
+            strategy_type, bead_width_0, bead_width_x, wall_transition_length, transitioning_angle, print_thin_walls, min_bead_width,
             min_feature_size, max_bead_count));
         const coord_t transition_filter_dist = beading_strat->optimal_width * 5;
         SkeletalTrapezoidation wall_maker(prepared_outline, *beading_strat, beading_strat->transitioning_angle, discretization_step_size, transition_filter_dist);


### PR DESCRIPTION
These are the implementations of a couple of new settings that tune the precise behaviour of variable line width.

See https://github.com/Ultimaker/Cura/pull/8861 for a description of the new settings, why the defaults are chosen as they are and discussion. Please keep the discussion of the desired behaviour to that ticket rather than here (but of course do review the code here).

Implements CURA-7686.