### PR TITLE
[CURA-7712] Re-enable Z-Seam position settings for 'extra' walls (Skin, Infill).

### DIFF
--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -495,19 +495,6 @@ private:
     bool processSkinPart(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SkinPart& skin_part) const;
 
     /*!
-     * Add the extra skin walls
-     * 
-     * \param[in] storage where the slice data is stored.
-     * \param gcode_layer The initial planning of the gcode of the layer.
-     * \param mesh The mesh for which to add to the layer plan \p gcode_layer.
-     * \param extruder_nr The extruder for which to print all features of the mesh which should be printed with this extruder
-     * \param mesh_config the line config with which to print a print feature
-     * \param skin_part The skin part for which to create gcode
-     * \param[out] added_something Whether this function added anything to the layer plan
-     */
-    void processSkinInsets(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const size_t extruder_nr, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, const VariableWidthPaths& skin_wall_paths, bool& added_something) const;
-
-    /*!
      * Add the roofing which is the area inside the innermost skin inset which has air 'directly' above
      * 
      * Perimeter gaps are generated when the pattern is concentric
@@ -556,6 +543,7 @@ private:
      * \param[in] storage where the slice data is stored.
      * \param gcode_layer The initial planning of the gcode of the layer.
      * \param mesh The mesh for which to add to the layer plan \p gcode_layer.
+     * \param mesh_config The mesh-config for which to add to the layer plan \p gcode_layer.
      * \param extruder_nr The extruder for which to print all features of the mesh which should be printed with this extruder
      * \param area The area to fill
      * \param config the line config with which to print the print feature
@@ -567,7 +555,7 @@ private:
      * \param[out] added_something Whether this function added anything to the layer plan
      * \param fan_speed fan speed override for this skin area
      */
-    void processSkinPrintFeature(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const size_t extruder_nr, const Polygons& area, const GCodePathConfig& config, EFillMethod pattern, const AngleDegrees skin_angle, const coord_t skin_overlap, const Ratio skin_density, Polygons* perimeter_gaps_output, bool& added_something, double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT) const;
+    void processSkinPrintFeature(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const size_t extruder_nr, const Polygons& area, const GCodePathConfig& config, EFillMethod pattern, const AngleDegrees skin_angle, const coord_t skin_overlap, const Ratio skin_density, Polygons* perimeter_gaps_output, bool& added_something, double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT) const;
 
     /*!
      * Add perimeter gaps of a mesh with the given extruder.

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -16,6 +16,13 @@ class LayerPlan;
 class InsetOrderOptimizer
 {
 public:
+    enum class WallType
+    {
+        OUTER_WALL,
+        EXTRA_SKIN,
+        EXTRA_INFILL
+    };
+
     /*!
      * Constructor for inset ordering optimizer.
      *
@@ -33,7 +40,7 @@ public:
      * \param part The part from which to read the previously generated insets.
      * \param layer_nr The current layer number.
      */
-    InsetOrderOptimizer(const FffGcodeWriter& gcode_writer, const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, unsigned int layer_nr);
+    InsetOrderOptimizer(const FffGcodeWriter& gcode_writer, const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const int extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const VariableWidthPaths& paths, unsigned int layer_nr);
 
     /*!
      * Adds the insets to the given layer plan.
@@ -42,7 +49,7 @@ public:
      * class, so this optimize function needs no additional information.
      * \return Whether anything was added to the layer plan.
      */
-    bool optimize();
+    bool optimize(const WallType& wall_type = WallType::OUTER_WALL);
 
 private:
 
@@ -52,7 +59,7 @@ private:
     const SliceMeshStorage& mesh;
     const size_t extruder_nr;
     const PathConfigStorage::MeshPathConfigs& mesh_config;
-    const SliceLayerPart& part;
+    const VariableWidthPaths& paths;
     const unsigned int layer_nr;
     const ZSeamConfig z_seam_config;
     bool added_something;


### PR DESCRIPTION
Mostly just a case of using inset-order optimizer (makes sense, since those walls are insets and they do need optimization of a kind) instead of whatever was used before (mostly just directly dumping the walls to the gcode layer). In order to do that properly, the inset-order-optimizer had to learn how to deal with different wall-types (which comes down to switching what configs are used).

(Note that of course in some cases, the extrusions don't from polygons, so the seam doesn't listen to the z-seam settings.)
