### PR TITLE
CURA-7830: Apply the Outer Wall Inset by regenerating outer toolpath

### DIFF
--- a/src/BeadingStrategy/BeadingStrategyFactory.cpp
+++ b/src/BeadingStrategy/BeadingStrategyFactory.cpp
@@ -41,7 +41,7 @@ std::string to_string(StrategyType type)
 }
 
 
-coord_t get_weighted_average(const coord_t preferred_bead_width_outer, const coord_t preferred_bead_width_inner, const coord_t max_bead_count)
+coord_t getWeightedAverage(const coord_t preferred_bead_width_outer, const coord_t preferred_bead_width_inner, const coord_t max_bead_count)
 {
     if (max_bead_count > 2)
     {
@@ -56,7 +56,8 @@ coord_t get_weighted_average(const coord_t preferred_bead_width_outer, const coo
 
 BeadingStrategy* BeadingStrategyFactory::makeStrategy(const StrategyType type, const coord_t preferred_bead_width_outer, const coord_t preferred_bead_width_inner, const coord_t preferred_transition_length, const float transitioning_angle, const bool print_thin_walls, const coord_t min_bead_width, const coord_t min_feature_size, const Ratio wall_transition_threshold, const coord_t max_bead_count)
 {
-    const coord_t bar_preferred_wall_width = get_weighted_average(preferred_bead_width_outer, preferred_bead_width_inner, max_bead_count);
+    const coord_t bar_preferred_wall_width = getWeightedAverage(preferred_bead_width_outer, preferred_bead_width_inner,
+                                                                max_bead_count);
     BeadingStrategy* ret = nullptr;
     switch (type)
     {

--- a/src/WallToolPaths.h
+++ b/src/WallToolPaths.h
@@ -23,7 +23,7 @@ public:
      * \param inset_count The maximum number of parallel extrusion lines that make up the wall
      * \param settings The settings as provided by the user
      */
-    WallToolPaths(const Polygons& outline, coord_t nominal_bead_width, size_t inset_count, const Settings& settings);
+    WallToolPaths(const Polygons& outline, coord_t nominal_bead_width, size_t inset_count, const Settings& settings, coord_t wall_0_inset = 0);
 
     /*!
      * A class that creates the toolpaths given an outline, nominal bead width and maximum amount of walls
@@ -33,7 +33,7 @@ public:
      * \param inset_count The maximum number of parallel extrusion lines that make up the wall
      * \param settings The settings as provided by the user
      */
-    WallToolPaths(const Polygons& outline, coord_t bead_width_0, coord_t bead_width_x, size_t inset_count, const Settings& settings);
+    WallToolPaths(const Polygons& outline, coord_t bead_width_0, coord_t bead_width_x, size_t inset_count, const Settings& settings, coord_t wall_0_inset = 0);
 
     /*!
      * Generates the Toolpaths
@@ -105,6 +105,7 @@ private:
     coord_t bead_width_0; //<! The nominal or first extrusion line width with which libArachne generates its walls
     coord_t bead_width_x; //<! The subsequently extrusion line width with which libArachne generates its walls if WallToolPaths was called with the nominal_bead_width Constructor this is the same as bead_width_0
     size_t inset_count; //<! The maximum number of walls to generate
+    coord_t wall_0_inset; //<! The inset applied to the outer wall toolpath. For the normal walls it takes the value of Outer Wall Inset, while for the infill and skin walls it is 0
     StrategyType strategy_type; //<! The wall generating strategy
     bool print_thin_walls; //<! Whether to enable the widening beading meta-strategy for thin features
     coord_t min_feature_size; //<! The minimum size of the features that can be widened by the widening beading meta-strategy. Features thinner than that will not be printed
@@ -115,6 +116,17 @@ private:
     VariableWidthPaths toolpaths; //<! The generated toolpaths
     Polygons inner_contour;  //<! The inner contour of the generated toolpaths
     const Settings& settings;
+
+    /*!
+     * Prepares the outline so that it is ready to be used in the skeletal trapezoidation. The prepared outline should
+     * be simplified and contain no self-intersections or near-self-intersections. This is required before the outline
+     * polygon can be consumed by boost::voronoi.
+     *
+     * \param apply_outer_wall_inset Whether to apply the outer wall inset or not
+     *
+     * \return The outline ready to be used for skeletal trapezoidation
+     */
+    Polygons prepareOutlineForSkeletalTrapezoidation(bool apply_outer_wall_inset = false);
 };
 } // namespace cura
 

--- a/src/WallToolPaths.h
+++ b/src/WallToolPaths.h
@@ -111,7 +111,6 @@ private:
     coord_t min_feature_size; //<! The minimum size of the features that can be widened by the widening beading meta-strategy. Features thinner than that will not be printed
     coord_t min_bead_width;  //<! The minimum bead size to use when widening thin model features with the widening beading meta-strategy
     double small_area_length; //<! The length of the small features which are to be filtered out, this is squared into a surface
-    coord_t transition_length; //<! The transitioning length when the amount of extrusion lines changes
     bool toolpaths_generated; //<! Are the toolpaths generated
     VariableWidthPaths toolpaths; //<! The generated toolpaths
     Polygons inner_contour;  //<! The inner contour of the generated toolpaths

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -129,6 +129,10 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
     WallToolPaths wall_tool_paths(part->outline, line_width_0, line_width_x, inset_count, settings, wall_0_inset);
     part->wall_toolpaths = wall_tool_paths.getToolPaths();
     part->inner_area = wall_tool_paths.getInnerContour();
+    if (recompute_outline_based_on_outer_wall)
+    {
+        part->print_outline = part->outline.offset(-wall_0_inset);
+    }
 }
 
 /*

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -126,7 +126,7 @@ void WallsComputation::generateInsets(SliceLayerPart* part)
     }
 
     // Call on libArachne:
-    WallToolPaths wall_tool_paths(part->outline, line_width_0, line_width_x, inset_count, settings);
+    WallToolPaths wall_tool_paths(part->outline, line_width_0, line_width_x, inset_count, settings, wall_0_inset);
     part->wall_toolpaths = wall_tool_paths.getToolPaths();
     part->inner_area = wall_tool_paths.getInnerContour();
 }


### PR DESCRIPTION
The process used is the following:

1.   Generate the wall toolpaths as if `Outer Wall Inset = 0`
2.   If the `Outer Wall Inset` is not 0, regenerate a second list of toolpaths, taking the inset into account (by insetting the outline before generating the toolpaths)
3.   Replace the wall toolpath at index 0 with the insetted wall toolpaths at index 0

This technique, although more resource intensive (as it generates the Skeletal Trapezoidation twice), it is more reliable as it does not suffer from the problem of how to inset outer walls at thin parts that already have only two beads. In such places, insetting the walls would lead in overlapping and overextrusion. Using the regenerated toolpaths, it is certain that libArachne will properly deal with these thin parts by generating a single ExtrusionLine

![image](https://user-images.githubusercontent.com/19388042/101188755-697fc280-3656-11eb-83be-d4af563862e3.png)


**Note:** I was considering generating only one toolpath the second time the skeletal trapezoidation is applied (using inset_count = 2) but that would then always generate a toolpath that has a width of exactly one outer wall line width. By generating all the toolpaths the second time, it is ensured that the beading strategy will do its job and reduce/increase the width in some places according to the total width, thus being closer to the original outer wall toolpath.

CURA-7830