### PR TITLE
Cura issue #8844, fix for recesses being removed at the bottom of models when using "Make Overhangs Printable"

### DIFF
--- a/src/ConicalOverhang.cpp
+++ b/src/ConicalOverhang.cpp
@@ -9,33 +9,66 @@
 
 namespace cura {
 
-void ConicalOverhang::apply(Slicer* slicer, const Mesh& mesh)
-{
-    const AngleRadians angle = mesh.settings.get<AngleRadians>("conical_overhang_angle");
-    const double tan_angle = tan(angle);  // the XY-component of the angle
-    const coord_t layer_thickness = mesh.settings.get<coord_t>("layer_height");
-    coord_t max_dist_from_lower_layer = tan_angle * layer_thickness; // max dist which can be bridged
+	void ConicalOverhang::apply(Slicer* slicer, const Mesh& mesh)
+	{
+		const AngleRadians angle = mesh.settings.get<AngleRadians>("conical_overhang_angle");
+		const double tan_angle = tan(angle);  // the XY-component of the angle
+		const coord_t layer_thickness = mesh.settings.get<coord_t>("layer_height");
+		coord_t max_dist_from_lower_layer = tan_angle * layer_thickness; // max dist which can be bridged
 
-    for (unsigned int layer_nr = slicer->layers.size() - 2; static_cast<int>(layer_nr) >= 0; layer_nr--)
-    {
-        SlicerLayer& layer = slicer->layers[layer_nr];
-        SlicerLayer& layer_above = slicer->layers[layer_nr + 1];
-        if (std::abs(max_dist_from_lower_layer) < 5)
-        { // magically nothing happens when max_dist_from_lower_layer == 0
-            // below magic code solves that
-            int safe_dist = 20;
-            Polygons diff = layer_above.polygons.difference(layer.polygons.offset(-safe_dist));
-            layer.polygons = layer.polygons.unionPolygons(diff);
-            layer.polygons = layer.polygons.smooth(safe_dist);
-            layer.polygons.simplify(safe_dist, safe_dist * safe_dist / 4);
-            // somehow layer.polygons get really jagged lines with a lot of vertices
-            // without the above steps slicing goes really slow
-        }
-        else
-        {
-            layer.polygons = layer.polygons.unionPolygons(layer_above.polygons.offset(-max_dist_from_lower_layer));
-        }
-    }
-}
+		for (unsigned int layer_nr = slicer->layers.size() - 2; static_cast<int>(layer_nr) >= 0; layer_nr--)
+		{
+			SlicerLayer& layer = slicer->layers[layer_nr];
+			SlicerLayer& layer_above = slicer->layers[layer_nr + 1];
+			if (std::abs(max_dist_from_lower_layer) < 5)
+			{ // magically nothing happens when max_dist_from_lower_layer == 0
+				// below magic code solves that
+				int safe_dist = 20;
+				Polygons diff = layer_above.polygons.difference(layer.polygons.offset(-safe_dist));
+				layer.polygons = layer.polygons.unionPolygons(diff);
+				layer.polygons = layer.polygons.smooth(safe_dist);
+				layer.polygons.simplify(safe_dist, safe_dist * safe_dist / 4);
+				// somehow layer.polygons get really jagged lines with a lot of vertices
+				// without the above steps slicing goes really slow
+			}
+			else
+			{
+				// Coded added to avoid closing up of recessed holes in the base of a model
+				// Detects when a hole is completely covered by the layer above and removes the hole from the layer above before adding it in
+				// This should have no effect any time a hole in a layer interacts with any polygon in the layer above
+				// Get the current layer and split it into parts
+				std::vector<PolygonsPart> layerParts = layer.polygons.splitIntoParts();
+				// Get a copy of the layer above to prune away before we shrink it
+				Polygons above = layer_above.polygons;
+
+				// Now go through all the holes in the current layer and check if they intersect anything in the layer above
+				// If not, then they're the top of a hole and should be cut from the layer above before the union
+				for (unsigned int part = 0; part < layerParts.size(); part++)
+				{
+					if (layerParts[part].size() > 1)		// first poly is the outer contour, 1..n are the holes
+					{
+						for (unsigned int hole_nr = 1; hole_nr < layerParts[part].size(); ++hole_nr)
+						{
+							Polygons holePoly;
+							holePoly.add(layerParts[part][hole_nr]);
+							Polygons holeWithAbove = holePoly.intersection(above);
+							if (!holeWithAbove.empty())
+							{
+								// The hole had some intersection with the above layer, check if it's a complete overlap
+								Polygons holeDifference = holePoly.xorPolygons(holeWithAbove);		// xor will return an empty result for identical polygons.
+								if (holeDifference.empty())
+								{
+									// The hole was returned unchanged, so the layer above must completely cover it.  Remove the hole from the layer above.
+									above = above.difference(holePoly);
+								}
+							}
+						}
+					}
+				}
+				// And now union with offset of the resulting above layer 
+				layer.polygons = layer.polygons.unionPolygons(above.offset(-max_dist_from_lower_layer));
+			}
+		}
+	}
 
 }//namespace cura

--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -92,8 +92,8 @@ bool Comb::calc(const ExtruderTrain& train, Point startPoint, Point endPoint, Co
     unsigned int end_inside_poly = NO_INDEX;
     const bool endInside = moveInside(boundary_inside_optimal, _endInside, inside_loc_to_line_optimal, endPoint, end_inside_poly);
 
-    unsigned int start_part_boundary_poly_idx;
-    unsigned int end_part_boundary_poly_idx;
+    unsigned int start_part_boundary_poly_idx = NO_INDEX;		// Added initial value to stop MSVC throwing an exception in debug mode
+    unsigned int end_part_boundary_poly_idx = NO_INDEX;
     unsigned int start_part_idx =   (start_inside_poly == NO_INDEX)?    NO_INDEX : partsView_inside_optimal.getPartContaining(start_inside_poly, &start_part_boundary_poly_idx);
     unsigned int end_part_idx =     (end_inside_poly == NO_INDEX)?      NO_INDEX : partsView_inside_optimal.getPartContaining(end_inside_poly, &end_part_boundary_poly_idx);
 


### PR DESCRIPTION
Using "Make Overhangs Printable" was removing any recessed areas at the bottom of the model due to the way this was calculated.  The top of the recessed area was solid and therefore completely filled the layer below it removing the hole.  This propagated down and filled the entire hole.

This fix checks each hole in a layer to see if it's completely occluded by the layer above.  If so its the top surface of a hole and we don't want to remove it. The hole polygon gets subtracted from the layer above before it gets offset and added to the layer below.   This only needs to happen on the top layer and it stops the propagation of the fill down through the hole.   Any time the hole polygon isn't completely occluded by the layer above no changes are made and the process carries on as per the initial implementation.   

Two test STL files attached, one showing the correct behavior for various arrangements of holes (i.e. not filling them) and one showing the correct behaviour for overhangs inside holes (where the overhang gets corrected but the hole isn't filled).

Also added two initial values into Comb.cpp, the MSVC debugger would throw an exception in debug mode when these values were passed to later functions (even though the values were never used)