### PR TITLE
[CURA-7612] Don't adjust recursion-depth downwards if already 0.

### DIFF
--- a/src/infill/SierpinskiFillProvider.cpp
+++ b/src/infill/SierpinskiFillProvider.cpp
@@ -76,7 +76,7 @@ SierpinskiFillProvider::FractalConfig SierpinskiFillProvider::getFractalConfig(c
         depth += 2;
     }
     const float half_sqrt2 = .5 * sqrt2;
-    if (aabb_size * half_sqrt2 >= max_side_length)
+    if (depth > 0 && aabb_size * half_sqrt2 >= max_side_length)
     {
         aabb_size *= half_sqrt2;
         depth--;
@@ -84,6 +84,7 @@ SierpinskiFillProvider::FractalConfig SierpinskiFillProvider::getFractalConfig(c
 
     Point radius(aabb_size / 2, aabb_size / 2);
     AABB aabb(model_middle - radius, model_middle + radius);
+
     return FractalConfig{depth, aabb};
 }
 


### PR DESCRIPTION
If infill is set to very sparse, and the object is relatively small, ignore the later adjustment step (after increasing it by 2 each time the doubling of the bounding box doesn't reach the size) not only if the AABB has gotten slightly too big, but also don't do that if the recursion depth is already 0 before that step.

