### PR TITLE
CMakeLists.txt: check for Protobuf compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ if(ENABLE_ARCUS)
     find_package(Protobuf 3.0.0 REQUIRED)
     find_package(Arcus REQUIRED)
     add_definitions(-DARCUS)
+    find_program(PROTOC "protoc")
+    if(${PROTOC} STREQUAL "PROTOC-NOTFOUND")
+        message(FATAL_ERROR "Protobuf compiler missing")
+    endif()
 endif()
 
 #For reading image files.


### PR DESCRIPTION
Fixes: #1386

On Debian there are separate packages libprotobuf-dev and
protobuf-compiler. So when building with ARCUS it is not enough to check
that the library is present. We must also check that the Protobuf compiler
is available.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>