### PR TITLE
Limits hole offsets to holes larger than configured only instead of all.

### DIFF
--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -55,6 +55,7 @@ void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, Sl
         result = layer->polygons.splitIntoParts(union_layers || union_all_remove_holes);
     }
     const coord_t hole_offset = settings.get<coord_t>("hole_xy_offset");
+    const coord_t max_hole_length = settings.get<coord_t>("hole_xy_offset_max_length");
     for(unsigned int i=0; i<result.size(); i++)
     {
         storageLayer.parts.emplace_back();
@@ -65,13 +66,13 @@ void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, Sl
             Polygons holes;
             for (const PolygonRef poly : result[i])
             {
-                if (poly.orientation())
+                if (!poly.orientation() && poly.shorterThan(max_hole_length))
                 {
-                    outline.add(poly);
+                    holes.add(poly.offset(hole_offset));
                 }
                 else
                 {
-                    holes.add(poly.offset(hole_offset));
+                    outline.add(poly);
                 }
             }
             for (PolygonRef hole : holes.unionPolygons().intersection(outline))


### PR DESCRIPTION
The original hole horizon expansion will expand all internal outlines. This will create problems in certain cases.

For example, with 1mm expansion (exaggerated), with following model, the compensation create different outlines for layers with and without holes in the vertical walls.

Model:
![image](https://user-images.githubusercontent.com/2102912/105668077-92fef100-5f17-11eb-98c8-11cb7e59329f.png)


Expanding (since the wall forms a enclosed circle, which considered as a "hole"):
![image](https://user-images.githubusercontent.com/2102912/105667826-081df680-5f17-11eb-81b7-bc04798c0359.png)

Not expanding (since the hole in the vertical wall breaks the wall outline):
![image](https://user-images.githubusercontent.com/2102912/105667851-15d37c00-5f17-11eb-8611-fb2d4daa8b43.png)

This behavior limits the applicable scenarios that this feature is usable. 
I think by adding an option to limit when the hole will receive the compensation might help.

Cura Options: https://github.com/Ultimaker/Cura/pull/9182