### PR TITLE
Fix edge case with disabling bridging

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2333,7 +2333,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage, LayerPlan
 
         const int angle = bridgeAngle(mesh.settings, skin_part.outline, storage, layer_nr, bridge_layer, support_layer, supported_skin_part_regions);
 
-        if (angle > -1 || (supported_skin_part_regions.area() / (skin_part.outline.area() + 1) < support_threshold))
+        if (angle > -1 || (support_threshold > 0 && (supported_skin_part_regions.area() / (skin_part.outline.area() + 1) < support_threshold)))
         {
             if (angle > -1)
             {


### PR DESCRIPTION
When the Bridge Skin Support Threshold is set to 0%, and there is a skin area that is actually 0% supported, CuraEngine was still marking some areas as needing to get bridged.

This was due to an algorithmic mistake. This code was explicitly checking for the setting being >0, and only trying to detect bridging if it was >0. If the threshold was exceeded it was not going to bridge, and otherwise it was. But with the case of the threshold being set to 0%, it was just continuing with the code as if it was going to bridge. This would then usually fail to bridge for not having enough islands to rest on. However if there were enough islands, it would still bridge then.
By contracting the two nested if-statements, the else case of not going to bridge is properly applied if the threshold is set to 0%, and the algorithm is stopped entirely. No bridging at all.

There's also a second fix in here which doesn't have any real implications to the outcome, but just pre-checks if the threshold is 0% to prevent having to compute the area of the skin or the area of supported regions. This check saves some computation time. It could be moved even further ahead to save more computation time, but the case doesn't happen often so I guess it's fine like this for now.

Most likely fixes an issue that @Orum was facing in Ultimaker/Cura#8770. Doesn't fix the whole issue though.