### PR TITLE
Fix Tree Support Floor layers missing every second layer.

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -176,7 +176,7 @@ void TreeSupport::drawCircles(SliceDataStorage& storage, const std::vector<std::
                 constexpr bool no_prime_tower = false;
                 floor_layer.add(support_layer.intersection(storage.getLayerOutlines(sample_layer, no_support, no_prime_tower)));
             }
-            floor_layer.unionPolygons();
+            floor_layer = floor_layer.unionPolygons();
             support_layer = support_layer.difference(floor_layer.offset(10)); //Subtract the support floor from the normal support.
         }
 


### PR DESCRIPTION
As unionPolygons does not work in place the result is not saved, which seems to cause issues down the line.
Should fix #1402

While fixing issues with my new tree support implementation, I found this issue, which is also present in the live version. So while I know that this fixes the issue I had, and that the issue is also present in the live version, I did not test that this fixes it in the live version. But the code is similar enough that I am pretty sure that it will behave identically here.
