### PR TITLE
Simplify inner contour of infill

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -120,6 +120,7 @@ void Infill::generate(VariableWidthPaths& toolpaths, Polygons& result_polygons, 
         // Now do the actual inset, to make place for the extra 'zig-zagify' lines:
         inner_contour = inner_contour.difference(gap_filled_areas).offset(-infill_line_width / 2);
     }
+    inner_contour.simplify(max_resolution, max_deviation);
 
     if (infill_multiplier > 1)
     {


### PR DESCRIPTION
when connect infill lines was selected, small travel moves were observed
 in the infill perimeter contour. This happened because stitching the
generated toolpaths - needed for obtaining the inner contour -
introduced small segments of lines. Simplifying this contour before the
crossings and segments are stitched ensured that these tiny segments
were "merged" in a proper way, not leaving any gaps in the connected
contour line segments.

Fixes CURA-7764_small_travel_moves