### PR TITLE
CURA-7936: Assert failure when transitioning from 2 to 4 beads

### DIFF
--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1927,7 +1927,7 @@ void SkeletalTrapezoidation::connectJunctions(ptr_vector_t<LineJunctions>& edge_
             if (edge_to_peak->prev)
             {
                 LineJunctions from_prev_junctions = *edge_to_peak->prev->data.getExtrusionJunctions();
-                if (!from_junctions.empty() && !from_prev_junctions.empty() && from_junctions.back().perimeter_index == from_prev_junctions.front().perimeter_index)
+                while (!from_junctions.empty() && !from_prev_junctions.empty() && from_junctions.back().perimeter_index <= from_prev_junctions.front().perimeter_index)
                 {
                     from_junctions.pop_back();
                 }
@@ -1942,7 +1942,7 @@ void SkeletalTrapezoidation::connectJunctions(ptr_vector_t<LineJunctions>& edge_
             if (edge_from_peak->next)
             {
                 LineJunctions to_next_junctions = *edge_from_peak->next->twin->data.getExtrusionJunctions();
-                if (!to_junctions.empty() && !to_next_junctions.empty() && to_junctions.back().perimeter_index == to_next_junctions.front().perimeter_index)
+                while (!to_junctions.empty() && !to_next_junctions.empty() && to_junctions.back().perimeter_index <= to_next_junctions.front().perimeter_index)
                 {
                     to_junctions.pop_back();
                 }


### PR DESCRIPTION
I'll try to explain the problem as best I can using my epic paint skills.

After generating the junctions on the graph, these junctions are connected to create the walls. The image below shows an example, where the junctions `j1` and `j2` are supposed to transition to the junctions `j6`, `j5` and `j4` according to their perimeter indices (`j1`->`j6` and `j2`->`j5`. `j4` isn't connected to anything, but it starts a new wall *hence the transition*).

![Support_infill_area_halfedge_graph_with_gradual_infill_zoomed_annotated](https://user-images.githubusercontent.com/19388042/107970797-e235c000-6fb1-11eb-8033-ffd56e59ea33.png)

The idea is that the junctions on the `edge_to_peak` ("from" junctions) should be connected with the junctions in the `edge_from_peak->next` ("to" junctions). According to the algorithm, before this happens, the "to" junctions are filled with the junctions of the `edge_from_peak` (`j3`), and if there are junctions in the `edge_from_peak->next` segment, then the `j3` junction is no longer considered a "to" junction and it is being replaced by the junctions `j4`, `j5`, and `j6`. This removal of the `j3` junction was being done by checking whether it has the same `p_idx` as the last junction of the `edge_from_peak->next` segment (`j4`). 

In most cases this is true and `j3` would be properly removed.  In some rare cases though (as is with the one in the image), this wasn't true, leading the "to" junctions to include both the `edge_from_peak` junctions AND the `edge_from_peak->next` junctions, thus having an incorrect transition (`j3` has p_idx=1, but it cannot really connect with `j2` that has the same perimeter index).

This PR fixes that by making sure that ALL the junctions of the `edge_from_peak` segment with an incorrect perimeter index are properly removed from the "to" junctions before the "to" junctions vector is filled with the ones from the `edge_from_peak->next` segment.