### PR TITLE
Properly round Voronoi coordinates to IntPoint coordinates

### DIFF
--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <stack>
@@ -13,7 +13,7 @@ namespace cura
 
 Point VoronoiUtils::p(const vd_t::vertex_type* node)
 {
-    return Point(node->x() + 0, node->y() + 0); // gets rid of negative zero
+    return Point(node->x() + 0.5d, node->y() + 0.5d); //Round to nearest integer coordinates.
 }
 
 bool VoronoiUtils::isSourcePoint(Point p, const vd_t::cell_type& cell, const std::vector<Point>& points, const std::vector<Segment>& segments, coord_t snap_dist)

--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -13,7 +13,9 @@ namespace cura
 
 Point VoronoiUtils::p(const vd_t::vertex_type* node)
 {
-    return Point(node->x() + 0.5d, node->y() + 0.5d); //Round to nearest integer coordinates.
+    const double x = node->x();
+    const double y = node->y();
+    return Point(x + 0.5d - (x < 0), y + 0.5d - (y < 0)); //Round to nearest integer coordinates.
 }
 
 bool VoronoiUtils::isSourcePoint(Point p, const vd_t::cell_type& cell, const std::vector<Point>& points, const std::vector<Segment>& segments, coord_t snap_dist)

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -470,8 +470,8 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         //h^2 = (L / b)^2     [square it]
         //h^2 = L^2 / b^2     [factor the divisor]
         const coord_t height_2 = area_removed_so_far * area_removed_so_far / base_length_2;
-        if ((height_2 <= 1 //Almost exactly colinear (barring rounding errors).
-            && LinearAlg2D::getDistFromLine(current, previous, next) <= 1)) // make sure that height_2 is not small because of cancellation of positive and negative areas
+        if ((height_2 <= 5 * 5 //Almost exactly colinear (barring rounding errors).
+            && LinearAlg2D::getDistFromLine(current, previous, next) <= 5)) // make sure that height_2 is not small because of cancellation of positive and negative areas
         {
             continue;
         }


### PR DESCRIPTION
Instead of just casting them, actually round them. The Voronoi calculation has some minor inaccuracies in due to floating point rounding. If the coordinates are rounded down this can cause a vertex from the source polygon to change position, causing it to no longer be recognised as a vertex from the source polygon.

Contributes to issue CURA-7970. It is not a complete solution though.