### PR TITLE
CURA-7952: Fix running into edges without a twin

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -63,7 +63,7 @@ const VariableWidthPaths& WallToolPaths::generate()
     prepared_outline.simplify(smallest_segment, allowed_distance);
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();
-    prepared_outline.removeColinearEdges();
+    prepared_outline.removeColinearEdges(AngleRadians(0.005));
     prepared_outline.removeSmallAreas(small_area_length * small_area_length, false);
 
     if (prepared_outline.area() > 0)

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -166,10 +166,10 @@ void SVG::writeAreas(ConstPolygonRef polygon, const ColorObject color, const Col
     fprintf(out,"\" />\n"); //The end of the polygon tag.
 }
 
-void SVG::writePoint(const Point& p, const bool write_coords, const int size, const ColorObject color) const
+void SVG::writePoint(const Point& p, const bool write_coords, const float size, const ColorObject color) const
 {
     FPoint3 pf = transformF(p);
-    fprintf(out, "<circle cx=\"%f\" cy=\"%f\" r=\"%d\" stroke=\"%s\" stroke-width=\"1\" fill=\"%s\" />\n",pf.x, pf.y, size, toString(color).c_str(), toString(color).c_str());
+    fprintf(out, "<circle cx=\"%f\" cy=\"%f\" r=\"%f\" stroke-width=\"0\" fill=\"%s\" />\n",pf.x, pf.y, size, toString(color).c_str());
     
     if (write_coords)
     {
@@ -177,7 +177,7 @@ void SVG::writePoint(const Point& p, const bool write_coords, const int size, co
     }
 }
 
-void SVG::writePoints(ConstPolygonRef poly, const bool write_coords, const int size, const ColorObject color) const
+void SVG::writePoints(ConstPolygonRef poly, const bool write_coords, const float size, const ColorObject color) const
 {
     for (const Point& p : poly)
     {
@@ -185,7 +185,7 @@ void SVG::writePoints(ConstPolygonRef poly, const bool write_coords, const int s
     }
 }
 
-void SVG::writePoints(const Polygons& polygons, const bool write_coords, const int size, const ColorObject color) const
+void SVG::writePoints(const Polygons& polygons, const bool write_coords, const float size, const ColorObject color) const
 {
     for(const ConstPolygonRef& poly : polygons)
     {

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -217,12 +217,11 @@ void SVG::writeLine(const Point& a, const Point& b, const ColorObject color, con
     fprintf(out, "<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" style=\"stroke:%s;stroke-width:%f\" />\n", fa.x, fa.y, fb.x, fb.y, toString(color).c_str(), stroke_width);
 }
 
-void SVG::writeArrow(const Point& a, const Point& b, const ColorObject color, const float stroke_width, const int rel_head_size_divisor) const
+void SVG::writeArrow(const Point& a, const Point& b, const ColorObject color, const float stroke_width, const float head_size) const
 {
     FPoint3 fa = transformF(a);
     FPoint3 fb = transformF(b);
     FPoint3 ab = fb - fa;
-    float head_size = ab.vSize() / rel_head_size_divisor;
     FPoint3 normal = FPoint3(ab.y, -ab.x, 0.0).normalized();
     FPoint3 direction = ab.normalized();
 

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -217,14 +217,19 @@ void SVG::writeLine(const Point& a, const Point& b, const ColorObject color, con
     fprintf(out, "<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" style=\"stroke:%s;stroke-width:%f\" />\n", fa.x, fa.y, fb.x, fb.y, toString(color).c_str(), stroke_width);
 }
 
-void SVG::writeArrow(const Point& a, const Point& b, const ColorObject color, const float stroke_width, const int rel_head_size_divisor, const coord_t offset) const
+void SVG::writeArrow(const Point& a, const Point& b, const ColorObject color, const float stroke_width, const int rel_head_size_divisor) const
 {
-    Point ab = b - a;
-    Point nd = turn90CCW(ab) / rel_head_size_divisor / 2;
-    Point n = normal(turn90CCW(ab), offset);
-    Point d = ab / rel_head_size_divisor / 2;
-    writeLine(a + n, b + n - d, color, stroke_width);
-    writeLine(b + n - d, b + n + nd - d * 3, color, stroke_width);
+    FPoint3 fa = transformF(a);
+    FPoint3 fb = transformF(b);
+    FPoint3 ab = fb - fa;
+    float head_size = ab.vSize() / rel_head_size_divisor;
+    FPoint3 normal = FPoint3(ab.y, -ab.x, 0.0).normalized();
+    FPoint3 direction = ab.normalized();
+
+    FPoint3 tip = fb + normal * head_size - direction * head_size;
+    FPoint3 b_base = fb + normal * stroke_width - direction * stroke_width * 2.41;
+    FPoint3 a_base = fa + normal * stroke_width;
+    fprintf(out, "<polygon fill=\"%s\" points=\"%f,%f %f,%f %f,%f %f,%f %f,%f\" />", toString(color).c_str(), fa.x, fa.y, fb.x, fb.y, tip.x, tip.y, b_base.x, b_base.y, a_base.x, a_base.y);
 }
 
 void SVG::writeLineRGB(const Point& from, const Point& to, const int r, const int g, const int b, const float stroke_width) const

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -13,7 +13,7 @@ namespace cura {
 
 
 
-std::string SVG::toString(Color color)
+std::string SVG::toString(Color color) const
 {
     switch (color)
     {
@@ -31,7 +31,7 @@ std::string SVG::toString(Color color)
     }
 }
 
-std::string SVG::toString(ColorObject& color)
+std::string SVG::toString(const ColorObject& color) const
 {
     if (color.is_enum) return toString(color.color);
     else
@@ -118,22 +118,22 @@ void SVG::nextLayer()
     fprintf(out,"    id=\"layer%zu\">\n", layer_nr );
 }
 
-Point SVG::transform(const Point& p) 
+Point SVG::transform(const Point& p) const
 {
     return Point((p.X - aabb.min.X) * scale, (p.Y - aabb.min.Y) * scale);
 }
 
-FPoint3 SVG::transformF(const Point& p) 
+FPoint3 SVG::transformF(const Point& p) const
 {
     return FPoint3((p.X - aabb.min.X) * scale, (p.Y-aabb.min.Y) * scale, 0.0);
 }
 
-void SVG::writeComment(std::string comment)
+void SVG::writeComment(const std::string& comment) const
 {
     fprintf(out, "<!-- %s -->\n", comment.c_str());
 }
 
-void SVG::writeAreas(const Polygons& polygons, ColorObject color, ColorObject outline_color, float stroke_width) 
+void SVG::writeAreas(const Polygons& polygons, const ColorObject color, const ColorObject outline_color, const float stroke_width) const
 {
     auto parts = polygons.splitIntoParts();
     for (auto part_it = parts.rbegin(); part_it != parts.rend(); ++part_it)
@@ -155,7 +155,7 @@ void SVG::writeAreas(const Polygons& polygons, ColorObject color, ColorObject ou
     }
 }
 
-void SVG::writeAreas(ConstPolygonRef polygon, ColorObject color, ColorObject outline_color, float stroke_width)
+void SVG::writeAreas(ConstPolygonRef polygon, const ColorObject color, const ColorObject outline_color, const float stroke_width) const
 {
     fprintf(out,"<polygon fill=\"%s\" stroke=\"%s\" stroke-width=\"%f\" points=\"",toString(color).c_str(),toString(outline_color).c_str(), stroke_width); //The beginning of the polygon tag.
     for (const Point& point : polygon) //Add every point to the list of points.
@@ -166,7 +166,7 @@ void SVG::writeAreas(ConstPolygonRef polygon, ColorObject color, ColorObject out
     fprintf(out,"\" />\n"); //The end of the polygon tag.
 }
 
-void SVG::writePoint(const Point& p, bool write_coords, int size, ColorObject color)
+void SVG::writePoint(const Point& p, const bool write_coords, const int size, const ColorObject color) const
 {
     FPoint3 pf = transformF(p);
     fprintf(out, "<circle cx=\"%f\" cy=\"%f\" r=\"%d\" stroke=\"%s\" stroke-width=\"1\" fill=\"%s\" />\n",pf.x, pf.y, size, toString(color).c_str(), toString(color).c_str());
@@ -177,7 +177,7 @@ void SVG::writePoint(const Point& p, bool write_coords, int size, ColorObject co
     }
 }
 
-void SVG::writePoints(ConstPolygonRef poly, bool write_coords, int size, ColorObject color)
+void SVG::writePoints(ConstPolygonRef poly, const bool write_coords, const int size, const ColorObject color) const
 {
     for (const Point& p : poly)
     {
@@ -185,15 +185,15 @@ void SVG::writePoints(ConstPolygonRef poly, bool write_coords, int size, ColorOb
     }
 }
 
-void SVG::writePoints(Polygons& polygons, bool write_coords, int size, ColorObject color)
+void SVG::writePoints(const Polygons& polygons, const bool write_coords, const int size, const ColorObject color) const
 {
-    for (PolygonRef poly : polygons)
+    for(const ConstPolygonRef& poly : polygons)
     {
         writePoints(poly, write_coords, size, color);
     }
 }
 
-void SVG::writeLines(std::vector<Point> polyline, ColorObject color)
+void SVG::writeLines(const std::vector<Point>& polyline, const ColorObject color) const
 {
     if(polyline.size() <= 1) //Need at least 2 points.
     {
@@ -201,7 +201,7 @@ void SVG::writeLines(std::vector<Point> polyline, ColorObject color)
     }
     
     FPoint3 transformed = transformF(polyline[0]); //Element 0 must exist due to the check above.
-    fprintf(out,"<path fill=\"none\" stroke=\"%s\" stroke-width=\"1\" d=\"M%f,%f",toString(color).c_str(), transformed.x, transformed.y); //Write the start of the path tag and the first endpoint.
+    fprintf(out,"<path fill=\"none\" stroke=\"%s\" stroke-width=\"1\" d=\"M%f,%f", toString(color).c_str(), transformed.x, transformed.y); //Write the start of the path tag and the first endpoint.
     for(size_t point = 1;point < polyline.size();point++)
     {
         transformed = transformF(polyline[point]);
@@ -210,14 +210,14 @@ void SVG::writeLines(std::vector<Point> polyline, ColorObject color)
     fprintf(out,"\" />\n"); //Write the end of the tag.
 }
 
-void SVG::writeLine(const Point& a, const Point& b, ColorObject color, float stroke_width)
+void SVG::writeLine(const Point& a, const Point& b, const ColorObject color, const float stroke_width) const
 {
     FPoint3 fa = transformF(a);
     FPoint3 fb = transformF(b);
     fprintf(out, "<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" style=\"stroke:%s;stroke-width:%f\" />\n", fa.x, fa.y, fb.x, fb.y, toString(color).c_str(), stroke_width);
 }
 
-void SVG::writeArrow(const Point& a, const Point& b, ColorObject color, float stroke_width, int rel_head_size_divisor, coord_t offset)
+void SVG::writeArrow(const Point& a, const Point& b, const ColorObject color, const float stroke_width, const int rel_head_size_divisor, const coord_t offset) const
 {
     Point ab = b - a;
     Point nd = turn90CCW(ab) / rel_head_size_divisor / 2;
@@ -227,27 +227,27 @@ void SVG::writeArrow(const Point& a, const Point& b, ColorObject color, float st
     writeLine(b + n - d, b + n + nd - d * 3, color, stroke_width);
 }
 
-void SVG::writeLineRGB(const Point& from, const Point& to, int r, int g, int b, float stroke_width)
+void SVG::writeLineRGB(const Point& from, const Point& to, const int r, const int g, const int b, const float stroke_width) const
 {
     FPoint3 fa = transformF(from);
     FPoint3 fb = transformF(to);
     fprintf(out, "<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" style=\"stroke:rgb(%i,%i,%i);stroke-width:%f\" />\n", fa.x, fa.y, fb.x, fb.y, r, g, b, stroke_width);
 }
 
-void SVG::writeDashedLine(const Point& a, const Point& b, ColorObject color)
+void SVG::writeDashedLine(const Point& a, const Point& b, ColorObject color) const
 {
     FPoint3 fa = transformF(a);
     FPoint3 fb = transformF(b);
     fprintf(out,"<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" stroke=\"%s\" stroke-width=\"1\" stroke-dasharray=\"5,5\" />\n",fa.x,fa.y,fb.x,fb.y,toString(color).c_str());
 }
 
-void SVG::writeText(Point p, std::string txt, ColorObject color, coord_t font_size)
+void SVG::writeText(const Point& p, const std::string& txt, const ColorObject color, const float font_size) const
 {
     FPoint3 pf = transformF(p);
-    fprintf(out, "<text x=\"%f\" y=\"%f\" style=\"font-size: %llipx;\" fill=\"%s\">%s</text>\n",pf.x, pf.y, font_size, toString(color).c_str(), txt.c_str());
+    fprintf(out, "<text x=\"%f\" y=\"%f\" style=\"font-size: %fpx;\" fill=\"%s\">%s</text>\n",pf.x, pf.y, font_size, toString(color).c_str(), txt.c_str());
 }
 
-void SVG::writePolygons(const Polygons& polys, ColorObject color, float stroke_width)
+void SVG::writePolygons(const Polygons& polys, const ColorObject color, const float stroke_width) const
 {
     for (ConstPolygonRef poly : polys)
     {
@@ -255,7 +255,7 @@ void SVG::writePolygons(const Polygons& polys, ColorObject color, float stroke_w
     }
 }
 
-void SVG::writePolygon(ConstPolygonRef poly, ColorObject color, float stroke_width)
+void SVG::writePolygon(ConstPolygonRef poly, const ColorObject color, const float stroke_width) const
 {
     if (poly.size() == 0)
     {
@@ -290,7 +290,7 @@ void SVG::writePolygon(ConstPolygonRef poly, ColorObject color, float stroke_wid
 }
 
 
-void SVG::writePolylines(const Polygons& polys, ColorObject color, float stroke_width)
+void SVG::writePolylines(const Polygons& polys, const ColorObject color, const float stroke_width) const
 {
     for (ConstPolygonRef poly : polys)
     {
@@ -298,7 +298,7 @@ void SVG::writePolylines(const Polygons& polys, ColorObject color, float stroke_
     }
 }
 
-void SVG::writePolyline(ConstPolygonRef poly, ColorObject color, float stroke_width)
+void SVG::writePolyline(ConstPolygonRef poly, const ColorObject color, const float stroke_width) const
 {
     if (poly.size() == 0)
     {

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -327,4 +327,26 @@ void SVG::writePolyline(ConstPolygonRef poly, const ColorObject color, const flo
     }
 }
 
+void SVG::writeCoordinateGrid(const coord_t grid_size, const Color color, const float stroke_width, const float font_size) const
+{
+    constexpr float dist_from_edge = 0.05; //As fraction of image width or height.
+    const coord_t min_x = aabb.min.X - (aabb.min.X % grid_size);
+    const coord_t min_y = aabb.min.Y - (aabb.min.Y % grid_size);
+
+    for(coord_t x = min_x; x < aabb.max.X; x += grid_size)
+    {
+        writeLine(Point(x, aabb.min.Y), Point(x, aabb.max.Y), color, stroke_width);
+        std::stringstream ss;
+        ss << INT2MM(x);
+        writeText(Point(x, aabb.min.Y + (aabb.max.Y - aabb.min.Y) * dist_from_edge), ss.str(), color, font_size);
+    }
+    for(coord_t y = min_y; y < aabb.max.Y; y += grid_size)
+    {
+        writeLine(Point(aabb.min.X, y), Point(aabb.max.Y, y), color, stroke_width);
+        std::stringstream ss;
+        ss << INT2MM(y);
+        writeText(Point(aabb.min.X + (aabb.max.X - aabb.min.X) * dist_from_edge, y), ss.str(), color, font_size);
+    }
+}
+
 } // namespace cura

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -50,8 +50,8 @@ public:
     };
 private:
 
-    std::string toString(Color color);
-    std::string toString(ColorObject& color);
+    std::string toString(const Color color) const;
+    std::string toString(const ColorObject& color) const;
 
     FILE* out; // the output file
     const AABB aabb; // the boundary box to display
@@ -64,9 +64,9 @@ private:
     bool output_is_html;
 
 public:
-    SVG(std::string filename, AABB aabb, Point canvas_size = Point(1024, 1024), ColorObject background = Color::NONE);
-    SVG(std::string filename, AABB aabb, double scale, ColorObject background = Color::NONE);
-    SVG(std::string filename, AABB aabb, double scale, Point canvas_size, ColorObject background = Color::NONE);
+    SVG(std::string filename, const AABB aabb, const Point canvas_size = Point(1024, 1024), const ColorObject background = Color::NONE);
+    SVG(std::string filename, const AABB aabb, const double scale, const ColorObject background = Color::NONE);
+    SVG(std::string filename, const AABB aabb, const double scale, const Point canvas_size, const ColorObject background = Color::NONE);
 
     ~SVG();
 
@@ -80,24 +80,24 @@ public:
     /*!
      * transform a point in real space to canvas space
      */
-    Point transform(const Point& p);
+    Point transform(const Point& p) const;
 
     /*!
      * transform a point in real space to canvas space with more precision
      */
-    FPoint3 transformF(const Point& p);
+    FPoint3 transformF(const Point& p) const;
 
-    void writeComment(std::string comment);
+    void writeComment(const std::string& comment) const;
 
-    void writeAreas(const Polygons& polygons, ColorObject color = Color::GRAY, ColorObject outline_color = Color::BLACK, float stroke_width = 1);
+    void writeAreas(const Polygons& polygons, const ColorObject color = Color::GRAY, const ColorObject outline_color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writeAreas(ConstPolygonRef polygon, ColorObject color = Color::GRAY, ColorObject outline_color = Color::BLACK, float stroke_width = 1);
+    void writeAreas(ConstPolygonRef polygon, const ColorObject color = Color::GRAY, const ColorObject outline_color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writePoint(const Point& p, bool write_coords=false, int size = 5, ColorObject color = Color::BLACK);
+    void writePoint(const Point& p, const bool write_coords = false, const int size = 5, const ColorObject color = Color::BLACK) const;
 
-    void writePoints(ConstPolygonRef poly, bool write_coords=false, int size = 5, ColorObject color = Color::BLACK);
+    void writePoints(ConstPolygonRef poly, const bool write_coords = false, const int size = 5, const ColorObject color = Color::BLACK) const;
 
-    void writePoints(Polygons& polygons, bool write_coords=false, int size = 5, ColorObject color = Color::BLACK);
+    void writePoints(const Polygons& polygons, const bool write_coords = false, const int size = 5, const ColorObject color = Color::BLACK) const;
 
     /*!
      * \brief Draws a polyline on the canvas.
@@ -110,13 +110,13 @@ public:
      * \param color The colour of the line segments. If this is not specified,
      * black will be used.
      */
-    void writeLines(std::vector<Point> polyline, ColorObject color = Color::BLACK);
+    void writeLines(const std::vector<Point>& polyline, const ColorObject color = Color::BLACK) const;
 
-    void writeLine(const Point& a, const Point& b, ColorObject color = Color::BLACK, float stroke_width = 1);
+    void writeLine(const Point& a, const Point& b, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writeArrow(const Point& a, const Point& b, ColorObject color = Color::BLACK, float stroke_width = 1, int rel_head_size_divisor = 20, coord_t offset = 20);
+    void writeArrow(const Point& a, const Point& b, const ColorObject color = Color::BLACK, const float stroke_width = 1, const int rel_head_size_divisor = 20, const coord_t offset = 20) const;
 
-    void writeLineRGB(const Point& from, const Point& to, int r = 0, int g = 0, int b = 0, float stroke_width = 1);
+    void writeLineRGB(const Point& from, const Point& to, const int r = 0, const int g = 0, const int b = 0, const float stroke_width = 1) const;
 
     /*!
      * \brief Draws a dashed line on the canvas from point A to point B.
@@ -127,29 +127,29 @@ public:
      * \param b The ending endpoint of the line.
      * \param color The stroke colour of the line.
      */
-    void writeDashedLine(const Point& a,const Point& b, ColorObject color = Color::BLACK);
+    void writeDashedLine(const Point& a,const Point& b, ColorObject color = Color::BLACK) const;
 
     template<typename... Args>
-    void printf(const char* txt, Args&&... args);
+    void printf(const char* txt, Args&&... args) const;
 
-    void writeText(Point p, std::string txt, ColorObject color = Color::BLACK, coord_t font_size = 10);
+    void writeText(const Point& p, const std::string& txt, const ColorObject color = Color::BLACK, const float font_size = 10) const;
 
-    void writePolygons(const Polygons& polys, ColorObject color = Color::BLACK, float stroke_width = 1);
+    void writePolygons(const Polygons& polys, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writePolygon(ConstPolygonRef poly, ColorObject color = Color::BLACK, float stroke_width = 1);
+    void writePolygon(ConstPolygonRef poly, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writePolylines(const Polygons& polys, ColorObject color = Color::BLACK, float stroke_width = 1);
+    void writePolylines(const Polygons& polys, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writePolyline(ConstPolygonRef poly, ColorObject color = Color::BLACK, float stroke_width = 1);
+    void writePolyline(ConstPolygonRef poly, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writePolylines(const Polygons& polys, Color color = Color::BLACK, float stroke_width = 1);
+    void writePolylines(const Polygons& polys, const Color color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writePolyline(ConstPolygonRef poly, Color color = Color::BLACK, float stroke_width = 1);
+    void writePolyline(ConstPolygonRef poly, const Color color = Color::BLACK, const float stroke_width = 1) const;
 
 };
 
 template<typename... Args>
-void SVG::printf(const char* txt, Args&&... args)
+void SVG::printf(const char* txt, Args&&... args) const
 {
     fprintf(out, txt, args...);
 }

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -114,7 +114,7 @@ public:
 
     void writeLine(const Point& a, const Point& b, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writeArrow(const Point& a, const Point& b, const ColorObject color = Color::BLACK, const float stroke_width = 1, const int rel_head_size_divisor = 20) const;
+    void writeArrow(const Point& a, const Point& b, const ColorObject color = Color::BLACK, const float stroke_width = 1, const float head_size = 5.0) const;
 
     void writeLineRGB(const Point& from, const Point& to, const int r = 0, const int g = 0, const int b = 0, const float stroke_width = 1) const;
 

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -93,11 +93,11 @@ public:
 
     void writeAreas(ConstPolygonRef polygon, const ColorObject color = Color::GRAY, const ColorObject outline_color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writePoint(const Point& p, const bool write_coords = false, const int size = 5, const ColorObject color = Color::BLACK) const;
+    void writePoint(const Point& p, const bool write_coords = false, const float size = 5.0, const ColorObject color = Color::BLACK) const;
 
-    void writePoints(ConstPolygonRef poly, const bool write_coords = false, const int size = 5, const ColorObject color = Color::BLACK) const;
+    void writePoints(ConstPolygonRef poly, const bool write_coords = false, const float size = 5.0, const ColorObject color = Color::BLACK) const;
 
-    void writePoints(const Polygons& polygons, const bool write_coords = false, const int size = 5, const ColorObject color = Color::BLACK) const;
+    void writePoints(const Polygons& polygons, const bool write_coords = false, const float size = 5.0, const ColorObject color = Color::BLACK) const;
 
     /*!
      * \brief Draws a polyline on the canvas.

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -146,6 +146,17 @@ public:
 
     void writePolyline(ConstPolygonRef poly, const Color color = Color::BLACK, const float stroke_width = 1) const;
 
+    /*!
+     * Draws a grid across the image and writes down coordinates.
+     *
+     * Coordinates are always written in millimeters.
+     * \param grid_size Size of the grid cells.
+     * \param color The colour to draw the grid with.
+     * \param stroke_width The width of the grid lines.
+     * \param font_size The size of the font to write the coordinates with.
+     */
+    void writeCoordinateGrid(const coord_t grid_size = MM2INT(1), const Color color = Color::BLACK, const float stroke_width = 0.1, const float font_size = 10) const;
+
 };
 
 template<typename... Args>

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -114,7 +114,7 @@ public:
 
     void writeLine(const Point& a, const Point& b, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
 
-    void writeArrow(const Point& a, const Point& b, const ColorObject color = Color::BLACK, const float stroke_width = 1, const int rel_head_size_divisor = 20, const coord_t offset = 20) const;
+    void writeArrow(const Point& a, const Point& b, const ColorObject color = Color::BLACK, const float stroke_width = 1, const int rel_head_size_divisor = 20) const;
 
     void writeLineRGB(const Point& from, const Point& to, const int r = 0, const int g = 0, const int b = 0, const float stroke_width = 1) const;
 

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -368,8 +368,12 @@ void PolygonRef::removeColinearEdges(const AngleRadians max_deviation_angle)
                 const Point& pt = rpath[point_idx];
                 const Point& next = rpath[(point_idx + 1) % pathlen];
 
-                // Check if the angle is large enough for the point to 'make sense' given the maximum deviation:
-                if (std::abs(M_PI - std::abs(LinearAlg2D::getAngleLeft(prev, pt, next))) > max_deviation_angle)
+                float angle = LinearAlg2D::getAngleLeft(prev, pt, next);  // [0 : 2 * pi]
+                if (angle >= M_PI) {angle -= M_PI;}  // map [pi : 2 * pi] to [0 : pi]
+
+                // Check if the angle is within limits for the point to 'make sense', given the maximum deviation.
+                // If the angle indicates near-parallel segments ignore the point 'pt'
+                if (angle > max_deviation_angle && angle < M_PI - max_deviation_angle)
                 {
                     new_path.push_back(pt);
                 }


### PR DESCRIPTION
The process of cleaning polygons to prepare them for SkeletalTrapezoidation sometimes would leave almost-colinear segments, which would lead to generating graph edges without a twin.

This PR fixes that by making sure that the `removeColinearSegments()` will properly cover all cases. It also increases the maximum_angle_deviation (i.e. the maximum angle allowed for two segments to be considered as colinear) when checking for colinearity.

Before:
![stages_of_outline_cleaning_before](https://user-images.githubusercontent.com/19388042/108512123-0c90c180-72c1-11eb-8f68-faa394a263c1.jpeg)



As it can be seen, the remove_colinear_edges actually leaves a point that is part of colinear segments, which cannot be handled by the generation of the graph and will lead to graph edge without a twin.

After:
![stages_of_outline_cleaning_after](https://user-images.githubusercontent.com/19388042/108511712-92603d00-72c0-11eb-9b7a-05daec26d1e7.jpeg)

The spike mentioned above no longer exists in the output of `removeColinearEdges()`.

CURA-7952
 