### PR TITLE
Do not wipe for continuously linked paths

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -740,8 +740,10 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const Settings& set
         ewall.emplace_back(p, nominal_line_width, dummy_perimeter_id);
     });
     ewall.emplace_back(*wall.begin(), nominal_line_width, dummy_perimeter_id);
-
-    addWall(ewall, start_idx, settings, non_bridge_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract, true, false, false);
+    constexpr bool is_closed = true;
+    constexpr bool is_reversed = false;
+    constexpr bool is_linked_path = false;
+    addWall(ewall, start_idx, settings, non_bridge_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract, is_closed, is_reversed, is_linked_path);
 }
 
 void LayerPlan::addWall(const LineJunctions& wall, int start_idx, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, coord_t wall_0_wipe_dist, float flow_ratio, bool always_retract, const bool is_closed, const bool is_reversed, const bool is_linked_path)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -991,7 +991,7 @@ void LayerPlan::addWalls(const PathJunctions& walls, const SliceMeshStorage& mes
     {
         p_end = path.backwards ? path.vertices->back().p : path.vertices->front().p;
         const cura::Point p_start = path.backwards ? path.vertices->front().p : path.vertices->back().p;
-        const bool linked_path = p_start == p_end;
+        const bool linked_path = p_start != p_end;
         addWall(*path.vertices, path.start_vertex, mesh, non_bridge_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract, path.is_closed, path.backwards, linked_path);
     }
 }

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -600,8 +600,9 @@ public:
      * \param is_closed Whether this wall is a closed loop (a polygon) or not (a
      * polyline).
      * \param is_reversed Whether to print this wall in reverse direction.
+     * \param is_linked_path Whether the path is a continuation off the previous path
      */
-    void addWall(const LineJunctions& wall, int start_idx, const SliceMeshStorage& mesh, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, coord_t wall_0_wipe_dist, float flow_ratio, bool always_retract, const bool is_closed = false, const bool is_reversed = false);
+    void addWall(const LineJunctions& wall, int start_idx, const SliceMeshStorage& mesh, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, coord_t wall_0_wipe_dist, float flow_ratio, bool always_retract, const bool is_closed, const bool is_reversed, const bool is_linked_path);
 
     /*!
      * Add an infill wall to the g-code


### PR DESCRIPTION
The problem is currently that the walls are fed as small segments and
the PathOrderOptimizer ensures they are processed in a correct order and
it really doesn't matter that all segments are small and broken up.
Now all is well, you would think, But then the outer wipe distance comes
in to play. Add the end of a small wall segment it thinks: He, I need to
wipe. I will traverse all long the path a do a travel afterwards. This
occurs after each small wall segment. So when a wall is split in two
walls it does the outer wall wipe thingy.

By storing the end point of the last path and checking if this is
aligned with the start point of the new point I will know it this path
is part of a continuously linked path consisting of smaller segments.
If that is the case the outer wall wipe isn't performed.

Contributes to CURA-7949_outer_wall_wipe_distance

The current solution depends on the order that it provides from the 
PathOrderOptimizer that is why there might still be some cases where
a unnecessary wipe might occur. See gif below. I don't consider that part
of this ticket and I will raise at the eCCB.

![Peek 2021-02-23 17-53](https://user-images.githubusercontent.com/8535734/108878379-7fbb7000-7600-11eb-9d59-d741f5e0a41e.gif)
