### PR TITLE
Fix crashing due to intersections when removing collinear edges

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -64,6 +64,9 @@ const VariableWidthPaths& WallToolPaths::generate()
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();
     prepared_outline.removeColinearEdges(AngleRadians(0.005));
+    // Removing collinear edges may introduce self intersections, so we need to fix them again
+    PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
+    prepared_outline.removeDegenerateVerts();
     prepared_outline.removeSmallAreas(small_area_length * small_area_length, false);
 
     if (prepared_outline.area() > 0)


### PR DESCRIPTION
When removing collinear edges, self-intersections may be introduced. These self-intersections cannot be handled properly by the Voronoi diagram generation, thus introducing edges without twins, which lead to crashes in the SkeletalTrapezoidation.

![self intersections after removing collinear edges](https://user-images.githubusercontent.com/19388042/109635500-c0f4d800-7b4a-11eb-9d4a-efbbbc8b8adb.png)


This commit fixes that by re-applying the `fixSelfIntersections()` function after removing collinear edges.

Fixes CURA-8056 and remaining crash in CURA-7948