### PR TITLE
Cura 7756 infill layer thickness

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1431,11 +1431,6 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                                mesh.settings.get<coord_t>("cross_infill_pocket_size"));
             infill_comp.generate(infill_paths, infill_polygons, infill_lines, mesh.settings, mesh.cross_fill_provider, &mesh);
         }
-        if (!infill_paths.empty())
-        {
-            InsetOrderOptimizer inset_order_optimizer(*this, storage, gcode_layer, mesh, extruder_nr, mesh_config, infill_paths, gcode_layer.getLayerNr());
-            added_something |= inset_order_optimizer.optimize(InsetOrderOptimizer::WallType::EXTRA_INFILL);
-        }
         if (!infill_lines.empty() || !infill_polygons.empty())
         {
             added_something = true;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1405,7 +1405,7 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
         const size_t infill_multiplier = mesh.settings.get<size_t>("infill_multiplier");
         Polygons infill_polygons;
         Polygons infill_lines;
-        VariableWidthPaths infill_paths;
+        VariableWidthPaths infill_paths = part.infill_wall_toolpaths;
         for (size_t density_idx = part.infill_area_per_combine_per_density.size() - 1; (int)density_idx >= 0; density_idx--)
         { // combine different density infill areas (for gradual infill)
             size_t density_factor = 2 << density_idx; // == pow(2, density_idx + 1)
@@ -1431,9 +1431,9 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                                mesh.settings.get<coord_t>("cross_infill_pocket_size"));
             infill_comp.generate(infill_paths, infill_polygons, infill_lines, mesh.settings, mesh.cross_fill_provider, &mesh);
         }
-        if (!part.infill_wall_toolpaths.empty())
+        if (!infill_paths.empty())
         {
-            InsetOrderOptimizer inset_order_optimizer(*this, storage, gcode_layer, mesh, extruder_nr, mesh_config, part.infill_wall_toolpaths, gcode_layer.getLayerNr());
+            InsetOrderOptimizer inset_order_optimizer(*this, storage, gcode_layer, mesh, extruder_nr, mesh_config, infill_paths, gcode_layer.getLayerNr());
             added_something |= inset_order_optimizer.optimize(InsetOrderOptimizer::WallType::EXTRA_INFILL);
         }
         if (!infill_lines.empty() || !infill_polygons.empty())

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1385,7 +1385,6 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
     }
     coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
     coord_t max_deviation = mesh.settings.get<coord_t>("meshfix_maximum_deviation");
-    const coord_t infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
     AngleDegrees infill_angle = 45; //Original default. This will get updated to an element from mesh->infill_angles.
     if (!mesh.infill_angles.empty())
     {
@@ -1417,16 +1416,19 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                 infill_line_distance_here /= 2;
             }
 
-            constexpr size_t wall_line_count = 0; // wall lines are always single layer
+            constexpr size_t wall_line_count = 0; // wall toolpaths are when gradual infill areas are determined
+            constexpr coord_t infill_overlap = 0; // Overlap is handled when the wall toolpaths are generated
             constexpr bool connected_zigzags = false;
             constexpr bool use_endpieces = true;
             constexpr bool skip_some_zags = false;
             constexpr size_t zag_skip_count = 0;
 
-            Infill infill_comp(infill_pattern, zig_zaggify_infill, connect_polygons, part.infill_area_per_combine_per_density[density_idx][combine_idx]
-                , infill_line_width, infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle, gcode_layer.z, infill_shift, max_resolution, max_deviation, wall_line_count, infill_origin
-                , connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count
-                , mesh.settings.get<coord_t>("cross_infill_pocket_size"));
+            Infill infill_comp(infill_pattern, zig_zaggify_infill, connect_polygons,
+                               part.infill_area_per_combine_per_density[density_idx][combine_idx], infill_line_width,
+                               infill_line_distance_here, infill_overlap, infill_multiplier, infill_angle,
+                               gcode_layer.z, infill_shift, max_resolution, max_deviation, wall_line_count,
+                               infill_origin, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count,
+                               mesh.settings.get<coord_t>("cross_infill_pocket_size"));
             infill_comp.generate(infill_paths, infill_polygons, infill_lines, mesh.settings, mesh.cross_fill_provider, &mesh);
         }
         if (!part.infill_wall_toolpaths.empty())
@@ -1577,11 +1579,11 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
             const size_t min_skin_below_wall_count = wall_line_count > 0 ? wall_line_count : 1;
             const size_t skin_below_wall_count = density_idx == last_idx ? min_skin_below_wall_count : 0;
             wall_tool_paths.emplace_back(VariableWidthPaths());
-            Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, infill_below_skin,
-                               infill_line_width, infill_line_distance_here, infill_overlap - (density_idx == last_idx ? 0 : wall_line_count * infill_line_width), infill_multiplier,
-                               infill_angle, gcode_layer.z, infill_shift, max_resolution, max_deviation, skin_below_wall_count, infill_origin,
-                               connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count,
-                               pocket_size);
+            const coord_t overlap = infill_overlap - (density_idx == last_idx ? 0 : wall_line_count * infill_line_width);
+            Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, infill_below_skin, infill_line_width,
+                               infill_line_distance_here, overlap, infill_multiplier, infill_angle, gcode_layer.z,
+                               infill_shift, max_resolution, max_deviation, skin_below_wall_count, infill_origin,
+                               connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
             infill_comp.generate(wall_tool_paths.back(), infill_polygons, infill_lines, mesh.settings, mesh.cross_fill_provider, &mesh);
 
             // Fixme: CURA-7848 for libArachne.
@@ -1618,8 +1620,8 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 
         Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, in_outline, infill_line_width,
                            infill_line_distance_here, overlap, infill_multiplier, infill_angle, gcode_layer.z,
-                           infill_shift, max_resolution, max_deviation, wall_line_count_here, infill_origin, connected_zigzags,
-                           use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
+                           infill_shift, max_resolution, max_deviation, wall_line_count_here, infill_origin,
+                           connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
         infill_comp.generate(wall_tool_paths.back(), infill_polygons, infill_lines, mesh.settings, mesh.cross_fill_provider, &mesh);
 
         // Fixme: CURA-7848 for libArachne.

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -43,14 +43,15 @@ static inline int computeScanSegmentIdx(int x, int line_width)
 
 namespace cura {
 
-Polygons& Infill::generateWalltoolpaths(VariableWidthPaths& toolpaths, const size_t number_of_walls, const coord_t wall_line_width, const Settings& settings)
+Polygons Infill::generateWalltoolpaths(VariableWidthPaths& toolpaths, Polygons& outer_contour, const size_t wall_line_count, const coord_t line_width, const coord_t infill_overlap, const Settings& settings)
 {
     outer_contour = outer_contour.offset(infill_overlap);
 
-    if (number_of_walls > 0)
+    Polygons inner_contour;
+    if (wall_line_count > 0)
     {
         constexpr coord_t wall_0_inset = 0; //Don't apply any outer wall inset for these. That's just for the outer wall.
-        WallToolPaths wall_toolpaths(outer_contour, wall_line_width, number_of_walls, wall_0_inset, settings);
+        WallToolPaths wall_toolpaths(outer_contour, line_width, wall_line_count, wall_0_inset, settings);
         wall_toolpaths.pushToolPaths(toolpaths);
         inner_contour = wall_toolpaths.getInnerContour();
     }
@@ -68,7 +69,7 @@ void Infill::generate(VariableWidthPaths& toolpaths, Polygons& result_polygons, 
         return;
     }
 
-    generateWalltoolpaths(toolpaths, wall_line_count, infill_line_width, settings);
+    inner_contour = generateWalltoolpaths(toolpaths, outer_contour, wall_line_count, infill_line_width, infill_overlap, settings);
 
     //Apply a half-line-width offset if the pattern prints partly alongside the walls, to get an area that we can simply print the centreline alongside the edge.
     //The lines along the edge must lie next to the border, not on it.

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -43,7 +43,7 @@ static inline int computeScanSegmentIdx(int x, int line_width)
 
 namespace cura {
 
-Polygons Infill::generateWalltoolpaths(VariableWidthPaths& toolpaths, Polygons& outer_contour, const size_t wall_line_count, const coord_t line_width, const coord_t infill_overlap, const Settings& settings)
+Polygons Infill::generateWallToolPaths(VariableWidthPaths& toolpaths, Polygons& outer_contour, const size_t wall_line_count, const coord_t line_width, const coord_t infill_overlap, const Settings& settings)
 {
     outer_contour = outer_contour.offset(infill_overlap);
 
@@ -69,7 +69,8 @@ void Infill::generate(VariableWidthPaths& toolpaths, Polygons& result_polygons, 
         return;
     }
 
-    inner_contour = generateWalltoolpaths(toolpaths, outer_contour, wall_line_count, infill_line_width, infill_overlap, settings);
+    inner_contour =
+        generateWallToolPaths(toolpaths, outer_contour, wall_line_count, infill_line_width, infill_overlap, settings);
 
     //Apply a half-line-width offset if the pattern prints partly alongside the walls, to get an area that we can simply print the centreline alongside the edge.
     //The lines along the edge must lie next to the border, not on it.

--- a/src/infill.h
+++ b/src/infill.h
@@ -117,7 +117,7 @@ public:
      * \param settings [in] A settings storage to use for generating variable-width walls.
      * \return The inner contour of the wall toolpaths
      */
-    static Polygons generateWalltoolpaths(VariableWidthPaths& toolpaths, Polygons& outer_contour, const size_t wall_line_count, const coord_t line_width, const coord_t infill_overlap, const Settings& settings);
+    static Polygons generateWallToolPaths(VariableWidthPaths& toolpaths, Polygons& outer_contour, const size_t wall_line_count, const coord_t line_width, const coord_t infill_overlap, const Settings& settings);
 private:
     /*!
      * Generate the infill pattern without the infill_multiplier functionality

--- a/src/infill.h
+++ b/src/infill.h
@@ -110,14 +110,14 @@ public:
      * This function is called within the generate() function but can also be called stand-alone
      *
      * \param toolpaths [out] The generated toolpaths
-     * \param number_of_walls [in] The number of walls that needs to be generated
-     * \param wall_line_width [in] The optimum wall line width of the walls
+     * \param outer_contour [in,out] the outer contour, this is offsetted with the infill overlap
+     * \param wall_line_count [in] The number of walls that needs to be generated
+     * \param line_width [in] The optimum wall line width of the walls
+     * \param infill_overlap [in] The overlap of the infill
      * \param settings [in] A settings storage to use for generating variable-width walls.
-     * \return The inner contour of the wall toolpaths, might be unused, since these are also set in the instance of the
-     * Infill class
+     * \return The inner contour of the wall toolpaths
      */
-    Polygons& generateWalltoolpaths(VariableWidthPaths& toolpaths, size_t number_of_walls,  coord_t wall_line_width, const Settings& settings);
-
+    static Polygons generateWalltoolpaths(VariableWidthPaths& toolpaths, Polygons& outer_contour, const size_t wall_line_count, const coord_t line_width, const coord_t infill_overlap, const Settings& settings);
 private:
     /*!
      * Generate the infill pattern without the infill_multiplier functionality

--- a/src/infill.h
+++ b/src/infill.h
@@ -105,6 +105,19 @@ public:
      */
     void generate(VariableWidthPaths& toolpaths, Polygons& result_polygons, Polygons& result_lines, const Settings& settings, const SierpinskiFillProvider* cross_fill_provider = nullptr, const SliceMeshStorage* mesh = nullptr);
 
+    /*!
+     * Generate the wall toolpaths of an infill area. It will return the inner contour and set the inner-contour.
+     * This function is called within the generate() function but can also be called stand-alone
+     *
+     * \param toolpaths [out] The generated toolpaths
+     * \param number_of_walls [in] The number of walls that needs to be generated
+     * \param wall_line_width [in] The optimum wall line width of the walls
+     * \param settings [in] A settings storage to use for generating variable-width walls.
+     * \return The inner contour of the wall toolpaths, might be unused, since these are also set in the instance of the
+     * Infill class
+     */
+    Polygons& generateWalltoolpaths(VariableWidthPaths& toolpaths, size_t number_of_walls,  coord_t wall_line_width, const Settings& settings);
+
 private:
     /*!
      * Generate the infill pattern without the infill_multiplier functionality

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -7,6 +7,7 @@
 #include "Slice.h"
 #include "ExtruderTrain.h"
 #include "skin.h"
+#include "infill.h"
 #include "sliceDataStorage.h"
 #include "settings/EnumSettings.h" //For EFillMethod.
 #include "settings/types/AngleRadians.h" //For the infill support angle.
@@ -453,6 +454,9 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
     const LayerIndex min_layer = mesh.settings.get<size_t>("initial_bottom_layers");
     const LayerIndex max_layer = mesh.layers.size() - 1 - mesh.settings.get<size_t>("top_layers");
 
+    const auto infill_wall_count = mesh.settings.get<size_t>("infill_wall_line_count");
+    const auto infill_wall_width = mesh.settings.get<coord_t>("infill_line_width");
+    const auto infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
     for (LayerIndex layer_idx = 0; layer_idx < static_cast<LayerIndex>(mesh.layers.size()); layer_idx++)
     { // loop also over layers which don't contain infill cause of bottom_ and top_layer to initialize their infill_area_per_combine_per_density
         SliceLayer& layer = mesh.layers[layer_idx];
@@ -461,7 +465,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
         {
             assert((part.infill_area_per_combine_per_density.empty() && "infill_area_per_combine_per_density is supposed to be uninitialized"));
 
-            const Polygons& infill_area = part.getOwnInfillArea();
+            const Polygons& infill_area = Infill::generateWalltoolpaths(part.infill_wall_toolpaths, part.getOwnInfillArea(), infill_wall_count, infill_wall_width, infill_overlap,  mesh.settings);
 
             if (infill_area.empty() || layer_idx < min_layer || layer_idx > max_layer)
             { // initialize infill_area_per_combine_per_density empty

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -465,7 +465,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
         {
             assert((part.infill_area_per_combine_per_density.empty() && "infill_area_per_combine_per_density is supposed to be uninitialized"));
 
-            const Polygons& infill_area = Infill::generateWalltoolpaths(part.infill_wall_toolpaths, part.getOwnInfillArea(), infill_wall_count, infill_wall_width, infill_overlap,  mesh.settings);
+            const Polygons& infill_area = Infill::generateWallToolPaths(part.infill_wall_toolpaths, part.getOwnInfillArea(), infill_wall_count, infill_wall_width, infill_overlap, mesh.settings);
 
             if (infill_area.empty() || layer_idx < min_layer || layer_idx > max_layer)
             { // initialize infill_area_per_combine_per_density empty

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -63,6 +63,7 @@ public:
     Polygons inner_area; //!< The area of the outline, minus the walls. This will be filled with either skin or infill.
     std::vector<SkinPart> skin_parts;  //!< The skin parts which are filled for 100% with lines and/or insets.
     VariableWidthPaths wall_toolpaths; //!< toolpaths for walls, will replace(?) the insets
+    VariableWidthPaths infill_wall_toolpaths; //!< toolpaths for the infill area's
 
     /*!
      * The areas inside of the mesh.


### PR DESCRIPTION
The problem was two fold:

1. ~~The wall toolpaths were generated in the function `processMultiLayerInfill` but never written to the GCode~~
2.  Wall toopaths should always be one layer in height with the optimal line width. But the lines should be a the intersect of the multiple layers. Since the area needed by the lines is depended on the inner contour of the wall toolpaths and these toolpaths should follow the normal infill area per layer. The generation of the infill walls for the sparsest area should be performed before the combining of the layers. The generation of the walls them self should then be removed from the processSingleLayerInfill and processMultiLayerInfill functions.

The function generateWalltoolpaths is introduced and is also used by the normal generate function. This ensures that other `Infill` class usage doesn't break with the regular interface.

> Note!
> setting the infill layer height to a multitude of the regular height and setting the skin edge support layers to a number higher then 1 does not generate that number of skin edge support layers. This also happens in master and I consider it a separate bug and not part of this one. I will raise it at the eCCB for tomorrow.