### PR TITLE
Fix missing transition endpoints in Arachne

### DIFF
--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -740,8 +740,8 @@ void SkeletalTrapezoidation::generateTransitionMids(ptr_vector_t<std::list<Trans
         }
         coord_t start_R = edge.from->data.distance_to_boundary;
         coord_t end_R = edge.to->data.distance_to_boundary;
-        coord_t start_bead_count = edge.from->data.bead_count;
-        coord_t end_bead_count = edge.to->data.bead_count;
+        int start_bead_count = edge.from->data.bead_count;
+        int end_bead_count = edge.to->data.bead_count;
 
         if (start_R == end_R)
         { // No transitions occur when both end points have the same distance_to_boundary
@@ -773,7 +773,7 @@ void SkeletalTrapezoidation::generateTransitionMids(ptr_vector_t<std::list<Trans
             RUN_ONCE(logWarning("Transitioning the wrong way around! This function expects to transition from small R to big R, but was transitioning from %i to %i.", start_R, end_R));
         }
         coord_t edge_size = vSize(edge.from->p - edge.to->p);
-        for (coord_t transition_lower_bead_count = start_bead_count; transition_lower_bead_count < end_bead_count; transition_lower_bead_count++)
+        for (int transition_lower_bead_count = start_bead_count; transition_lower_bead_count < end_bead_count; transition_lower_bead_count++)
         {
             coord_t mid_R = beading_strategy.getTransitionThickness(transition_lower_bead_count) / 2;
             if (mid_R > end_R)

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "SkeletalTrapezoidation.h"
@@ -904,7 +904,7 @@ std::list<SkeletalTrapezoidation::TransitionMidRef> SkeletalTrapezoidation::diss
         {
             auto& transitions = *aligned_edge->data.getTransitions();
             for (auto transition_it = transitions.begin(); transition_it != transitions.end(); ++ transition_it)
-            { // Note: this is not neccesarily iterating in the traveling direction!
+            { // Note: this is not necessarily iterating in the traveling direction!
                 // Check whether we should dissolve
                 coord_t pos = is_aligned? transition_it->pos : ab_size - transition_it->pos;
                 if (traveled_dist + pos < max_dist
@@ -1118,7 +1118,6 @@ bool SkeletalTrapezoidation::generateTransitionEnd(edge_t& edge, coord_t start_p
         bool is_lower_end = end_rest == 0; // TODO collapse this parameter into the bool for which it is used here!
         coord_t pos = -1;
 
-        edge_transition_ends.emplace_back(std::make_shared<std::list<TransitionEnd>>());
         edge_t* upward_edge = nullptr;
         if (edge.isUpward())
         {
@@ -1130,9 +1129,16 @@ bool SkeletalTrapezoidation::generateTransitionEnd(edge_t& edge, coord_t start_p
             upward_edge = edge.twin;
             pos = ab_size - end_pos;
         }
-        upward_edge->data.setTransitionEnds(edge_transition_ends.back());  // initialization
+
+        if(!upward_edge->data.hasTransitionEnds())
+        {
+            //This edge doesn't have a data structure yet for the transition ends. Make one.
+            edge_transition_ends.emplace_back(std::make_shared<std::list<TransitionEnd>>());
+            upward_edge->data.setTransitionEnds(edge_transition_ends.back());
+        }
         auto transitions = upward_edge->data.getTransitionEnds();
 
+        //Add a transition to it (on the correct side).
         assert(ab_size == vSize(edge.twin->from->p - edge.twin->to->p));
         assert(pos <= ab_size);
         if (transitions->empty() || pos < transitions->front().pos)

--- a/src/SkeletalTrapezoidationEdge.h
+++ b/src/SkeletalTrapezoidationEdge.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef SKELETAL_TRAPEZOIDATION_EDGE_H
@@ -26,8 +26,8 @@ public:
     struct TransitionMiddle
     {
         coord_t pos; // Position along edge as measure from edge.from.p
-        coord_t lower_bead_count;
-        TransitionMiddle(coord_t pos, coord_t lower_bead_count)
+        int lower_bead_count;
+        TransitionMiddle(coord_t pos, int lower_bead_count)
             : pos(pos), lower_bead_count(lower_bead_count)
         {}
     };
@@ -38,9 +38,9 @@ public:
     struct TransitionEnd
     {
         coord_t pos; // Position along edge as measure from edge.from.p, where the edge is always the half edge oriented from lower to higher R
-        coord_t lower_bead_count;
+        int lower_bead_count;
         bool is_lower_end; // Whether this is the ed of the transition with lower bead count
-        TransitionEnd(coord_t pos, coord_t lower_bead_count, bool is_lower_end)
+        TransitionEnd(coord_t pos, int lower_bead_count, bool is_lower_end)
             : pos(pos), lower_bead_count(lower_bead_count), is_lower_end(is_lower_end)
         {}
     };


### PR DESCRIPTION
After 3 developers and 2 days of debugging each, we found an issue that was causing transitions to omit some transition endpoints, resulting in weirdly thin and displaced lines.

![image](https://user-images.githubusercontent.com/2448634/109673157-08448e00-7b76-11eb-82f6-a8a3b3c1d32d.png)

The problem was that the data structure that stores endpoints of transitions was being re-created with every endpoint, if an edge had multiple endpoints. We need to initialise that data structure only once, and add to it later.

![image](https://user-images.githubusercontent.com/2448634/109673403-49d53900-7b76-11eb-89da-bf4967cdf2dd.png)

While debugging this initially, I found the bead counts to be confusing as `coord_t`. I can't make them `size_t` since they are used as negative numbers as well, but at least we could make them `int` since they are definitely not coordinates.

Fixes CURA-7854.