### PR TITLE
Fixes dangling references in Polygons::removeSmallAreas

### DIFF
--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -526,56 +526,63 @@ void Polygons::removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& 
 
 void Polygons::removeSmallAreas(const double min_area_size, const bool remove_holes)
 {
-    std::vector<ConstPolygonRef> outlines_removed;
-    std::vector<size_t> small_hole_indices;
-    Polygons& thiss = *this;
-    for(size_t i = 0; i < size(); i++)
+    auto new_end = paths.end();
+    if(remove_holes)
     {
-        double area = INT2MM(INT2MM(thiss[i].area()));
-        // holes have negative area and small holes will be ignored unless remove_holes is true
-        // or the hole is contained within an outline that is itself smaller in area than the threshold
-        if (fabs(area) < min_area_size)
+        for(auto it = paths.begin(); it < new_end; it++)
         {
-            if (!remove_holes)
+            // All polygons smaller than target are removed by replacing them with a polygon from the back of the vector
+            if(fabs(INT2MM2(ClipperLib::Area(*it))) < min_area_size)
             {
-                if (area > 0)
-                {
-                    // remember this outline has been removed so we can later check if it contains any holes that also need to be removed
-                    outlines_removed.push_back(thiss[i]);
-                }
-                else
-                {
-                    // remember this small hole so we can later check if it is contained within an outline that has been removed
-                    small_hole_indices.push_back(i);
-                }
-            }
-            // the polygon area is below the threshold, remove it if it is an outline or we are removing holes as well as outlines
-            if (area > 0 || remove_holes)
-            {
-                remove(i);
-                i -= 1;
+                new_end--;
+                *it = std::move(*new_end);
+                it--; // wind back the iterator such that the polygon just swaped in is checked next
             }
         }
     }
-    if (outlines_removed.size() > 0 && small_hole_indices.size() > 0)
+    else
     {
-        size_t num_holes_removed = 0;
-        // now remove any holes that are inside outlines that have been removed
-        for (size_t small_hole_index : small_hole_indices)
-        {
-            const size_t hole_index = small_hole_index - num_holes_removed; // adjust index to account for removed holes
-            // if hole polygon's first point is inside a removed polygon, remove the hole polygon also
-            for (ConstPolygonRef removed_outline : outlines_removed)
+        // For each polygon, computes the signed area, move small outlines at the end of the vector and keep references on small holes
+        std::vector<PolygonRef> small_holes;
+        for(auto it = paths.begin(); it < new_end; it++) {
+            double area = INT2MM2(ClipperLib::Area(*it));
+            if (fabs(area) < min_area_size)
             {
-                if (removed_outline.inside(thiss[hole_index][0]))
+                if(area >= 0)
                 {
-                    remove(hole_index);
-                    ++num_holes_removed;
+                    new_end--;
+                    if(it < new_end) {
+                        std::swap(*new_end, *it);
+                        it--;
+                    }
+                    else
+                    { // Don't self-swap the last Path
+                        break;
+                    }
+                }
+                else
+                {
+                    small_holes.push_back(*it);
+                }
+            }
+        }
+
+        // Removes small holes that have their first point inside one of the removed outlines
+        // Iterating in reverse ensures that unprocessed small holes won't be moved
+        const auto removed_outlines_start = new_end;
+        for(auto hole_it = small_holes.rbegin(); hole_it < small_holes.rend(); hole_it++)
+        {
+            for(auto outline_it = removed_outlines_start; outline_it < paths.end() ; outline_it++)
+            {
+                if(PolygonRef(*outline_it).inside(*hole_it->begin())) {
+                    new_end--;
+                    **hole_it = std::move(*new_end);
                     break;
                 }
             }
         }
     }
+    paths.resize(new_end-paths.begin());
 }
 
 Polygons Polygons::toPolygons(ClipperLib::PolyTree& poly_tree)


### PR DESCRIPTION
Since commit 377ee8f379a986fb81f5226ce9181b175a0492c3, #1156, `Polygons.removeSmallAreas(remove_holes=false)` also removes small holes contained within small outlines. 

Using the AdressSanitizer I found that it doesn't (no longer?) works with the `Polygons::remove(int)` and `ConstPolygonRef` implementation.  

`removeSmallAreas` creates `ConstPolygonRef`s  to small outlines for later reference at the small holes check. These outlines are overwritten by a call `remove(i)` which replace them with an element from the end. I think the heap-use-after-free reported by Asan was caused by the vector shrinking enough for it's storage to be reallocated : <details>

```
0x6080000169a8 is located 8 bytes inside of 96-byte region [0x6080000169a0,0x608000016a00)
freed by thread T20 here:
    #0 0x55ebd49c5c29 in operator delete(void*) (build-CuraEngine-Clang-Debug/CuraEngine+0x1ddc29)
    #1 0x55ebd4a7f1eb in __gnu_cxx::new_allocator<ClipperLib::IntPoint>::deallocate(ClipperLib::IntPoint*, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/ext/new_allocator.h:133:2
    #2 0x55ebd4a7f1d8 in std::allocator_traits<std::allocator<ClipperLib::IntPoint> >::deallocate(std::allocator<ClipperLib::IntPoint>&, ClipperLib::IntPoint*, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/alloc_traits.h:492:13
    #3 0x55ebd4a7f1cd in std::_Vector_base<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >::_M_deallocate(ClipperLib::IntPoint*, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/stl_vector.h:354:4
    #4 0x55ebd4a7eb83 in std::_Vector_base<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >::~_Vector_base() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/stl_vector.h:335:2
    #5 0x55ebd4a788b5 in std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >::~vector() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/stl_vector.h:683:7
    #6 0x55ebd4a7db38 in void std::_Destroy<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> > >(std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/stl_construct.h:140:19
    #7 0x55ebd4a7db1f in void std::_Destroy_aux<false>::__destroy<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*>(std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*, std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/stl_construct.h:152:6
    #8 0x55ebd4a7dae8 in void std::_Destroy<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*>(std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*, std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/stl_construct.h:184:7
    #9 0x55ebd4a7dac8 in void std::_Destroy<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*, std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> > >(std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*, std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*, std::allocator<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> > >&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/alloc_traits.h:738:7
    #10 0x55ebd4a7da7c in std::vector<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >, std::allocator<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> > > >::_M_erase_at_end(std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/stl_vector.h:1796:6
    #11 0x55ebd4a8283c in std::vector<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> >, std::allocator<std::vector<ClipperLib::IntPoint, std::allocator<ClipperLib::IntPoint> > > >::resize(unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/stl_vector.h:942:4
    #12 0x55ebd4a815e1 in cura::Polygons::remove(unsigned int) CuraEngine/src/utils/polygon.h:698:15
    #13 0x55ebd4a74ffd in cura::Polygons::removeSmallAreas(double, bool) CuraEngine/src/utils/polygon.cpp:639:17
```

</details>
This change keeps the original behavior by moving small outlines at the end without resizing the vector until small holes are checked for inclusion in them. `remove()` calls are replaced with moves/swaps and a single resizing of the Path vector.

Few things:
* It's only ok to [self-move](https://ericniebler.com/2017/03/31/post-conditions-on-self-move/) the last element if it's value won't be relied upon anymore. That's why the self-swap of the last outline is avoided.
* I separated the `remove_holes=true` case because it is a lot simpler and helps to understand what happens in the other case.