### PR TITLE
Fix asymmetrical bead widths

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -867,6 +867,7 @@ void LayerPlan::addWall(const LineJunctions& wall, int start_idx, const Settings
     for(size_t point_idx = 1; point_idx < max_index; point_idx++)
     {
         const ExtrusionJunction& p1 = wall[(wall.size() + start_idx + point_idx * direction) % wall.size()];
+        const coord_t line_width = (p0.w + p1.w) / 2; //For lines which in itself vary in width, use the average width of the variable line.
 
         if (!bridge_wall_mask.empty())
         {
@@ -884,11 +885,11 @@ void LayerPlan::addWall(const LineJunctions& wall, int start_idx, const Settings
             if (is_small_feature)
             {
                 constexpr bool spiralize = false;
-                addExtrusionMove(p1.p, non_bridge_config, SpaceFillType::Polygons, flow_ratio * (p1.w * nominal_line_width_multiplier), spiralize, small_feature_speed_factor);
+                addExtrusionMove(p1.p, non_bridge_config, SpaceFillType::Polygons, flow_ratio * (line_width * nominal_line_width_multiplier), spiralize, small_feature_speed_factor);
             }
             else
             {
-                addWallLine(p0.p, p1.p, settings, non_bridge_config, bridge_config, flow_ratio * (p1.w * nominal_line_width_multiplier), non_bridge_line_volume, speed_factor, distance_to_bridge_start);
+                addWallLine(p0.p, p1.p, settings, non_bridge_config, bridge_config, flow_ratio * (line_width * nominal_line_width_multiplier), non_bridge_line_volume, speed_factor, distance_to_bridge_start);
             }
         }
         else

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1494,7 +1494,7 @@ void SkeletalTrapezoidation::generateSegments()
     propagateBeadingsUpward(upward_quad_mids, node_beadings);
 
     propagateBeadingsDownward(upward_quad_mids, node_beadings);
-    
+
     ptr_vector_t<LineJunctions> edge_junctions; // junctions ordered high R to low R
     generateJunctions(node_beadings, edge_junctions);
 
@@ -1727,9 +1727,9 @@ void SkeletalTrapezoidation::generateJunctions(ptr_vector_t<BeadingPropagation>&
         Point ab = b - a;
 
         const size_t num_junctions = beading->toolpath_locations.size();
-        coord_t junction_idx;
+        size_t junction_idx;
         // Compute starting junction_idx for this segment
-        for (junction_idx = (std::max(size_t(1), beading->toolpath_locations.size()) - 1) / 2; junction_idx >= 0 && junction_idx < coord_t(num_junctions); junction_idx--)
+        for (junction_idx = (std::max(size_t(1), beading->toolpath_locations.size()) - 1) / 2; junction_idx < num_junctions; junction_idx--)
         {
             coord_t bead_R = beading->toolpath_locations[junction_idx];
             if (bead_R <= start_R)
@@ -1740,7 +1740,7 @@ void SkeletalTrapezoidation::generateJunctions(ptr_vector_t<BeadingPropagation>&
 
         // Robustness against odd segments which might lie just slightly outside of the range due to rounding errors
         // not sure if this is really needed (TODO)
-        if (junction_idx + 1 < coord_t(num_junctions)
+        if (junction_idx + 1 < num_junctions
             && beading->toolpath_locations[junction_idx + 1] <= start_R + 5
             && beading->total_thickness < start_R + 5
         )
@@ -1748,7 +1748,7 @@ void SkeletalTrapezoidation::generateJunctions(ptr_vector_t<BeadingPropagation>&
             junction_idx++;
         }
 
-        for (; junction_idx >= 0 && junction_idx < coord_t(num_junctions); junction_idx--)
+        for (; junction_idx < num_junctions; junction_idx--) //When junction_idx underflows, it'll be more than num_junctions too.
         {
             coord_t bead_R = beading->toolpath_locations[junction_idx];
             assert(bead_R >= 0);

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1955,7 +1955,7 @@ void SkeletalTrapezoidation::connectJunctions(ptr_vector_t<LineJunctions>& edge_
                 to_junctions.reserve(to_junctions.size() + to_next_junctions.size());
                 to_junctions.insert(to_junctions.end(), to_next_junctions.begin(), to_next_junctions.end());
                 assert(!edge_from_peak->next->next);
-                if(edge_to_peak->next->next)
+                if(edge_from_peak->next->next)
                 {
                     RUN_ONCE(logWarning("The edge we're about to connect is already connected!\n"));
                 }
@@ -1965,7 +1965,6 @@ void SkeletalTrapezoidation::connectJunctions(ptr_vector_t<LineJunctions>& edge_
             {
                 logWarning("Can't create a transition when connecting two perimeters where the number of beads differs too much! %i vs. %i", from_junctions.size(), to_junctions.size());
             }
-
 
             size_t segment_count = std::min(from_junctions.size(), to_junctions.size());
             for (size_t junction_rev_idx = 0; junction_rev_idx < segment_count; junction_rev_idx++)


### PR DESCRIPTION
Instead of with the width at the far end of the line segment, print it with the average.

Previously, the width of a line would depend on the direction in which you were printing it. Quite often, as a path went into a narrow peak and back out, one side of this peak would be printed with a small line width (the destination in the peak being narrow) and as the nozzle goes back out, that segment would be printed with a large line width (the destination at the base being wider). This is inconsistent and leads to larger flow changes than necessary. Often this would also vary from layer to layer, a different bug, which looks extra messy.

Before this change:
![Screenshot from 2021-04-06 03-35-20](https://user-images.githubusercontent.com/2448634/113646654-87ebde00-9689-11eb-8553-daeb7d42c964.png)

After this change:
![Screenshot from 2021-04-06 03-34-40](https://user-images.githubusercontent.com/2448634/113646662-8e7a5580-9689-11eb-8703-0c3f26c17032.png)

The first two commits are clean-ups of things that I found during this investigation, and don't affect the outcome. Tests seem to be failing due to the build environment in the CI server still.

Fixes issue CURA-8073. This doesn't fix yet that the lines exceed the volume of the original model significantly, but I did find the cause of that and reported that in the CCB just now.