### PR TITLE
[CURA-8149] Z-Seam tie-breaker

### DIFF
--- a/src/pathOrderOptimizer.cpp
+++ b/src/pathOrderOptimizer.cpp
@@ -155,7 +155,7 @@ int PathOrderOptimizer::getClosestPointInPolygon(Point prev_point, int poly_idx)
     const Point focus_fixed_point =
         (config.type == EZSeamType::USER_SPECIFIED) ?
         config.pos :
-        Point(0, -std::sqrt(std::numeric_limits<coord_t>::max()));  // NOTE: Use sqrt, so the squared size can be used when comparing distances.
+        Point(0, std::sqrt(std::numeric_limits<coord_t>::max()));  // NOTE: Use sqrt, so the squared size can be used when comparing distances.
     coord_t smallest_dist_sqd = std::numeric_limits<coord_t>::max();
     for (unsigned int point_idx = 0; point_idx < poly.size(); point_idx++)
     {


### PR DESCRIPTION
Previously, shapes derived from, for instance, circles, had a definite preference for seam-location, due to the simplification not working _completely_ correctly.

Since we fixed that, the z-seam location for sharpest corner for circular and similar shapes is all over the place, since circles don't have an _actual_ sharpest corner.

Users still expect some consistency though, so it was decided to give (all else being equal to within a fixed epsilon) a certain location a slight preference, so the z-seam is at least roughly 'in the same place' when comparing between layers for these sort of models, even if the z-seam placement/settings doesn't have an _actual_ preference.