### PR TITLE
Truncated octahedron infill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ set(engine_SRCS # Except main.cpp.
     src/infill/SierpinskiFillProvider.cpp
     src/infill/SubDivCube.cpp
     src/infill/GyroidInfill.cpp
+    src/infill/TroctInfill.cpp
 
     src/pathPlanning/Comb.cpp
     src/pathPlanning/GCodePath.cpp

--- a/src/infill/TroctInfill.cpp
+++ b/src/infill/TroctInfill.cpp
@@ -1,0 +1,237 @@
+//Copyright (c) 2021 David Eccles (gringer)
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+/*
+Creates a contiguous sequence of points at a specified height that make
+up a horizontal slice of the edges of a space filling truncated
+octahedron tesselation. The octahedrons are oriented so that the
+square faces are in the horizontal plane with edges parallel to the X
+and Y axes.
+
+Note: this code is derived from David Eccles' truncated octahedron
+infill (3D honeycomb) from Slic3r.
+*/
+
+#include "TroctInfill.h"
+#include "../utils/AABB.h"
+#include "../utils/linearAlg2D.h"
+#include "../utils/polygon.h"
+
+namespace cura {
+
+TroctInfill::TroctInfill() {
+}
+
+TroctInfill::~TroctInfill() {
+}
+
+// sign function
+template <typename T> int sgn(T val) {
+  return (T(0) < val) - (val < T(0));
+}
+  
+// triangular wave function
+// this has period (gridSize * 2), and amplitude (gridSize / 2),
+// with triWave(pos = 0) = 0
+float TroctInfill::triWave(float pos, float gridSize)
+{
+  float t = (pos / (gridSize * 2.)) + 0.25; // convert relative to grid size
+  t = t - (int)t; // extract fractional part
+  return((1. - abs(t * 8. - 4.)) * (gridSize / 4.) + (gridSize / 4.));
+}
+
+// truncated octagonal waveform, with period and offset
+// as per the triangular wave function. The Z position adjusts
+// the maximum offset [between -(gridSize / 4) and (gridSize / 4)], with a
+// period of (gridSize * 2) and troctWave(Zpos = 0) = 0
+float TroctInfill::troctWave(float pos, float gridSize, float Zpos)
+{
+  float Zcycle = triWave(Zpos, gridSize);
+  float perpOffset = Zcycle / 2;
+  float y = triWave(pos, gridSize);
+  return((abs(y) > abs(perpOffset)) ?
+	 (sgn(y) * perpOffset) :
+	 (y * sgn(perpOffset)));
+}
+
+// Identify the important points of curve change within a truncated
+// octahedron wave (as waveform fraction t):
+// 1. Start of wave (always 0.0)
+// 2. Transition to upper "horizontal" part
+// 3. Transition from upper "horizontal" part
+// 4. Transition to lower "horizontal" part
+// 5. Transition from lower "horizontal" part
+/*    o---o
+ *   /     \
+ * o/       \
+ *           \       /
+ *            \     /
+ *             o---o
+ */
+std::vector<float> TroctInfill::getCriticalPoints(float Zpos, float gridSize)
+{
+  std::vector<float> res = {0.};
+  float perpOffset = abs(triWave(Zpos, gridSize) / 2.);
+
+  float normalisedOffset = perpOffset / gridSize;
+  // note: 0 == straight line
+  if(normalisedOffset > 0){
+    res.push_back(gridSize * (0. + normalisedOffset));
+    res.push_back(gridSize * (1. - normalisedOffset));
+    res.push_back(gridSize * (1. + normalisedOffset));
+    res.push_back(gridSize * (2. - normalisedOffset));
+  }
+  return(res);
+}
+
+// Generate an array of points that are in the same direction as the
+// basic printing line (i.e. Y points for columns, X points for rows)
+// Note: a negative offset only causes a change in the perpendicular
+// direction
+std::vector<float> TroctInfill::colinearPoints(const float Zpos, float gridSize,
+					       std::vector<float> critPoints,
+					       const size_t boundsMin,
+					       const size_t boundsMax)
+{
+  std::vector<float> points;
+  points.push_back(boundsMin);
+  for (float cLoc = boundsMin; cLoc < boundsMax; cLoc+= (gridSize * 2)) {
+    for(size_t pi = 0; pi < critPoints.size(); pi++){
+      points.push_back(boundsMin + cLoc + critPoints[pi]);
+    }
+  }
+  points.push_back(boundsMax);
+  return points;
+}
+
+// Generate an array of points for the dimension that is perpendicular to
+// the basic printing line (i.e. X points for columns, Y points for rows)
+std::vector<float> TroctInfill::perpendPoints(const float Zpos, float gridSize,
+					      std::vector<float> critPoints,
+					      const size_t baseLocation,
+					      const size_t boundsMin,
+					      const size_t boundsMax, float perpDir)
+{
+  std::vector<float> points;
+  points.push_back(baseLocation);
+  for (float cLoc = boundsMin; cLoc < boundsMax; cLoc+= (gridSize * 2)) {
+    for(size_t pi = 0; pi < critPoints.size(); pi++){
+      float offset = troctWave(critPoints[pi], gridSize, Zpos);
+      points.push_back(baseLocation + (offset * perpDir));
+    }
+  }
+  points.push_back(baseLocation);
+  return points;
+}
+
+void TroctInfill::zip(PolygonRef result,
+		      const std::vector<float> &x,
+		      const std::vector<float> &y)
+{
+    assert(x.size() == y.size());
+    for (size_t i = 0; i < x.size(); ++ i){
+      Point current = Point(x[i], y[i]);
+      result.add(current);
+    }
+}
+
+// Generate a set of curves (array of array of 2d points) that
+// describe a horizontal slice of a truncated regular octahedron with
+// a specified grid square size. gridWidth and gridHeight define the
+// width and height of the bounding box respectively
+Polygons TroctInfill::makeGrid(float Zpos, float gridSize,
+			       const AABB bounds)
+{
+  Polygons result;
+  std::vector<float> critPoints = getCriticalPoints(Zpos, gridSize);
+  float zCycle = fmod(Zpos + gridSize/2, gridSize * 2.) / (gridSize * 2.);
+  bool printVert = zCycle < 0.5;
+  if (printVert) {
+    int perpDir = -1;
+    for (float x = bounds.min.X; x <= (bounds.max.X); x+= gridSize, perpDir *= -1) {
+      PolygonRef newPoints = result.newPoly();
+      zip(newPoints,
+	  perpendPoints(Zpos, gridSize, critPoints, x,
+			bounds.min.Y, bounds.max.Y, perpDir), 
+	  colinearPoints(Zpos, gridSize, critPoints, bounds.min.Y, bounds.max.Y));
+      if (perpDir == 1)
+	newPoints.reverse();
+    }
+  } else {
+    int perpDir = 1;
+    for (float y = bounds.min.Y + gridSize;
+	 y <= (bounds.max.Y); y+= gridSize, perpDir *= -1) {
+      PolygonRef newPoints = result.newPoly();
+      zip(newPoints,
+	  colinearPoints(Zpos, gridSize, critPoints, bounds.min.X, bounds.max.X),
+	  perpendPoints(Zpos, gridSize, critPoints, y,
+			bounds.min.X, bounds.max.X, perpDir));
+      if (perpDir == -1)
+	newPoints.reverse();
+    }
+  }
+  return result;
+}
+
+void TroctInfill::
+generateTotalTroctInfill(
+			 Polygons& result_lines, bool zig_zaggify,
+			 coord_t outline_offset, coord_t infill_line_width,
+			 coord_t line_distance, const Polygons& in_outline,
+			 coord_t z)
+{
+
+    const Polygons outline = in_outline.offset(outline_offset);
+    const AABB aabb(outline);
+
+    // Note: with equally-scaled X/Y/Z, the pattern will create a vertically-stretched
+    // truncated octahedron; so Z is pre-adjusted first by scaling by sqrt(2)
+    float zScale = sqrt(2);
+    float estDensity = infill_line_width / line_distance; // assumed
+
+    // adjustment to account for the additional distance of octagram curves
+    // note: this only strictly applies for a rectangular area where the total
+    //       Z travel distance is a multiple of the spacing
+    // = 4 * integrate(func=4*x(sqrt(2) - 1) + 1, from=0, to=0.25)
+    // = (sqrt(2) + 1) / 2 [... I think]
+    // make a first guess at the preferred grid Size
+    float gridSize = (line_distance * ((zScale + 1.) / 2.));
+
+    // This density calculation is incorrect for many values > 25%, possibly
+    // due to quantisation error, so this value is used as a first guess, then the
+    // Z scale is adjusted to make the layer patterns consistent / symmetric
+    // This means that the resultant infill won't be an ideal truncated octahedron,
+    // but it should look better than the equivalent quantised version
+    
+    float layerHeight = infill_line_width; // assume width == height
+    // ceiling to an integer value of layers per Z
+    // (with a little nudge in case it's close to perfect)
+    float layersPerModule = floor((gridSize * 2) / (zScale * layerHeight) + 0.05);
+    if(estDensity > 0.42){ // exact layer pattern for >42% density
+      layersPerModule = 2;
+      // re-adjust the grid size for a partial octahedral path
+      // (scale of 1.1 guessed based on modeling)
+      gridSize = (line_distance * 1.1);
+      // re-adjust zScale to make layering consistent
+      zScale = (gridSize * 2) / (layersPerModule * layerHeight);
+    } else {
+      if(layersPerModule < 2){
+	layersPerModule = 2;
+      }
+      // re-adjust zScale to make layering consistent
+      zScale = (gridSize * 2) / (layersPerModule * layerHeight);
+      // re-adjust the grid size to account for the new zScale
+      gridSize = (line_distance * ((zScale + 1.) / 2.));
+      // re-calculate layersPerModule and zScale
+      layersPerModule = floor((gridSize * 2) / (zScale * layerHeight) + 0.05);
+      if(layersPerModule < 2){
+	layersPerModule = 2;
+      }
+      zScale = (gridSize * 2) / (layersPerModule * layerHeight);
+    }
+
+    Polygons result = makeGrid(z * zScale, gridSize, aabb);
+    result_lines = result;
+}
+
+} // namespace cura

--- a/src/infill/TroctInfill.h
+++ b/src/infill/TroctInfill.h
@@ -1,0 +1,48 @@
+//Copyright (c) 2018 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include "../utils/Coord_t.h"
+#include "../utils/AABB.h"
+#include "../utils/polygon.h"
+
+namespace cura
+{
+
+class Polygons;
+
+class TroctInfill
+{
+public:
+  TroctInfill();
+
+  ~TroctInfill();
+  
+  static void generateTotalTroctInfill(Polygons& result_lines,
+				       bool zig_zaggify, coord_t outline_offset,
+				       coord_t infill_line_width,
+				       coord_t line_distance,
+				       const Polygons& in_outline, coord_t z);
+    
+private:
+
+  static float triWave(float pos, float gridSize);
+  static float troctWave(float pos, float gridSize, float Zpos);
+  static std::vector<float> getCriticalPoints(float Zpos, float gridSize);
+  static std::vector<float> colinearPoints(const float Zpos, float gridSize,
+					   std::vector<float> critPoints,
+					   const size_t boundsMin,
+					   const size_t boundsMax);
+  static std::vector<float> perpendPoints(const float Zpos, float gridSize,
+					  std::vector<float> critPoints,
+					  const size_t baseLocation,
+					  const size_t boundsMin,
+					  const size_t boundsMax, float perpDir);
+  static void zip(PolygonRef result,
+		  const std::vector<float> &x,
+		  const std::vector<float> &y);
+  static Polygons makeGrid(float Zpos, float gridSize, AABB bounds);
+
+};
+
+} // namespace cura
+


### PR DESCRIPTION
This is the backend code for 3D Honeycomb / Truncated Octahedron infill, as seen in Slic3r (but not [yet] PrusaSlicer). The infill pattern only bridges once per "module", at the smallest bridge point on the square horizontal faces (with a bridge span of approximately [line_distance / 2]). This produces a strong infill pattern which should work at very low infill percentages.

Note that this is only the backend code. It will need to be bolted onto the frontend interface. To make that easier, I've tried to make sure that the public function syntax is exactly the same as the Gyroid infill, so hopefully it should just be a matter of copying the Gyroid definitions, and replacing "Gyroid" with "Troct".

See the following image, taken from my fork of PrusaSlicer, demonstrating a 5% infill with no walls, where I've changed the colour at each direction change. I've been having trouble testing this code (see below); this image is based onthe PrusaSlicer equivalent of the code in this branch:

![density_5pct](https://user-images.githubusercontent.com/856314/116075339-f3ecbf80-a6e6-11eb-9d2e-98e070e65ec3.png)

In other words, this code, in its current form, probably won't work. I'm hoping that someone with Cura building capabilities can test it, or help me build a working test setup on my Debian system.

I have also attempted to tweak the density calculation to make it more accurate. Assuming I've got the right density calculation (i.e. [infill_line_width / line_distance]), it should have a similar accuracy to the gyroid and rectilinear infills.

Note: this is essentially the same change I've opened a pull request for in PrusaSlicer. There are some additional minor bug fixes due to pattern start/end points, but probably more introduced bugs due to the porting process.

p.s. I'm having a really hard time getting the Lulzbot Cura GUI to compile on my computer, and the test scripts for CuraEngine aren't working for me. Here's an example that I tried to run, and its output:

```
grinja@hera:~/install/CuraEngine$ ./build/CuraEngine slice -v -s machine_extruder_count="1" -j ../Cura/resources/definitions/fdmextruder.def.json -j ../Cura/resources/extruders/prusa_i3_mk3_extruder_0.def.json -j ../Cura/resources/definitions/prusa_i3_mk3.def.json -o "output/test.gcode" -l "/model_1.stl"

Cura_SteamEngine version master
Copyright (C) 2020 Ultimaker

This program is free software: you can redistribute it and/or modify
it under the terms of the GNU Affero General Public License as published by
the Free Software Foundation, either version 3 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU Affero General Public License for more details.

You should have received a copy of the GNU Affero General Public License
along with this program.  If not, see <http://www.gnu.org/licenses/>.
[ERROR] Couldn't find definition file with ID: fdmextruder
[ERROR] Inherited JSON file "fdmextruder" not found.
[ERROR] Failed to load JSON file: ../Cura/resources/extruders/prusa_i3_mk3_extruder_0.def.json

```
I don't need a GUI; I just need some way to test out this pattern and produce GCode.
