### PR TITLE
Fix priming secondary extruders on first layer

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <list>
@@ -978,7 +978,7 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, LayerIn
 
     if (include_helper_parts)
     { // add prime tower if it hasn't already been added
-        int prev_extruder = gcode_layer.getExtruder(); // most likely the same extruder as we are extruding with now
+        const size_t prev_extruder = gcode_layer.getExtruder(); // most likely the same extruder as we are extruding with now
 
         if (gcode_layer.getLayerNr() != 0 || storage.primeTower.extruder_order[0] == prev_extruder)
         {
@@ -2971,7 +2971,7 @@ void FffGcodeWriter::setExtruder_addPrime(const SliceDataStorage& storage, Layer
     }
 }
 
-void FffGcodeWriter::addPrimeTower(const SliceDataStorage& storage, LayerPlan& gcode_layer, int prev_extruder) const
+void FffGcodeWriter::addPrimeTower(const SliceDataStorage& storage, LayerPlan& gcode_layer, const size_t prev_extruder) const
 {
     if (!Application::getInstance().current_slice->scene.current_mesh_group->settings.get<bool>("prime_tower_enable"))
     {

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef GCODE_WRITER_H
@@ -691,7 +691,7 @@ private:
      * \param gcodeLayer The initial planning of the gcode of the layer.
      * \param prev_extruder The current extruder with which we last printed.
      */
-    void addPrimeTower(const SliceDataStorage& storage, LayerPlan& gcodeLayer, int prev_extruder) const;
+    void addPrimeTower(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const size_t prev_extruder) const;
     
     /*!
      * Add the end gcode and set all temperatures to zero.

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -316,11 +316,20 @@ private:
      * \note At the planning stage we only have information on areas, not how those are filled.
      * If an area is too small to be filled with anything it will still get specified as being used with the extruder for that area.
      * 
-     * Computes \ref FffGcodeWriter::extruder_prime_layer_nr, \ref FffGcodeWriter::extruder_order_per_layer and \ref FffGcodeWriter::extruder_order_per_layer_negative_layers
+     * Computes \ref FffGcodeWriter::extruder_order_per_layer and \ref FffGcodeWriter::extruder_order_per_layer_negative_layers
      * 
      * \param[in] storage where the slice data is stored.
      */
     void calculateExtruderOrderPerLayer(const SliceDataStorage& storage);
+
+    /*!
+     * Calculate on which layer we should be priming for each extruder.
+     *
+     * The extruders are primed on the lowest layer at which they are used.
+     * \param storage Slice data storage containing information on which layers
+     * each extruder is used.
+     */
+    void calculatePrimeLayerPerExtruder(const SliceDataStorage& storage);
 
     /*!
      * Gets a list of extruders that are used on the given layer, but excluding the given starting extruder.

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <algorithm>
@@ -174,7 +174,7 @@ void PrimeTower::generateStartLocations()
     PolygonUtils::spreadDots(segment_start, segment_end, number_of_prime_tower_start_locations, prime_tower_start_locations);
 }
 
-void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int prev_extruder, const int new_extruder) const
+void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_layer, const size_t prev_extruder, const size_t new_extruder) const
 {
     if (!enabled)
     {

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef PRIME_TOWER_H
@@ -85,7 +85,7 @@ public:
      * \param prev_extruder The previous extruder with which paths were planned; from which extruder a switch was made
      * \param new_extruder The switched to extruder with which the prime tower paths should be generated.
      */
-    void addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_layer, const int prev_extruder, const int new_extruder) const;
+    void addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_layer, const size_t prev_extruder, const size_t new_extruder) const;
 
     /*!
      * \brief Subtract the prime tower from the support areas in storage.


### PR DESCRIPTION
This fixes an issue where the second (and third, fourth, etc.) extruder doesn't prime on the first layer. In fact, it doesn't prime at all with the `G280` command since that command is only given on the first layer.

Previously we were only counting the last extruder of a layer, to see which extruders would need to get primed on that layer. With two extruders this kind of works, because if the extruder was the last one of the layer that means that you had switched to that extruder on that layer (since you switch exactly once per layer). However with more than 2 extruders, this would miss some extruders. It also had the problem that if the extruder order was not optimal (e.g. there are empty extruder plans) it would misbehave, causing travel moves to go to 0,0 in order to prime there.

Conceptually, it doesn't matter in which order extruders are printing on a layer to determine what layer the extruders first need to be primed on. They should just get primed on the first layer at which they are used. Previously this calculation was intertwined with the calculation of extruder order, but I've now put it in a separate function which uses the used extruders per layer to find at which layer an extruder is first used. This not just fixes the bug but also separates the code better to indicate how separate of an operation it really is.

I've also fixed a compiler warning which I was encountering when making these changes. This changes the data type of a few `extruder_nr` variables from `int` (which is signed) to `size_t` (to indicate they are indices to an array somewhere).

Fixes CURA-8188.