### PR TITLE
Fix alternating extruders and detection of used extruders

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1182,9 +1182,13 @@ void FffGcodeWriter::calculatePrimeLayerPerExtruder(const SliceDataStorage& stor
 {
     for(LayerIndex layer_nr = -Raft::getTotalExtraLayers(); layer_nr < static_cast<LayerIndex>(storage.print_layer_count); ++layer_nr)
     {
-        for(size_t extruder_nr : storage.getExtrudersUsed(layer_nr))
+        const std::vector<bool> used_extruders = storage.getExtrudersUsed(layer_nr);
+        for(size_t extruder_nr = 0; extruder_nr < used_extruders.size(); ++extruder_nr)
         {
-            extruder_prime_layer_nr[extruder_nr] = std::min(extruder_prime_layer_nr[extruder_nr], layer_nr);
+            if(used_extruders[extruder_nr])
+            {
+                extruder_prime_layer_nr[extruder_nr] = std::min(extruder_prime_layer_nr[extruder_nr], layer_nr);
+            }
         }
     }
 }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1174,6 +1174,7 @@ void FffGcodeWriter::calculateExtruderOrderPerLayer(const SliceDataStorage& stor
     {
         std::vector<std::vector<size_t>>& extruder_order_per_layer_here = (layer_nr < 0) ? extruder_order_per_layer_negative_layers : extruder_order_per_layer;
         extruder_order_per_layer_here.push_back(getUsedExtrudersOnLayerExcludingStartingExtruder(storage, last_extruder, layer_nr));
+        last_extruder = extruder_order_per_layer_here.back().back();
     }
 }
 

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -547,7 +547,7 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed(LayerIndex layer_nr) const
         { // process brim/skirt
             for (size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
             {
-                if (skirt_brim[extruder_nr].size() > 0)
+                if(!skirt_brim[extruder_nr].empty())
                 {
                     ret[extruder_nr] = true;
                     continue;


### PR DESCRIPTION
This fixes two pretty serious issues:
* The extruder order was no longer alternating. It should decide on the extruder order by prioritising the extruder that the previous layer ended on, to reduce the number of extruder switches. This had been broken because of an earlier refactoring where I removed a line too many.
* The used extruders on a layer was being misinterpreted. This is a function that returns a vector of booleans, where each entry indicates whether the extruder with that entry's index is used or not. It was being interpreted as if it returned a vector of the extruder indices that are being used on the layer.

Fixes CURA-8188.