### PR TITLE
Add option to print centre wall last

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -165,7 +165,7 @@ size_t InsetOrderOptimizer::getOuterRegionId(const VariableWidthPaths& toolpaths
     return outer_region_id;
 }
 
-BinJunctions InsetOrderOptimizer::variableWidthPathToBinJunctions(const VariableWidthPaths& toolpaths, const bool& ignore_inner_inset_order, const bool& pack_regions_by_inset, std::set<size_t>* p_bins_with_index_zero_insets)
+BinJunctions InsetOrderOptimizer::variableWidthPathToBinJunctions(const VariableWidthPaths& toolpaths, const bool ignore_inner_inset_order, const bool pack_regions_by_inset, std::set<size_t>* p_bins_with_index_zero_insets)
 {
     // Find the largest inset-index:
     size_t max_inset_index = 0;

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -81,11 +81,13 @@ public:
      * \param p_bins_with_index_zero_insets When optimizing, not all inset zero indices are in the zeroth bin. (Can be set to nullptr, which won't negate optimize.)
      * \return A bin of walls, consisting of a vector of paths consisting of vector of lines
      */
-    static BinJunctions variableWidthPathToBinJunctions(
+    static BinJunctions variableWidthPathToBinJunctions
+    (
             const VariableWidthPaths& toolpaths,
             const bool pack_regions_by_inset = true,
             const bool center_last = false,
-            std::set<size_t>* p_bins_with_index_zero_insets = nullptr);
+            std::set<size_t>* p_bins_with_index_zero_insets = nullptr
+    );
 };
 
 } //namespace cura

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -81,7 +81,11 @@ public:
      * \param p_bins_with_index_zero_insets When optimizing, not all inset zero indices are in the zeroth bin. (Can be set to nullptr, which won't negate optimize.)
      * \return A bin of walls, consisting of a vector of paths consisting of vector of lines
      */
-    static BinJunctions variableWidthPathToBinJunctions(const VariableWidthPaths& toolpaths, const bool pack_regions_by_inset = true, std::set<size_t>* p_bins_with_index_zero_insets = nullptr);
+    static BinJunctions variableWidthPathToBinJunctions(
+            const VariableWidthPaths& toolpaths,
+            const bool pack_regions_by_inset = true,
+            const bool center_last = false,
+            std::set<size_t>* p_bins_with_index_zero_insets = nullptr);
 };
 
 } //namespace cura

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -77,19 +77,11 @@ public:
      * Converts the VariableWidthPath to a bin of walls, consisting of a vector of paths, consisting of a vector of
      * lines
      * \param toolpaths The toolpaths to convert
-     * \param ignore_inner_inset_order True: Bins per region (not per inset, except for the 0 insets), in an optimized order. False: Do bin by inset,
-     *        and only distinguish 'everything in the outer region' and 'the inner regions'.
      * \param pack_by_inset Pack regions by inset, otherwise, pack insets by region. Useful for outer/inner first situations.
      * \param p_bins_with_index_zero_insets When optimizing, not all inset zero indices are in the zeroth bin. (Can be set to nullptr, which won't negate optimize.)
      * \return A bin of walls, consisting of a vector of paths consisting of vector of lines
      */
-    static BinJunctions variableWidthPathToBinJunctions
-    (
-        const VariableWidthPaths& toolpaths,
-        const bool ignore_inner_inset_order = false,
-        const bool pack_regions_by_inset = true,
-        std::set<size_t>* p_bins_with_index_zero_insets = nullptr
-    );
+    static BinJunctions variableWidthPathToBinJunctions(const VariableWidthPaths& toolpaths, const bool pack_regions_by_inset = true, std::set<size_t>* p_bins_with_index_zero_insets = nullptr);
 };
 
 } //namespace cura

--- a/src/InsetOrderOptimizer.h
+++ b/src/InsetOrderOptimizer.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef INSET_ORDER_OPTIMIZER_H
@@ -86,8 +86,8 @@ public:
     static BinJunctions variableWidthPathToBinJunctions
     (
         const VariableWidthPaths& toolpaths,
-        const bool& ignore_inner_inset_order = false,
-        const bool& pack_regions_by_inset = true,
+        const bool ignore_inner_inset_order = false,
+        const bool pack_regions_by_inset = true,
         std::set<size_t>* p_bins_with_index_zero_insets = nullptr
     );
 };

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "Application.h" //To flush g-code through the communication channel.
@@ -96,7 +96,7 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
         const Settings& extruder_settings = Application::getInstance().current_slice->scene.extruders[prev_layer->extruder_plans.back().extruder_nr].settings;
         prev_layer->setIsInside(new_layer_destination_state->second);
         const bool force_retract = extruder_settings.get<bool>("retract_at_layer_change") ||
-          (mesh_group_settings.get<bool>("travel_retract_before_outer_wall") && (mesh_group_settings.get<bool>("outer_inset_first") || mesh_group_settings.get<size_t>("wall_line_count") == 1)); //Moving towards an outer wall.
+          (mesh_group_settings.get<bool>("travel_retract_before_outer_wall") && (mesh_group_settings.get<InsetDirection>("inset_direction") == InsetDirection::OUTSIDE_IN || mesh_group_settings.get<size_t>("wall_line_count") == 1)); //Moving towards an outer wall.
         prev_layer->final_travel_z = newest_layer->z;
         GCodePath &path = prev_layer->addTravel(first_location_new_layer, force_retract);
         if (force_retract && !path.retract)

--- a/src/settings/EnumSettings.h
+++ b/src/settings/EnumSettings.h
@@ -1,8 +1,8 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
-#ifndef SETTINGSBASEVIRTUAL_H
-#define SETTINGSBASEVIRTUAL_H
+#ifndef ENUMSETTINGS_H
+#define ENUMSETTINGS_H
 
 namespace cura
 {
@@ -201,6 +201,28 @@ enum class EGCodeFlavor
     REPRAP = 8,
 };
 
+/*!
+ * Direction in which to print walls, inside vs. outside.
+ */
+enum class InsetDirection
+{
+    /*!
+     * The innermost wall is printed first, then the second-innermost wall, etc.
+     */
+    INSIDE_OUT,
+
+    /*!
+     * The outermost wall is printed first, then the second wall, etc.
+     */
+    OUTSIDE_IN,
+
+    /*!
+     * If the innermost wall is a central wall, it is printed last. Otherwise
+     * prints the same as inside out.
+     */
+    CENTER_LAST
+};
+
 } //Cura namespace.
 
-#endif //SETTINGSBASEVIRTUAL_H
+#endif //ENUMSETTINGS_H

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <cctype>
@@ -556,6 +556,23 @@ template<> SlicingTolerance Settings::get<SlicingTolerance>(const std::string& k
     else //Default.
     {
         return SlicingTolerance::MIDDLE;
+    }
+}
+
+template<> InsetDirection Settings::get<InsetDirection>(const std::string& key) const
+{
+    const std::string& value = get<std::string>(key);
+    if(value == "center_last")
+    {
+        return InsetDirection::CENTER_LAST;
+    }
+    else if(value == "outside_in")
+    {
+        return InsetDirection::OUTSIDE_IN;
+    }
+    else //Default.
+    {
+        return InsetDirection::INSIDE_OUT;
     }
 }
 


### PR DESCRIPTION
This implementation adds a new option for the order in which walls are printed. Instead of just printing from inside to outside, or from outside to inside, it is now also possible to print from inside to outside, except to print the centre lines last.

If selected, the printer will first complete all the doubled-up / looped walls:
![image](https://user-images.githubusercontent.com/2448634/122537790-35825280-d026-11eb-9335-a6ac366e8fd1.png)

... and then print the odd-numbered centre walls afterwards in a separate pass:
![image](https://user-images.githubusercontent.com/2448634/122537948-61053d00-d026-11eb-842d-1bfe4202707b.png)

The benefit in print quality of this has not yet been tested, only theorised. There are two theoretical advantages to this option:
* The odd-numbered centre walls are thought to have a problem with overextrusion, moreso than other walls (although why they overextrude is not yet known). This overextrusion propagates towards the outside, causing the surface to become more irregular.
* Printing all loops first ensures that loops are closed all at once, reducing the number of short travel moves during the printing of those loops in some cases, in favour of longer travel moves towards the end.

The new option is a drop-down called Wall Ordering. It replaces the previous setting "Outer Before Inner Walls" which was always a bit of a difficult name for a setting, and then adds this as a third option to what was formerly a boolean setting.
![image](https://user-images.githubusercontent.com/2448634/122538505-e983dd80-d026-11eb-9fe1-6a8553120c03.png)

This implementation depends on a change to the list of settings, which is made here: https://github.com/Ultimaker/Cura/pull/9997

Implements CURA-8109.