### PR TITLE
[CURA-8275] Simplify: Fix different output for 'begin' and 'end' of polygon.

### DIFF
--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -179,6 +179,15 @@ void ExtrusionLine::simplify(const coord_t smallest_line_segment_squared, const 
 
     // Ending junction (vertex) should always exist in the simplified path
     new_junctions.emplace_back(junctions.back());
+
+    /* In case this is a closed polygon (instead of a poly-line-segments), the invariant that the first and last points are the same should be enforced.
+     * Since one of them didn't move, and the other can't have been moved further than the constraints, if originally equal, they can simply be equated.
+     */
+    if (vSize2(junctions.front().p - junctions.back().p) == 0)
+    {
+        new_junctions.back().p = junctions.front().p;
+    }
+
     junctions = new_junctions;
 }
 


### PR DESCRIPTION
Enforce the property that closed polygon loops should have the exact same point as begin and end. Since the beginning isn't moved at all, but the end can, this could lead to a situation where the begin and end points of the polygon are different. This then 'creates' and 'extra' point where there was none, which is very probably still incredibly close to the other point, as none of the simplification constraints where checked, since we assume those two points to be exactly the same (which is in fact how we check if it is indeed a polygon in a few places.

 -- fix for #1449 -- ~~if also a problem for the main branch should be backported probably~~  if this occurs in the current main branch as well it must have a different cause -- I'll just assume that the original issue was reported against Arachne, as that seems likely