### PR TITLE
Fix integer underflow if print is less than half the initial layer height

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -131,7 +131,15 @@ bool FffPolygonGenerator::sliceModel(MeshGroup* meshgroup, TimeKeeper& timeKeepe
     }
     else
     {
-        slice_layer_count = round_divide(storage.model_max.z - initial_layer_thickness, layer_thickness) + 1;
+        const coord_t height_without_first_layer = storage.model_max.z - initial_layer_thickness;
+        if(height_without_first_layer <= 0)
+        {
+            slice_layer_count = 0;
+        }
+        else
+        {
+            slice_layer_count = round_divide(height_without_first_layer, layer_thickness) + 1;
+        }
     }
 
     // Model is shallower than layer_height_0, so not even the first layer is sliced. Return an empty model then.


### PR DESCRIPTION
The round_divide function takes unsigned integers, so if it's fed a number less than 0 it'll produce a huge amount of layers.

Fixes Ultimaker/Cura#10104.