### PR TITLE
[CURA-8459] Differentiate even vs. uneven nr. of walls for add/split middle wall transitions.

### DIFF
--- a/src/BeadingStrategy/BeadingStrategyFactory.cpp
+++ b/src/BeadingStrategy/BeadingStrategyFactory.cpp
@@ -10,6 +10,8 @@
 #include "RedistributeBeadingStrategy.h"
 #include "OuterWallInsetBeadingStrategy.h"
 
+#include <limits>
+
 namespace cura
 {
 
@@ -36,12 +38,12 @@ BeadingStrategy* BeadingStrategyFactory::makeStrategy
     const bool print_thin_walls,
     const coord_t min_bead_width,
     const coord_t min_feature_size,
-    const Ratio wall_transition_threshold,
+    const Ratio wall_split_middle_threshold,
+    const Ratio wall_add_middle_threshold,
     const coord_t max_bead_count,
     const coord_t outer_wall_offset,
     const int inward_distributed_center_wall_count,
     const double minimum_variable_line_width
-
 )
 {
     const coord_t bar_preferred_wall_width = getWeightedAverage(preferred_bead_width_outer, preferred_bead_width_inner, max_bead_count);
@@ -49,13 +51,13 @@ BeadingStrategy* BeadingStrategyFactory::makeStrategy
     switch (type)
     {
         case StrategyType::Center:
-            ret = new CenterDeviationBeadingStrategy(bar_preferred_wall_width, transitioning_angle, wall_transition_threshold);
+            ret = new CenterDeviationBeadingStrategy(bar_preferred_wall_width, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold);
             break;
         case StrategyType::Distributed:
-            ret = new DistributedBeadingStrategy(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, wall_transition_threshold, 99999);
+            ret = new DistributedBeadingStrategy(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold, std::numeric_limits<int>::max());
             break;
         case StrategyType::InwardDistributed:
-            ret = new DistributedBeadingStrategy(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, wall_transition_threshold, inward_distributed_center_wall_count);
+            ret = new DistributedBeadingStrategy(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold, inward_distributed_center_wall_count);
             break;
         default:
             logError("Cannot make strategy!\n");

--- a/src/BeadingStrategy/BeadingStrategyFactory.h
+++ b/src/BeadingStrategy/BeadingStrategyFactory.h
@@ -24,19 +24,20 @@ class BeadingStrategyFactory
 public:
     static BeadingStrategy* makeStrategy
     (
-        StrategyType type,
-        coord_t preferred_bead_width_outer = MM2INT(0.5),
-        coord_t preferred_bead_width_inner = MM2INT(0.5),
-        coord_t preferred_transition_length = MM2INT(0.4),
-        float transitioning_angle = M_PI_4,
-        bool print_thin_walls = false,
-        coord_t min_bead_width = 0,
-        coord_t min_feature_size = 0,
-        Ratio wall_transition_thresold = 0.5_r,
-        coord_t max_bead_count = 0,
-        coord_t outer_wall_offset = 0,
-        int inward_distributed_center_wall_count = 2,
-        double minimum_variable_line_width = 0.5
+        const StrategyType type,
+        const coord_t preferred_bead_width_outer = MM2INT(0.5),
+        const coord_t preferred_bead_width_inner = MM2INT(0.5),
+        const coord_t preferred_transition_length = MM2INT(0.4),
+        const float transitioning_angle = M_PI_4,
+        const bool print_thin_walls = false,
+        const coord_t min_bead_width = 0,
+        const coord_t min_feature_size = 0,
+        const Ratio wall_split_middle_threshold = 0.5_r,
+        const Ratio wall_add_middle_threshold = 0.5_r,
+        const coord_t max_bead_count = 0,
+        const coord_t outer_wall_offset = 0,
+        const int inward_distributed_center_wall_count = 2,
+        const double minimum_variable_line_width = 0.5
     );
 };
 

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -5,9 +5,10 @@
 
 namespace cura
 {
-    CenterDeviationBeadingStrategy::CenterDeviationBeadingStrategy(const coord_t pref_bead_width, const AngleRadians transitioning_angle, const Ratio wall_transition_threshold)
+    CenterDeviationBeadingStrategy::CenterDeviationBeadingStrategy(const coord_t pref_bead_width, const AngleRadians transitioning_angle, const Ratio wall_split_middle_threshold, const Ratio wall_add_middle_threshold)
     : BeadingStrategy(pref_bead_width, pref_bead_width / 2, transitioning_angle)
-    , minimum_line_width(pref_bead_width * wall_transition_threshold)
+    , minimum_line_width_split(pref_bead_width * wall_split_middle_threshold)
+    , minimum_line_width_add(pref_bead_width* wall_add_middle_threshold)
     {
         name = "CenterDeviationBeadingStrategy";
     }
@@ -54,13 +55,14 @@ namespace cura
 
     coord_t CenterDeviationBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
     {
-        return lower_bead_count * optimal_width + minimum_line_width;
+        return lower_bead_count * optimal_width + (lower_bead_count % 2 == 1 ? minimum_line_width_split : minimum_line_width_add);
     }
 
     coord_t CenterDeviationBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
     {
         const coord_t naive_count = thickness / optimal_width; //How many lines we can fit in for sure.
         const coord_t remainder = thickness - naive_count * optimal_width; //Space left after fitting that many lines.
+        const coord_t minimum_line_width = naive_count % 2 == 1 ? minimum_line_width_split : minimum_line_width_add;
         return naive_count + (remainder > minimum_line_width); //If there's enough space, fit an extra one.
     }
 

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
@@ -27,16 +27,13 @@ class CenterDeviationBeadingStrategy : public BeadingStrategy
 #endif
 
 private:
-    /*!
-     * Minimum allowed line width.
-     *
-     * If the innermost two lines would be below this line width, it should use
-     * a single line instead. If the innermost center line would be below this
-     * line width, it should be left out as a gap.
-     */
-    coord_t minimum_line_width;
+    // For uneven numbers of lines: Minimum line width for which the middle line will be split into two lines.
+    coord_t minimum_line_width_split;
+
+    // For even numbers of lines: Minimum line width for which a new middle line will be added between the two innermost lines.
+    coord_t minimum_line_width_add;
 public:
-    CenterDeviationBeadingStrategy(const coord_t pref_bead_width, const AngleRadians transitioning_angle, const Ratio wall_transition_threshold);
+    CenterDeviationBeadingStrategy(const coord_t pref_bead_width, const AngleRadians transitioning_angle, const Ratio wall_split_middle_threshold, const Ratio wall_add_middle_threshold);
 
     virtual ~CenterDeviationBeadingStrategy() override {}
     Beading compute(coord_t thickness, coord_t bead_count) const override;

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -9,10 +9,12 @@ namespace cura
 DistributedBeadingStrategy::DistributedBeadingStrategy(const coord_t optimal_width,
                                 const coord_t default_transition_length,
                                 const AngleRadians transitioning_angle,
-                                const Ratio wall_transition_threshold,
+                                const Ratio wall_split_middle_threshold,
+                                const Ratio wall_add_middle_threshold,
                                 const int distribution_radius)
-    : BeadingStrategy(optimal_width, default_transition_length, transitioning_angle),
-      wall_transition_threshold(wall_transition_threshold)
+    : BeadingStrategy(optimal_width, default_transition_length, transitioning_angle)
+    , wall_split_middle_threshold(wall_split_middle_threshold)
+    , wall_add_middle_threshold(wall_add_middle_threshold)
 {
     if(distribution_radius >= 1)
     {
@@ -97,7 +99,7 @@ coord_t DistributedBeadingStrategy::getOptimalThickness(coord_t bead_count) cons
 
 coord_t DistributedBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
 {
-    return lower_bead_count * optimal_width + optimal_width * wall_transition_threshold;
+    return lower_bead_count * optimal_width + optimal_width * (lower_bead_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold);
 }
 
 coord_t DistributedBeadingStrategy::getOptimalBeadCount(coord_t thickness) const

--- a/src/BeadingStrategy/DistributedBeadingStrategy.h
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.h
@@ -18,11 +18,12 @@ namespace cura
 class DistributedBeadingStrategy : public BeadingStrategy
 {
 protected:
-    /*!
-     * Threshold line width at which it will use fewer, wider lines instead of
-     * reducing the line width further.
-     */
-    Ratio wall_transition_threshold;
+     // For uneven numbers of lines: Minimum factor of the optimal width for which the middle line will be split into two lines.
+    Ratio wall_split_middle_threshold;
+    
+    // For even numbers of lines: Minimum factor of the optimal width for which a new middle line will be added between the two innermost lines.
+    Ratio wall_add_middle_threshold;
+
     float one_over_distribution_radius_squared; // (1 / distribution_radius)^2
 
 public:
@@ -32,7 +33,8 @@ public:
     DistributedBeadingStrategy( const coord_t optimal_width,
                                 const coord_t default_transition_length,
                                 const AngleRadians transitioning_angle,
-                                const Ratio wall_transition_threshold,
+                                const Ratio wall_split_middle_threshold,
+                                const Ratio wall_add_middle_threshold,
                                 const int distribution_radius);
 
     virtual ~DistributedBeadingStrategy() override {}

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -72,14 +72,37 @@ const VariableWidthPaths& WallToolPaths::generate()
     if (prepared_outline.area() > 0)
     {
         const coord_t wall_transition_length = settings.get<coord_t>("wall_transition_length");
-        const Ratio wall_transition_threshold = settings.get<Ratio>("wall_transition_threshold");
+        const Ratio wall_split_middle_threshold = settings.get<Ratio>("wall_split_middle_threshold");  // For an uneven nr. of lines: When to split the middle wall into two.
+        const Ratio wall_add_middle_threshold = settings.get<Ratio>("wall_add_middle_threshold");      // For an even nr. of lines: When to add a new middle in between the innermost two walls.
         const int wall_distribution_count = settings.get<int>("wall_distribution_count");
         const size_t max_bead_count = 2 * inset_count;
-        const auto beading_strat = std::unique_ptr<BeadingStrategy>(BeadingStrategyFactory::makeStrategy(
-            strategy_type, bead_width_0, bead_width_x, wall_transition_length, transitioning_angle, print_thin_walls, min_bead_width,
-            min_feature_size, wall_transition_threshold, max_bead_count, wall_0_inset, wall_distribution_count));
+        const auto beading_strat =
+            std::unique_ptr<BeadingStrategy>(BeadingStrategyFactory::makeStrategy
+            (
+                strategy_type,
+                bead_width_0,
+                bead_width_x,
+                wall_transition_length,
+                transitioning_angle,
+                print_thin_walls,
+                min_bead_width,
+                min_feature_size,
+                wall_split_middle_threshold,
+                wall_add_middle_threshold,
+                max_bead_count,
+                wall_0_inset,
+                wall_distribution_count
+            ));
         const coord_t transition_filter_dist = settings.get<coord_t>("wall_transition_filter_distance");
-        SkeletalTrapezoidation wall_maker(prepared_outline, *beading_strat, beading_strat->getTransitioningAngle(), discretization_step_size, transition_filter_dist, wall_transition_length);
+        SkeletalTrapezoidation wall_maker
+        (
+            prepared_outline,
+            *beading_strat,
+            beading_strat->getTransitioningAngle(),
+            discretization_step_size,
+            transition_filter_dist,
+            wall_transition_length
+        );
         wall_maker.generateToolpaths(toolpaths);
         computeInnerContour();
     }

--- a/tests/WallsComputationTest.cpp
+++ b/tests/WallsComputationTest.cpp
@@ -60,7 +60,8 @@ public:
         settings.add("wall_transition_angle", "30");
         settings.add("wall_transition_filter_distance", "1");
         settings.add("wall_transition_length", "1");
-        settings.add("wall_transition_threshold", "50");
+        settings.add("wall_split_middle_threshold", "50");
+        settings.add("wall_add_middle_threshold", "50");
         settings.add("wall_x_extruder_nr", "0");
         settings.add("wall_distribution_count", "2");
     }

--- a/tests/beading_strategy/CenterDeviationBeadingStrategyTest.cpp
+++ b/tests/beading_strategy/CenterDeviationBeadingStrategyTest.cpp
@@ -14,14 +14,14 @@ namespace cura
  */
 TEST(CenterDeviationBeadingStrategy, Construction)
 {
-    CenterDeviationBeadingStrategy strategy(400, 0.6, 0.5); //Pretty standard settings.
-    EXPECT_EQ(strategy.minimum_line_width, 200) << "Since the transition threshold was 50%, the minimum line width should be 0.5 times the preferred width.";
-    strategy = CenterDeviationBeadingStrategy(400, 0.6, 0);
-    EXPECT_EQ(strategy.minimum_line_width, 0) << "Since the transition threshold was 0%, the minimum line width should be 0.";
-    strategy = CenterDeviationBeadingStrategy(0, 0.6, 0.5);
-    EXPECT_EQ(strategy.minimum_line_width, 0) << "Since the line width was 0%, the minimum line width should also be 0.";
-    strategy = CenterDeviationBeadingStrategy(400, 0.6, 1);
-    EXPECT_EQ(strategy.minimum_line_width, 400) << "Since the transition threshold was 100%, the minimum line width equals the preferred width.";
+    CenterDeviationBeadingStrategy strategy(400, 0.6, 0.5, 0.5); //Pretty standard settings.
+    EXPECT_EQ(strategy.minimum_line_width_split, 200) << "Since the transition threshold was 50%, the minimum line width should be 0.5 times the preferred width.";
+    strategy = CenterDeviationBeadingStrategy(400, 0.6, 0, 0);
+    EXPECT_EQ(strategy.minimum_line_width_split, 0) << "Since the transition threshold was 0%, the minimum line width should be 0.";
+    strategy = CenterDeviationBeadingStrategy(0, 0.6, 0.5, 0.5);
+    EXPECT_EQ(strategy.minimum_line_width_split, 0) << "Since the line width was 0%, the minimum line width should also be 0.";
+    strategy = CenterDeviationBeadingStrategy(400, 0.6, 1, 1);
+    EXPECT_EQ(strategy.minimum_line_width_split, 400) << "Since the transition threshold was 100%, the minimum line width equals the preferred width.";
 }
 
 /*!
@@ -33,7 +33,7 @@ TEST(CenterDeviationBeadingStrategy, Construction)
 TEST(CenterDeviationBeadingStrategy, GetOptimalThickness)
 {
     constexpr coord_t line_width = 400;
-    CenterDeviationBeadingStrategy strategy(line_width, 0.6, 0.5);
+    CenterDeviationBeadingStrategy strategy(line_width, 0.6, 0.5, 0.5);
     EXPECT_EQ(strategy.getOptimalThickness(0), 0) << "With 0 beads, you'll fill 0 space.";
     EXPECT_EQ(strategy.getOptimalThickness(1), line_width) << "With 1 bead, optimally you'll want to print that bead at the optimal line width.";
     EXPECT_EQ(strategy.getOptimalThickness(4), 4 * line_width) << "With 4 beads, optimally fill 4 line widths.";
@@ -48,31 +48,31 @@ TEST(CenterDeviationBeadingStrategy, GetTransitionThickness)
     constexpr coord_t line_width = 400;
 
     //Transition ratio 25%.
-    CenterDeviationBeadingStrategy strategy(line_width, 0.6, 0.25);
+    CenterDeviationBeadingStrategy strategy(line_width, 0.6, 0.25, 0.25);
     EXPECT_EQ(strategy.getTransitionThickness(0), 0.25 * line_width) << "The transition from 0 beads to 1 happens at 25% line width.";
     EXPECT_EQ(strategy.getTransitionThickness(1), 1.25 * line_width) << "The transition from 1 bead to 2 happens at 125% line width.";
     EXPECT_EQ(strategy.getTransitionThickness(4), 4.25 * line_width) << "The transition from 4 beads to 5 happens at 4 + 25% line width.";
 
     //Transition ratio 50%.
-    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 0.5);
+    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 0.5, 0.5);
     EXPECT_EQ(strategy.getTransitionThickness(0), 0.5 * line_width) << "The transition from 0 beads to 1 happens at 50% line width.";
     EXPECT_EQ(strategy.getTransitionThickness(1), 1.5 * line_width) << "The transition from 1 bead to 2 happens at 150% line width.";
     EXPECT_EQ(strategy.getTransitionThickness(5), 5.5 * line_width) << "The transition from 5 beads to 6 happens at 5 + 50% line width.";
 
     //Transition ratio 95%.
-    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 0.95);
+    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 0.95, 0.95);
     EXPECT_EQ(strategy.getTransitionThickness(0), 0.95 * line_width) << "The transition from 0 beads to 1 happens at 95% line width.";
     EXPECT_EQ(strategy.getTransitionThickness(1), 1.95 * line_width) << "The transition from 1 bead to 2 happens at 195% line width.";
     EXPECT_EQ(strategy.getTransitionThickness(3), 3.95 * line_width) << "The transition from 3 beads to 4 happens at 3 + 95% line width.";
 
     //Transition ratio 100%.
-    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 1);
+    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 1, 1);
     EXPECT_EQ(strategy.getTransitionThickness(0), line_width) << "Only transition to have a line if it fits completely.";
     EXPECT_EQ(strategy.getTransitionThickness(1), 2 * line_width) << "Only transition to have two lines if they both fit completely.";
     EXPECT_EQ(strategy.getTransitionThickness(2), 3 * line_width) << "Only transition to have three lines if they all fit completely.";
 
     //Transition ratio 0%.
-    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 0);
+    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 0, 0);
     EXPECT_EQ(strategy.getTransitionThickness(0), 0) << "Always transition to 1 line. The minimum line width is 0 after all.";
     EXPECT_EQ(strategy.getTransitionThickness(1), line_width) << "If 1 line fits completely, immediately transition to 2 lines.";
     EXPECT_EQ(strategy.getTransitionThickness(6), 6 * line_width) << "If 6 lines fit completely, immediately transition to 7 lines.";
@@ -86,7 +86,7 @@ TEST(CenterDeviationBeadingStrategy, GetOptimalBeadCount)
     constexpr coord_t line_width = 400;
 
     //Transition ratio 25%.
-    CenterDeviationBeadingStrategy strategy(line_width, 0.6, 0.25);
+    CenterDeviationBeadingStrategy strategy(line_width, 0.6, 0.25, 0.25);
     //Anything below 25% line width should then produce 0 lines.
     for(coord_t width = 0; width < 0.25 * line_width; width += 10)
     {
@@ -104,7 +104,7 @@ TEST(CenterDeviationBeadingStrategy, GetOptimalBeadCount)
     }
 
     //Transition ratio 80%.
-    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 0.8);
+    strategy = CenterDeviationBeadingStrategy(line_width, 0.6, 0.8, 0.8);
     //Anything below 80% line width should then produce 0 lines.
     for(coord_t width = 0; width < 0.8 * line_width; width += 10)
     {
@@ -147,8 +147,8 @@ TEST(CenterDeviationBeadingStrategy, LineCompactnessMonotonic)
                 const float high_compactness = compactnesses[high_index];
 
                 EXPECT_GE(
-                        CenterDeviationBeadingStrategy(line_width, 0.6, low_compactness).getOptimalBeadCount(width),
-                        CenterDeviationBeadingStrategy(line_width, 0.6, high_compactness).getOptimalBeadCount(width)
+                        CenterDeviationBeadingStrategy(line_width, 0.6, low_compactness, low_compactness).getOptimalBeadCount(width),
+                        CenterDeviationBeadingStrategy(line_width, 0.6, high_compactness, high_compactness).getOptimalBeadCount(width)
                 ) << "When the compactness is low, the number of beads should always be greater or equal to when the compactness is high.";
             }
         }


### PR DESCRIPTION
Instead of a single threshold for when to increase the number of walls, have a separate threshold for the minimum line width factor for introducing a new middle wall (in case of an even number of walls) and one for splitting the middle wall into two (in case of an uneven number of walls).

See front-end PR: https://github.com/Ultimaker/Cura/pull/10271