### PR TITLE
Cura 8069 centerline

### DIFF
--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -1,69 +1,86 @@
-//Copyright (c) 2021 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2021 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
+#include <algorithm>
 
 #include "CenterDeviationBeadingStrategy.h"
 
 namespace cura
 {
-    CenterDeviationBeadingStrategy::CenterDeviationBeadingStrategy(const coord_t pref_bead_width, const AngleRadians transitioning_angle, const Ratio wall_split_middle_threshold, const Ratio wall_add_middle_threshold)
-    : BeadingStrategy(pref_bead_width, pref_bead_width / 2, transitioning_angle)
-    , minimum_line_width_split(pref_bead_width * wall_split_middle_threshold)
-    , minimum_line_width_add(pref_bead_width* wall_add_middle_threshold)
-    {
-        name = "CenterDeviationBeadingStrategy";
-    }
+CenterDeviationBeadingStrategy::CenterDeviationBeadingStrategy(const coord_t pref_bead_width,
+                                                               const AngleRadians transitioning_angle,
+                                                               const Ratio wall_split_middle_threshold,
+                                                               const Ratio wall_add_middle_threshold)
+  : BeadingStrategy(pref_bead_width, pref_bead_width / 2, transitioning_angle),
+    minimum_line_width_split(pref_bead_width * wall_split_middle_threshold),
+    minimum_line_width_add(pref_bead_width * wall_add_middle_threshold)
+{
+    name = "CenterDeviationBeadingStrategy";
+}
 
-    CenterDeviationBeadingStrategy::Beading CenterDeviationBeadingStrategy::compute(coord_t thickness, coord_t bead_count) const
-    {
-        Beading ret;
+CenterDeviationBeadingStrategy::Beading CenterDeviationBeadingStrategy::compute(coord_t thickness, coord_t bead_count) const
+{
+    Beading ret;
 
-        ret.total_thickness = thickness;
-        if (bead_count > 0)
+    ret.total_thickness = thickness;
+    if (bead_count > 0)
+    {
+        // Set the bead widths
+        ret.bead_widths = std::vector<coord_t>(static_cast<size_t>(bead_count), optimal_width);
+        const coord_t optimal_thickness = getOptimalThickness(bead_count);
+        const coord_t diff_thickness = (thickness - optimal_thickness) / 2;
+        const coord_t inner_bead_widths = optimal_width + diff_thickness;
+        const size_t center_bead_idx = ret.bead_widths.size() / 2;
+        if (bead_count % 2 == 0) // Even lines
         {
-            for (coord_t bead_idx = 0; bead_idx < bead_count / 2; bead_idx++)
+            if (inner_bead_widths < minimum_line_width_add)
             {
-                ret.bead_widths.emplace_back(optimal_width);
-                ret.toolpath_locations.emplace_back(optimal_width * (bead_idx * 2 + 1) / 2);
+                return compute(thickness, bead_count - 1);
             }
-            if (bead_count % 2 == 1)
-            {
-                ret.bead_widths.emplace_back(thickness - (bead_count - 1) * optimal_width);
-                ret.toolpath_locations.emplace_back(thickness / 2);
-                ret.left_over = 0;
-            }
-            else
-            {
-                ret.left_over = thickness - bead_count * optimal_width;
-            }
-            for (coord_t bead_idx = (bead_count + 1) / 2; bead_idx < bead_count; bead_idx++)
-            {
-                ret.bead_widths.emplace_back(optimal_width);
-                ret.toolpath_locations.emplace_back(thickness - (bead_count - bead_idx) * optimal_width + optimal_width / 2);
-            }
+            ret.bead_widths[center_bead_idx - 1] = inner_bead_widths;
+            ret.bead_widths[center_bead_idx] = inner_bead_widths;
         }
-        else
+        else // Uneven lines
         {
-            ret.left_over = thickness;
+            if (inner_bead_widths < minimum_line_width_split)
+            {
+                return compute(thickness, bead_count - 1);
+            }
+            ret.bead_widths[center_bead_idx] = inner_bead_widths;
         }
-        return ret;
-    }
 
-    coord_t CenterDeviationBeadingStrategy::getOptimalThickness(coord_t bead_count) const
-    {
-        return bead_count * optimal_width;
+        // Set the center line location of the bead toolpaths.
+        ret.toolpath_locations.resize(ret.bead_widths.size());
+        ret.toolpath_locations.front() = ret.bead_widths.front() / 2;
+        for (size_t bead_idx = 1; bead_idx < ret.bead_widths.size(); ++bead_idx)
+        {
+            ret.toolpath_locations[bead_idx] =
+              ret.toolpath_locations[bead_idx - 1] + (ret.bead_widths[bead_idx] + ret.bead_widths[bead_idx - 1]) / 2;
+        }
+        ret.left_over = 0;
     }
+    else
+    {
+        ret.left_over = thickness;
+    }
+    return ret;
+}
 
-    coord_t CenterDeviationBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
-    {
-        return lower_bead_count * optimal_width + (lower_bead_count % 2 == 1 ? minimum_line_width_split : minimum_line_width_add);
-    }
+coord_t CenterDeviationBeadingStrategy::getOptimalThickness(coord_t bead_count) const
+{
+    return bead_count * optimal_width;
+}
 
-    coord_t CenterDeviationBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
-    {
-        const coord_t naive_count = thickness / optimal_width; //How many lines we can fit in for sure.
-        const coord_t remainder = thickness - naive_count * optimal_width; //Space left after fitting that many lines.
-        const coord_t minimum_line_width = naive_count % 2 == 1 ? minimum_line_width_split : minimum_line_width_add;
-        return naive_count + (remainder > minimum_line_width); //If there's enough space, fit an extra one.
-    }
+coord_t CenterDeviationBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
+{
+    return lower_bead_count * optimal_width + (lower_bead_count % 2 == 1 ? minimum_line_width_split : minimum_line_width_add);
+}
+
+coord_t CenterDeviationBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
+{
+    const coord_t naive_count = thickness / optimal_width; // How many lines we can fit in for sure.
+    const coord_t remainder = thickness - naive_count * optimal_width; // Space left after fitting that many lines.
+    const coord_t minimum_line_width = naive_count % 2 == 1 ? minimum_line_width_split : minimum_line_width_add;
+    return naive_count + (remainder > minimum_line_width); // If there's enough space, fit an extra one.
+}
 
 } // namespace cura

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
@@ -1,5 +1,5 @@
-//Copyright (c) 2021 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2021 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 
 #ifndef CENTER_DEVIATION_BEADING_STRATEGY_H
@@ -8,7 +8,7 @@
 #include "../settings/types/Ratio.h" //For the wall transition threshold.
 #include "BeadingStrategy.h"
 #ifdef BUILD_TESTS
-    #include <gtest/gtest_prod.h> //Friend tests, so that they can inspect the privates.
+#include <gtest/gtest_prod.h> //Friend tests, so that they can inspect the privates.
 #endif
 
 namespace cura
@@ -26,16 +26,20 @@ class CenterDeviationBeadingStrategy : public BeadingStrategy
     FRIEND_TEST(CenterDeviationBeadingStrategy, Construction);
 #endif
 
-private:
+  private:
     // For uneven numbers of lines: Minimum line width for which the middle line will be split into two lines.
     coord_t minimum_line_width_split;
 
     // For even numbers of lines: Minimum line width for which a new middle line will be added between the two innermost lines.
     coord_t minimum_line_width_add;
-public:
-    CenterDeviationBeadingStrategy(const coord_t pref_bead_width, const AngleRadians transitioning_angle, const Ratio wall_split_middle_threshold, const Ratio wall_add_middle_threshold);
 
-    virtual ~CenterDeviationBeadingStrategy() override {}
+  public:
+    CenterDeviationBeadingStrategy(coord_t pref_bead_width,
+                                   AngleRadians transitioning_angle,
+                                   Ratio wall_split_middle_threshold,
+                                   Ratio wall_add_middle_threshold);
+
+    ~CenterDeviationBeadingStrategy() override{};
     Beading compute(coord_t thickness, coord_t bead_count) const override;
     coord_t getOptimalThickness(coord_t bead_count) const override;
     coord_t getTransitionThickness(coord_t lower_bead_count) const override;

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -24,7 +24,8 @@ RedistributeBeadingStrategy::RedistributeBeadingStrategy(   const coord_t optima
 
 coord_t RedistributeBeadingStrategy::getOptimalThickness(coord_t bead_count) const
 {
-    return parent->getOptimalThickness(bead_count);
+    const coord_t inner_bead_count = bead_count > 2 ? bead_count - 2 : 0;
+    return parent->getOptimalThickness(inner_bead_count) + optimal_width_outer * 2;
 }
 
 coord_t RedistributeBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -25,7 +25,9 @@ RedistributeBeadingStrategy::RedistributeBeadingStrategy(   const coord_t optima
 coord_t RedistributeBeadingStrategy::getOptimalThickness(coord_t bead_count) const
 {
     const coord_t inner_bead_count = bead_count > 2 ? bead_count - 2 : 0;
-    return parent->getOptimalThickness(inner_bead_count) + optimal_width_outer * 2;
+    const coord_t outer_bead_count = bead_count - inner_bead_count;
+
+    return parent->getOptimalThickness(inner_bead_count) + optimal_width_outer * outer_bead_count;
 }
 
 coord_t RedistributeBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const


### PR DESCRIPTION
While working on this I discovered that the `getOptimalThickness` of the Redistribution class (also used by the other strategies) only used the width of the inner bead. This would result in an under-/overestimation of the thickness of the whole region. Resulting in variances of the innermost inner beads compared with outermost inner beads. This occurs when the shape wasn't completely filled and the beads could have their optimal width. The first commit fixes this, by using the optimal width of the two outer walls and the optimal width of the other innerwalls.

The center deviation strategy now generates a centerline again. When this strategy is used it will either deviate the width
of both inner lines, in the case of an even number of beads, or deviate the inner line, when there is an uneven number.

It now also handles the splitting and adding of the centerline correctly.

Fixes CURA-8069