### PR TITLE
[CURA-8256] Prevent accumulation of error?

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1494,8 +1494,9 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
     Communication* communication = Application::getInstance().communication;
     communication->setLayerForSend(layer_nr);
     communication->sendCurrentPosition(gcode.getPositionXY());
+
+    gcode.resetExtrusionValue();
     gcode.setLayerNr(layer_nr);
-    
     gcode.writeLayerComment(layer_nr);
 
     // flow-rate compensation


### PR DESCRIPTION
Actual prints don't seem to be affected by the blobs reported earlier in the preview of reloaded-from-disk gcode, and this only removes them in the case of absolute extrusion anyway even if true, but it couldn't hurt.