### PR TITLE
CURA-8471: Fix edge case crash with hole horizontal expansion

### DIFF
--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -55,7 +55,7 @@ void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, Sl
         result = layer->polygons.splitIntoParts(union_layers || union_all_remove_holes);
     }
     const coord_t hole_offset = settings.get<coord_t>("hole_xy_offset");
-    for(unsigned int i=0; i<result.size(); i++)
+    for(auto & part : result)
     {
         storageLayer.parts.emplace_back();
         if (hole_offset != 0)
@@ -63,7 +63,7 @@ void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, Sl
             // holes are to be expanded or shrunk
             Polygons outline;
             Polygons holes;
-            for (const PolygonRef poly : result[i])
+            for (const PolygonRef poly : part)
             {
                 if (poly.orientation())
                 {
@@ -74,13 +74,17 @@ void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, Sl
                     holes.add(poly.offset(hole_offset));
                 }
             }
-            storageLayer.parts[i].outline.add(outline.difference(holes.unionPolygons()));
+            storageLayer.parts.back().outline.add(outline.difference(holes.unionPolygons()));
         }
         else
         {
-            storageLayer.parts[i].outline = result[i];
+            storageLayer.parts.back().outline = part;
         }
-        storageLayer.parts[i].boundaryBox.calculate(storageLayer.parts[i].outline);
+        storageLayer.parts.back().boundaryBox.calculate(storageLayer.parts.back().outline);
+        if (storageLayer.parts.back().outline.empty())
+        {
+            storageLayer.parts.pop_back();
+        }
     }
 }
 void createLayerParts(SliceMeshStorage& mesh, Slicer* slicer)

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -727,7 +727,7 @@ bool ConstPolygonRef::smooth_corner_complex(const Point p1, ListPolyIt& p0_it, L
         if (success)
         {
 #ifdef ASSERT_INSANE_OUTPUT
-            assert(vSize(new_p0) < 400000);
+            assert(new_p0.X < 400000 && new_p0.Y < 400000);
 #endif // #ifdef ASSERT_INSANE_OUTPUT
             p0_it = ListPolyIt::insertPointNonDuplicate(p0_2_it, p0_it, new_p0);
         }
@@ -756,7 +756,7 @@ bool ConstPolygonRef::smooth_corner_complex(const Point p1, ListPolyIt& p0_it, L
         if (success)
         {
 #ifdef ASSERT_INSANE_OUTPUT
-            assert(vSize(new_p2) < 400000);
+            assert(new_p2.X < 400000 && new_p2.Y < 400000);
 #endif // #ifdef ASSERT_INSANE_OUTPUT
             p2_it = ListPolyIt::insertPointNonDuplicate(p2_it, p2_2_it, new_p2);
         }


### PR DESCRIPTION
If the "Hole Horizontal Expansion" setting was on, there was a case that the holes wouldn't generate an outline and, as a result, the outline of the part was being left empty. This was leading to crashes later on when trying to access the points of the outline.
This PR fixes that by ensuring that if the outline of the part is empty, then the part is removed from the `storageLayer`.

Fixes https://github.com/Ultimaker/Cura/issues/10178.

CURA-8471