### PR TITLE
Set default fanspeed for monotonic ironing to -1

### DIFF
--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -624,7 +624,7 @@ public:
      * \param flow_ratio The ratio with which to multiply the extrusion amount.
      * \param fan_speed Fan speed override for this path.
      */
-    void addLinesMonotonic(const Polygons& polygons, const GCodePathConfig& config, const SpaceFillType space_fill_type, const AngleRadians monotonic_direction, const coord_t max_adjacent_distance, const coord_t wipe_dist = 0, const Ratio flow_ratio = 1.0_r, const double fan_speed = 100.0);
+    void addLinesMonotonic(const Polygons& polygons, const GCodePathConfig& config, const SpaceFillType space_fill_type, const AngleRadians monotonic_direction, const coord_t max_adjacent_distance, const coord_t wipe_dist = 0, const Ratio flow_ratio = 1.0_r, const double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
 
     /*!
      * Add a spiralized slice of wall that is interpolated in X/Y between \p last_wall and \p wall.


### PR DESCRIPTION
Since it was set to 100 by default, it would always turn the fan on fully.
This was probalby missed during the first tests, as most of the default settings have the fanspeed at 100.

CURA-8567
Fixes Ultimaker/Cura#10407