### PR TITLE
CURA-7976: Combing strategy to avoid top and bottom most surface skins

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -243,6 +243,19 @@ Polygons LayerPlan::computeCombBoundaryInside(const size_t max_inset)
                     }
                 }
             }
+            else if (combing_mode == CombingMode::NO_OUTER_SURFACES)
+            {
+                Polygons top_and_bottom_most_fill;
+                for (const SliceLayerPart& part : layer.parts)
+                {
+                    for (const SkinPart& skin_part : part.skin_parts)
+                    {
+                        top_and_bottom_most_fill.add(skin_part.top_most_surface_fill);
+                        top_and_bottom_most_fill.add(skin_part.bottom_most_surface_fill);
+                    }
+                }
+                comb_boundary.add(layer.getInnermostWalls(max_inset, mesh).difference(top_and_bottom_most_fill));
+            }
             else if (combing_mode == CombingMode::INFILL)
             {
                 for (const SliceLayerPart& part : layer.parts)

--- a/src/settings/EnumSettings.h
+++ b/src/settings/EnumSettings.h
@@ -101,6 +101,7 @@ enum class CombingMode
     OFF,
     ALL,
     NO_SKIN,
+    NO_OUTER_SURFACES,
     INFILL
 };
 

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -497,6 +497,10 @@ template<> CombingMode Settings::get<CombingMode>(const std::string& key) const
     {
         return CombingMode::NO_SKIN;
     }
+    else if (value == "no_outer_surfaces")
+    {
+        return CombingMode::NO_OUTER_SURFACES;
+    }
     else if (value == "infill")
     {
         return CombingMode::INFILL;

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -787,16 +787,23 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
     }
 }
 
-    void SkinInfillAreaComputation::generateTopAndBottomMostSkinSurfaces(SliceLayerPart &part) {
+/*
+ * This function is executed in a parallel region based on layer_nr.
+ * When modifying make sure any changes does not introduce data races.
+ *
+ * this function may only read/write the skin and infill from the *current* layer.
+ */
 
-        for (SkinPart& skin_part : part.skin_parts) {
-            Polygons no_air_above = generateNoAirAbove(part, 1);
-            skin_part.top_most_surface_fill = skin_part.inner_infill.difference(no_air_above);
+void SkinInfillAreaComputation::generateTopAndBottomMostSkinSurfaces(SliceLayerPart &part) {
 
-            Polygons no_air_below = generateNoAirBelow(part, 1);
-            skin_part.bottom_most_surface_fill = skin_part.inner_infill.difference(no_air_below);
-        }
+    for (SkinPart& skin_part : part.skin_parts) {
+        Polygons no_air_above = generateNoAirAbove(part, 1);
+        skin_part.top_most_surface_fill = skin_part.inner_infill.difference(no_air_above);
+
+        Polygons no_air_below = generateNoAirBelow(part, 1);
+        skin_part.bottom_most_surface_fill = skin_part.inner_infill.difference(no_air_below);
     }
+}
 
 
 }//namespace cura

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -473,7 +473,7 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
 
     for (SkinPart& skin_part : part.skin_parts)
     {
-        Polygons no_air_above = generateNoAirAbove(part);
+        Polygons no_air_above = generateNoAirAbove(part, roofing_layer_count);
         skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
         skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
 
@@ -512,9 +512,8 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
  *
  * this function may only read the skin and infill from the *current* layer.
  */
-Polygons SkinInfillAreaComputation::generateNoAirAbove(SliceLayerPart& part)
+Polygons SkinInfillAreaComputation::generateNoAirAbove(SliceLayerPart& part, size_t roofing_layer_count)
 {
-    const size_t roofing_layer_count = std::min(mesh.settings.get<size_t>("roofing_layer_count"), mesh.settings.get<size_t>("top_layers"));
     const size_t wall_idx = std::min(size_t(2), mesh.settings.get<size_t>("wall_line_count"));
 
     Polygons no_air_above = getWalls(part, layer_nr + roofing_layer_count, wall_idx);
@@ -553,8 +552,10 @@ Polygons SkinInfillAreaComputation::generateNoAirAbove(SliceLayerPart& part)
  */
 void SkinInfillAreaComputation::regenerateRoofingFillAndInnerInfill(SliceLayerPart& part, SkinPart& skin_part)
 {
+    const size_t roofing_layer_count = std::min(mesh.settings.get<size_t>("roofing_layer_count"), mesh.settings.get<size_t>("top_layers"));
+
     generateInnerSkinInfill(skin_part);
-    Polygons no_air_above = generateNoAirAbove(part);
+    Polygons no_air_above = generateNoAirAbove(part, roofing_layer_count);
     skin_part.roofing_fill = skin_part.inner_infill.difference(no_air_above);
     skin_part.inner_infill = skin_part.inner_infill.intersection(no_air_above);
 }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -554,21 +554,25 @@ Polygons SkinInfillAreaComputation::generateNoAirAbove(SliceLayerPart& part, siz
  */
     Polygons SkinInfillAreaComputation::generateNoAirBelow(SliceLayerPart& part, size_t flooring_layer_count)
     {
-        const size_t wall_idx = std::min(size_t(2), mesh.settings.get<size_t>("wall_line_count"));
-        if (layer_nr - flooring_layer_count >= 0)
+        if (layer_nr < flooring_layer_count)
         {
-            Polygons no_air_below = getWalls(part, layer_nr - flooring_layer_count, wall_idx);
-            if (!no_small_gaps_heuristic)
-            {
-                for (int layer_nr_below = layer_nr - flooring_layer_count + 1; layer_nr_below < layer_nr; layer_nr_below++)
-                {
-                    Polygons outlines_below = getWalls(part, layer_nr_below, wall_idx);
-                    no_air_below = no_air_below.intersection(outlines_below);
-                }
-            }
-            return no_air_below;
+            return {};
         }
-        return {};
+        constexpr size_t min_wall_line_count = 2;
+        const size_t wall_idx = std::min(min_wall_line_count, mesh.settings.get<size_t>("wall_line_count"));
+        const int lowest_flooring_layer = layer_nr - flooring_layer_count;
+        Polygons no_air_below = getWalls(part, lowest_flooring_layer, wall_idx);
+
+        if (!no_small_gaps_heuristic)
+        {
+            const int next_lowest_flooring_layer = lowest_flooring_layer + 1;
+            for (int layer_nr_below = next_lowest_flooring_layer; layer_nr_below < layer_nr; layer_nr_below++)
+            {
+                Polygons outlines_below = getWalls(part, layer_nr_below, wall_idx);
+                no_air_below = no_air_below.intersection(outlines_below);
+            }
+        }
+        return no_air_below;
     }
 
 /*

--- a/src/skin.h
+++ b/src/skin.h
@@ -138,6 +138,9 @@ protected:
      * Helper function to calculate and return the areas which are 'directly' under air.
      *
      * \param part Where to get the SkinParts to get the outline info from
+     * \param roofing_layer_count The number of layers above the layer which we are looking into
+     */
+    Polygons generateNoAirAbove(SliceLayerPart& part, size_t roofing_layer_count);
      */
     Polygons generateNoAirAbove(SliceLayerPart& part);
 

--- a/src/skin.h
+++ b/src/skin.h
@@ -135,14 +135,30 @@ protected:
     void generateRoofing(SliceLayerPart& part);
 
     /*!
+     * Remove the areas which are directly under air in the top-most surface and directly above air in bottom-most
+     * surfaces from the \ref SkinPart::inner_infill and save them in the \ref SkinPart::bottom_most_surface_fill and
+     * \ref SkinPart::top_most_surface_fill (respectively) of the \p part.
+     *
+     * \param[in,out] part Where to get the SkinParts to get the outline info from and to store the top and bottom-most
+     * infill areas
+     */
+    void generateTopAndBottomMostSkinSurfaces(SliceLayerPart& part);
+
+    /*!
      * Helper function to calculate and return the areas which are 'directly' under air.
      *
      * \param part Where to get the SkinParts to get the outline info from
      * \param roofing_layer_count The number of layers above the layer which we are looking into
      */
     Polygons generateNoAirAbove(SliceLayerPart& part, size_t roofing_layer_count);
+
+    /*!
+     * Helper function to calculate and return the areas which are 'directly' above air.
+     *
+     * \param part Where to get the SkinParts to get the outline info from
+     * \param flooring_layer_count The number of layers below the layer which we are looking into
      */
-    Polygons generateNoAirAbove(SliceLayerPart& part);
+    Polygons generateNoAirBelow(SliceLayerPart& part, size_t flooring_layer_count);
 
     /*!
      * Helper function to recalculate the roofing fill and inner infill in roofing layers where the 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -40,6 +40,8 @@ public:
     Polygons perimeter_gaps; //!< The gaps between the extra skin walls and gaps between the outer skin wall and the inner part inset
     Polygons inner_infill; //!< The inner infill of the skin with which the area within the innermost inset is filled
     Polygons roofing_fill; //!< The inner infill which has air directly above
+    Polygons top_most_surface_fill; //!< The inner infill of the uppermost top layer which has air directly above.
+    Polygons bottom_most_surface_fill; //!< The inner infill of the bottommost bottom layer which has air directly below.
 };
 
 


### PR DESCRIPTION
New combing mode "Not in Outer Surfaces" to avoid going through the skin, only on the bottom-most and too-most outer surfaces. Compared to the "Not in Skin" option, which avoids combing through all the skin surfaces regardless if they are visible, the "Not in Outer Surfaces" avoids only the skin surfaces that are actually exposed and will be visible in the printed model. This has the added benefit that it saves time while preserving visual quality.

The "Not in Outer Surfaces" option will be enabled by default in the following cases:
1. Monotonic Top/Bottom Order is enabled (in any extruder)
2. Ironing is enabled (in any extruder)
3. Top Surface Skin Layers > 0 and Monotonic Top Surface Order is enabled (in any extruder)

Backend of https://github.com/Ultimaker/Cura/pull/10536.

CURA-7976