### PR TITLE
CURA-8537 Fix introduction of micro length segments when compensate wall overlap enabled

### DIFF
--- a/src/utils/PolygonProximityLinker.cpp
+++ b/src/utils/PolygonProximityLinker.cpp
@@ -375,11 +375,11 @@ void PolygonProximityLinker::addProximityEnding(const ProximityPointLink& link, 
 
 ListPolyIt PolygonProximityLinker::addNewPolyPoint(const Point point, const ListPolyIt line_start, const ListPolyIt line_end, const ListPolyIt before_this)
 {
-    if (point == line_start.p())
+    if (vSize(line_start.p() - point) < proximity_distance)
     {
         return line_start;
     }
-    if (point == line_end.p())
+    if (vSize(line_end.p() - point) < proximity_distance)
     {
         return line_end;
     }


### PR DESCRIPTION
Micro length segments could be introduced when `Compensate wall overlaps`
was enabled. Compensate wall overlap was allowed to break up segments
when a line partially overlapped with another wall. This ensured that
the flow reduction was only performed when there was actually an
overlap, instead of the complete segment. Since this algorithm was
executed after the simplification of the polygons, it could happen that
these newly created segments violated the minimum allowed length.
Simplifying the final polygons would break the linked segments of the
other polygon and wasn't a viable solution.

A "simple" fix was to only allow the creation of such a segment if the
resulting segment wasn't too small. This can still result in some
unbalanced overlapping flows on rare edge-cases; which was deemed to be
acceptable after discussing it with our tester(s) and @kostas.
Especially since Arachne will get rid of this method as a whole.

The minimum allowed segment length was empirically determined to be
roughly in the neighborhood as the `proximity_distance` a.k.a. the
`line_width`.

Fixes CURA-8537