### PR TITLE
[CURA-8614] Make a round-divide for signed integers.

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -132,15 +132,7 @@ bool FffPolygonGenerator::sliceModel(MeshGroup* meshgroup, TimeKeeper& timeKeepe
     }
     else
     {
-        const coord_t height_without_first_layer = storage.model_max.z - initial_layer_thickness;
-        if(height_without_first_layer <= 0)
-        {
-            slice_layer_count = 0;
-        }
-        else
-        {
-            slice_layer_count = round_divide(height_without_first_layer, layer_thickness) + 1;
-        }
+        slice_layer_count = round_divide_signed(storage.model_max.z - initial_layer_thickness, layer_thickness) + 1;
     }
 
     // Model is shallower than layer_height_0, so not even the first layer is sliced. Return an empty model then.

--- a/src/utils/math.h
+++ b/src/utils/math.h
@@ -17,6 +17,11 @@ static constexpr float sqrt2 = 1.41421356237;
 
 template<typename T> inline T square(const T& a) { return a * a; }
 
+inline unsigned int round_divide_signed(int dividend, int divisor) //!< Return dividend divided by divisor rounded to the nearest integer
+{
+    const int abs_div = std::abs(divisor);
+    return (dividend * divisor > 0 ? 1 : -1) * ((std::abs(dividend) + abs_div / 2) / abs_div);
+}
 inline unsigned int round_divide(unsigned int dividend, unsigned int divisor) //!< Return dividend divided by divisor rounded to the nearest integer
 {
     return (dividend + divisor / 2) / divisor;


### PR DESCRIPTION
Instead of trying to work around it, which caused a bug  that would prevent models equal to or under the initial layer height from actually adding the first layer.
