### PR TITLE
Fix infill expanding into skin where there is no infill

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -662,8 +662,7 @@ void FffPolygonGenerator::processPerimeterGaps(SliceDataStorage& storage)
                         // we print them as a perimeter gap
                         inner = inner.offset(-skin_line_width / 2).offset(skin_line_width / 2);
                     }
-                    inner.add(part.infill_area.offset(-infill_line_width / 2).offset(infill_line_width / 2));
-                    inner = inner.unionPolygons();
+                    inner = inner.unionPolygons(part.infill_area);
                     part.perimeter_gaps.add(outer.difference(inner));
 
                     if (filter_out_tiny_gaps) {

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -420,45 +420,24 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
     {
         return; // the last wall is not present, the part should only get inter perimeter gaps, but no infill.
     }
+    const EFillMethod fill_pattern = mesh.settings.get<EFillMethod>("infill_pattern");
 
-    auto get_offset = [this]()
+    coord_t inner_wall_offset = -innermost_wall_line_width / 2; //The innermost wall is a centerline, not the actual area covered by the wall.
+    const Polygons* offset_from_wall = &part.insets.back();
+    if(fill_pattern == EFillMethod::CONCENTRIC)
     {
-        const auto infill_line_distance = mesh.settings.get<coord_t>("infill_line_distance");
-        if (wall_line_count > 0)
-        { // calculate offset_from_inner_wall
-            coord_t extra_perimeter_offset = 0; // to align concentric polygons across layers
-            const auto fill_pattern = mesh.settings.get<EFillMethod>("infill_pattern");
-            const coord_t infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
-            if (fill_pattern == EFillMethod::CONCENTRIC
-                && infill_line_distance > mesh.settings.get<coord_t>("infill_line_width") * 2)
-            {
-                if (mesh.settings.get<bool>("alternate_extra_perimeter")
-                    && layer_nr % 2 == 0)
-                { // compensate shifts otherwise caused by alternating an extra perimeter
-                    extra_perimeter_offset = -innermost_wall_line_width;
-                }
-                if (layer_nr == 0)
-                { // compensate for shift caused by walls being expanded by the initial line width multiplier
-                    const auto normal_wall_line_width_0 = mesh.settings.get<coord_t>("wall_line_width_0");
-                    const auto normal_wall_line_width_x = mesh.settings.get<coord_t>("wall_line_width_x");
-                    const coord_t normal_walls_width = normal_wall_line_width_0 + (wall_line_count - 1) * normal_wall_line_width_x;
-                    const coord_t walls_width = normal_walls_width * mesh.settings.get<Ratio>("initial_layer_line_width_factor");
+        //With concentric, we want the pattern to line up between layers if the outline is the same.
+        //This means that effects such as alternate extra walls and initial layer line width should not be taken into account.
+        //So instead, we'll offset from the outermost wall with a fixed size that is the same for every layer.
+        offset_from_wall = &part.insets.front();
+        const coord_t wall_line_width_0 = mesh.settings.get<coord_t>("wall_line_width_0");
+        const coord_t wall_line_width_x = mesh.settings.get<coord_t>("wall_line_width_x");
+        inner_wall_offset = -wall_line_width_0 - (wall_line_count - 1) * wall_line_width_x + innermost_wall_line_width / 2;
+    }
+    const Polygons inside_area_border = offset_from_wall->offset(inner_wall_offset); //Area that should get filled with skin/infill.
 
-                    extra_perimeter_offset += walls_width - normal_walls_width;
-                    while (extra_perimeter_offset > 0)
-                    {
-                        extra_perimeter_offset -= infill_line_distance;
-                    }
-                }
-            }
-            return extra_perimeter_offset - innermost_wall_line_width / 2 + infill_overlap;
-        }
-        return coord_t(0);
-    };
-
-    const coord_t offset_from_inner_wall = get_offset();
-
-    part.infill_area = part.insets.back().offset(offset_from_inner_wall).difference(skin);
+    const coord_t infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
+    part.infill_area = inside_area_border.difference(skin).offset(infill_overlap);
     part.infill_area.removeSmallAreas(MIN_AREA_SIZE);
 }
 

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -437,7 +437,7 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
     const Polygons inside_area_border = offset_from_wall->offset(inner_wall_offset); //Area that should get filled with skin/infill.
 
     const coord_t infill_overlap = mesh.settings.get<coord_t>("infill_overlap_mm");
-    part.infill_area = inside_area_border.difference(skin).offset(infill_overlap);
+    part.infill_area = inside_area_border.difference(skin).offset(-10).offset(infill_overlap + 10); //First subtract skin, then inset by 10 units to prevent rounding errors, then apply infill overlap.
     part.infill_area.removeSmallAreas(MIN_AREA_SIZE);
 }
 


### PR DESCRIPTION
This fixes a case where the Infill Overlap setting was causing infill to appear in areas that are filled completely with skin, if combined with Extra Skin Walls.

A project file that reproduces the original issue:
[CE3_Part2.zip](https://github.com/Ultimaker/CuraEngine/files/7454082/CE3_Part2.zip)

Fixes CURA-8644.