### PR TITLE
Fuzzy skin fix

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1176,7 +1176,7 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
                 { // 'a' is the (next) new point between p0 and p1
                     Point p0p1 = p1 - *p0;
                     int64_t p0p1_size = vSize(p0p1);
-                    int64_t dist_last_point = dist_left_over + p0p1_size * 2; // so that p0p1_size - dist_last_point evaulates to dist_left_over - p0p1_size
+                    int64_t dist_last_point = p0p1_size * 2 - dist_left_over; // so that p0p1_size - dist_last_point evaulates to dist_left_over - p0p1_size
                     for (int64_t p0pa_dist = dist_left_over; p0pa_dist < p0p1_size; p0pa_dist += min_dist_between_points + rand() % range_random_point_dist)
                     {
                         int r = rand() % (fuzziness * 2) - fuzziness;

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1176,17 +1176,17 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
                 { // 'a' is the (next) new point between p0 and p1
                     Point p0p1 = p1 - *p0;
                     int64_t p0p1_size = vSize(p0p1);
-                    int64_t dist_last_point = p0p1_size * 2 - dist_left_over; // so that p0p1_size - dist_last_point evaulates to dist_left_over - p0p1_size
-                    for (int64_t p0pa_dist = dist_left_over; p0pa_dist < p0p1_size; p0pa_dist += min_dist_between_points + rand() % range_random_point_dist)
+                    int64_t p0pa_dist = dist_left_over;
+                    for (; p0pa_dist < p0p1_size; p0pa_dist += min_dist_between_points + rand() % range_random_point_dist)
                     {
                         int r = rand() % (fuzziness * 2) - fuzziness;
                         Point perp_to_p0p1 = turn90CCW(p0p1);
                         Point fuzz = normal(perp_to_p0p1, r);
                         Point pa = *p0 + normal(p0p1, p0pa_dist) + fuzz;
                         result.add(pa);
-                        dist_last_point = p0pa_dist;
                     }
-                    dist_left_over = p0p1_size - dist_last_point;
+                    // p0pa_dist > p0p1_size now because we broke out of the for-loop
+                    dist_left_over = p0pa_dist - p0p1_size;
 
                     p0 = &p1;
                 }


### PR DESCRIPTION
Fuzzy skin has a problem where it sometimes produces weird long overshoots:
https://github.com/Ultimaker/Cura/issues/10585

![image](https://user-images.githubusercontent.com/8895761/139687433-48b30761-f46c-4180-95eb-2f1f47eb45ea.png)

The problem can be made extra clear by setting the point distance high while the thickness should be low. In usch a case you would still expect a very low deviation from the surface, but it is actually rather high.
![image](https://user-images.githubusercontent.com/8895761/139686530-7c081de9-0e55-474e-acc2-567a06627922.png)

I know you will have to reimplement the feature for Arachne, but then you'll probably look at the old implementation first, so it might be nice to merge this fix or at least keep it in the back of your minds when working on CURA-7887


Totoro is happy with this PR:
![image](https://user-images.githubusercontent.com/8895761/139846466-878e97b7-982f-45f2-8575-d85f8fda5c47.png)

At a way too high sample point distance you get this error which was always a problem in fuzzy skin, but at least no overshoots any more.
![image](https://user-images.githubusercontent.com/8895761/139846638-3954284b-d683-48d1-b2f8-5a0a869b9643.png)

Dual fuzzy squirtle is ambivalent about these changes:
![image](https://user-images.githubusercontent.com/8895761/139847426-ff125923-9988-4736-9982-6c0b05f477ee.png)

Surface image logo is very flashy with these changes:
![image](https://user-images.githubusercontent.com/8895761/139847661-aaa16b0e-7817-436f-89fb-9ecb868fefb9.png)
