### PR TITLE
Fix case where a single line containing only a zero was added to the …

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1269,7 +1269,7 @@ void GCodeExport::writeBedTemperatureCommand(const Temperature& temperature, con
     { // The UM2 family doesn't support temperature commands (they are fixed in the firmware)
         return;
     }
-
+    bool wrote_command = false;
     if (wait)
     {
         if(bed_temperature != temperature) //Not already at the desired temperature.
@@ -1282,12 +1282,17 @@ void GCodeExport::writeBedTemperatureCommand(const Temperature& temperature, con
             }
         }
         *output_stream << "M190 S";
+        wrote_command = true;
     }
     else if(bed_temperature != temperature)
     {
         *output_stream << "M140 S";
+        wrote_command = true;
     }
-    *output_stream << PrecisionedDouble{1, temperature} << new_line;
+    if(wrote_command)
+    {
+        *output_stream << PrecisionedDouble{1, temperature} << new_line;
+    }
     bed_temperature = temperature;
 }
 


### PR DESCRIPTION
…gcode

There were cases where no g-code was printed but it would add the final temp (0).
This in turn would cause issues with certain printers as a single zero could not be
parsed as a g-code instruction

CURA-8673
Fixes Ultimaker/Cura#10719