### PR TITLE
[CURA-8713] Revert "Prevent accumulation of error?"

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1558,9 +1558,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
     Communication* communication = Application::getInstance().communication;
     communication->setLayerForSend(layer_nr);
     communication->sendCurrentPosition(gcode.getPositionXY());
-
-    gcode.resetExtrusionValue();
     gcode.setLayerNr(layer_nr);
+    
     gcode.writeLayerComment(layer_nr);
 
     // flow-rate compensation


### PR DESCRIPTION
This reverts commit 55d0e58de3d8d22e4470431fc9b9f8992779dc93.

That commit was done as an unsure 'well if it can't harm' kind of way in order to _maybe_ halfway fix a bug that wasn't possibly wasn't affecting our prints and now appears to have been fixed in other ways, as I can't even reproduce it anymore. However, the now reverted fix may have casued the issue in CURA-8713 -- retracts in gcode preventing the UM2+ from finishing prints.