### PR TITLE
Fixed extra z-hops in Surface slicing mode

### DIFF
--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -784,6 +784,13 @@ void SlicerLayer::makePolygons(const Mesh* mesh)
     polygons.simplify();
 
     polygons.removeDegenerateVerts(); // remove verts connected to overlapping line segments
+
+    // Clean up polylines for Surface Mode printing
+    it = std::remove_if(openPolylines.begin(), openPolylines.end(), [snap_distance](PolygonRef poly) { return poly.shorterThan(snap_distance); });
+    openPolylines.erase(it, openPolylines.end());
+
+    openPolylines.simplify();
+    openPolylines.removeDegenerateVerts();
 }
 
 Slicer::Slicer(Mesh* i_mesh, const coord_t thickness, const size_t slice_layer_count,


### PR DESCRIPTION
closes #1532 

Open poly lines were never cleaned up the same way that polygons are.