### PR TITLE
Improve mesh loading

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -77,7 +77,7 @@ public:
 
     /*!
      * Insert a new 3D point into the map and returns its identifier.
-     * If a previously inserted point is found in a sphere of vertex_meld_distance radius, returns its identifier instead.
+     * If a previously inserted point is found, returns its identifier instead.
      * \param vertices Vector mapping identifiers to already inserted points. New identifier are generated from it's size. Read when rehashing.
      */
     Item insert(const Point3& p, const std::vector<MeshVertex>& vertices);
@@ -90,13 +90,6 @@ private:
     uint8_t bits = min_bits; //!< log2 size of map
 
     void init(); //!< Allocate the map. bits must be set beforehand.
-
-    /*!
-     * Inserts a point and its associated value in each of the 8 cubes overlapping
-     * the sphere of radius=vertex_meld_distance centered on the point.
-     * \param value Vertex identifier plus one (0 is the marker for empty slot)
-     */
-    void insert8(const Point3& p, Item value);
 
     /*!
      * Probing primitive.

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -6,8 +6,9 @@
 
 #include "settings/Settings.h"
 #include "utils/AABB3D.h"
-#include "utils/floatpoint.h"
 #include "utils/FMatrix4x3.h"
+#include "utils/NoCopy.h"
+#include "utils/floatpoint.h"
 
 namespace cura
 {
@@ -59,7 +60,7 @@ A Mesh is the most basic representation of a 3D model. It contains all the faces
 
 See MeshFace for the specifics of how/when faces are connected.
 */
-class Mesh
+class Mesh : public NoCopy
 {
     //! The vertex_hash_map stores a index reference of each vertex for the hash of that location. Allows for quick retrieval of points with the same location.
     std::unordered_map<uint32_t, std::vector<uint32_t> > vertex_hash_map;
@@ -67,11 +68,11 @@ class Mesh
 public:
     std::vector<MeshVertex> vertices;//!< list of all vertices in the mesh
     std::vector<MeshFace> faces; //!< list of all faces in the mesh
-    Settings settings;
+    Settings settings = {};
     std::string mesh_name;
 
-    Mesh(Settings& parent);
-    Mesh();
+    Mesh() = default;
+    Mesh(size_t face_count);
 
     void addFace(Point3& v0, Point3& v1, Point3& v2); //!< add a face to the mesh without settings it's connected_faces.
     void clear(); //!< clears all data
@@ -107,8 +108,8 @@ public:
      */
     bool isPrinted() const;
 private:
-    mutable bool has_disconnected_faces; //!< Whether it has been logged that this mesh contains disconnected faces
-    mutable bool has_overlapping_faces; //!< Whether it has been logged that this mesh contains overlapping faces
+    mutable bool has_disconnected_faces = false; //!< Whether it has been logged that this mesh contains disconnected faces
+    mutable bool has_overlapping_faces = false; //!< Whether it has been logged that this mesh contains overlapping faces
     int findIndexOfVertex(const Point3& v); //!< find index of vertex close to the given point, or create a new vertex and return its index.
 
     /*!

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -65,7 +65,7 @@ class HashMap3D
 {
 public:
     using Item = mesh_idx_t;
-    using hash_t = uint32_t;
+    using hash_t = uint64_t;
 
     HashMap3D() : HashMap3D(0){};
     HashMap3D(size_t nvertices);

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -12,6 +12,8 @@
 
 namespace cura
 {
+using mesh_idx_t = uint32_t; //!< Type for vertex and face indices
+
 /*!
 Vertex type to be used in a Mesh.
 
@@ -21,7 +23,7 @@ class MeshVertex
 {
 public:
     Point3 p; //!< location of the vertex
-    std::vector<uint32_t> connected_faces; //!< list of the indices of connected faces
+    std::vector<mesh_idx_t> connected_faces; //!< list of the indices of connected faces
 
     MeshVertex(Point3 p) : p(p) {connected_faces.reserve(8);} //!< doesn't set connected_faces
 };
@@ -50,8 +52,8 @@ In such a case the face_index stored in connected_face_index is the one connecte
 class MeshFace
 {
 public:
-    int vertex_index[3] = {-1}; //!< counter-clockwise ordering
-    int connected_face_index[3]; //!< same ordering as vertex_index (connected_face 0 is connected via vertex 0 and 1, etc.)
+    mesh_idx_t vertex_index[3] = {}; //!< counter-clockwise ordering
+    mesh_idx_t connected_face_index[3]; //!< same ordering as vertex_index (connected_face 0 is connected via vertex 0 and 1, etc.)
 };
 
 
@@ -110,7 +112,7 @@ public:
 private:
     mutable bool has_disconnected_faces = false; //!< Whether it has been logged that this mesh contains disconnected faces
     mutable bool has_overlapping_faces = false; //!< Whether it has been logged that this mesh contains overlapping faces
-    int findIndexOfVertex(const Point3& v); //!< find index of vertex close to the given point, or create a new vertex and return its index.
+    mesh_idx_t findIndexOfVertex(const Point3& v); //!< find index of vertex close to the given point, or create a new vertex and return its index.
 
     /*!
      * Get the index of the face connected to the face with index \p notFaceIdx, via vertices \p idx0 and \p idx1.
@@ -123,7 +125,7 @@ private:
      * \param notFaceVertexIdx should be the third vertex of face \p notFaceIdx.
      * \return the face index of a face sharing the edge from \p idx0 to \p idx1
     */
-    int getFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx, int notFaceVertexIdx) const;
+    ptrdiff_t getFaceIdxWithPoints(mesh_idx_t idx0, mesh_idx_t idx1, mesh_idx_t notFaceIdx, mesh_idx_t notFaceVertexIdx) const;
 };
 
 }//namespace cura

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -8,6 +8,7 @@
 #include "utils/AABB3D.h"
 #include "utils/FMatrix4x3.h"
 #include "utils/NoCopy.h"
+#include <boost/container/small_vector.hpp>
 #include <memory>
 
 namespace cura
@@ -23,9 +24,11 @@ class MeshVertex
 {
 public:
     Point3 p; //!< location of the vertex
-    std::vector<mesh_idx_t> connected_faces; //!< list of the indices of connected faces
+    boost::container::small_vector<mesh_idx_t, 8> connected_faces; //!< list of the indices of connected faces
 
-    MeshVertex(Point3 p) : p(p) {connected_faces.reserve(8);} //!< doesn't set connected_faces
+    MeshVertex(Point3 p) : p(p)
+    {
+    } //!< doesn't set connected_faces
 };
 
 /*! A MeshFace is a 3 dimensional model triangle with 3 points. These points are already converted to integers

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -8,7 +8,7 @@
 #include "utils/AABB3D.h"
 #include "utils/FMatrix4x3.h"
 #include "utils/NoCopy.h"
-#include "utils/floatpoint.h"
+#include <memory>
 
 namespace cura
 {
@@ -56,6 +56,53 @@ public:
     mesh_idx_t connected_face_index[3]; //!< same ordering as vertex_index (connected_face 0 is connected via vertex 0 and 1, etc.)
 };
 
+/*!
+ * \brief 3D Spatial hashmap
+ * Generates unique identifiers for deduplicated 3D vertices that are no closer to each other than a static distance (vertex_meld_distance).
+ * Use Morton encoding and Python's dict probing.
+ */
+class HashMap3D
+{
+public:
+    using Item = mesh_idx_t;
+    using hash_t = uint32_t;
+
+    HashMap3D() : HashMap3D(0){};
+    HashMap3D(size_t nvertices);
+
+    void clear(); //!< Drop content, free memory.
+
+    /*!
+     * Insert a new 3D point into the map and returns its identifier.
+     * If a previously inserted point is found in a sphere of vertex_meld_distance radius, returns its identifier instead.
+     * \param vertices Vector mapping identifiers to already inserted points. New identifier are generated from it's size. Read when rehashing.
+     */
+    Item insert(const Point3& p, const std::vector<MeshVertex>& vertices);
+
+private:
+    static constexpr uint8_t min_bits = 10; //!< Default log2 size of the map when zero initialized.
+    std::unique_ptr<Item[]> map;
+    hash_t mask = 0; //!< Bit mask for open adressing in map. (map.size()-1)
+    mesh_idx_t free_vertices = 0; //!< Number of vertices that can be inserted before a rehash (when reaching 0)
+    uint8_t bits = min_bits; //!< log2 size of map
+
+    void init(); //!< Allocate the map. bits must be set beforehand.
+
+    /*!
+     * Inserts a point and its associated value in each of the 8 cubes overlapping
+     * the sphere of radius=vertex_meld_distance centered on the point.
+     * \param value Vertex identifier plus one (0 is the marker for empty slot)
+     */
+    void insert8(const Point3& p, Item value);
+
+    /*!
+     * Probing primitive.
+     * Iterates over slots starting from the specified hash. Stops when an empty slot (=0) is found or when the predicates returns true.
+     */
+    template<typename P>
+    Item& probe(hash_t hash, const P& predicate);
+};
+
 
 /*!
 A Mesh is the most basic representation of a 3D model. It contains all the faces as MeshFaces.
@@ -64,11 +111,9 @@ See MeshFace for the specifics of how/when faces are connected.
 */
 class Mesh : public NoCopy
 {
-    //! The vertex_hash_map stores a index reference of each vertex for the hash of that location. Allows for quick retrieval of points with the same location.
-    std::unordered_map<uint32_t, std::vector<uint32_t> > vertex_hash_map;
     AABB3D aabb;
 public:
-    std::vector<MeshVertex> vertices;//!< list of all vertices in the mesh
+    std::vector<MeshVertex> vertices; //!< list of all vertices in the mesh
     std::vector<MeshFace> faces; //!< list of all faces in the mesh
     Settings settings = {};
     std::string mesh_name;
@@ -84,7 +129,7 @@ public:
     Point3 max() const; //!< max (in x,y and z) vertex of the bounding box
     AABB3D getAABB() const; //!< Get the axis aligned bounding box
     void expandXY(int64_t offset); //!< Register applied horizontal expansion in the AABB
-    
+
     /*!
      * Offset the whole mesh (all vertices and the bounding box).
      * \param offset The offset byu which to offset the whole mesh.
@@ -110,24 +155,25 @@ public:
      */
     bool isPrinted() const;
 private:
+    HashMap3D spatial_map = {};
+
     mutable bool has_disconnected_faces = false; //!< Whether it has been logged that this mesh contains disconnected faces
     mutable bool has_overlapping_faces = false; //!< Whether it has been logged that this mesh contains overlapping faces
     mesh_idx_t findIndexOfVertex(const Point3& v); //!< find index of vertex close to the given point, or create a new vertex and return its index.
 
     /*!
      * Get the index of the face connected to the face with index \p notFaceIdx, via vertices \p idx0 and \p idx1.
-     * 
+     *
      * In case multiple faces connect with the same edge, return the next counter-clockwise face when viewing from \p idx1 to \p idx0.
-     * 
+     *
      * \param idx0 the first vertex index
      * \param idx1 the second vertex index
      * \param notFaceIdx the index of a face which shouldn't be returned
      * \param notFaceVertexIdx should be the third vertex of face \p notFaceIdx.
      * \return the face index of a face sharing the edge from \p idx0 to \p idx1
-    */
+     */
     ptrdiff_t getFaceIdxWithPoints(mesh_idx_t idx0, mesh_idx_t idx1, mesh_idx_t notFaceIdx, mesh_idx_t notFaceVertexIdx) const;
 };
 
 }//namespace cura
-#endif//MESH_H
-
+#endif // MESH_H

--- a/include/utils/NoCopy.h
+++ b/include/utils/NoCopy.h
@@ -11,20 +11,23 @@
 class NoCopy
 {
 protected:
-    NoCopy() {}
-
-private:
-    /*!
-     * Private copy constructor.
-     * Cannot be called because it is private.
-     */
-    NoCopy(const NoCopy&);
+    NoCopy() noexcept
+    {
+    }
+    NoCopy(NoCopy&&) noexcept = default;
+    NoCopy& operator=(NoCopy&&) noexcept = default;
 
     /*!
-     * Private assign operator.
-     * Cannot be called because it is private.
+     * Copy constructor.
+     * Cannot be called because it is deleted.
      */
-    NoCopy& operator =(const NoCopy&);
+    NoCopy(const NoCopy&) = delete;
+
+    /*!
+     * Assign (copy) operator.
+     * Cannot be called because it is deleted.
+     */
+    NoCopy& operator=(const NoCopy&) = delete;
 };
 
 #endif // UTILS_NO_COPY_H

--- a/include/utils/floatpoint.h
+++ b/include/utils/floatpoint.h
@@ -81,7 +81,7 @@ public:
 //            a.x*b.y-a.y*b.x);
     }
 
-    Point3 toPoint3()
+    Point3 toPoint3() const
     {
         return Point3(MM2INT(x), MM2INT(y), MM2INT(z));
     }

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -113,6 +113,10 @@ void MeshGroup::finalize()
 
 void MeshGroup::scaleFromBottom(const Ratio factor_xy, const Ratio factor_z)
 {
+    if (factor_xy == 1.0 && factor_z == 1.0)
+    {
+        return;
+    }
     const Point3 center = (max() + min()) / 2;
     const Point3 origin(center.x, center.y, 0);
 

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -273,10 +273,11 @@ bool loadMeshIntoMeshGroup(MeshGroup* meshgroup, const char* filename, const FMa
     const char* ext = strrchr(filename, '.');
     if (ext && (strcmp(ext, ".stl") == 0 || strcmp(ext, ".STL") == 0))
     {
-        Mesh mesh(object_parent_settings);
+        Mesh mesh;
+        mesh.settings.setParent(&object_parent_settings);
         if (loadMeshSTL(&mesh, filename, transformation)) // Load it! If successful...
         {
-            meshgroup->meshes.push_back(mesh);
+            meshgroup->meshes.emplace_back(std::move(mesh));
             spdlog::info("loading '{}' took {:3} seconds", filename, load_timer.restart());
             return true;
         }

--- a/src/communication/ArcusCommunicationPrivate.cpp
+++ b/src/communication/ArcusCommunicationPrivate.cpp
@@ -91,7 +91,6 @@ void ArcusCommunication::Private::readMeshGroupMessage(const proto::ObjectList& 
         mesh_group.settings.add(setting.name(), setting.value());
     }
 
-    FMatrix4x3 matrix;
     for (const cura::proto::Object& object : mesh_group_message.objects())
     {
         const size_t bytes_per_face = sizeof(FPoint3) * 3; // 3 vectors per face.
@@ -114,15 +113,15 @@ void ArcusCommunication::Private::readMeshGroupMessage(const proto::ObjectList& 
         ExtruderTrain& extruder = mesh.settings.get<ExtruderTrain&>("extruder_nr"); // Set the parent setting to the correct extruder.
         mesh.settings.setParent(&extruder.settings);
 
+        const char* vertices = object.vertices().data();
         for (size_t face = 0; face < face_count; face++)
         {
-            const std::string data = object.vertices().substr(face * bytes_per_face, bytes_per_face);
-            const FPoint3* float_vertices = reinterpret_cast<const FPoint3*>(data.data());
+            const FPoint3* float_vertices = reinterpret_cast<const FPoint3*>(vertices + face * bytes_per_face);
 
             Point3 verts[3];
-            verts[0] = matrix.apply(float_vertices[0]);
-            verts[1] = matrix.apply(float_vertices[1]);
-            verts[2] = matrix.apply(float_vertices[2]);
+            verts[0] = float_vertices[0].toPoint3();
+            verts[1] = float_vertices[1].toPoint3();
+            verts[2] = float_vertices[2].toPoint3();
             mesh.addFace(verts[0], verts[1], verts[2]);
         }
 

--- a/src/communication/ArcusCommunicationPrivate.cpp
+++ b/src/communication/ArcusCommunicationPrivate.cpp
@@ -103,7 +103,7 @@ void ArcusCommunication::Private::readMeshGroupMessage(const proto::ObjectList& 
             continue;
         }
 
-        mesh_group.meshes.emplace_back();
+        mesh_group.meshes.emplace_back(face_count);
         Mesh& mesh = mesh_group.meshes.back();
 
         // Load the settings for the mesh.

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -9,7 +9,9 @@
 namespace cura
 {
 
-const int vertex_meld_distance = MM2INT(0.03);
+const coord_t vertex_meld_distance = MM2INT(0.032);
+static_assert(vertex_meld_distance && (vertex_meld_distance & (vertex_meld_distance - 1)) == 0, "vertex_meld_distance should be a power of two for fast divisions");
+
 /*!
  * returns a hash for the location, but first divides by the vertex_meld_distance,
  * so that any point within a box of vertex_meld_distance by vertex_meld_distance would get mapped to the same hash.

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -224,7 +224,7 @@ bool Mesh::isPrinted() const
     return ! settings.get<bool>("infill_mesh") && ! settings.get<bool>("cutting_mesh") && ! settings.get<bool>("anti_overhang_mesh");
 }
 
-mesh_idx_t Mesh::findIndexOfVertex(const Point3& v)
+inline mesh_idx_t Mesh::findIndexOfVertex(const Point3& v)
 {
     const mesh_idx_t new_idx = vertices.size();
     auto idx = spatial_map.insert(v, vertices);
@@ -260,7 +260,7 @@ See <a href="http://stackoverflow.com/questions/14066933/direct-way-of-computing
 
 
 */
-ptrdiff_t Mesh::getFaceIdxWithPoints(mesh_idx_t idx0, mesh_idx_t idx1, mesh_idx_t notFaceIdx, mesh_idx_t notFaceVertexIdx) const
+inline ptrdiff_t Mesh::getFaceIdxWithPoints(mesh_idx_t idx0, mesh_idx_t idx1, mesh_idx_t notFaceIdx, mesh_idx_t notFaceVertexIdx) const
 {
     boost::container::small_vector<mesh_idx_t, 5> candidateFaces; // in case more than two faces meet at an edge, multiple candidates are generated
     for (mesh_idx_t f : vertices[idx0].connected_faces) // search through all faces connected to the first vertex and find those that are also connected to the second

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -142,8 +142,16 @@ void Mesh::finish()
 {
     // Finish up the mesh, clear the vertex_hash_map, as it's no longer needed from this point on and uses quite a bit of memory.
     spatial_map.clear();
-    faces.shrink_to_fit();
-    vertices.shrink_to_fit();
+    // Shrink to fit vectors if more than 1/3 is wasted
+    if (faces.size() * 3 < 2 * faces.capacity())
+    {
+        faces.shrink_to_fit();
+    }
+    if (vertices.size() * 3 < 2 * vertices.capacity())
+    {
+        vertices.shrink_to_fit();
+    }
+
 
     // For each face, store which other face is connected with it.
     for (ptrdiff_t i = 0; i < ptrdiff_t(faces.size()); i++)

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -13,18 +13,28 @@ const coord_t vertex_meld_distance = MM2INT(0.032);
 static_assert(vertex_meld_distance && (vertex_meld_distance & (vertex_meld_distance - 1)) == 0, "vertex_meld_distance must be a power of two");
 
 /// 1D coordinate to discretized grid of 2 * vertex_meld_distance wide cells
-static inline uint32_t hash_coord(coord_t p)
+static inline HashMap3D::hash_t hash_coord(coord_t p)
 {
-    return uint32_t(p / (2 * vertex_meld_distance));
+    return HashMap3D::hash_t(p / (2 * vertex_meld_distance));
 };
 
 /// Intersperse bits by inserting 2 zeros beetwen each bit from the input bitstring
-static inline uint32_t intersperse3bits(uint32_t x)
+[[maybe_unused]] static inline uint32_t intersperse3bits(uint32_t x)
 {
     x = (x | x << 16) & 0x30000ff;
     x = (x | x << 8) & 0x300f00f;
     x = (x | x << 4) & 0x30c30c3;
     x = (x | x << 2) & 0x9249249;
+    return x;
+}
+
+[[maybe_unused]] static inline uint64_t intersperse3bits(uint64_t x)
+{
+    x = (x | x << 32) & 0x1f00000000ffff;
+    x = (x | x << 16) & 0x1f0000ff0000ff;
+    x = (x | x << 8) & 0x100f00f00f00f00f;
+    x = (x | x << 4) & 0x10c30c30c30c30c3;
+    x = (x | x << 2) & 0x1249249249249249;
     return x;
 }
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -262,7 +262,7 @@ See <a href="http://stackoverflow.com/questions/14066933/direct-way-of-computing
 */
 ptrdiff_t Mesh::getFaceIdxWithPoints(mesh_idx_t idx0, mesh_idx_t idx1, mesh_idx_t notFaceIdx, mesh_idx_t notFaceVertexIdx) const
 {
-    std::vector<mesh_idx_t> candidateFaces; // in case more than two faces meet at an edge, multiple candidates are generated
+    boost::container::small_vector<mesh_idx_t, 5> candidateFaces; // in case more than two faces meet at an edge, multiple candidates are generated
     for (mesh_idx_t f : vertices[idx0].connected_faces) // search through all faces connected to the first vertex and find those that are also connected to the second
     {
         if (f == notFaceIdx)

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -19,12 +19,10 @@ static inline uint32_t pointHash(const Point3& p)
     return ((p.x + vertex_meld_distance / 2) / vertex_meld_distance) ^ (((p.y + vertex_meld_distance / 2) / vertex_meld_distance) << 10) ^ (((p.z + vertex_meld_distance / 2) / vertex_meld_distance) << 20);
 }
 
-Mesh::Mesh(Settings& parent) : settings(parent), has_disconnected_faces(false), has_overlapping_faces(false)
+Mesh::Mesh(size_t face_count)
 {
-}
-
-Mesh::Mesh() : settings(), has_disconnected_faces(false), has_overlapping_faces(false)
-{
+    faces.reserve(face_count);
+    vertices.reserve(face_count / 2);
 }
 
 void Mesh::addFace(Point3& v0, Point3& v1, Point3& v2)
@@ -56,7 +54,8 @@ void Mesh::clear()
 void Mesh::finish()
 {
     // Finish up the mesh, clear the vertex_hash_map, as it's no longer needed from this point on and uses quite a bit of memory.
-    vertex_hash_map.clear();
+    faces.shrink_to_fit();
+    vertices.shrink_to_fit();
 
     // For each face, store which other face is connected with it.
     for (unsigned int i = 0; i < faces.size(); i++)

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -104,8 +104,8 @@ int SlicerLayer::getNextSegmentIdx(const SlicerSegment& segment, const size_t st
     {
         // segment ended at vertex
 
-        const std::vector<uint32_t>& faces_to_try = segment.endVertex->connected_faces;
-        for (int face_to_try : faces_to_try)
+        const auto& faces_to_try = segment.endVertex->connected_faces;
+        for (mesh_idx_t face_to_try : faces_to_try)
         {
             const int result_segment_idx = tryFaceNextSegmentIdx(segment, face_to_try, start_segment_idx);
             if (result_segment_idx == static_cast<int>(start_segment_idx))


### PR DESCRIPTION
This is a work in progress of a re-implementation of vertices merging during mesh loading, made to be more precise and more efficient. A 3DBenchy no longer triggers the warning `Mesh has overlapping faces!`.

**Background:** `Mesh::addFace` lockups vertices in a spatial hash map. This recovers the connectivity while accommodating for inaccuracies in STLs. Vertices closer than a 0.03 mm are merged together.

Previously, a vertex was inserted into a 0.03 mm wide cubic bucket. During lookup, a single bucket is searched for a neighboring vertex. Vertices close the the side of one cube will miss merge candidates from neighboring cubes. This could lead to unexpected behavior, and exacerbate the order sensitivity of the greedy merge algorithm.

This implementation uses half-open 0.064mm wide cubic buckets for merging vertices closer than 0.032 mm. It is optimized for queries: on insertion, a vertex is inserted in all of the 8 buckets overlapping with the 0.032mm radius sphere centered on the vertex. A query gets all candidates vertices from a single bucket.

For this purpose I wrote a specialized hash map. Iterating over a bucket is accomplished by iteratively probing the hash map. This gets some collisions during lookup, but they are filtered by the distance checks anyway. Using `std::unordered_map`, as in the current implementation, requires an indirection to dynamically sized buckets and can't combine collision checks with distance checks.

The hash map implementation is minimalist but supports rehashing when the number of vertices can't be estimated beforehand. Some cache locality is recovered from the inherent spatial locality of meshes: 
 * Point coordinates are hashed to their [Morton codes](https://en.wikipedia.org/wiki/Z-order_curve),
 * The probing strategy is copied from [Python's dict](https://github.com/python/cpython/blob/master/Objects/dictnotes.txt#L120),
 * Load factor is 2/3, growth factor is 4. Map sizes are powers of two, starting from 2^10.

This was a fun exercise, but I'd like to know if there is an interest in this before polishing it.
I'm in the process of benchmarking, and experimenting with different strategies and constants. (I will update with the results). But overall, the one above seems to perform the best for it's simplicity.