### PR TITLE
[CURA-8079] Alternate Wall Directions

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1363,7 +1363,7 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
     {
         part_order_optimizer.addPolygon(&part);
     }
-    part_order_optimizer.optimize();
+    part_order_optimizer.optimize(gcode_layer.getLayerNr() % 2 == 0);
     for(const PathOrderOptimizer<const SliceLayerPart*>::Path& path : part_order_optimizer.paths)
     {
         addMeshPartToGCode(storage, mesh, extruder_nr, mesh_config, *path.vertices, gcode_layer);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1363,7 +1363,8 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
     {
         part_order_optimizer.addPolygon(&part);
     }
-    part_order_optimizer.optimize(gcode_layer.getLayerNr() % 2 == 0);
+    const bool should_alternate_walls = mesh.settings.get<bool>("material_alternate_walls") && (gcode_layer.getLayerNr() % 2 == 0);
+    part_order_optimizer.optimize(should_alternate_walls);
     for(const PathOrderOptimizer<const SliceLayerPart*>::Path& path : part_order_optimizer.paths)
     {
         addMeshPartToGCode(storage, mesh, extruder_nr, mesh_config, *path.vertices, gcode_layer);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1363,8 +1363,7 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
     {
         part_order_optimizer.addPolygon(&part);
     }
-    const bool should_alternate_walls = mesh.settings.get<bool>("material_alternate_walls") && (gcode_layer.getLayerNr() % 2 == 0);
-    part_order_optimizer.optimize(should_alternate_walls);
+    part_order_optimizer.optimize();
     for(const PathOrderOptimizer<const SliceLayerPart*>::Path& path : part_order_optimizer.paths)
     {
         addMeshPartToGCode(storage, mesh, extruder_nr, mesh_config, *path.vertices, gcode_layer);

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -115,13 +115,14 @@ bool InsetOrderOptimizer::optimize(const WallType& wall_type)
         gcode_layer.setIsInside(true); //Going to print walls, which are always inside.
         ZSeamConfig z_seam_config(mesh.settings.get<EZSeamType>("z_seam_type"), mesh.getZSeamHint(), mesh.settings.get<EZSeamCornerPrefType>("z_seam_corner"), mesh.settings.get<coord_t>("wall_line_width_0") * 2);
 
+        const bool alternate_direction_modifier = inset % 2 == 0;
         if(bins_with_index_zero_insets.count(inset) > 0) //Print using outer wall config.
         {
-            gcode_layer.addWalls(insets[inset], mesh.settings, inset_0_non_bridge_config, inset_0_bridge_config, z_seam_config, wall_0_wipe_dist, flow, retract_before_outer_wall);
+            gcode_layer.addWalls(insets[inset], mesh.settings, inset_0_non_bridge_config, inset_0_bridge_config, z_seam_config, wall_0_wipe_dist, flow, retract_before_outer_wall, alternate_direction_modifier);
         }
         else
         {
-            gcode_layer.addWalls(insets[inset], mesh.settings, inset_X_non_bridge_config, inset_X_bridge_config, z_seam_config, 0, flow, false);
+            gcode_layer.addWalls(insets[inset], mesh.settings, inset_X_non_bridge_config, inset_X_bridge_config, z_seam_config, 0, flow, false, alternate_direction_modifier);
         }
     }
     return added_something;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1038,7 +1038,8 @@ void LayerPlan::addWalls
     const ZSeamConfig& z_seam_config,
     coord_t wall_0_wipe_dist,
     float flow_ratio,
-    bool always_retract
+    bool always_retract,
+    bool alternate_direction_modifier
 )
 {
     constexpr bool detect_loops = true;
@@ -1049,7 +1050,7 @@ void LayerPlan::addWalls
     }
 
     cura::Point p_end {0, 0};
-    order_optimizer.optimize(layer_nr % 2 == 0);
+    order_optimizer.optimize(layer_nr % 2 == (alternate_direction_modifier ? 1 : 0));
     for(const PathOrderOptimizer<const LineJunctions*>::Path& path : order_optimizer.paths)
     {
         p_end = path.backwards ? path.vertices->back().p : path.vertices->front().p;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1040,7 +1040,7 @@ void LayerPlan::addWalls
     coord_t wall_0_wipe_dist,
     float flow_ratio,
     bool always_retract,
-    bool alternate_direction_modifier
+    bool alternate_inset_direction_modifier
 )
 {
     constexpr bool detect_loops = true;
@@ -1051,7 +1051,9 @@ void LayerPlan::addWalls
     }
 
     cura::Point p_end {0, 0};
-    const bool alternate_walls = settings.get<bool>("material_alternate_walls") && (layer_nr % 2 == (alternate_direction_modifier ? 1 : 0));
+    //When we alternate walls, also alternate the direction at which the first wall starts in.
+    //On even layers we start with normal direction, on odd layers with inverted direction.
+    const bool alternate_walls = settings.get<bool>("material_alternate_walls") && (layer_nr % 2 == (alternate_inset_direction_modifier ? 1 : 0));
     order_optimizer.optimize(alternate_walls);
     for(const PathOrderOptimizer<const LineJunctions*>::Path& path : order_optimizer.paths)
     {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1022,7 +1022,8 @@ void LayerPlan::addWalls
     {
         orderOptimizer.addPolygon(walls[poly_idx]);
     }
-    orderOptimizer.optimize(layer_nr % 2 == 0);
+    const bool alternate_walls = settings.get<bool>("material_alternate_walls") && layer_nr % 2 == 0;
+    orderOptimizer.optimize(alternate_walls);
     for(const PathOrderOptimizer<ConstPolygonRef>::Path& path : orderOptimizer.paths)
     {
         addWall(*path.vertices, path.start_vertex, settings, non_bridge_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract);
@@ -1050,7 +1051,8 @@ void LayerPlan::addWalls
     }
 
     cura::Point p_end {0, 0};
-    order_optimizer.optimize(layer_nr % 2 == (alternate_direction_modifier ? 1 : 0));
+    const bool alternate_walls = settings.get<bool>("material_alternate_walls") && (layer_nr % 2 == (alternate_direction_modifier ? 1 : 0));
+    order_optimizer.optimize(alternate_walls);
     for(const PathOrderOptimizer<const LineJunctions*>::Path& path : order_optimizer.paths)
     {
         p_end = path.backwards ? path.vertices->back().p : path.vertices->front().p;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1004,7 +1004,17 @@ void LayerPlan::addInfillWall(const LineJunctions& wall, const GCodePathConfig& 
     }
 }
 
-void LayerPlan::addWalls(const Polygons& walls, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, const ZSeamConfig& z_seam_config, coord_t wall_0_wipe_dist, float flow_ratio, bool always_retract)
+void LayerPlan::addWalls
+(
+    const Polygons& walls,
+    const Settings& settings,
+    const GCodePathConfig& non_bridge_config,
+    const GCodePathConfig& bridge_config,
+    const ZSeamConfig& z_seam_config,
+    coord_t wall_0_wipe_dist,
+    float flow_ratio,
+    bool always_retract
+)
 {
     //TODO: Deprecated in favor of ExtrusionJunction version below.
     PathOrderOptimizer<ConstPolygonRef> orderOptimizer(getLastPlannedPositionOrStartingPosition(), z_seam_config);
@@ -1019,7 +1029,17 @@ void LayerPlan::addWalls(const Polygons& walls, const Settings& settings, const 
     }
 }
 
-void LayerPlan::addWalls(const PathJunctions& walls, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, const ZSeamConfig& z_seam_config, coord_t wall_0_wipe_dist, float flow_ratio, bool always_retract)
+void LayerPlan::addWalls
+(
+    const PathJunctions& walls,
+    const Settings& settings,
+    const GCodePathConfig& non_bridge_config,
+    const GCodePathConfig& bridge_config,
+    const ZSeamConfig& z_seam_config,
+    coord_t wall_0_wipe_dist,
+    float flow_ratio,
+    bool always_retract
+)
 {
     constexpr bool detect_loops = true;
     PathOrderOptimizer<const LineJunctions*> order_optimizer(getLastPlannedPositionOrStartingPosition(), z_seam_config, detect_loops);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1022,8 +1022,7 @@ void LayerPlan::addWalls
     {
         orderOptimizer.addPolygon(walls[poly_idx]);
     }
-    const bool alternate_walls = settings.get<bool>("material_alternate_walls") && layer_nr % 2 == 0;
-    orderOptimizer.optimize(alternate_walls);
+    orderOptimizer.optimize();
     for(const PathOrderOptimizer<ConstPolygonRef>::Path& path : orderOptimizer.paths)
     {
         addWall(*path.vertices, path.start_vertex, settings, non_bridge_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -576,7 +576,7 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
     {
         orderOptimizer.addPolygon(polygons[poly_idx]);
     }
-    orderOptimizer.optimize(layer_nr % 2 == 0);
+    orderOptimizer.optimize();
 
     if(!reverse_order)
     {
@@ -1090,7 +1090,7 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathCon
     {
         order_optimizer.addPolyline(polygons[line_idx]);
     }
-    order_optimizer.optimize(layer_nr % 2 == 0);
+    order_optimizer.optimize();
 
     for(size_t order_idx = 0; order_idx < order_optimizer.paths.size(); order_idx++)
     {
@@ -1165,7 +1165,7 @@ void LayerPlan::addLinesMonotonic
     {
         line_order.addPolyline(polyline);
     }
-    line_order.optimize(layer_nr % 2 == 0);
+    line_order.optimize();
 
     const auto is_inside_exclusion =
         [&exclude_areas, &exclude_dist2](ConstPolygonRef path)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -576,7 +576,7 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
     {
         orderOptimizer.addPolygon(polygons[poly_idx]);
     }
-    orderOptimizer.optimize();
+    orderOptimizer.optimize(layer_nr % 2 == 0);
 
     if(!reverse_order)
     {
@@ -1012,7 +1012,7 @@ void LayerPlan::addWalls(const Polygons& walls, const Settings& settings, const 
     {
         orderOptimizer.addPolygon(walls[poly_idx]);
     }
-    orderOptimizer.optimize();
+    orderOptimizer.optimize(layer_nr % 2 == 0);
     for(const PathOrderOptimizer<ConstPolygonRef>::Path& path : orderOptimizer.paths)
     {
         addWall(*path.vertices, path.start_vertex, settings, non_bridge_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract);
@@ -1029,7 +1029,7 @@ void LayerPlan::addWalls(const PathJunctions& walls, const Settings& settings, c
     }
 
     cura::Point p_end {0, 0};
-    order_optimizer.optimize();
+    order_optimizer.optimize(layer_nr % 2 == 0);
     for(const PathOrderOptimizer<const LineJunctions*>::Path& path : order_optimizer.paths)
     {
         p_end = path.backwards ? path.vertices->back().p : path.vertices->front().p;
@@ -1069,7 +1069,7 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons, const GCodePathCon
     {
         order_optimizer.addPolyline(polygons[line_idx]);
     }
-    order_optimizer.optimize();
+    order_optimizer.optimize(layer_nr % 2 == 0);
 
     for(size_t order_idx = 0; order_idx < order_optimizer.paths.size(); order_idx++)
     {
@@ -1144,7 +1144,7 @@ void LayerPlan::addLinesMonotonic
     {
         line_order.addPolyline(polyline);
     }
-    line_order.optimize();
+    line_order.optimize(layer_nr % 2 == 0);
 
     const auto is_inside_exclusion =
         [&exclude_areas, &exclude_dist2](ConstPolygonRef path)

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -578,6 +578,7 @@ public:
      * \param wall_0_wipe_dist The distance to travel along each wall after it has been laid down, in order to wipe the start and end of the wall together
      * \param flow_ratio The ratio with which to multiply the extrusion amount
      * \param always_retract Whether to force a retraction when moving to the start of a wall (used for outer walls)
+     * \param alternate_inset_direction_modifier Whether to alternate the direction of the walls for each inset.
      */
     void addWalls
     (
@@ -600,7 +601,7 @@ public:
         coord_t wall_0_wipe_dist = 0,
         float flow_ratio = 1.0,
         bool always_retract = false,
-        bool alternate_direction_modifier = false
+        bool alternate_inset_direction_modifier = false
     );
 
     /*!

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -599,7 +599,8 @@ public:
         const ZSeamConfig& z_seam_config = ZSeamConfig(),
         coord_t wall_0_wipe_dist = 0,
         float flow_ratio = 1.0,
-        bool always_retract = false
+        bool always_retract = false,
+        bool alternate_direction_modifier = false
     );
 
     /*!

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -579,8 +579,28 @@ public:
      * \param flow_ratio The ratio with which to multiply the extrusion amount
      * \param always_retract Whether to force a retraction when moving to the start of a wall (used for outer walls)
      */
-    void addWalls(const Polygons& walls, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, const ZSeamConfig& z_seam_config = ZSeamConfig(), coord_t wall_0_wipe_dist = 0, float flow_ratio = 1.0, bool always_retract = false);
-    void addWalls(const PathJunctions& walls, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, const ZSeamConfig& z_seam_config = ZSeamConfig(), coord_t wall_0_wipe_dist = 0, float flow_ratio = 1.0, bool always_retract = false);
+    void addWalls
+    (
+        const Polygons& walls,
+        const Settings& settings,
+        const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& bridge_config,
+        const ZSeamConfig& z_seam_config = ZSeamConfig(),
+        coord_t wall_0_wipe_dist = 0,
+        float flow_ratio = 1.0,
+        bool always_retract = false
+    );
+    void addWalls
+    (
+        const PathJunctions& walls,
+        const Settings& settings,
+        const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& bridge_config,
+        const ZSeamConfig& z_seam_config = ZSeamConfig(),
+        coord_t wall_0_wipe_dist = 0,
+        float flow_ratio = 1.0,
+        bool always_retract = false
+    );
 
     /*!
      * Add lines to the gcode with optimized order.

--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -181,7 +181,7 @@ public:
      * This reorders the \ref paths field and fills their starting vertices and
      * directions.
      */
-    void optimize(bool mirrored = false)
+    void optimize()
     {
         if(paths.empty())
         {
@@ -335,7 +335,7 @@ public:
         }
 
         //Apply the optimized order to the output field. Reverse if ordered to reverse.
-        if(mirrored)
+        if(reverse_direction)
         {
             //Reverse-insert the optimized order, to invert the ordering.
             std::vector<Path> reversed;

--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -146,11 +146,12 @@ public:
      * it into a polygon.
      * \param combing_boundary Boundary to avoid when making travel moves.
      */
-    PathOrderOptimizer(const Point start_point, const ZSeamConfig seam_config = ZSeamConfig(), const bool detect_loops = false, const Polygons* combing_boundary = nullptr)
+    PathOrderOptimizer(const Point start_point, const ZSeamConfig seam_config = ZSeamConfig(), const bool detect_loops = false, const Polygons* combing_boundary = nullptr, const bool reverse_direction = false)
     : start_point(start_point)
     , seam_config(seam_config)
     , combing_boundary((combing_boundary != nullptr && !combing_boundary->empty()) ? combing_boundary : nullptr)
     , detect_loops(detect_loops)
+    , reverse_direction(reverse_direction)
     {
     }
 
@@ -400,6 +401,14 @@ protected:
      * that is not one of the endpoints of the polyline.
      */
     bool detect_loops;
+
+    /*!
+     * Whether to reverse the ordering completely.
+     *
+     * This reverses the order in which parts are printed, and inverts the
+     * direction of each path as well.
+     */
+    bool reverse_direction;
 
     /*!
      * Find the vertex which will be the starting point of printing a polygon or

--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -179,14 +179,13 @@ public:
      * This reorders the \ref paths field and fills their starting vertices and
      * directions.
      */
-    void optimize()
+    void optimize(bool mirrored = false)
     {
         if(paths.empty())
         {
             return;
         }
 
-        constexpr bool mirrored = true; // TODO: Make variable which (in other parts of the code will) depend(s) on layer- and inset-#'s
         const std::function<Point(const Point&)> maybe_mirror =
             [&mirrored](const Point& p)
             {


### PR DESCRIPTION
Adds a setting to alternate the direction a wall is printed every other layer (and inset, if applicable).

See also front-end pull: https://github.com/Ultimaker/Cura/pull/11049