### PR TITLE
[CURA-8081] Shrinkage Plate

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -812,7 +812,8 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
     
     coord_t layer_height = train.settings.get<coord_t>("raft_surface_thickness");
 
-    for (LayerIndex raft_surface_layer = 1; static_cast<size_t>(raft_surface_layer) <= train.settings.get<size_t>("raft_surface_layers"); raft_surface_layer++)
+    const size_t num_surface_layers = train.settings.get<size_t>("raft_surface_layers");
+    for (LayerIndex raft_surface_layer = 1; static_cast<size_t>(raft_surface_layer) <= num_surface_layers; raft_surface_layer++)
     { // raft surface layers
         const LayerIndex layer_nr = initial_raft_layer_nr + 2 + raft_surface_layer - 1; // 2: 1 base layer, 1 interface layer
         z += layer_height;
@@ -839,7 +840,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         raft_outline_path.simplify(); //Remove those micron-movements.
         const coord_t infill_outline_width = gcode_layer.configs_storage.raft_interface_config.getLineWidth();
         Polygons raft_lines;
-        AngleDegrees fill_angle = 90 * raft_surface_layer;
+        AngleDegrees fill_angle = (num_surface_layers - raft_surface_layer) % 2 ? 45 : 135; //Alternate between -45 and +45 degrees, ending up 90 degrees rotated from the default skin angle.
         constexpr bool zig_zaggify_infill = true;
 
         constexpr size_t wall_line_count = 0;

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -42,7 +42,6 @@ void Raft::generate(SliceDataStorage& storage)
 
     if (settings.get<bool>("raft_is_shrink_plate"))
     {
-        storage.raftOutline = storage.raftOutline.approxConvexHull();
         storage.raftOutline.makeConvex();
     }
 }

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -40,8 +40,7 @@ void Raft::generate(SliceDataStorage& storage)
     const coord_t smoothing = settings.get<coord_t>("raft_smoothing");
     storage.raftOutline = storage.raftOutline.offset(smoothing, ClipperLib::jtRound).offset(-smoothing, ClipperLib::jtRound); // remove small holes and smooth inward corners
 
-    constexpr bool shrinkage_plate = true;
-    if (shrinkage_plate)
+    if (settings.get<bool>("raft_is_shrink_plate"))
     {
         storage.raftOutline = storage.raftOutline.approxConvexHull();
         storage.raftOutline.makeConvex();

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -40,7 +40,7 @@ void Raft::generate(SliceDataStorage& storage)
     const coord_t smoothing = settings.get<coord_t>("raft_smoothing");
     storage.raftOutline = storage.raftOutline.offset(smoothing, ClipperLib::jtRound).offset(-smoothing, ClipperLib::jtRound); // remove small holes and smooth inward corners
 
-    if (settings.get<bool>("raft_is_shrink_plate"))
+    if (settings.get<bool>("raft_remove_inside_corners"))
     {
         storage.raftOutline.makeConvex();
     }

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -37,12 +37,15 @@ void Raft::generate(SliceDataStorage& storage)
                                         .difference(ooze_shield.offset(-distance - shield_line_width_layer0 / 2, ClipperLib::jtRound)); // end distance inside shield
         storage.raftOutline = storage.raftOutline.unionPolygons(ooze_shield_raft);
     }
-    const coord_t smoothing = settings.get<coord_t>("raft_smoothing");
-    storage.raftOutline = storage.raftOutline.offset(smoothing, ClipperLib::jtRound).offset(-smoothing, ClipperLib::jtRound); // remove small holes and smooth inward corners
 
-    if (settings.get<bool>("raft_remove_inside_corners"))
+    if(settings.get<bool>("raft_remove_inside_corners"))
     {
         storage.raftOutline.makeConvex();
+    }
+    else
+    {
+        const coord_t smoothing = settings.get<coord_t>("raft_smoothing");
+        storage.raftOutline = storage.raftOutline.offset(smoothing, ClipperLib::jtRound).offset(-smoothing, ClipperLib::jtRound); // remove small holes and smooth inward corners
     }
 }
 

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -39,6 +39,13 @@ void Raft::generate(SliceDataStorage& storage)
     }
     const coord_t smoothing = settings.get<coord_t>("raft_smoothing");
     storage.raftOutline = storage.raftOutline.offset(smoothing, ClipperLib::jtRound).offset(-smoothing, ClipperLib::jtRound); // remove small holes and smooth inward corners
+
+    constexpr bool shrinkage_plate = true;
+    if (shrinkage_plate)
+    {
+        storage.raftOutline = storage.raftOutline.approxConvexHull();
+        storage.raftOutline.makeConvex();
+    }
 }
 
 coord_t Raft::getTotalThickness()

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -102,7 +102,7 @@ void Polygons::makeConvex()
         Polygon convexified;
 
         //Start from a vertex that is known to be on the convex hull: The one with the lowest X.
-        const size_t start_index = std::min_element(poly.begin(), poly.end(), [](Point a, Point b) {return a.X < b.X;}) - poly.begin();
+        const size_t start_index = std::min_element(poly.begin(), poly.end(), [](Point a, Point b) { return a.X == b.X ? a.Y < b.Y : a.X < b.X; }) - poly.begin();
         convexified.path->push_back(poly[start_index]);
 
         for(size_t i = (start_index + 1) % poly.size(); i != start_index; i = (i + 1) % poly.size())

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -111,6 +111,11 @@ void Polygons::makeConvex()
             const Point& after = poly[(i + 1) % poly.size()];
             if(LinearAlg2D::pointIsLeftOfLine(current, convexified.path->back(), after) < 0)
             {
+                //Track backwards to make sure we haven't been in a concave pocket for multiple vertices already.
+                while(convexified.size() >= 2 && LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], current) > 0)
+                {
+                    convexified.path->pop_back();
+                }
                 convexified.path->push_back(current);
             }
         }

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -93,18 +93,18 @@ Polygons Polygons::approxConvexHull(int extra_outset)
 
 void Polygons::makeConvex()
 {
-    for (PolygonRef poly : *this)
+    for(PolygonRef poly : *this)
     {
         Polygon convexified;
-        Point a = poly.back();
-        for (size_t i = 0; i < poly.size(); ++i)
+        Point before = poly.back();
+        for(size_t i = 0; i < poly.size(); ++i)
         {
-            const Point& b = poly[i];
-            const Point& c = poly[(i + 1) % poly.size()];
-            if (LinearAlg2D::pointIsLeftOfLine(b, a, c) < 0)
+            const Point& current = poly[i];
+            const Point& after = poly[(i + 1) % poly.size()];
+            if(LinearAlg2D::pointIsLeftOfLine(current, before, after) < 0)
             {
-                convexified.path->push_back(b);
-                a = b;
+                convexified.path->push_back(current);
+                before = current;
             }
         }
         poly.path->swap(*convexified.path); //Due to vector's implementation, this is constant time.

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -105,20 +105,20 @@ void Polygons::makeConvex()
         const size_t start_index = std::min_element(poly.begin(), poly.end(), [](Point a, Point b) { return a.X == b.X ? a.Y < b.Y : a.X < b.X; }) - poly.begin();
         convexified.path->push_back(poly[start_index]);
 
-        for(size_t i = (start_index + 1) % poly.size(); i != start_index; i = (i + 1) % poly.size())
+        for(size_t i = 1; i <= poly.size(); ++ i)
         {
-            const Point& current = poly[i];
-            const Point& after = poly[(i + 1) % poly.size()];
-            if(LinearAlg2D::pointIsLeftOfLine(current, convexified.path->back(), after) < 0)
+            const Point& current = poly[(start_index + i) % poly.size()];
+
+            //Track backwards to make sure we haven't been in a concave pocket for multiple vertices already.
+            while(convexified.size() >= 2 && LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], current) >= 0)
             {
-                //Track backwards to make sure we haven't been in a concave pocket for multiple vertices already.
-                while(convexified.size() >= 2 && LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], current) > 0)
-                {
-                    convexified.path->pop_back();
-                }
-                convexified.path->push_back(current);
+                convexified.path->pop_back();
             }
+            convexified.path->push_back(current);
         }
+        //remove last vertex as the starting vertex is added in the last iteration of the loop
+        convexified.path->pop_back();
+
         poly.path->swap(*convexified.path); //Due to vector's implementation, this is constant time.
     }
 }

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -95,16 +95,24 @@ void Polygons::makeConvex()
 {
     for(PolygonRef poly : *this)
     {
-        Polygon convexified;
-        Point before = poly.back();
-        for(size_t i = 0; i < poly.size(); ++i)
+        if(poly.size() <= 3)
         {
+            continue; //Already convex.
+        }
+        Polygon convexified;
+
+        //Start from a vertex that is known to be on the convex hull: The one with the lowest X.
+        const size_t start_index = std::min_element(poly.begin(), poly.end(), [](Point a, Point b) {return a.X < b.X;}) - poly.begin();
+        convexified.path->push_back(poly[start_index]);
+
+        for(size_t i = (start_index + 1) % poly.size(); i != start_index; i = (i + 1) % poly.size())
+        {
+            const Point& before = poly[(start_index + poly.size() - 1) % poly.size()];
             const Point& current = poly[i];
             const Point& after = poly[(i + 1) % poly.size()];
             if(LinearAlg2D::pointIsLeftOfLine(current, before, after) < 0)
             {
                 convexified.path->push_back(current);
-                before = current;
             }
         }
         poly.path->swap(*convexified.path); //Due to vector's implementation, this is constant time.

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -107,10 +107,9 @@ void Polygons::makeConvex()
 
         for(size_t i = (start_index + 1) % poly.size(); i != start_index; i = (i + 1) % poly.size())
         {
-            const Point& before = poly[(start_index + poly.size() - 1) % poly.size()];
             const Point& current = poly[i];
             const Point& after = poly[(i + 1) % poly.size()];
-            if(LinearAlg2D::pointIsLeftOfLine(current, before, after) < 0)
+            if(LinearAlg2D::pointIsLeftOfLine(current, convexified.path->back(), after) < 0)
             {
                 convexified.path->push_back(current);
             }

--- a/tests/utils/PolygonTest.cpp
+++ b/tests/utils/PolygonTest.cpp
@@ -664,4 +664,138 @@ TEST_F(PolygonTest, simplifyToDegenerate)
     EXPECT_NE(d.size(), 2);
 }
 
+/*
+ * The convex hull of a cube should still be a cube
+ */
+TEST_F(PolygonTest, convexTestCube)
+{
+    Polygons d_polygons;
+    PolygonRef d = d_polygons.newPoly();
+    d.add(Point(0, 0));
+    d.add(Point(10, 0));
+    d.add(Point(10, 10));
+    d.add(Point(0, 10));
+
+    d_polygons.makeConvex();
+
+    EXPECT_EQ(d.size(), 4);
+    EXPECT_EQ(d[0], Point(0, 0));
+    EXPECT_EQ(d[1], Point(10, 0));
+    EXPECT_EQ(d[2], Point(10, 10));
+    EXPECT_EQ(d[3], Point(0, 10));
+}
+
+/*
+ * The convex hull of a star should remove the inner points of the star
+ */
+TEST_F(PolygonTest, convexHullStar)
+{
+    Polygons d_polygons;
+    PolygonRef d = d_polygons.newPoly();
+
+    const int num_points = 10;
+    const int outer_radius = 20;
+    const int inner_radius = 10;
+    const double angle_step = M_PI * 2.0 / num_points;
+    for (int i = 0; i < num_points; ++ i)
+    {
+        coord_t x_outer = -std::cos(angle_step * i) * outer_radius;
+        coord_t y_outer = -std::sin(angle_step * i) * outer_radius;
+        d.add(Point(x_outer, y_outer));
+
+        coord_t x_inner = -std::cos(angle_step * (i + 0.5)) * inner_radius;
+        coord_t y_inner = -std::sin(angle_step * (i + 0.5)) * inner_radius;
+        d.add(Point(x_inner, y_inner));
+    }
+
+    d_polygons.makeConvex();
+
+    EXPECT_EQ(d.size(), num_points);
+    for (int i = 0; i < num_points; ++ i)
+    {
+        double angle = angle_step * i;
+        coord_t x = -std::cos(angle) * outer_radius;
+        coord_t y = -std::sin(angle) * outer_radius;
+        EXPECT_EQ(d[i], Point(x, y));
+    }
+}
+
+/*
+ * Multiple min-x points
+ * the convex hull the point with minimal x value. if there are multiple it might go wrong
+ */
+TEST_F(PolygonTest, convexHullMultipleMinX)
+{
+    Polygons d_polygons;
+    PolygonRef d = d_polygons.newPoly();
+    d.add(Point(0, 0));
+    d.add(Point(0, -10));
+    d.add(Point(10, 0));
+    d.add(Point(0, 10));
+
+    /*
+     *   x\                          x\
+     *   | \                        | \
+     *   x  x    should result in   |  x
+     *   | /                        | /
+     *   x/                         x/
+     *
+     */
+
+    d_polygons.makeConvex();
+
+    EXPECT_EQ(d.size(), 3);
+}
+
+/*
+ * The convex hull should remove collinear points
+ */
+TEST_F(PolygonTest, convexTestCubeColinear)
+{
+    Polygons d_polygons;
+    PolygonRef d = d_polygons.newPoly();
+    d.add(Point(0, 0));
+    d.add(Point(5, 0));
+    d.add(Point(10, 0));
+    d.add(Point(10, 5));
+    d.add(Point(10, 10));
+    d.add(Point(5, 10));
+    d.add(Point(0, 10));
+    d.add(Point(0, 5));
+
+    d_polygons.makeConvex();
+
+    EXPECT_EQ(d.size(), 4);
+    EXPECT_EQ(d[0], Point(0, 0));
+    EXPECT_EQ(d[1], Point(10, 0));
+    EXPECT_EQ(d[2], Point(10, 10));
+    EXPECT_EQ(d[3], Point(0, 10));
+}
+
+
+/*
+ * The convex hull should remove duplicate points
+ */
+TEST_F(PolygonTest, convexHullRemoveDuplicatePoints)
+{
+    Polygons d_polygons;
+    PolygonRef d = d_polygons.newPoly();
+    d.add(Point(0, 0));
+    d.add(Point(0, 0));
+    d.add(Point(10, 0));
+    d.add(Point(10, 0));
+    d.add(Point(10, 10));
+    d.add(Point(10, 10));
+    d.add(Point(0, 10));
+    d.add(Point(0, 10));
+
+    d_polygons.makeConvex();
+
+    EXPECT_EQ(d.size(), 4);
+    EXPECT_EQ(d[0], Point(0, 0));
+    EXPECT_EQ(d[1], Point(10, 0));
+    EXPECT_EQ(d[2], Point(10, 10));
+    EXPECT_EQ(d[3], Point(0, 10));
+}
+
 }


### PR DESCRIPTION
For materials with massive shrinkage, add a convex raft-like option. We might add the capability to change top/bottom raft extruders separately when this branch progresses further.

See front-end PR: https://github.com/Ultimaker/Cura/pull/11052