### PR TITLE
[CURA-8083] Split 'shrinkage compensation' in XY versus Z axis.

### DIFF
--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -107,15 +107,15 @@ void MeshGroup::finalize()
         }
         mesh.offset(mesh_offset + meshgroup_offset);
     }
-    scaleFromBottom(settings.get<Ratio>("material_shrinkage_percentage")); //Compensate for the shrinkage of the material.
+    scaleFromBottom(settings.get<Ratio>("material_shrinkage_percentage_xy"), settings.get<Ratio>("material_shrinkage_percentage_z")); //Compensate for the shrinkage of the material.
 }
 
-void MeshGroup::scaleFromBottom(const Ratio factor)
+void MeshGroup::scaleFromBottom(const Ratio factor_xy, const Ratio factor_z)
 {
     const Point3 center = (max() + min()) / 2;
     const Point3 origin(center.x, center.y, 0);
 
-    const FMatrix4x3 transformation = FMatrix4x3::scale(factor, origin);
+    const FMatrix4x3 transformation = FMatrix4x3::scale(factor_xy, factor_xy, factor_z, origin);
     for(Mesh& mesh : meshes)
     {
         mesh.transform(transformation);

--- a/src/MeshGroup.h
+++ b/src/MeshGroup.h
@@ -38,7 +38,7 @@ public:
      * that's the center in the X and Y directions, but Z=0. This simulates the
      * shrinkage while sticking to the build plate.
      */
-    void scaleFromBottom(const Ratio factor);
+    void scaleFromBottom(const Ratio factor_xy, const Ratio factor_z);
 };
 
 /*!

--- a/src/utils/FMatrix4x3.cpp
+++ b/src/utils/FMatrix4x3.cpp
@@ -9,19 +9,23 @@
 
 namespace cura
 {
-    
+
 FMatrix4x3 FMatrix4x3::scale(const Ratio scale, const Point3 origin)
 {
+    return FMatrix4x3::scale(scale, scale, scale, origin);
+}
+
+FMatrix4x3 FMatrix4x3::scale(const Ratio scale_x, const Ratio scale_y, const Ratio scale_z, const Point3 origin)
+{
     FMatrix4x3 result;
-    result.m[0][0] = scale; //X scale.
-    result.m[1][1] = scale; //Y scale.
-    result.m[2][2] = scale; //Z scale.
+    result.m[0][0] = scale_x; //X scale.
+    result.m[1][1] = scale_y; //Y scale.
+    result.m[2][2] = scale_z; //Z scale.
 
     //Apply a transformation to scale it away from the origin.
-    const Ratio delta_scale = scale - 1;
-    result.m[3][0] = delta_scale * -origin.x; //Arrived at by manually applying an inverse move, the scale, then a move.
-    result.m[3][1] = delta_scale * -origin.y;
-    result.m[3][2] = delta_scale * -origin.z;
+    result.m[3][0] = (scale_x - 1.0) * -origin.x; //Arrived at by manually applying an inverse move, the scale, then a move.
+    result.m[3][1] = (scale_y - 1.0) * -origin.y;
+    result.m[3][2] = (scale_z - 1.0) * -origin.z;
 
     return result;
 }

--- a/src/utils/FMatrix4x3.h
+++ b/src/utils/FMatrix4x3.h
@@ -28,6 +28,7 @@ public:
      * increased, all coordinates will go away from this origin.
      */
     static FMatrix4x3 scale(const Ratio scale, const Point3 origin);
+    static FMatrix4x3 scale(const Ratio scale_x, const Ratio scale_y, const Ratio scale_z, const Point3 origin);
 
     /*!
      * The matrix data, row-endian.

--- a/tests/test_global_settings.txt
+++ b/tests/test_global_settings.txt
@@ -503,3 +503,5 @@ support_interface_height=1
 raft_interface_thickness=0.30000000000000004
 retraction_hop_only_when_collides=True
 ironing_flow=10.0
+material_shrinkage_percentage_z=100
+material_shrinkage_percentage_xy=100


### PR DESCRIPTION
See frontend PR: https://github.com/Ultimaker/Cura/pull/11075
