### PR TITLE
Fix tree support using only a single branch for a big area

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ set(engine_SRCS # Except main.cpp.
     src/support.cpp
     src/timeEstimate.cpp
     src/TopSurface.cpp
+    src/TreeModelVolumes.cpp
     src/TreeSupport.cpp
     src/WallsComputation.cpp
     src/wallOverlap.cpp

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -94,9 +94,12 @@ const Polygons& TreeModelVolumes::calculateCollision(const RadiusLayerPair& key)
         else if(layer_idx + z_distance_layers < static_cast<LayerIndex>(layer_outlines_.size()))
         {
             //If Z overrides X/Y, use X/Y distance if the surface is vertical, or Min X/Y distance if not.
-            Polygons z_influenced = layer_outlines_[layer_idx + z_distance_layers].difference(layer_outlines_[layer_idx]); //In-between layers are ignored for performance.
+            Polygons z_influenced = layer_outlines_[layer_idx + z_distance_layers].difference(layer_outlines_[layer_idx]).offset(xy_distance_); //In-between layers are ignored for performance.
             Polygons collision_not_overhang = layer_outlines_[layer_idx].offset(xy_distance_); //In places where there is no overhang nearby, use the normal X/Y distance.
-            collision_not_overhang = collision_not_overhang.difference(z_influenced);
+            if(!z_influenced.empty())
+            {
+                collision_not_overhang = collision_not_overhang.difference(z_influenced);
+            }
             Polygons collision_model = collision_not_overhang.unionPolygons(layer_outlines_[layer_idx].offset(xy_distance_overhang)); //Apply the minimum distance everywhere else.
             collision_areas = collision_areas.unionPolygons(collision_model.offset(radius));
         }

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -89,7 +89,7 @@ const Polygons& TreeModelVolumes::calculateCollision(const RadiusLayerPair& key)
         if(distance_priority == SupportDistPriority::XY_OVERRIDES_Z)
         {
             //If X/Y overrides Z, simply use the X/Y distance as distance to keep away from the model.
-            collision_areas = collision_areas.unionPolygons(layer_outlines_[layer_idx].offset(xy_distance_ + radius, ClipperLib::JoinType::jtRound));
+            collision_areas = collision_areas.unionPolygons(layer_outlines_[layer_idx].offset(xy_distance_ + radius));
         }
         else if(layer_idx + z_distance_layers < static_cast<LayerIndex>(layer_outlines_.size()))
         {

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -1,0 +1,144 @@
+//Copyright (c) 2021 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include "sliceDataStorage.h"
+#include "TreeModelVolumes.h"
+
+namespace cura
+{
+
+TreeModelVolumes::TreeModelVolumes(const SliceDataStorage& storage, coord_t xy_distance, coord_t max_move,
+                           coord_t radius_sample_resolution) :
+    machine_border_{calculateMachineBorderCollision(storage.getMachineBorder())},
+    xy_distance_{xy_distance},
+    max_move_{max_move},
+    radius_sample_resolution_{radius_sample_resolution}
+{
+    for (std::size_t layer_idx  = 0; layer_idx < storage.support.supportLayers.size(); ++layer_idx)
+    {
+        constexpr bool include_support = false;
+        constexpr bool include_prime_tower = true;
+        layer_outlines_.push_back(storage.getLayerOutlines(layer_idx, include_support, include_prime_tower));
+    }
+}
+
+const Polygons& TreeModelVolumes::getCollision(coord_t radius, LayerIndex layer_idx) const
+{
+    radius = ceilRadius(radius);
+    RadiusLayerPair key{radius, layer_idx};
+    const auto it = collision_cache_.find(key);
+    if (it != collision_cache_.end())
+    {
+        return it->second;
+    }
+    else
+    {
+        return calculateCollision(key);
+    }
+}
+
+const Polygons& TreeModelVolumes::getAvoidance(coord_t radius, LayerIndex layer_idx) const
+{
+    radius = ceilRadius(radius);
+    RadiusLayerPair key{radius, layer_idx};
+    const auto it = avoidance_cache_.find(key);
+    if (it != avoidance_cache_.end())
+    {
+        return it->second;
+    }
+    else
+    {
+        return calculateAvoidance(key);
+    }
+}
+
+const Polygons& TreeModelVolumes::getInternalModel(coord_t radius, LayerIndex layer_idx) const
+{
+    radius = ceilRadius(radius);
+    RadiusLayerPair key{radius, layer_idx};
+    const auto it = internal_model_cache_.find(key);
+    if (it != internal_model_cache_.end())
+    {
+        return it->second;
+    }
+    else
+    {
+        return calculateInternalModel(key);
+    }
+}
+
+coord_t TreeModelVolumes::ceilRadius(coord_t radius) const
+{
+    const auto remainder = radius % radius_sample_resolution_;
+    const auto delta = remainder != 0 ? radius_sample_resolution_- remainder : 0;
+    return radius + delta;
+}
+
+const Polygons& TreeModelVolumes::calculateCollision(const RadiusLayerPair& key) const
+{
+    const auto& radius = key.first;
+    const auto& layer_idx = key.second;
+
+    auto collision_areas = machine_border_;
+    if (layer_idx < static_cast<int>(layer_outlines_.size()))
+    {
+        collision_areas = collision_areas.unionPolygons(layer_outlines_[layer_idx]);
+    }
+    collision_areas = collision_areas.offset(xy_distance_ + radius, ClipperLib::JoinType::jtRound);
+    const auto ret = collision_cache_.insert({key, std::move(collision_areas)});
+    assert(ret.second);
+    return ret.first->second;
+}
+
+const Polygons& TreeModelVolumes::calculateAvoidance(const RadiusLayerPair& key) const
+{
+    const auto& radius = key.first;
+    const auto& layer_idx = key.second;
+
+    if (layer_idx == 0)
+    {
+        avoidance_cache_[key] = getCollision(radius, 0);
+        return avoidance_cache_[key];
+    }
+
+    // Avoidance for a given layer depends on all layers beneath it so could have very deep recursion depths if
+    // called at high layer heights. We can limit the reqursion depth to N by checking if the if the layer N
+    // below the current one exists and if not, forcing the calculation of that layer. This may cause another recursion
+    // if the layer at 2N below the current one but we won't exceed our limit unless there are N*N uncalculated layers
+    // below our current one.
+    constexpr auto max_recursion_depth = 100;
+    // Check if we would exceed the recursion limit by trying to process this layer
+    if (layer_idx >= max_recursion_depth
+        && avoidance_cache_.find({radius, layer_idx - max_recursion_depth}) == avoidance_cache_.end())
+    {
+        // Force the calculation of the layer `max_recursion_depth` below our current one, ignoring the result.
+        getAvoidance(radius, layer_idx - max_recursion_depth);
+    }
+    auto avoidance_areas = getAvoidance(radius, layer_idx - 1).offset(-max_move_).smooth(5);
+    avoidance_areas = avoidance_areas.unionPolygons(getCollision(radius, layer_idx));
+    const auto ret = avoidance_cache_.insert({key, std::move(avoidance_areas)});
+    assert(ret.second);
+    return ret.first->second;
+}
+
+const Polygons& TreeModelVolumes::calculateInternalModel(const RadiusLayerPair& key) const
+{
+    const auto& radius = key.first;
+    const auto& layer_idx = key.second;
+
+    const auto& internal_areas = getAvoidance(radius, layer_idx).difference(getCollision(radius, layer_idx));
+    const auto ret = internal_model_cache_.insert({key, internal_areas});
+    assert(ret.second);
+    return ret.first->second;
+}
+
+Polygons TreeModelVolumes::calculateMachineBorderCollision(Polygon machine_border)
+{
+    Polygons machine_volume_border;
+    machine_volume_border.add(machine_border.offset(MM2INT(1000))); //Put a border of 1m around the print volume so that we don't collide.
+    machine_border.reverse(); //Makes the polygon negative so that we subtract the actual volume from the collision area.
+    machine_volume_border.add(machine_border);
+    return machine_volume_border;
+}
+
+}

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -10,11 +10,14 @@ namespace cura
 TreeModelVolumes::TreeModelVolumes(const SliceDataStorage& storage, const Settings& settings)
     : machine_border_(calculateMachineBorderCollision(storage.getMachineBorder()))
     , xy_distance_(settings.get<coord_t>("support_xy_distance"))
+    , xy_distance_overhang(settings.get<coord_t>("support_xy_distance_overhang"))
+    , distance_priority(settings.get<SupportDistPriority>("support_xy_overrides_z"))
     , radius_sample_resolution_(settings.get<coord_t>("support_tree_collision_resolution"))
 {
     const coord_t layer_height = settings.get<coord_t>("layer_height");
     const AngleRadians angle = settings.get<AngleRadians>("support_tree_angle");
     max_move_ = (angle < TAU / 4) ? (coord_t)(tan(angle) * layer_height) : std::numeric_limits<coord_t>::max();
+    z_distance_layers = round_up_divide(settings.get<coord_t>("support_top_distance"), layer_height) + 1;
     for (std::size_t layer_idx  = 0; layer_idx < storage.support.supportLayers.size(); ++layer_idx)
     {
         constexpr bool include_support = false;

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -7,13 +7,14 @@
 namespace cura
 {
 
-TreeModelVolumes::TreeModelVolumes(const SliceDataStorage& storage, coord_t xy_distance, coord_t max_move,
-                           coord_t radius_sample_resolution) :
-    machine_border_{calculateMachineBorderCollision(storage.getMachineBorder())},
-    xy_distance_{xy_distance},
-    max_move_{max_move},
-    radius_sample_resolution_{radius_sample_resolution}
+TreeModelVolumes::TreeModelVolumes(const SliceDataStorage& storage, const Settings& settings)
+    : machine_border_(calculateMachineBorderCollision(storage.getMachineBorder()))
+    , xy_distance_(settings.get<coord_t>("support_xy_distance"))
+    , radius_sample_resolution_(settings.get<coord_t>("support_tree_collision_resolution"))
 {
+    const coord_t layer_height = settings.get<coord_t>("layer_height");
+    const AngleRadians angle = settings.get<AngleRadians>("support_tree_angle");
+    max_move_ = (angle < TAU / 4) ? (coord_t)(tan(angle) * layer_height) : std::numeric_limits<coord_t>::max();
     for (std::size_t layer_idx  = 0; layer_idx < storage.support.supportLayers.size(); ++layer_idx)
     {
         constexpr bool include_support = false;

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -83,12 +83,11 @@ const Polygons& TreeModelVolumes::calculateCollision(const RadiusLayerPair& key)
     const auto& radius = key.first;
     const auto& layer_idx = key.second;
 
-    auto collision_areas = machine_border_;
-    if (layer_idx < static_cast<int>(layer_outlines_.size()))
+    Polygons collision_areas = machine_border_;
+    if(layer_idx < static_cast<int>(layer_outlines_.size()))
     {
-        collision_areas = collision_areas.unionPolygons(layer_outlines_[layer_idx]);
+        collision_areas = collision_areas.unionPolygons(layer_outlines_[layer_idx].offset(xy_distance_ + radius, ClipperLib::JoinType::jtRound));
     }
-    collision_areas = collision_areas.offset(xy_distance_ + radius, ClipperLib::JoinType::jtRound);
     const auto ret = collision_cache_.insert({key, std::move(collision_areas)});
     assert(ret.second);
     return ret.first->second;

--- a/src/TreeModelVolumes.h
+++ b/src/TreeModelVolumes.h
@@ -1,0 +1,179 @@
+//Copyright (c) 2021 Ultimaker B.V.
+//CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef TREEMODELVOLUMES_H
+#define TREEMODELVOLUMES_H
+
+#include <unordered_map>
+
+#include "settings/types/LayerIndex.h" //Part of the RadiusLayerPair.
+#include "utils/polygon.h" //For polygon parameters.
+
+namespace cura
+{
+
+class SliceDataStorage;
+class LayerIndex;
+
+/*!
+ * \brief Lazily generates tree guidance volumes.
+ *
+ * \warning This class is not currently thread-safe and should not be accessed in OpenMP blocks
+ */
+class TreeModelVolumes
+{
+public:
+    TreeModelVolumes() = default;
+    /*!
+     * \brief Construct the TreeModelVolumes object
+     *
+     * \param storage The slice data storage object to extract the model
+     * contours from.
+     * \param xy_distance The required clearance between the model and the
+     * tree branches.
+     * \param max_move The maximum allowable movement between nodes on
+     * adjacent layers
+     * \param radius_sample_resolution Sample size used to round requested node radii.
+     */
+    TreeModelVolumes(const SliceDataStorage& storage, coord_t xy_distance, coord_t max_move,
+                     coord_t radius_sample_resolution);
+
+    TreeModelVolumes(TreeModelVolumes&& original) = default;
+    TreeModelVolumes& operator=(TreeModelVolumes&& original) = default;
+
+    TreeModelVolumes(const TreeModelVolumes& original) = delete;
+    TreeModelVolumes& operator=(const TreeModelVolumes& original) = delete;
+
+    /*!
+     * \brief Creates the areas that have to be avoided by the tree's branches.
+     *
+     * The result is a 2D area that would cause nodes of radius \p radius to
+     * collide with the model.
+     *
+     * \param radius The radius of the node of interest
+     * \param layer The layer of interest
+     * \return Polygons object
+     */
+    const Polygons& getCollision(coord_t radius, LayerIndex layer_idx) const;
+
+    /*!
+     * \brief Creates the areas that have to be avoided by the tree's branches
+     * in order to reach the build plate.
+     *
+     * The result is a 2D area that would cause nodes of radius \p radius to
+     * collide with the model or be unable to reach the build platform.
+     *
+     * The input collision areas are inset by the maximum move distance and
+     * propagated upwards.
+     *
+     * \param radius The radius of the node of interest
+     * \param layer The layer of interest
+     * \return Polygons object
+     */
+    const Polygons& getAvoidance(coord_t radius, LayerIndex layer_idx) const;
+
+    /*!
+     * \brief Generates the area of a given layer that must be avoided if the
+     * branches wish to go towards the model
+     *
+     * The area represents the areas that do not collide with the model but
+     * are unable to reach the build platform
+     *
+     * \param radius The radius of the node of interest
+     * \param layer The layer of interest
+     * \return Polygons object
+     */
+    const Polygons& getInternalModel(coord_t radius, LayerIndex layer_idx) const;
+
+private:
+    /*!
+     * \brief Convenience typedef for the keys to the caches
+     */
+    using RadiusLayerPair = std::pair<coord_t, LayerIndex>;
+
+    /*!
+     * \brief Round \p radius upwards to a multiple of radius_sample_resolution_
+     *
+     * \param radius The radius of the node of interest
+     */
+    coord_t ceilRadius(coord_t radius) const;
+
+    /*!
+     * \brief Calculate the collision areas at the radius and layer indicated
+     * by \p key.
+     *
+     * \param key The radius and layer of the node of interest
+     */
+    const Polygons& calculateCollision(const RadiusLayerPair& key) const;
+
+    /*!
+     * \brief Calculate the avoidance areas at the radius and layer indicated
+     * by \p key.
+     *
+     * \param key The radius and layer of the node of interest
+     */
+    const Polygons& calculateAvoidance(const RadiusLayerPair& key) const;
+
+    /*!
+     * \brief Calculate the internal model areas at the radius and layer
+     * indicated by \p key.
+     *
+     * \param key The radius and layer of the node of interest
+     */
+    const Polygons& calculateInternalModel(const RadiusLayerPair& key) const;
+
+    /*!
+     * \brief Calculate the collision area around the printable area of the machine.
+     *
+     * \param a Polygons object representing the non-printable areas on and around the build platform
+     */
+    static Polygons calculateMachineBorderCollision(Polygon machine_border);
+
+    /*!
+     * \brief Polygons representing the limits of the printable area of the
+     * machine
+     */
+    Polygons machine_border_;
+
+    /*!
+     * \brief The required clearance between the model and the tree branches
+     */
+    coord_t xy_distance_;
+
+    /*!
+     * \brief The maximum distance that the centrepoint of a tree branch may
+     * move in consequtive layers
+     */
+    coord_t max_move_;
+
+    /*!
+     * \brief Sample resolution for radius values.
+     *
+     * The radius will be rounded (upwards) to multiples of this value before
+     * calculations are done when collision, avoidance and internal model
+     * Polygons are requested.
+     */
+    coord_t radius_sample_resolution_;
+
+    /*!
+     * \brief Storage for layer outlines of the meshes.
+     */
+    std::vector<Polygons> layer_outlines_;
+
+    /*!
+     * \brief Caches for the collision, avoidance and internal model polygons
+     * at given radius and layer indices.
+     *
+     * These are mutable to allow modification from const function. This is
+     * generally considered OK as the functions are still logically const
+     * (ie there is no difference in behaviour for the user betweeen
+     * calculating the values each time vs caching the results).
+     */
+    mutable std::unordered_map<RadiusLayerPair, Polygons> collision_cache_;
+    mutable std::unordered_map<RadiusLayerPair, Polygons> avoidance_cache_;
+    mutable std::unordered_map<RadiusLayerPair, Polygons> internal_model_cache_;
+};
+
+}
+
+#endif //TREEMODELVOLUMES_H

--- a/src/TreeModelVolumes.h
+++ b/src/TreeModelVolumes.h
@@ -14,6 +14,7 @@ namespace cura
 
 class SliceDataStorage;
 class LayerIndex;
+class Settings;
 
 /*!
  * \brief Lazily generates tree guidance volumes.
@@ -29,14 +30,14 @@ public:
      *
      * \param storage The slice data storage object to extract the model
      * contours from.
+     * \param settings The settings object to get relevant settings from.
      * \param xy_distance The required clearance between the model and the
      * tree branches.
      * \param max_move The maximum allowable movement between nodes on
      * adjacent layers
      * \param radius_sample_resolution Sample size used to round requested node radii.
      */
-    TreeModelVolumes(const SliceDataStorage& storage, coord_t xy_distance, coord_t max_move,
-                     coord_t radius_sample_resolution);
+    TreeModelVolumes(const SliceDataStorage& storage, const Settings& settings);
 
     TreeModelVolumes(TreeModelVolumes&& original) = default;
     TreeModelVolumes& operator=(TreeModelVolumes&& original) = default;

--- a/src/TreeModelVolumes.h
+++ b/src/TreeModelVolumes.h
@@ -6,6 +6,7 @@
 
 #include <unordered_map>
 
+#include "settings/EnumSettings.h" //To store whether X/Y or Z distance gets priority.
 #include "settings/types/LayerIndex.h" //Part of the RadiusLayerPair.
 #include "utils/polygon.h" //For polygon parameters.
 
@@ -140,6 +141,27 @@ private:
      * \brief The required clearance between the model and the tree branches
      */
     coord_t xy_distance_;
+
+    /*!
+     * The minimum X/Y distance between the model and the tree branches.
+     *
+     * Used only if the Z distance overrides the X/Y distance and in places that
+     * are near the surface where the Z distance applies.
+     */
+    coord_t xy_distance_overhang;
+
+    /*!
+     * The number of layers of spacing to hold as Z distance.
+     *
+     * This determines where the overhang X/Y distance is used, if the Z
+     * distance overrides the X/Y distance.
+     */
+    int z_distance_layers;
+
+    /*!
+     * The priority of X/Y distance over Z distance.
+     */
+    SupportDistPriority distance_priority;
 
     /*!
      * \brief The maximum distance that the centrepoint of a tree branch may

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -555,7 +555,7 @@ void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vecto
             {
                 if (overhang_bounds.contains(candidate))
                 {
-                    constexpr coord_t distance_inside = 0; //Move point towards the border of the polygon if it is closer than half the overhang distance: Catch points that fall between overhang areas on constant surfaces.
+                    constexpr coord_t distance_inside = 1; //Move point towards the border of the polygon if it is closer than half the overhang distance: Catch points that fall between overhang areas on constant surfaces.
                     PolygonUtils::moveInside(overhang_part, candidate, distance_inside, half_overhang_distance * half_overhang_distance);
                     constexpr bool border_is_inside = true;
                     if (overhang_part.inside(candidate, border_is_inside) && !volumes_.getCollision(0, layer_nr).inside(candidate, border_is_inside))

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -42,7 +42,7 @@ TreeSupport::TreeSupport(const SliceDataStorage& storage)
         = (angle < TAU / 4) ? (coord_t)(tan(angle) * layer_height) : std::numeric_limits<coord_t>::max();
     const coord_t radius_sample_resolution = mesh_group_settings.get<coord_t>("support_tree_collision_resolution");
 
-    volumes_ = ModelVolumes(storage, xy_distance, maximum_move_distance, radius_sample_resolution);
+    volumes_ = TreeModelVolumes(storage, xy_distance, maximum_move_distance, radius_sample_resolution);
 }
 
 void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
@@ -610,140 +610,6 @@ void TreeSupport::insertDroppedNode(std::vector<Node*>& nodes_layer, Node* p_nod
     Node* conflicting_node = *conflicting_node_it;
     conflicting_node->distance_to_top = std::max(conflicting_node->distance_to_top, p_node->distance_to_top);
     conflicting_node->support_roof_layers_below = std::max(conflicting_node->support_roof_layers_below, p_node->support_roof_layers_below);
-}
-
-ModelVolumes::ModelVolumes(const SliceDataStorage& storage, coord_t xy_distance, coord_t max_move,
-                           coord_t radius_sample_resolution) :
-    machine_border_{calculateMachineBorderCollision(storage.getMachineBorder())},
-    xy_distance_{xy_distance},
-    max_move_{max_move},
-    radius_sample_resolution_{radius_sample_resolution}
-{
-    for (std::size_t layer_idx  = 0; layer_idx < storage.support.supportLayers.size(); ++layer_idx)
-    {
-        constexpr bool include_support = false;
-        constexpr bool include_prime_tower = true;
-        layer_outlines_.push_back(storage.getLayerOutlines(layer_idx, include_support, include_prime_tower));
-    }
-}
-
-const Polygons& ModelVolumes::getCollision(coord_t radius, LayerIndex layer_idx) const
-{
-    radius = ceilRadius(radius);
-    RadiusLayerPair key{radius, layer_idx};
-    const auto it = collision_cache_.find(key);
-    if (it != collision_cache_.end())
-    {
-        return it->second;
-    }
-    else
-    {
-        return calculateCollision(key);
-    }
-}
-
-const Polygons& ModelVolumes::getAvoidance(coord_t radius, LayerIndex layer_idx) const
-{
-    radius = ceilRadius(radius);
-    RadiusLayerPair key{radius, layer_idx};
-    const auto it = avoidance_cache_.find(key);
-    if (it != avoidance_cache_.end())
-    {
-        return it->second;
-    }
-    else
-    {
-        return calculateAvoidance(key);
-    }
-}
-
-const Polygons& ModelVolumes::getInternalModel(coord_t radius, LayerIndex layer_idx) const
-{
-    radius = ceilRadius(radius);
-    RadiusLayerPair key{radius, layer_idx};
-    const auto it = internal_model_cache_.find(key);
-    if (it != internal_model_cache_.end())
-    {
-        return it->second;
-    }
-    else
-    {
-        return calculateInternalModel(key);
-    }
-}
-
-coord_t ModelVolumes::ceilRadius(coord_t radius) const
-{
-    const auto remainder = radius % radius_sample_resolution_;
-    const auto delta = remainder != 0 ? radius_sample_resolution_- remainder : 0;
-    return radius + delta;
-}
-
-const Polygons& ModelVolumes::calculateCollision(const RadiusLayerPair& key) const
-{
-    const auto& radius = key.first;
-    const auto& layer_idx = key.second;
-
-    auto collision_areas = machine_border_;
-    if (layer_idx < static_cast<int>(layer_outlines_.size()))
-    {
-        collision_areas = collision_areas.unionPolygons(layer_outlines_[layer_idx]);
-    }
-    collision_areas = collision_areas.offset(xy_distance_ + radius, ClipperLib::JoinType::jtRound);
-    const auto ret = collision_cache_.insert({key, std::move(collision_areas)});
-    assert(ret.second);
-    return ret.first->second;
-}
-
-const Polygons& ModelVolumes::calculateAvoidance(const RadiusLayerPair& key) const
-{
-    const auto& radius = key.first;
-    const auto& layer_idx = key.second;
-
-    if (layer_idx == 0)
-    {
-        avoidance_cache_[key] = getCollision(radius, 0);
-        return avoidance_cache_[key];
-    }
-
-    // Avoidance for a given layer depends on all layers beneath it so could have very deep recursion depths if
-    // called at high layer heights. We can limit the reqursion depth to N by checking if the if the layer N
-    // below the current one exists and if not, forcing the calculation of that layer. This may cause another recursion
-    // if the layer at 2N below the current one but we won't exceed our limit unless there are N*N uncalculated layers
-    // below our current one.
-    constexpr auto max_recursion_depth = 100;
-    // Check if we would exceed the recursion limit by trying to process this layer
-    if (layer_idx >= max_recursion_depth
-        && avoidance_cache_.find({radius, layer_idx - max_recursion_depth}) == avoidance_cache_.end())
-    {
-        // Force the calculation of the layer `max_recursion_depth` below our current one, ignoring the result.
-        getAvoidance(radius, layer_idx - max_recursion_depth);
-    }
-    auto avoidance_areas = getAvoidance(radius, layer_idx - 1).offset(-max_move_).smooth(5);
-    avoidance_areas = avoidance_areas.unionPolygons(getCollision(radius, layer_idx));
-    const auto ret = avoidance_cache_.insert({key, std::move(avoidance_areas)});
-    assert(ret.second);
-    return ret.first->second;
-}
-
-const Polygons& ModelVolumes::calculateInternalModel(const RadiusLayerPair& key) const
-{
-    const auto& radius = key.first;
-    const auto& layer_idx = key.second;
-
-    const auto& internal_areas = getAvoidance(radius, layer_idx).difference(getCollision(radius, layer_idx));
-    const auto ret = internal_model_cache_.insert({key, internal_areas});
-    assert(ret.second);
-    return ret.first->second;
-}
-
-Polygons ModelVolumes::calculateMachineBorderCollision(Polygon machine_border)
-{
-    Polygons machine_volume_border;
-    machine_volume_border.add(machine_border.offset(MM2INT(1000))); //Put a border of 1m around the print volume so that we don't collide.
-    machine_border.reverse(); //Makes the polygon negative so that we subtract the actual volume from the collision area.
-    machine_volume_border.add(machine_border);
-    return machine_volume_border;
 }
 
 } //namespace cura

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -491,17 +491,17 @@ void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vecto
     constexpr double rotate_angle = 22.0 / 180.0 * M_PI;
     const Point bounding_box_size = bounding_box.max - bounding_box.min;
 
-    // Store centre of AABB so we can relocate the generated points
-    const auto centre = bounding_box.getMiddle();
-    const auto sin_angle = std::sin(rotate_angle);
-    const auto cos_angle = std::cos(rotate_angle);
+    // Store center of AABB so we can relocate the generated points
+    const Point center = bounding_box.getMiddle();
+    const double sin_angle = std::sin(rotate_angle);
+    const double cos_angle = std::cos(rotate_angle);
     // Calculate the dimensions of the AABB of the mesh AABB after being rotated
     // by `rotate_angle`. Halve the dimensions since we'll be using it as a +-
     // offset from the centre of `bounding_box`.
     // This formulation will only work with rotation angles <90 degrees. If the
     // rotation angle becomes a user-configurable value then this will need to
     // be changed
-    const auto rotated_dims = Point(
+    const Point rotated_dims = Point(
         bounding_box_size.X * cos_angle + bounding_box_size.Y * sin_angle,
         bounding_box_size.X * sin_angle + bounding_box_size.Y * cos_angle) / 2;
 
@@ -510,9 +510,9 @@ void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vecto
     {
         for (auto y = -rotated_dims.Y; y <= rotated_dims.Y; y += point_spread)
         {
-            // Construct a point as an offset from the mesh AABB centre, rotated
-            // about the mesh AABB centre
-            const auto pt = rotate(Point(x, y), rotate_angle) + centre;
+            // Construct a point as an offset from the mesh AABB center, rotated
+            // about the mesh AABB center
+            const Point pt = rotate(Point(x, y), rotate_angle) + center;
             // Only add to grid points if we have a chance to collide with the
             // mesh
             if (bounding_box.contains(pt))

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -34,15 +34,7 @@ namespace cura
 TreeSupport::TreeSupport(const SliceDataStorage& storage)
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-
-    const coord_t xy_distance = mesh_group_settings.get<coord_t>("support_xy_distance");
-    const coord_t layer_height = mesh_group_settings.get<coord_t>("layer_height");
-    const AngleRadians angle = mesh_group_settings.get<AngleRadians>("support_tree_angle");
-    const coord_t maximum_move_distance
-        = (angle < TAU / 4) ? (coord_t)(tan(angle) * layer_height) : std::numeric_limits<coord_t>::max();
-    const coord_t radius_sample_resolution = mesh_group_settings.get<coord_t>("support_tree_collision_resolution");
-
-    volumes_ = TreeModelVolumes(storage, xy_distance, maximum_move_distance, radius_sample_resolution);
+    volumes_ = TreeModelVolumes(storage, mesh_group_settings);
 }
 
 void TreeSupport::generateSupportAreas(SliceDataStorage& storage)

--- a/src/TreeSupport.h
+++ b/src/TreeSupport.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2017 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef TREESUPPORT_H
@@ -7,167 +7,10 @@
 #include <forward_list>
 #include <unordered_set>
 
+#include "TreeModelVolumes.h" //Caching collision and avoidance regions.
 
 namespace cura
 {
-/*!
- * \brief Lazily generates tree guidance volumes.
- *
- * \warning This class is not currently thread-safe and should not be accessed in OpenMP blocks
- */
-class ModelVolumes
-{
-public:
-    ModelVolumes() = default;
-    /*!
-     * \brief Construct the ModelVolumes object
-     *
-     * \param storage The slice data storage object to extract the model
-     * contours from.
-     * \param xy_distance The required clearance between the model and the
-     * tree branches.
-     * \param max_move The maximum allowable movement between nodes on
-     * adjacent layers
-     * \param radius_sample_resolution Sample size used to round requested node radii.
-     */
-    ModelVolumes(const SliceDataStorage& storage, coord_t xy_distance, coord_t max_move,
-                 coord_t radius_sample_resolution);
-
-    ModelVolumes(ModelVolumes&&) = default;
-    ModelVolumes& operator=(ModelVolumes&&) = default;
-
-    ModelVolumes(const ModelVolumes&) = delete;
-    ModelVolumes& operator=(const ModelVolumes&) = delete;
-
-    /*!
-     * \brief Creates the areas that have to be avoided by the tree's branches.
-     *
-     * The result is a 2D area that would cause nodes of radius \p radius to
-     * collide with the model.
-     *
-     * \param radius The radius of the node of interest
-     * \param layer The layer of interest
-     * \return Polygons object
-     */
-    const Polygons& getCollision(coord_t radius, LayerIndex layer_idx) const;
-
-    /*!
-     * \brief Creates the areas that have to be avoided by the tree's branches
-     * in order to reach the build plate.
-     *
-     * The result is a 2D area that would cause nodes of radius \p radius to
-     * collide with the model or be unable to reach the build platform.
-     *
-     * The input collision areas are inset by the maximum move distance and
-     * propagated upwards.
-     *
-     * \param radius The radius of the node of interest
-     * \param layer The layer of interest
-     * \return Polygons object
-     */
-    const Polygons& getAvoidance(coord_t radius, LayerIndex layer_idx) const;
-
-    /*!
-     * \brief Generates the area of a given layer that must be avoided if the
-     * branches wish to go towards the model
-     *
-     * The area represents the areas that do not collide with the model but
-     * are unable to reach the build platform
-     *
-     * \param radius The radius of the node of interest
-     * \param layer The layer of interest
-     * \return Polygons object
-     */
-    const Polygons& getInternalModel(coord_t radius, LayerIndex layer_idx) const;
-
-private:
-    /*!
-     * \brief Convenience typedef for the keys to the caches
-     */
-    using RadiusLayerPair = std::pair<coord_t, LayerIndex>;
-
-    /*!
-     * \brief Round \p radius upwards to a multiple of radius_sample_resolution_
-     *
-     * \param radius The radius of the node of interest
-     */
-    coord_t ceilRadius(coord_t radius) const;
-
-    /*!
-     * \brief Calculate the collision areas at the radius and layer indicated
-     * by \p key.
-     *
-     * \param key The radius and layer of the node of interest
-     */
-    const Polygons& calculateCollision(const RadiusLayerPair& key) const;
-
-    /*!
-     * \brief Calculate the avoidance areas at the radius and layer indicated
-     * by \p key.
-     *
-     * \param key The radius and layer of the node of interest
-     */
-    const Polygons& calculateAvoidance(const RadiusLayerPair& key) const;
-
-    /*!
-     * \brief Calculate the internal model areas at the radius and layer
-     * indicated by \p key.
-     *
-     * \param key The radius and layer of the node of interest
-     */
-    const Polygons& calculateInternalModel(const RadiusLayerPair& key) const;
-
-    /*!
-     * \brief Calculate the collision area around the printable area of the machine.
-     *
-     * \param a Polygons object representing the non-printable areas on and around the build platform
-     */
-    static Polygons calculateMachineBorderCollision(Polygon machine_border);
-
-    /*!
-     * \brief Polygons representing the limits of the printable area of the
-     * machine
-     */
-    Polygons machine_border_;
-
-    /*!
-     * \brief The required clearance between the model and the tree branches
-     */
-    coord_t xy_distance_;
-
-    /*!
-     * \brief The maximum distance that the centrepoint of a tree branch may
-     * move in consequtive layers
-     */
-    coord_t max_move_;
-
-    /*!
-     * \brief Sample resolution for radius values.
-     *
-     * The radius will be rounded (upwards) to multiples of this value before
-     * calculations are done when collision, avoidance and internal model
-     * Polygons are requested.
-     */
-    coord_t radius_sample_resolution_;
-
-    /*!
-     * \brief Storage for layer outlines of the meshes.
-     */
-    std::vector<Polygons> layer_outlines_;
-
-    /*!
-     * \brief Caches for the collision, avoidance and internal model polygons
-     * at given radius and layer indices.
-     *
-     * These are mutable to allow modification from const function. This is
-     * generally considered OK as the functions are still logically const
-     * (ie there is no difference in behaviour for the user betweeen
-     * calculating the values each time vs caching the results).
-     */
-    mutable std::unordered_map<RadiusLayerPair, Polygons> collision_cache_;
-    mutable std::unordered_map<RadiusLayerPair, Polygons> avoidance_cache_;
-    mutable std::unordered_map<RadiusLayerPair, Polygons> internal_model_cache_;
-};
 
 class SliceDataStorage;
 class SliceMeshStorage;
@@ -295,7 +138,7 @@ private:
      * Lazily computes volumes as needed.
      *  \warning This class is NOT currently thread-safe and should not be accessed in OpenMP blocks
      */
-    ModelVolumes volumes_;
+    TreeModelVolumes volumes_;
 
     /*!
      * \brief Draws circles around each node of the tree into the final support.


### PR DESCRIPTION
This fixes an issue reported here: https://github.com/Ultimaker/Cura/issues/10523 . See that report for some screenshots of the issue.

Tree Support will attempt to support a model by placing a grid of contact points on the overhanging surface. This normally supports the model fine, but in some cases the model wasn't being supported by that. Instead, it was supported by a fallback, where Tree Support will place one contact point in the centre of the overhanging area of a layer. The fallback was intended only for downwards pointing corners, like the tip of a spear, but it was also applied to large areas.

The issue turned out to be twofold. Two effects were both preventing the contact points from being placed.

* Due to layers supporting the next layer some ways beyond their own extent, there are gaps in the overhang. Around the Overhang Angle, the actual overhang is often miniscule (~10 micron width is not uncommon). Most of the contact points will fall between the overhang areas. There was a method for it to move nearby contact points inside, but it was checking afterwards if that succeeded (because there's a limit of how far it may move it). The moveInside moved it exactly on the edge, and rounding errors made it think the point was not inside then, causing it to be discarded as too far. This is fixed by moving it inside by 1 extra micron.
* Tree support never had a proper implementation of X/Y Distance Priority. It was always giving X/Y Distance priority over Z distance. Because of this, the generated contact points were always seen as being too close to the model and then discarded. This is fixed by implementing the case where Z distance has priority over X/Y distance. This takes more processing power, but it didn't feel significantly more. Should probably be measured in testing to see if it meets acceptance criteria.

Note for reviewers: I'd really recommend reviewing this per-commit rather than per-file. It makes the differences easier to see by filtering out [a refactor that moved a class to a separate file](https://github.com/Ultimaker/CuraEngine/pull/1544/commits/21a577a962c29579180c717dd0cea68746fb5ae0).

Fixes Ultimaker/Cura#10523 and CURA-8635.