### PR TITLE
Break long line segments in pieces if deviation is exceeded

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -950,7 +950,15 @@ void LayerPlan::addWall(const LineJunctions& wall, int start_idx, const Settings
         const coord_t delta_line_width = p1.w - p0.w;
         const Point line_vector = p1.p - p0.p;
         const coord_t line_length = vSize(line_vector);
-        const coord_t line_area_deviation = std::abs(delta_line_width) * line_length / 8; //How much the line would deviate from the trapezoidal shape if printed at average width.
+        /*
+        Calculate how much the line would deviate from the trapezoidal shape if printed at average width.
+        This formula is:
+        - Half the length times half the delta width, for the rectangular shape of the deviating side.
+        - Half of that because the ideal line width is trapezoidal, making the deviating part triangular.
+        - Double of that because the deviation occurs on both sides of the idealised line width.
+        This results in delta_line_width / 2 * line_length / 2 / 2 * 2 == delta_line_width * line_length / 4.
+        */
+        const coord_t line_area_deviation = std::abs(delta_line_width) * line_length / 4;
         size_t pieces = std::max(size_t(1), round_up_divide(line_area_deviation, max_area_deviation)); //How many pieces we'd need to stay beneath the max area deviation.
         if(coord_t(line_length / pieces) < max_resolution) //This line is bound by the maximum resolution, not the maximum area deviation.
         {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -959,11 +959,9 @@ void LayerPlan::addWall(const LineJunctions& wall, int start_idx, const Settings
         This results in delta_line_width / 2 * line_length / 2 / 2 * 2 == delta_line_width * line_length / 4.
         */
         const coord_t line_area_deviation = std::abs(delta_line_width) * line_length / 4;
-        size_t pieces = std::max(size_t(1), round_up_divide(line_area_deviation, max_area_deviation)); //How many pieces we'd need to stay beneath the max area deviation.
-        if(coord_t(line_length / pieces) < max_resolution) //This line is bound by the maximum resolution, not the maximum area deviation.
-        {
-            pieces = std::max(size_t(1), size_t(line_length / max_resolution)); //Round down this time, to not exceed the maximum resolution.
-        }
+        const size_t pieces_limit_deviation = round_up_divide(line_area_deviation, max_area_deviation); //How many pieces we'd need to stay beneath the max area deviation.
+        const size_t pieces_limit_resolution = line_length / max_resolution; //Round down this time, to not exceed the maximum resolution.
+        const size_t pieces = std::max(size_t(1), std::min(pieces_limit_deviation, pieces_limit_resolution)); //Resolution overrides deviation, if resolution is a constraint.
         const coord_t piece_length = round_divide(line_length, pieces);
 
         for(size_t piece = 0; piece < pieces; ++piece)


### PR DESCRIPTION
This breaks a long line into multiple pieces if the Maximum Extrusion Area Deviation is exceeded. Long line segments weren't broken up by the Skeletal Trapezoidation if there was no additional rib in the skeletal graph. There would only be additional ribs if the number of lines changes, or if there is a vertex in the contour. This fixes that issue: It will now test if a line needs to be broken up into multiple pieces, by evaluating how much a line deviates in its area from the maximum deviation.

If it is exceeded, it will calculate how many pieces it needs to use to stay beneath the maximum extrusion area deviation. If this causes the pieces to be shorter than the maximum resolution, the maximum resolution is held. Thus this implements the following constraints:
* Lines should not get broken up into pieces smaller than the Maximum Resolution.
* If possible with the first constraint, lines should get broken up into the fewest amount of pieces needed to hold the Maximum Extrusion Area Deviation.

Each piece gets its line width calculated from the average width along its length.

Implements CURA-8170.