### PR TITLE
Simplify polylines for Surface mode

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1312,6 +1312,10 @@ void FffGcodeWriter::addMeshLayerToGCode_meshSurfaceMode(const SliceDataStorage&
         polygons.add(part.outline);
     }
 
+    coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
+    coord_t max_deviation = mesh.settings.get<coord_t>("meshfix_maximum_deviation");
+    polygons.simplify(max_resolution, max_deviation);
+
     ZSeamConfig z_seam_config(mesh.settings.get<EZSeamType>("z_seam_type"), mesh.getZSeamHint(), mesh.settings.get<EZSeamCornerPrefType>("z_seam_corner"), mesh.settings.get<coord_t>("wall_line_width_0") * 2);
     const bool spiralize = Application::getInstance().current_slice->scene.current_mesh_group->settings.get<bool>("magic_spiralize");
     gcode_layer.addPolygonsByOptimizer(polygons, mesh_config.inset0_config, z_seam_config, mesh.settings.get<coord_t>("wall_0_wipe_dist"), spiralize);

--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -27,6 +27,10 @@ namespace cura {
 void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, SlicerLayer* layer)
 {
     storageLayer.openPolyLines = layer->openPolylines;
+    
+    const coord_t maximum_resolution = settings.get<coord_t>("meshfix_maximum_resolution");
+    const coord_t maximum_deviation = settings.get<coord_t>("meshfix_maximum_deviation");
+    storageLayer.openPolyLines.simplifyPolylines(maximum_resolution, maximum_deviation);
 
     const bool union_all_remove_holes = settings.get<bool>("meshfix_union_all_remove_holes");
     if (union_all_remove_holes)

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -410,12 +410,20 @@ void PolygonRef::removeColinearEdges(const AngleRadians max_deviation_angle)
 
 void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coord_t allowed_error_distance_squared)
 {
-    if (size() < 3)
+    _simplify(smallest_line_segment_squared, allowed_error_distance_squared, false);
+}
+void PolygonRef::simplifyPolyline(const coord_t smallest_line_segment_squared, const coord_t allowed_error_distance_squared)
+{
+    _simplify(smallest_line_segment_squared, allowed_error_distance_squared, true);
+}
+void PolygonRef::_simplify(const coord_t smallest_line_segment_squared, const coord_t allowed_error_distance_squared, bool processing_polylines)
+{
+    if (size() < 3 - static_cast<size_t>(processing_polylines))
     {
         clear();
         return;
     }
-    if (size() == 3)
+    if (size() == 3 - static_cast<size_t>(processing_polylines))
     {
         return;
     }
@@ -445,7 +453,7 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
     for (size_t point_idx = 0; point_idx < size(); point_idx++)
     {
         current = path->at(point_idx % size());
-
+        
         //Check if the accumulated area doesn't exceed the maximum.
         Point next;
         if (point_idx + 1 < size())
@@ -460,12 +468,18 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         {
             next = path->at((point_idx + 1) % size());
         }
+        bool bypass = processing_polylines && (point_idx == 0 || point_idx + 1 == size()); // bypass all checks for deleting a vertex when processing the start or end of a polyline
+
         const coord_t removed_area_next = current.X * next.Y - current.Y * next.X; // Twice the Shoelace formula for area of polygon per line segment.
         const coord_t negative_area_closing = next.X * previous.Y - next.Y * previous.X; // area between the origin and the short-cutting segment
         accumulated_area_removed += removed_area_next;
 
+
+        if (!processing_polylines || (point_idx != 0 && point_idx + 1 != size()))
+        { // bypass all checks for deleting a vertex when processing the start or end of a polyline
         const coord_t length2 = vSize2(current - previous);
-        if (length2 < 25)
+        if (length2 < 25
+            && !bypass) // never delete when bypassing 
         {
             // We're allowed to always delete segments of less than 5 micron.
             continue;
@@ -474,7 +488,8 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         const coord_t area_removed_so_far = accumulated_area_removed + negative_area_closing; // close the shortcut area polygon
         const coord_t base_length_2 = vSize2(next - previous);
 
-        if (base_length_2 == 0) //Two line segments form a line back and forth with no area.
+        if (base_length_2 == 0 //Two line segments form a line back and forth with no area.
+             && !bypass) // never delete when bypassing 
         {
             continue; //Remove the vertex.
         }
@@ -487,13 +502,15 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
         //h^2 = L^2 / b^2     [factor the divisor]
         const coord_t height_2 = area_removed_so_far * area_removed_so_far / base_length_2;
         if ((height_2 <= 5 * 5 //Almost exactly colinear (barring rounding errors).
-            && LinearAlg2D::getDistFromLine(current, previous, next) <= 5)) // make sure that height_2 is not small because of cancellation of positive and negative areas
+            && LinearAlg2D::getDistFromLine(current, previous, next) <= 5) // make sure that height_2 is not small because of cancellation of positive and negative areas
+            && !bypass) // never delete when bypassing 
         {
             continue;
         }
 
         if (length2 < smallest_line_segment_squared
-            && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.)
+            && height_2 <= allowed_error_distance_squared // removing the vertex doesn't introduce too much error.)
+            && !bypass) // never delete when bypassing 
         {
             const coord_t next_length2 = vSize2(current - next);
             if (next_length2 > smallest_line_segment_squared)
@@ -517,7 +534,9 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                     // New point seems like a valid one.
                     current = intersection_point;
                     // If there was a previous point added, remove it.
-                    if(!new_path.empty())
+                    if (!new_path.empty()
+                        && (!processing_polylines || new_path.size() > 1) // never delete the first point of a polyline
+                    )
                     {
                         new_path.pop_back();
                         previous = previous_previous;
@@ -529,11 +548,30 @@ void PolygonRef::simplify(const coord_t smallest_line_segment_squared, const coo
                 continue; //Remove the vertex.
             }
         }
+        }
         //Don't remove the vertex.
         accumulated_area_removed = removed_area_next; // so that in the next iteration it's the area between the origin, [previous] and [current]
         previous_previous = previous;
         previous = current; //Note that "previous" is only updated if we don't remove the vertex.
         new_path.push_back(current);
+    }
+
+    if (processing_polylines)
+    { // make sure the last segment is not 5u short
+        size_t second_to_last_idx = new_path.size() - 2;
+        if (vSize2(new_path.back() - new_path[second_to_last_idx]) < 25)
+        {
+            new_path.erase(new_path.begin() + second_to_last_idx);
+        }
+    }
+
+    if (processing_polylines)
+    { // make sure the last segment is not 5u short
+        size_t second_to_last_idx = new_path.size() - 2;
+        if (vSize2(new_path.back() - new_path[second_to_last_idx]) < 25)
+        {
+            new_path.erase(new_path.begin() + second_to_last_idx);
+        }
     }
 
     *path = new_path;

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -477,77 +477,77 @@ void PolygonRef::_simplify(const coord_t smallest_line_segment_squared, const co
 
         if (!processing_polylines || (point_idx != 0 && point_idx + 1 != size()))
         { // bypass all checks for deleting a vertex when processing the start or end of a polyline
-        const coord_t length2 = vSize2(current - previous);
-        if (length2 < 25
-            && !bypass) // never delete when bypassing 
-        {
-            // We're allowed to always delete segments of less than 5 micron.
-            continue;
-        }
-
-        const coord_t area_removed_so_far = accumulated_area_removed + negative_area_closing; // close the shortcut area polygon
-        const coord_t base_length_2 = vSize2(next - previous);
-
-        if (base_length_2 == 0 //Two line segments form a line back and forth with no area.
-             && !bypass) // never delete when bypassing 
-        {
-            continue; //Remove the vertex.
-        }
-        //We want to check if the height of the triangle formed by previous, current and next vertices is less than allowed_error_distance_squared.
-        //1/2 L = A           [actual area is half of the computed shoelace value] // Shoelace formula is .5*(...) , but we simplify the computation and take out the .5
-        //A = 1/2 * b * h     [triangle area formula]
-        //L = b * h           [apply above two and take out the 1/2]
-        //h = L / b           [divide by b]
-        //h^2 = (L / b)^2     [square it]
-        //h^2 = L^2 / b^2     [factor the divisor]
-        const coord_t height_2 = area_removed_so_far * area_removed_so_far / base_length_2;
-        if ((height_2 <= 5 * 5 //Almost exactly colinear (barring rounding errors).
-            && LinearAlg2D::getDistFromLine(current, previous, next) <= 5) // make sure that height_2 is not small because of cancellation of positive and negative areas
-            && !bypass) // never delete when bypassing 
-        {
-            continue;
-        }
-
-        if (length2 < smallest_line_segment_squared
-            && height_2 <= allowed_error_distance_squared // removing the vertex doesn't introduce too much error.)
-            && !bypass) // never delete when bypassing 
-        {
-            const coord_t next_length2 = vSize2(current - next);
-            if (next_length2 > smallest_line_segment_squared)
+            const coord_t length2 = vSize2(current - previous);
+            if (length2 < 25
+                && !bypass) // never delete when bypassing 
             {
-                // Special case; The next line is long. If we were to remove this, it could happen that we get quite noticeable artifacts.
-                // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.
-                // By taking the intersection of these two lines, we get a point that preserves the direction (so it makes the corner a bit more pointy).
-                // We just need to be sure that the intersection point does not introduce an artifact itself.
-                Point intersection_point;
-                bool has_intersection = LinearAlg2D::lineLineIntersection(previous_previous, previous, current, next, intersection_point);
-                if (!has_intersection
-                    || LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared
-                    || vSize2(intersection_point - previous) > smallest_line_segment_squared  // The intersection point is way too far from the 'previous'
-                    || vSize2(intersection_point - next) > smallest_line_segment_squared)     // and 'next' points, so it shouldn't replace 'current'
-                {
-                    // We can't find a better spot for it, but the size of the line is more than 5 micron.
-                    // So the only thing we can do here is leave it in...
-                }
-                else
-                {
-                    // New point seems like a valid one.
-                    current = intersection_point;
-                    // If there was a previous point added, remove it.
-                    if (!new_path.empty()
-                        && (!processing_polylines || new_path.size() > 1) // never delete the first point of a polyline
-                    )
-                    {
-                        new_path.pop_back();
-                        previous = previous_previous;
-                    }
-                }
+                // We're allowed to always delete segments of less than 5 micron.
+                continue;
             }
-            else
+
+            const coord_t area_removed_so_far = accumulated_area_removed + negative_area_closing; // close the shortcut area polygon
+            const coord_t base_length_2 = vSize2(next - previous);
+
+            if (base_length_2 == 0 //Two line segments form a line back and forth with no area.
+                && !bypass) // never delete when bypassing 
             {
                 continue; //Remove the vertex.
             }
-        }
+            //We want to check if the height of the triangle formed by previous, current and next vertices is less than allowed_error_distance_squared.
+            //1/2 L = A           [actual area is half of the computed shoelace value] // Shoelace formula is .5*(...) , but we simplify the computation and take out the .5
+            //A = 1/2 * b * h     [triangle area formula]
+            //L = b * h           [apply above two and take out the 1/2]
+            //h = L / b           [divide by b]
+            //h^2 = (L / b)^2     [square it]
+            //h^2 = L^2 / b^2     [factor the divisor]
+            const coord_t height_2 = area_removed_so_far * area_removed_so_far / base_length_2;
+            if ((height_2 <= 5 * 5 //Almost exactly colinear (barring rounding errors).
+                && LinearAlg2D::getDistFromLine(current, previous, next) <= 5) // make sure that height_2 is not small because of cancellation of positive and negative areas
+                && !bypass) // never delete when bypassing 
+            {
+                continue;
+            }
+
+            if (length2 < smallest_line_segment_squared
+                && height_2 <= allowed_error_distance_squared // removing the vertex doesn't introduce too much error.)
+                && !bypass) // never delete when bypassing 
+            {
+                const coord_t next_length2 = vSize2(current - next);
+                if (next_length2 > smallest_line_segment_squared)
+                {
+                    // Special case; The next line is long. If we were to remove this, it could happen that we get quite noticeable artifacts.
+                    // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.
+                    // By taking the intersection of these two lines, we get a point that preserves the direction (so it makes the corner a bit more pointy).
+                    // We just need to be sure that the intersection point does not introduce an artifact itself.
+                    Point intersection_point;
+                    bool has_intersection = LinearAlg2D::lineLineIntersection(previous_previous, previous, current, next, intersection_point);
+                    if (!has_intersection
+                        || LinearAlg2D::getDist2FromLine(intersection_point, previous, current) > allowed_error_distance_squared
+                        || vSize2(intersection_point - previous) > smallest_line_segment_squared  // The intersection point is way too far from the 'previous'
+                        || vSize2(intersection_point - next) > smallest_line_segment_squared)     // and 'next' points, so it shouldn't replace 'current'
+                    {
+                        // We can't find a better spot for it, but the size of the line is more than 5 micron.
+                        // So the only thing we can do here is leave it in...
+                    }
+                    else
+                    {
+                        // New point seems like a valid one.
+                        current = intersection_point;
+                        // If there was a previous point added, remove it.
+                        if (!new_path.empty()
+                            && (!processing_polylines || new_path.size() > 1) // never delete the first point of a polyline
+                        )
+                        {
+                            new_path.pop_back();
+                            previous = previous_previous;
+                        }
+                    }
+                }
+                else
+                {
+                    continue; //Remove the vertex.
+                }
+            }
         }
         //Don't remove the vertex.
         accumulated_area_removed = removed_area_next; // so that in the next iteration it's the area between the origin, [previous] and [current]

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -370,6 +370,8 @@ class PolygonPointer;
 class PolygonRef : public ConstPolygonRef
 {
     friend class PolygonPointer;
+    friend class Polygons;
+    friend class PolygonsPart;
 public:
     PolygonRef(ClipperLib::Path& polygon)
     : ConstPolygonRef(polygon)
@@ -506,6 +508,19 @@ public:
      */
     void simplify(const coord_t smallest_line_segment_squared = MM2INT(0.01) * MM2INT(0.01), const coord_t allowed_error_distance_squared = 25);
 
+    /*!
+     * See simplify(.)
+     */
+    void simplifyPolyline(const coord_t smallest_line_segment_squared = 100, const coord_t allowed_error_distance_squared = 25);
+protected:
+    /*!
+     * Private implementation for both simplify and simplifyPolygons.
+     * 
+     * Made private to avoid accidental use of the wrong function.
+     */
+    void _simplify(const coord_t smallest_line_segment_squared = 100, const coord_t allowed_error_distance_squared = 25, bool processing_polylines = false);
+
+public:
     void pop_back()
     {
         path->pop_back();
@@ -1004,19 +1019,30 @@ public:
      */
     void simplify(const coord_t smallest_line_segment = 10, const coord_t allowed_error_distance = 5)
     {
+        _simplify(smallest_line_segment, allowed_error_distance, false);
+    }
+    void simplifyPolylines(const coord_t smallest_line_segment = 10, const coord_t allowed_error_distance = 5) 
+    {
+        _simplify(smallest_line_segment, allowed_error_distance, true);
+    }
+private:
+    void _simplify(const coord_t smallest_line_segment = 10, const coord_t allowed_error_distance = 5, bool processing_polylines = false) 
+    {
         const coord_t allowed_error_distance_squared = allowed_error_distance * allowed_error_distance;
         const coord_t smallest_line_segment_squared = smallest_line_segment * smallest_line_segment;
         Polygons& thiss = *this;
         for (size_t p = 0; p < size(); p++)
         {
-            thiss[p].simplify(smallest_line_segment_squared, allowed_error_distance_squared);
-            if (thiss[p].size() < 3)
+            thiss[p]._simplify(smallest_line_segment_squared, allowed_error_distance_squared, processing_polylines);
+            if (thiss[p].size() < 3 // remove polygons with 2 verts
+                - static_cast<size_t>(processing_polylines)) // remove polylines with 1 vert
             {
                 remove(p);
                 p--;
             }
         }
     }
+public:
 
     void scale(const Ratio& ratio)
     {


### PR DESCRIPTION
Rebase of https://github.com/Ultimaker/CuraEngine/pull/1354

I've verified that it still works and does the same

---- Copy of that PR's text

Applies the Max Resolution settings to Surface mode as well.

Tested extremely zoomed in with an extremely small line width, so you can easily see the Max resolution setting at work.

Before:
![image](https://user-images.githubusercontent.com/8895761/98391698-45c95c80-2057-11eb-912d-79a9d54a75bb.png)

After:
![image](https://user-images.githubusercontent.com/8895761/98391673-3ba75e00-2057-11eb-8a35-f5d6ada1c56a.png)

Project:
![image](https://user-images.githubusercontent.com/8895761/98392162-e91a7180-2057-11eb-9568-4b70bc402896.png)
[tiny_open_mesh_surface_mode.3mf.rename.zip](https://github.com/Ultimaker/CuraEngine/files/5502373/tiny_open_mesh_surface_mode.3mf.rename.zip)
