### PR TITLE
Raft extruders

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -696,8 +696,8 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
     coord_t z = 0;
     const LayerIndex initial_raft_layer_nr = -Raft::getTotalExtraLayers();
-    const ExtruderTrain& surface_train = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr");
-    const size_t num_surface_layers = surface_train.settings.get<size_t>("raft_surface_layers");
+    const Settings& surface_settings = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").settings;
+    const size_t num_surface_layers = surface_settings.get<size_t>("raft_surface_layers");
 
     // some infill config for all lines infill generation below
     constexpr double fill_overlap = 0; // raft line shouldn't be expanded - there is no boundary polygon printed
@@ -710,22 +710,22 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
     unsigned int current_extruder_nr = extruder_nr;
 
     { // raft base layer
-        const ExtruderTrain& base_train = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr");
+        const Settings& base_settings = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").settings;
         LayerIndex layer_nr = initial_raft_layer_nr;
-        const coord_t layer_height = base_train.settings.get<coord_t>("raft_base_thickness");
+        const coord_t layer_height = base_settings.get<coord_t>("raft_base_thickness");
         z += layer_height;
-        const coord_t comb_offset = base_train.settings.get<coord_t>("raft_base_line_spacing");
+        const coord_t comb_offset = base_settings.get<coord_t>("raft_base_line_spacing");
 
         std::vector<FanSpeedLayerTimeSettings> fan_speed_layer_time_settings_per_extruder_raft_base = fan_speed_layer_time_settings_per_extruder; // copy so that we change only the local copy
         for (FanSpeedLayerTimeSettings& fan_speed_layer_time_settings : fan_speed_layer_time_settings_per_extruder_raft_base)
         {
-            double regular_fan_speed = base_train.settings.get<Ratio>("raft_base_fan_speed") * 100.0;
+            double regular_fan_speed = base_settings.get<Ratio>("raft_base_fan_speed") * 100.0;
             fan_speed_layer_time_settings.cool_fan_speed_min = regular_fan_speed;
             fan_speed_layer_time_settings.cool_fan_speed_0 = regular_fan_speed; // ignore initial layer fan speed stuff
         }
 
-        const coord_t line_width = base_train.settings.get<coord_t>("raft_base_line_width");
-        const coord_t avoid_distance = base_train.settings.get<coord_t>("travel_avoid_distance");
+        const coord_t line_width = base_settings.get<coord_t>("raft_base_line_width");
+        const coord_t avoid_distance = base_settings.get<coord_t>("travel_avoid_distance");
         LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_height, extruder_nr, fan_speed_layer_time_settings_per_extruder_raft_base, comb_offset, line_width, avoid_distance);
         gcode_layer.setIsInside(true);
 
@@ -738,16 +738,16 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr bool zig_zaggify_infill = false;
         constexpr bool connect_polygons = true; // causes less jerks, so better adhesion
 
-        const size_t wall_line_count = base_train.settings.get<size_t>("raft_base_wall_count");
-        const coord_t line_spacing = base_train.settings.get<coord_t>("raft_base_line_spacing");
+        const size_t wall_line_count = base_settings.get<size_t>("raft_base_wall_count");
+        const coord_t line_spacing = base_settings.get<coord_t>("raft_base_line_spacing");
         const Point& infill_origin = Point();
         constexpr bool connected_zigzags = false;
         constexpr bool use_endpieces = true;
         constexpr bool skip_some_zags = false;
         constexpr int zag_skip_count = 0;
         constexpr coord_t pocket_size = 0;
-        const coord_t max_resolution = base_train.settings.get<coord_t>("meshfix_maximum_resolution");
-        const coord_t max_deviation = base_train.settings.get<coord_t>("meshfix_maximum_deviation");
+        const coord_t max_resolution = base_settings.get<coord_t>("meshfix_maximum_resolution");
+        const coord_t max_deviation = base_settings.get<coord_t>("meshfix_maximum_deviation");
 
         Infill infill_comp(
             EFillMethod::LINES, zig_zaggify_infill, connect_polygons, storage.raftOutline, gcode_layer.configs_storage.raft_base_config.getLineWidth(), line_spacing,
@@ -756,13 +756,13 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             wall_line_count, infill_origin, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
             );
         VariableWidthPaths raft_paths;
-        infill_comp.generate(raft_paths, raft_polygons, raftLines, base_train.settings);
+        infill_comp.generate(raft_paths, raft_polygons, raftLines, base_settings);
         if(!raft_paths.empty())
         {
             const BinJunctions binned_paths = InsetOrderOptimizer::variableWidthPathToBinJunctions(raft_paths);
             for (const PathJunctions& wall_junctions : binned_paths)
             {
-                gcode_layer.addWalls(wall_junctions, base_train.settings, gcode_layer.configs_storage.raft_base_config, gcode_layer.configs_storage.raft_base_config);
+                gcode_layer.addWalls(wall_junctions, base_settings, gcode_layer.configs_storage.raft_base_config, gcode_layer.configs_storage.raft_base_config);
             }
         }
         gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_base_config, SpaceFillType::Lines);
@@ -782,21 +782,21 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
     { // raft interface layer
         const LayerIndex layer_nr = initial_raft_layer_nr + 1;
-        const ExtruderTrain& interface_train = mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr");
-        const coord_t layer_height = interface_train.settings.get<coord_t>("raft_interface_thickness");
+        const Settings& interface_settings = mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").settings;
+        const coord_t layer_height = interface_settings.get<coord_t>("raft_interface_thickness");
         z += layer_height;
-        const coord_t comb_offset = interface_train.settings.get<coord_t>("raft_interface_line_spacing");
+        const coord_t comb_offset = interface_settings.get<coord_t>("raft_interface_line_spacing");
 
         std::vector<FanSpeedLayerTimeSettings> fan_speed_layer_time_settings_per_extruder_raft_interface = fan_speed_layer_time_settings_per_extruder; // copy so that we change only the local copy
         for (FanSpeedLayerTimeSettings& fan_speed_layer_time_settings : fan_speed_layer_time_settings_per_extruder_raft_interface)
         {
-            double regular_fan_speed = interface_train.settings.get<Ratio>("raft_interface_fan_speed") * 100.0;
+            double regular_fan_speed = interface_settings.get<Ratio>("raft_interface_fan_speed") * 100.0;
             fan_speed_layer_time_settings.cool_fan_speed_min = regular_fan_speed;
             fan_speed_layer_time_settings.cool_fan_speed_0 = regular_fan_speed; // ignore initial layer fan speed stuff
         }
 
-        const coord_t line_width = interface_train.settings.get<coord_t>("raft_interface_line_width");
-        const coord_t avoid_distance = interface_train.settings.get<coord_t>("travel_avoid_distance");
+        const coord_t line_width = interface_settings.get<coord_t>("raft_interface_line_width");
+        const coord_t avoid_distance = interface_settings.get<coord_t>("travel_avoid_distance");
         LayerPlan& gcode_layer = *new LayerPlan(storage, layer_nr, z, layer_height, current_extruder_nr, fan_speed_layer_time_settings_per_extruder_raft_interface, comb_offset, line_width, avoid_distance);
         gcode_layer.setIsInside(true);
 
@@ -814,15 +814,15 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr bool connect_polygons = true; // why not?
 
         constexpr int wall_line_count = 0;
-        const coord_t line_spacing = interface_train.settings.get<coord_t>("raft_interface_line_spacing");
+        const coord_t line_spacing = interface_settings.get<coord_t>("raft_interface_line_spacing");
         const Point& infill_origin = Point();
         constexpr bool connected_zigzags = false;
         constexpr bool use_endpieces = true;
         constexpr bool skip_some_zags = false;
         constexpr int zag_skip_count = 0;
         constexpr coord_t pocket_size = 0;
-        const coord_t max_resolution = interface_train.settings.get<coord_t>("meshfix_maximum_resolution");
-        const coord_t max_deviation = interface_train.settings.get<coord_t>("meshfix_maximum_deviation");
+        const coord_t max_resolution = interface_settings.get<coord_t>("meshfix_maximum_resolution");
+        const coord_t max_deviation = interface_settings.get<coord_t>("meshfix_maximum_deviation");
 
         Infill infill_comp(
             EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, infill_outline_width, line_spacing,
@@ -831,20 +831,20 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             wall_line_count, infill_origin, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
             );
         VariableWidthPaths raft_paths; //Should remain empty, since we have no walls.
-        infill_comp.generate(raft_paths, raft_polygons, raftLines, interface_train.settings);
+        infill_comp.generate(raft_paths, raft_polygons, raftLines, interface_settings);
         gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_interface_config, SpaceFillType::Lines, false, 0, 1.0, last_planned_position);
 
         layer_plan_buffer.handle(gcode_layer, gcode);
         last_planned_position = gcode_layer.getLastPlannedPositionOrStartingPosition();
     }
 
-    coord_t layer_height = surface_train.settings.get<coord_t>("raft_surface_thickness");
-    const coord_t surface_line_spacing = surface_train.settings.get<coord_t>("raft_surface_line_spacing");
-    const coord_t surface_max_resolution = surface_train.settings.get<coord_t>("meshfix_maximum_resolution");
-    const coord_t surface_max_deviation = surface_train.settings.get<coord_t>("meshfix_maximum_deviation");
-    const coord_t surface_line_width = surface_train.settings.get<coord_t>("raft_surface_line_width");
-    const coord_t surface_avoid_distance = surface_train.settings.get<coord_t>("travel_avoid_distance");
-    const Ratio surface_fan_speed = surface_train.settings.get<Ratio>("raft_surface_fan_speed");
+    coord_t layer_height = surface_settings.get<coord_t>("raft_surface_thickness");
+    const coord_t surface_line_spacing = surface_settings.get<coord_t>("raft_surface_line_spacing");
+    const coord_t surface_max_resolution = surface_settings.get<coord_t>("meshfix_maximum_resolution");
+    const coord_t surface_max_deviation = surface_settings.get<coord_t>("meshfix_maximum_deviation");
+    const coord_t surface_line_width = surface_settings.get<coord_t>("raft_surface_line_width");
+    const coord_t surface_avoid_distance = surface_settings.get<coord_t>("travel_avoid_distance");
+    const Ratio surface_fan_speed = surface_settings.get<Ratio>("raft_surface_fan_speed");
 
     for (LayerIndex raft_surface_layer = 1; static_cast<size_t>(raft_surface_layer) <= num_surface_layers; raft_surface_layer++)
     { // raft surface layers
@@ -892,7 +892,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             wall_line_count, infill_origin, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
             );
         VariableWidthPaths raft_paths; //Should remain empty, since we have no walls.
-        infill_comp.generate(raft_paths, raft_polygons, raft_lines, surface_train.settings);
+        infill_comp.generate(raft_paths, raft_polygons, raft_lines, surface_settings);
         gcode_layer.addLinesByOptimizer(raft_lines, gcode_layer.configs_storage.raft_surface_config, SpaceFillType::Lines, false, 0, 1.0, last_planned_position);
 
         layer_plan_buffer.handle(gcode_layer, gcode);

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef GCODE_WRITER_H
@@ -166,12 +166,14 @@ private:
     /*!
      * Get the extruder with which to start the print.
      * 
-     * Generally this is the adhesion_extruder_nr, but in case the platform adhesion type is none,
-     * the extruder with lowest number which is used on the first layer is used as initial extruder.
+     * Generally this is the extruder of the adhesion type in use, but in case
+     * the platform adhesion type is none, the support extruder is used. If
+     * support is also disabled, the extruder with lowest number which is used
+     * on the first layer is used as initial extruder.
      * 
      * \param[in] storage where to get settings from.
      */
-    unsigned int getStartExtruder(const SliceDataStorage& storage);
+    size_t getStartExtruder(const SliceDataStorage& storage);
 
     /*!
      * Set the infill angles and skin angles in the SliceDataStorage.

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <algorithm>
@@ -945,7 +945,7 @@ void FffPolygonGenerator::processDraftShield(SliceDataStorage& storage)
 void FffPolygonGenerator::processPlatformAdhesion(SliceDataStorage& storage)
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-    ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr");
+    ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>("skirt_brim_extruder_nr");
 
     Polygons first_layer_outline;
     coord_t primary_line_count;

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -306,7 +306,7 @@ bool FffPolygonGenerator::sliceModel(MeshGroup* meshgroup, TimeKeeper& timeKeepe
             // add the raft offset to each layer
             if (has_raft)
             {
-                const ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr");
+                const ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr");
                 layer.printZ +=
                     Raft::getTotalThickness()
                     + train.settings.get<coord_t>("raft_airgap")
@@ -792,7 +792,8 @@ void FffPolygonGenerator::computePrintHeightStatistics(SliceDataStorage& storage
 
     std::vector<int>& max_print_height_per_extruder = storage.max_print_height_per_extruder;
     assert(max_print_height_per_extruder.size() == 0 && "storage.max_print_height_per_extruder shouldn't have been initialized yet!");
-    max_print_height_per_extruder.resize(extruder_count, -(Raft::getTotalExtraLayers() + 1)); //Initialize all as -1 (or lower in case of raft).
+    const int raft_layers = Raft::getTotalExtraLayers();
+    max_print_height_per_extruder.resize(extruder_count, -(raft_layers + 1)); //Initialize all as -1 (or lower in case of raft).
     { // compute max_object_height_per_extruder
         //Height of the meshes themselves.
         for (SliceMeshStorage& mesh : storage.meshes)
@@ -816,25 +817,43 @@ void FffPolygonGenerator::computePrintHeightStatistics(SliceDataStorage& storage
 
         //Height of where the support reaches.
         Scene& scene = Application::getInstance().current_slice->scene;
-        const size_t support_infill_extruder_nr = scene.current_mesh_group->settings.get<ExtruderTrain&>("support_infill_extruder_nr").extruder_nr; // TODO: Support extruder should be configurable per object.
+        const Settings& mesh_group_settings = scene.current_mesh_group->settings;
+        const size_t support_infill_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("support_infill_extruder_nr").extruder_nr; // TODO: Support extruder should be configurable per object.
         max_print_height_per_extruder[support_infill_extruder_nr] =
             std::max(max_print_height_per_extruder[support_infill_extruder_nr],
                      storage.support.layer_nr_max_filled_layer);
-        const size_t support_roof_extruder_nr = scene.current_mesh_group->settings.get<ExtruderTrain&>("support_roof_extruder_nr").extruder_nr; // TODO: Support roof extruder should be configurable per object.
+        const size_t support_roof_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("support_roof_extruder_nr").extruder_nr; // TODO: Support roof extruder should be configurable per object.
         max_print_height_per_extruder[support_roof_extruder_nr] =
             std::max(max_print_height_per_extruder[support_roof_extruder_nr],
                      storage.support.layer_nr_max_filled_layer);
-        const size_t support_bottom_extruder_nr = scene.current_mesh_group->settings.get<ExtruderTrain&>("support_bottom_extruder_nr").extruder_nr; //TODO: Support bottom extruder should be configurable per object.
+        const size_t support_bottom_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("support_bottom_extruder_nr").extruder_nr; //TODO: Support bottom extruder should be configurable per object.
         max_print_height_per_extruder[support_bottom_extruder_nr] =
             std::max(max_print_height_per_extruder[support_bottom_extruder_nr],
                      storage.support.layer_nr_max_filled_layer);
 
         //Height of where the platform adhesion reaches.
-        if (scene.current_mesh_group->settings.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::NONE)
+        const EPlatformAdhesion adhesion_type = mesh_group_settings.get<EPlatformAdhesion>("adhesion_type");
+        switch(adhesion_type)
         {
-            const size_t adhesion_extruder_nr = scene.current_mesh_group->settings.get<ExtruderTrain&>("adhesion_extruder_nr").extruder_nr;
-            max_print_height_per_extruder[adhesion_extruder_nr] =
-                std::max(0, max_print_height_per_extruder[adhesion_extruder_nr]);
+            case EPlatformAdhesion::SKIRT:
+            case EPlatformAdhesion::BRIM:
+            {
+                const size_t skirt_brim_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("skirt_brim_extruder_nr").extruder_nr;
+                max_print_height_per_extruder[skirt_brim_extruder_nr] = std::max(0, max_print_height_per_extruder[skirt_brim_extruder_nr]); //Includes layer 0.
+                break;
+            }
+            case EPlatformAdhesion::RAFT:
+            {
+                const size_t base_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr;
+                max_print_height_per_extruder[base_extruder_nr] = std::max(-raft_layers, max_print_height_per_extruder[base_extruder_nr]); //Includes the lowest raft layer.
+                const size_t interface_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr;
+                max_print_height_per_extruder[interface_extruder_nr] = std::max(-raft_layers + 1, max_print_height_per_extruder[interface_extruder_nr]); //Includes the second-lowest raft layer.
+                const size_t surface_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").extruder_nr;
+                max_print_height_per_extruder[surface_extruder_nr] = std::max(-1, max_print_height_per_extruder[surface_extruder_nr]); //Includes up to the first layer below the model (so -1).
+                break;
+            }
+            default:
+                break; //No adhesion, so no maximum necessary.
         }
     }
 
@@ -846,7 +865,7 @@ void FffPolygonGenerator::computePrintHeightStatistics(SliceDataStorage& storage
     }
     else
     {
-        storage.max_print_height_second_to_last_extruder = -(Raft::getTotalExtraLayers() + 1);
+        storage.max_print_height_second_to_last_extruder = -(raft_layers + 1);
     }
 }
 

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <algorithm>
@@ -71,7 +71,7 @@ void PrimeTower::generateGroundpoly()
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     const coord_t tower_size = mesh_group_settings.get<coord_t>("prime_tower_size");
     
-    const Settings& brim_extruder_settings = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr").settings;
+    const Settings& brim_extruder_settings = mesh_group_settings.get<ExtruderTrain&>("skirt_brim_extruder_nr").settings;
     const bool has_raft = (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") == EPlatformAdhesion::RAFT);
     const bool has_prime_brim = mesh_group_settings.get<bool>("prime_tower_brim_enable");
     const coord_t offset = (has_raft || ! has_prime_brim) ? 0 :

--- a/src/Wireframe2gcode.cpp
+++ b/src/Wireframe2gcode.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <cmath> // sqrt
@@ -24,7 +24,7 @@ namespace cura
 void Wireframe2gcode::writeGCode()
 {
     Settings& scene_settings = Application::getInstance().current_slice->scene.settings;
-    const size_t start_extruder_nr = scene_settings.get<ExtruderTrain&>("adhesion_extruder_nr").extruder_nr; // TODO: figure out how Wireframe works with dual extrusion
+    const size_t start_extruder_nr = scene_settings.get<ExtruderTrain&>("skirt_brim_extruder_nr").extruder_nr; // TODO: figure out how Wireframe works with dual extrusion
     gcode.preSetup(start_extruder_nr);
     gcode.setInitialAndBuildVolumeTemps(start_extruder_nr);
 
@@ -567,7 +567,7 @@ void Wireframe2gcode::processStartingCode()
 {
     const Settings& scene_settings = Application::getInstance().current_slice->scene.settings;
     const size_t extruder_count = Application::getInstance().current_slice->scene.extruders.size();
-    size_t start_extruder_nr = scene_settings.get<ExtruderTrain&>("adhesion_extruder_nr").extruder_nr;
+    size_t start_extruder_nr = scene_settings.get<ExtruderTrain&>("skirt_brim_extruder_nr").extruder_nr;
 
     if (Application::getInstance().communication->isSequential())
     {

--- a/src/settings/PathConfigStorage.cpp
+++ b/src/settings/PathConfigStorage.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "PathConfigStorage.h"
@@ -132,31 +132,34 @@ PathConfigStorage::PathConfigStorage(const SliceDataStorage& storage, const Laye
 : support_infill_extruder_nr(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("support_infill_extruder_nr").extruder_nr)
 , support_roof_extruder_nr(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("support_roof_extruder_nr").extruder_nr)
 , support_bottom_extruder_nr(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("support_bottom_extruder_nr").extruder_nr)
-, adhesion_extruder_train(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("adhesion_extruder_nr"))
+, skirt_brim_train(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("skirt_brim_extruder_nr"))
+, raft_base_train(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("raft_base_extruder_nr"))
+, raft_interface_train(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("raft_interface_extruder_nr"))
+, raft_surface_train(Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("raft_surface_extruder_nr"))
 , support_infill_train(Application::getInstance().current_slice->scene.extruders[support_infill_extruder_nr])
 , support_roof_train(Application::getInstance().current_slice->scene.extruders[support_roof_extruder_nr])
 , support_bottom_train(Application::getInstance().current_slice->scene.extruders[support_bottom_extruder_nr])
 , line_width_factor_per_extruder(PathConfigStorage::getLineWidthFactorPerExtruder(layer_nr))
 , raft_base_config(
             PrintFeatureType::SupportInterface
-            , adhesion_extruder_train.settings.get<coord_t>("raft_base_line_width")
-            , adhesion_extruder_train.settings.get<coord_t>("raft_base_thickness")
-            , ((layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0))
-            , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train.settings.get<Velocity>("raft_base_speed"), adhesion_extruder_train.settings.get<Acceleration>("raft_base_acceleration"), adhesion_extruder_train.settings.get<Velocity>("raft_base_jerk")}
+            , raft_base_train.settings.get<coord_t>("raft_base_line_width")
+            , raft_base_train.settings.get<coord_t>("raft_base_thickness")
+            , Ratio(1.0)
+            , GCodePathConfig::SpeedDerivatives{raft_base_train.settings.get<Velocity>("raft_base_speed"), raft_base_train.settings.get<Acceleration>("raft_base_acceleration"), raft_base_train.settings.get<Velocity>("raft_base_jerk")}
         )
 , raft_interface_config(
             PrintFeatureType::Support
-            , adhesion_extruder_train.settings.get<coord_t>("raft_interface_line_width")
-            , adhesion_extruder_train.settings.get<coord_t>("raft_interface_thickness")
-            , (layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0)
-            , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train.settings.get<Velocity>("raft_interface_speed"), adhesion_extruder_train.settings.get<Acceleration>("raft_interface_acceleration"), adhesion_extruder_train.settings.get<Velocity>("raft_interface_jerk")}
+            , raft_interface_train.settings.get<coord_t>("raft_interface_line_width")
+            , raft_interface_train.settings.get<coord_t>("raft_interface_thickness")
+            , Ratio(1.0)
+            , GCodePathConfig::SpeedDerivatives{raft_interface_train.settings.get<Velocity>("raft_interface_speed"), raft_interface_train.settings.get<Acceleration>("raft_interface_acceleration"), raft_interface_train.settings.get<Velocity>("raft_interface_jerk")}
         )
 , raft_surface_config(
             PrintFeatureType::SupportInterface
-            , adhesion_extruder_train.settings.get<coord_t>("raft_surface_line_width")
-            , adhesion_extruder_train.settings.get<coord_t>("raft_surface_thickness")
-            , (layer_nr == 0) ? adhesion_extruder_train.settings.get<Ratio>("material_flow_layer_0") : Ratio(1.0)
-            , GCodePathConfig::SpeedDerivatives{adhesion_extruder_train.settings.get<Velocity>("raft_surface_speed"), adhesion_extruder_train.settings.get<Acceleration>("raft_surface_acceleration"), adhesion_extruder_train.settings.get<Velocity>("raft_surface_jerk")}
+            , raft_surface_train.settings.get<coord_t>("raft_surface_line_width")
+            , raft_surface_train.settings.get<coord_t>("raft_surface_thickness")
+            , Ratio(1.0)
+            , GCodePathConfig::SpeedDerivatives{raft_surface_train.settings.get<Velocity>("raft_surface_speed"), raft_surface_train.settings.get<Acceleration>("raft_surface_acceleration"), raft_surface_train.settings.get<Velocity>("raft_surface_jerk")}
         )
 , support_roof_config(
             PrintFeatureType::SupportInterface

--- a/src/settings/PathConfigStorage.h
+++ b/src/settings/PathConfigStorage.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef SETTINGS_PATH_CONFIGS_H
@@ -26,10 +26,13 @@ private:
     const size_t support_infill_extruder_nr;
     const size_t support_roof_extruder_nr;
     const size_t support_bottom_extruder_nr;
-    const ExtruderTrain& adhesion_extruder_train;
-    const ExtruderTrain& support_infill_train;
-    const ExtruderTrain& support_roof_train;
-    const ExtruderTrain& support_bottom_train;
+    ExtruderTrain& skirt_brim_train;
+    ExtruderTrain& raft_base_train;
+    ExtruderTrain& raft_interface_train;
+    ExtruderTrain& raft_surface_train;
+    ExtruderTrain& support_infill_train;
+    ExtruderTrain& support_roof_train;
+    ExtruderTrain& support_bottom_train;
 
     const std::vector<Ratio> line_width_factor_per_extruder;
     static std::vector<Ratio> getLineWidthFactorPerExtruder(const LayerIndex& layer_nr);

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -489,7 +489,7 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed(const LayerIndex layer_nr) 
         // support
         if (layer_nr < int(support.supportLayers.size()))
         {
-            const SupportLayer& support_layer = support.supportLayers[layer_nr];
+            const SupportLayer& support_layer = support.supportLayers[std::max(LayerIndex(0), layer_nr)]; //Below layer 0, it's the same as layer 0 (even though it's not stored here).
             if (layer_nr == 0)
             {
                 if (!support_layer.support_infill_parts.empty())

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "Application.h" //To get settings.
@@ -374,18 +374,25 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed() const
     ret.resize(Application::getInstance().current_slice->scene.extruders.size(), false);
 
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-    if (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::NONE)
+    const EPlatformAdhesion adhesion_type = mesh_group_settings.get<EPlatformAdhesion>("adhesion_type");
+    if(adhesion_type == EPlatformAdhesion::SKIRT || adhesion_type == EPlatformAdhesion::BRIM)
     {
-        ret[mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr").extruder_nr] = true;
-        { // process brim/skirt
-            for (size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
+        for(size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
+        {
+            if(!skirt_brim[extruder_nr].empty())
             {
-                if (skirt_brim[extruder_nr].size() > 0)
-                {
-                    ret[extruder_nr] = true;
-                    continue;
-                }
+                ret[extruder_nr] = true;
             }
+        }
+    }
+    else if(adhesion_type == EPlatformAdhesion::RAFT)
+    {
+        ret[mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr] = true;
+        ret[mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr] = true;
+        const size_t num_surface_layers = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr").settings.get<size_t>("raft_surface_layers");
+        if(num_surface_layers > 0)
+        {
+            ret[mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").extruder_nr] = true;
         }
     }
 
@@ -421,11 +428,12 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed() const
     return ret;
 }
 
-std::vector<bool> SliceDataStorage::getExtrudersUsed(LayerIndex layer_nr) const
+std::vector<bool> SliceDataStorage::getExtrudersUsed(const LayerIndex layer_nr) const
 {
     std::vector<bool> ret;
     ret.resize(Application::getInstance().current_slice->scene.extruders.size(), false);
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
+    const EPlatformAdhesion adhesion_type = mesh_group_settings.get<EPlatformAdhesion>("adhesion_type");
 
     bool include_adhesion = true;
     bool include_helper_parts = true;
@@ -437,28 +445,39 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed(LayerIndex layer_nr) const
         {
             include_helper_parts = false;
         }
-        else
-        {
-            layer_nr = 0; // because the helper parts are copied from the initial layer in the filler layer
-            include_adhesion = false;
-        }
     }
-    else if (layer_nr > 0 || mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") == EPlatformAdhesion::RAFT)
+    else if(layer_nr > 0 || adhesion_type == EPlatformAdhesion::RAFT)
     { // only include adhesion only for layers where platform adhesion actually occurs
         // i.e. layers < 0 are for raft, layer 0 is for brim/skirt
         include_adhesion = false;
     }
-    if (include_adhesion && mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::NONE)
+
+    if(include_adhesion)
     {
-        ret[mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr").extruder_nr] = true;
-        { // process brim/skirt
-            for (size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
+        if(layer_nr == 0 && (adhesion_type == EPlatformAdhesion::SKIRT || adhesion_type == EPlatformAdhesion::BRIM))
+        {
+            for(size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); ++extruder_nr)
             {
                 if(!skirt_brim[extruder_nr].empty())
                 {
                     ret[extruder_nr] = true;
-                    continue;
                 }
+            }
+        }
+        if(adhesion_type == EPlatformAdhesion::RAFT)
+        {
+            const LayerIndex raft_layers = Raft::getTotalExtraLayers();
+            if(layer_nr == -raft_layers) //Base layer.
+            {
+                ret[mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr] = true;
+            }
+            else if(layer_nr == -raft_layers + 1) //Interface layer.
+            {
+                ret[mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr] = true;
+            }
+            else if(layer_nr < -static_cast<LayerIndex>(Raft::getFillerLayerCount())) //Any of the surface layers.
+            {
+                ret[mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").extruder_nr] = true;
             }
         }
     }

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <cmath> // sqrt, round
@@ -480,12 +480,12 @@ Polygons AreaSupport::join(const SliceDataStorage& storage, const Polygons& supp
                 break;
         }
         coord_t adhesion_size = 0; //Make sure there is enough room for the platform adhesion around support.
-        const ExtruderTrain& adhesion_extruder = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr");
+        const ExtruderTrain& skirt_brim_extruder = mesh_group_settings.get<ExtruderTrain&>("skirt_brim_extruder_nr");
         coord_t extra_skirt_line_width = 0;
         const std::vector<bool> is_extruder_used = storage.getExtrudersUsed();
         for (size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
         {
-            if (extruder_nr == adhesion_extruder.extruder_nr || !is_extruder_used[extruder_nr]) //Unused extruders and the primary adhesion extruder don't generate an extra skirt line.
+            if (extruder_nr == skirt_brim_extruder.extruder_nr || !is_extruder_used[extruder_nr]) //Unused extruders and the primary adhesion extruder don't generate an extra skirt line.
             {
                 continue;
             }
@@ -495,13 +495,16 @@ Polygons AreaSupport::join(const SliceDataStorage& storage, const Polygons& supp
         switch (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type"))
         {
             case EPlatformAdhesion::BRIM:
-                adhesion_size = adhesion_extruder.settings.get<coord_t>("skirt_brim_line_width") * adhesion_extruder.settings.get<Ratio>("initial_layer_line_width_factor") * adhesion_extruder.settings.get<size_t>("brim_line_count") + extra_skirt_line_width;
+                adhesion_size = skirt_brim_extruder.settings.get<coord_t>("skirt_brim_line_width") * skirt_brim_extruder.settings.get<Ratio>("initial_layer_line_width_factor") * skirt_brim_extruder.settings.get<size_t>("brim_line_count") + extra_skirt_line_width;
                 break;
             case EPlatformAdhesion::RAFT:
-                adhesion_size = adhesion_extruder.settings.get<coord_t>("raft_margin");
+            {
+                const ExtruderTrain& raft_extruder = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr");
+                adhesion_size = raft_extruder.settings.get<coord_t>("raft_margin");
                 break;
+            }
             case EPlatformAdhesion::SKIRT:
-                adhesion_size = adhesion_extruder.settings.get<coord_t>("skirt_gap") + adhesion_extruder.settings.get<coord_t>("skirt_brim_line_width") * adhesion_extruder.settings.get<Ratio>("initial_layer_line_width_factor") * adhesion_extruder.settings.get<size_t>("skirt_line_count") + extra_skirt_line_width;
+                adhesion_size = skirt_brim_extruder.settings.get<coord_t>("skirt_gap") + skirt_brim_extruder.settings.get<coord_t>("skirt_brim_line_width") * skirt_brim_extruder.settings.get<Ratio>("initial_layer_line_width_factor") * skirt_brim_extruder.settings.get<size_t>("skirt_line_count") + extra_skirt_line_width;
                 break;
             case EPlatformAdhesion::NONE:
                 adhesion_size = 0;

--- a/tests/LayerPlanTest.cpp
+++ b/tests/LayerPlanTest.cpp
@@ -98,6 +98,10 @@ public:
         settings->add("acceleration_support_roof", "5004");
         settings->add("acceleration_travel", "5006");
         settings->add("skirt_brim_extruder_nr", "0");
+        settings->add("adhesion_extruder_nr", "0");
+        settings->add("raft_base_extruder_nr", "0");
+        settings->add("raft_interface_extruder_nr", "0");
+        settings->add("raft_surface_extruder_nr", "0");
         settings->add("adhesion_type", "brim");
         settings->add("cool_fan_full_layer", "3");
         settings->add("cool_fan_speed_0", "0");

--- a/tests/LayerPlanTest.cpp
+++ b/tests/LayerPlanTest.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2019 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <gtest/gtest.h>
@@ -97,7 +97,7 @@ public:
         settings->add("acceleration_support_infill", "5009");
         settings->add("acceleration_support_roof", "5004");
         settings->add("acceleration_travel", "5006");
-        settings->add("adhesion_extruder_nr", "0");
+        settings->add("skirt_brim_extruder_nr", "0");
         settings->add("adhesion_type", "brim");
         settings->add("cool_fan_full_layer", "3");
         settings->add("cool_fan_speed_0", "0");


### PR DESCRIPTION
This pull request adds the possibility to have different extruders for each part of the raft.

The main requirement is to be able to change the extruder of just the surface layers. To be consistent with how we work with child settings in Cura, this change adds the possibility to change all 3 parts of the raft, and the brim/skirt separately. So you could have the raft base be printed with the first extruder, the raft interface with the second extruder and the raft surface with the first extruder again or something.

The changes in this PR include 3 main topics:
* Make sure the settings are obtained from the correct extruders.
* Make sure the initial extruder is still correctly calculated.
* Make sure the used extruders are still correctly calculated.

![image](https://user-images.githubusercontent.com/2448634/149183496-9b88d162-febc-44ea-9563-50f95b3ce9f3.png)

Implements CURA-8868.