### PR TITLE
[CURA-8852] Revert "Don't re-apply Support Z Offset for support roof"

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -141,6 +141,9 @@ void TreeSupport::drawCircles(SliceDataStorage& storage, const std::vector<std::
         }
         support_layer = support_layer.unionPolygons();
         roof_layer = roof_layer.unionPolygons();
+        const size_t z_collision_layer = static_cast<size_t>(std::max(0, static_cast<int>(layer_nr) - static_cast<int>(z_distance_bottom_layers) + 1)); //Layer to test against to create a Z-distance.
+        support_layer = support_layer.difference(volumes_.getCollision(0, z_collision_layer)); //Subtract the model itself (sample 0 is with 0 diameter but proper X/Y offset).
+        roof_layer = roof_layer.difference(volumes_.getCollision(branch_radius, z_collision_layer));
         support_layer = support_layer.difference(roof_layer);
         //We smooth this support as much as possible without altering single circles. So we remove any line less than the side length of those circles.
         const double diameter_angle_scale_factor_this_layer = static_cast<double>(storage.support.supportLayers.size() - layer_nr - tip_layers) * diameter_angle_scale_factor; //Maximum scale factor.


### PR DESCRIPTION
Reverts the commit that's causing Tree Support to go through the model. Seems like this commit was meant as an extra clean-up after CURA-8635, so reverting it shouldn't damage the existing solution as far as I can see.

This reverts commit 62a61544f4067c3824dcb16c07effb2effd74c3f.

