### PR TITLE
Mb fix spiralize+support

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2629,6 +2629,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
     constexpr bool use_endpieces = true;
     constexpr coord_t pocket_size = 0;
     constexpr bool connect_polygons = false; // polygons are too distant to connect for sparse support
+    bool need_travel_to_end_of_last_spiral = true;
 
     //Print the thicker infill lines first. (double or more layer thickness, infill combined with previous layers)
     for(const PathOrderOptimizer<const SupportInfillPart*>::Path& path : island_order_optimizer.paths)
@@ -2679,6 +2680,27 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                                    wall_count, infill_origin, support_connect_zigzags,
                                    use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
                 infill_comp.generate(wall_toolpaths, support_polygons, support_lines, infill_extruder.settings, storage.support.cross_fill_provider);
+            }
+
+            if (need_travel_to_end_of_last_spiral && infill_extruder.settings.get<bool>("magic_spiralize"))
+            {
+                if ((!wall_toolpaths.empty() || !support_polygons.empty() || !support_lines.empty()))
+                {
+                    int layer_nr = gcode_layer.getLayerNr();
+                    if(layer_nr > (int)infill_extruder.settings.get<size_t>("bottom_layers"))
+                    {
+                        // bit of subtlety here... support is being used on a spiralized model and to ensure the travel move from the end of the last spiral
+                        // to the start of the support does not go through the model we have to tell the slicer what the current location of the nozzle is
+                        // by adding a travel move to the end vertex of the last spiral. Of course, if the slicer could track the final location on the previous
+                        // layer then this wouldn't be necessary but that's not done due to the multi-threading.
+                        const Polygons* last_wall_outline = storage.spiralize_wall_outlines[layer_nr - 1];
+                        if (last_wall_outline != nullptr)
+                        {
+                            gcode_layer.addTravel((*last_wall_outline)[0][storage.spiralize_seam_vertex_indices[layer_nr - 1]]);
+                            need_travel_to_end_of_last_spiral = false;
+                        }
+                    }
+                }
             }
 
             setExtruder_addPrime(storage, gcode_layer, extruder_nr); // only switch extruder if we're sure we're going to switch

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1332,7 +1332,9 @@ void LayerPlan::spiralizeWallSlice(const GCodePathConfig& config, ConstPolygonRe
 
     // once we are into the spiral we always start at the end point of the last layer (if any)
     const Point origin = (last_seam_vertex_idx >= 0 && !is_bottom_layer) ? last_wall[last_seam_vertex_idx] : wall[seam_vertex_idx];
-    addTravel_simple(origin);
+    // NOTE: this used to use addTravel_simple() but if support is being generated then combed travel is required to avoid
+    // the nozzle crossing the model on its return from printing the support.
+    addTravel(origin);
 
     if (!smooth_contours && last_seam_vertex_idx >= 0) {
         // when not smoothing, we get to the (unchanged) outline for this layer as quickly as possible so that the remainder of the


### PR DESCRIPTION
This PR fixes the issue with travel moves being routed straight through a spiralized model when support is being generated. It is discussed in https://github.com/Ultimaker/Cura/issues/11370. A similar fix has been tested using the 4.13.1 release and the OP confirms that it solves the problem.

In essence, this PR works around the deficiency in the multi-threaded CuraEngine that at the start of each layer, the slicer doesn't know the current location of the nozzle and, therefore, it can't sensibly generate combed travel to the start of the support.

Obviously using spiralization and support together is an unusual combination but if someone wants to use it, then it may as well work nicely rather than producing even uglier results.