### PR TITLE
Raft Middle Layers

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -854,7 +854,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
     for (LayerIndex raft_surface_layer = 1; static_cast<size_t>(raft_surface_layer) <= num_surface_layers; raft_surface_layer++)
     { // raft surface layers
-        const LayerIndex layer_nr = initial_raft_layer_nr + 1 + num_interface_layers + raft_surface_layer - 1;
+        const LayerIndex layer_nr = initial_raft_layer_nr + 1 + num_interface_layers + raft_surface_layer - 1; // +1: 1 base layer
         z += surface_layer_height;
 
         std::vector<FanSpeedLayerTimeSettings> fan_speed_layer_time_settings_per_extruder_raft_surface = fan_speed_layer_time_settings_per_extruder; // copy so that we change only the local copy

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "clipper.hpp"
@@ -53,7 +53,7 @@ coord_t Raft::getTotalThickness()
 {
     const ExtruderTrain& train = Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("adhesion_extruder_nr");
     return train.settings.get<coord_t>("raft_base_thickness")
-        + train.settings.get<coord_t>("raft_interface_thickness")
+        + train.settings.get<size_t>("raft_interface_layers") * train.settings.get<coord_t>("raft_interface_thickness")
         + train.settings.get<size_t>("raft_surface_layers") * train.settings.get<coord_t>("raft_surface_thickness");
 }
 
@@ -99,7 +99,7 @@ size_t Raft::getTotalExtraLayers()
     {
         return 0;
     }
-    return 2 + train.settings.get<size_t>("raft_surface_layers") + getFillerLayerCount();
+    return 1 + train.settings.get<size_t>("raft_interface_layers") + train.settings.get<size_t>("raft_surface_layers") + getFillerLayerCount();
 }
 
 

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -388,8 +388,12 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed() const
     else if(adhesion_type == EPlatformAdhesion::RAFT)
     {
         ret[mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr] = true;
-        ret[mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr] = true;
-        const size_t num_surface_layers = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr").settings.get<size_t>("raft_surface_layers");
+        const size_t num_interface_layers = mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").settings.get<size_t>("raft_interface_layers");
+        if(num_interface_layers > 0)
+        {
+            ret[mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr] = true;
+        }
+        const size_t num_surface_layers = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").settings.get<size_t>("raft_surface_layers");
         if(num_surface_layers > 0)
         {
             ret[mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").extruder_nr] = true;


### PR DESCRIPTION
This adds a setting to change the number of middle layers to print in the raft. You can then print almost any number of middle layers (up to integer overflow range).

This functionality is added because if the raft surface can be printed with a different extruder to create a proper separation layer, you might still want to determine the thickness of the rest of the raft to maintain a proper rigidity. The 2 remaining layers aren't always enough.

![image](https://user-images.githubusercontent.com/2448634/152369592-87d0152f-6697-4ba2-b5b4-d8b895f90463.png)

This depends on a pull request in the front-end that adds the setting, updates the used extruders and the build volume. Link pending.

Contributes to issue CURA-8915.