### PR TITLE
print support walls, even if there are no support infill areas

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2644,6 +2644,18 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
         // process sub-areas in this support infill area with different densities
         if ((default_support_line_distance <= 0 && support_structure != ESupportStructure::TREE) || part.infill_area_per_combine_per_density.empty())
         {
+            if (! part.wall_toolpaths.empty())
+            {
+                const BinJunctions bins = InsetOrderOptimizer::variableWidthPathToBinJunctions(part.wall_toolpaths);
+                for (const PathJunctions& paths : bins)
+                {
+                    for (const LineJunctions& line : paths)
+                    {
+                        gcode_layer.addInfillWall(line, gcode_layer.configs_storage.support_infill_config[0], false);
+                    }
+                }
+                added_something = true;
+            }
             continue;
         }
 


### PR DESCRIPTION
Hi there, we sometimes want to print supports with several walls, and this is currently broken in master.  If a support layer consists of only walls, no infill, then it does not get printed:

![Screenshot from 2022-02-10 12-31-49](https://user-images.githubusercontent.com/46073098/153483578-459ec3c3-1a56-42eb-ad0b-75531cca5682.png)

This PR fixes the issue:

![Screenshot from 2022-02-10 12-33-12](https://user-images.githubusercontent.com/46073098/153483569-61dd88d0-c179-4f6f-a91c-a9ffea3acb72.png)

I'm not sure this fix is the best way to resolve the issue and I welcome feedback.