### PR TITLE
swap M104 and M109

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1706,11 +1706,6 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
             const ExtruderTrain& extruder = Application::getInstance().current_slice->scene.extruders[extruder_nr];
 
-            { // require printing temperature to be met
-                constexpr bool wait = true;
-                gcode.writeTemperatureCommand(extruder_nr, extruder_plan.required_start_temperature, wait);
-            }
-
             if (extruder_plan.prev_extruder_standby_temp)
             { // turn off previous extruder
                 constexpr bool wait = false;
@@ -1721,6 +1716,11 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                     prev_extruder_temp = 0; // TODO ? should there be a setting for extruder_off_temperature ?
                 }
                 gcode.writeTemperatureCommand(prev_extruder, prev_extruder_temp, wait);
+            }
+
+            { // require printing temperature to be met
+                constexpr bool wait = true;
+                gcode.writeTemperatureCommand(extruder_nr, extruder_plan.required_start_temperature, wait);
             }
 
             const double extra_prime_amount = extruder.settings.get<bool>("retraction_enable") ? extruder.settings.get<double>("switch_extruder_extra_prime_amount") : 0;


### PR DESCRIPTION
The idle nozzle can start cooling down, while printing nozzle is heating up. This saves a few seconds of oozing, which is significant for materials like TPU. PP-122