### PR TITLE
Fix missing infill with small parts

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1712,8 +1712,8 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
 
         constexpr size_t wall_line_count_here = 0; // Wall toolpaths were generated in generateGradualInfill for the sparsest density, denser parts don't have walls by default
         constexpr coord_t overlap = 0; // overlap is already applied for the sparsest density in the generateGradualInfill
-        wall_tool_paths.emplace_back(part.infill_wall_toolpaths);
 
+        wall_tool_paths.emplace_back();
         Infill infill_comp(pattern, zig_zaggify_infill, connect_polygons, in_outline, infill_line_width,
                            infill_line_distance_here, overlap, infill_multiplier, infill_angle, gcode_layer.z,
                            infill_shift, max_resolution, max_deviation, wall_line_count_here, infill_origin,
@@ -1731,6 +1731,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
         infill_polygons.add(infill_polygons_here);
     }
 
+    wall_tool_paths.emplace_back(part.infill_wall_toolpaths); //The extra infill walls were generated separately. Add these too.
     const bool walls_generated = std::any_of(wall_tool_paths.cbegin(), wall_tool_paths.cend(), [](const VariableWidthPaths& tp){ return !tp.empty(); });
     if(!infill_lines.empty() || !infill_polygons.empty() || walls_generated)
     {

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -226,7 +226,7 @@ void AreaSupport::generateGradualSupport(SliceDataStorage& storage)
                         break;
                     }
 
-                    // compute intersections with relevent upper parts
+                    // compute intersections with relevant upper parts
                     const std::vector<SupportInfillPart> upper_infill_parts = storage.support.supportLayers[upper_layer_idx].support_infill_parts;
                     Polygons relevant_upper_polygons;
                     for (unsigned int upper_part_idx = 0; upper_part_idx < upper_infill_parts.size(); ++upper_part_idx)


### PR DESCRIPTION
This fixes an issue where infill was missing if the extra infill walls were so wide that no actual infill pattern was remaining, in a part.

![image](https://user-images.githubusercontent.com/2448634/153910718-1e28948e-ec3d-4420-a8fc-62aa66a8c03a.png)

The same issue exists for support. That is also fixed.

The issue in both cases was that the extra infill walls were added in the loop that loops over the various infill densities for gradual infill. However if there is no infill pattern due to the infill walls pushing away the pattern, the array of infill densities was (correctly) left empty. The fix is therefore to print the extra infill walls outside of that loop over infill densities. The walls should not be dependent on the infill density, so this makes sense.

In the case of infill, this is simple since all of the lines are coalesced in a single vector (or rather, three vectors: One for lines, one for polygons and one for paths). In the case of support this is not so simple (lest we refactor that) so there we have to print the walls first and then proceed with the pattern.

Fixes CURA-8067. Fixes Ultimaker/Cura#11210.