### PR TITLE
Replace abs() with std::abs()

### DIFF
--- a/src/ConicalOverhang.cpp
+++ b/src/ConicalOverhang.cpp
@@ -49,7 +49,7 @@ namespace cura {
 						{
 							Polygons holePoly;
 							holePoly.add(layerParts[part][hole_nr]);
-							if (maxHoleArea > 0.0 && INT2MM(INT2MM(fabs(holePoly.area()))) < maxHoleArea)
+							if (maxHoleArea > 0.0 && INT2MM2(std::abs(holePoly.area())) < maxHoleArea)
 							{
 								Polygons holeWithAbove = holePoly.intersection(above);
 								if (!holeWithAbove.empty())

--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -480,14 +480,14 @@ protected:
                 }
                 break;
             case EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_ANY:
-                score = score_distance - fabs(corner_angle) * corner_shift; //Still give sharper corners more advantage.
+                score = score_distance - std::abs(corner_angle) * corner_shift; //Still give sharper corners more advantage.
                 break;
             case EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE:
                 score = score_distance; //No advantage for sharper corners.
                 break;
             case EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_WEIGHTED: //Give sharper corners some advantage, but sharper concave corners even more.
                 {
-                    float score_corner = fabs(corner_angle) * corner_shift;
+                    float score_corner = std::abs(corner_angle) * corner_shift;
                     if(corner_angle > 0) //Concave corner.
                     {
                         score_corner *= 2;

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -166,7 +166,7 @@ int bridgeAngle(const Settings& settings, const Polygons& skin_outline, const Sl
         //Skip internal holes
         if (!islands[n].orientation())
             continue;
-        double area = fabs(islands[n].area());
+        double area = std::abs(islands[n].area());
         if (area > area1)
         {
             if (area1 > area2)

--- a/src/timeEstimate.cpp
+++ b/src/timeEstimate.cpp
@@ -168,7 +168,7 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
     for(size_t n = 0; n < NUM_AXIS; n++)
     {
         block.delta[n] = newPos[n] - currentPosition[n];
-        block.absDelta[n] = fabs(block.delta[n]);
+        block.absDelta[n] = std::abs(block.delta[n]);
         block.maxTravel = std::max(block.maxTravel, block.absDelta[n]);
     }
     if (block.maxTravel <= 0)
@@ -192,7 +192,7 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
     for(size_t n = 0; n < NUM_AXIS; n++)
     {
         current_feedrate[n] = (block.delta[n] * feedrate) / block.distance;
-        current_abs_feedrate[n] = fabs(current_feedrate[n]);
+        current_abs_feedrate[n] = std::abs(current_feedrate[n]);
         if (current_abs_feedrate[n] > max_feedrate[n])
         {
             feedrate_factor = std::min(feedrate_factor, Ratio(max_feedrate[n] / current_abs_feedrate[n]));
@@ -239,14 +239,16 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
         if (xy_jerk > max_xy_jerk)
         {
             vmax_junction_factor = Ratio(max_xy_jerk / xy_jerk);
-        } 
-        if (fabs(current_feedrate[Z_AXIS] - previous_feedrate[Z_AXIS]) > max_z_jerk)
+        }
+        const double z_jerk = std::abs(current_feedrate[Z_AXIS] - previous_feedrate[Z_AXIS]);
+        if (z_jerk > max_z_jerk)
         {
-            vmax_junction_factor = std::min(vmax_junction_factor, Ratio(max_z_jerk / fabs(current_feedrate[Z_AXIS] - previous_feedrate[Z_AXIS])));
-        } 
-        if (fabs(current_feedrate[E_AXIS] - previous_feedrate[E_AXIS]) > max_e_jerk)
+            vmax_junction_factor = std::min(vmax_junction_factor, Ratio(max_z_jerk / z_jerk));
+        }
+        const double e_jerk = std::abs(current_feedrate[E_AXIS] - previous_feedrate[E_AXIS]);
+        if (e_jerk > max_e_jerk)
         {
-            vmax_junction_factor = std::min(vmax_junction_factor, Ratio(max_e_jerk / fabs(current_feedrate[E_AXIS] - previous_feedrate[E_AXIS])));
+            vmax_junction_factor = std::min(vmax_junction_factor, Ratio(max_e_jerk / e_jerk));
         }
         vmax_junction = std::min(previous_nominal_feedrate, vmax_junction * vmax_junction_factor); // Limit speed to max previous speed
     }

--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -220,13 +220,13 @@ coord_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A,
      * */
     const coord_t ab_length = vSize(B - A);
     const coord_t bc_length = vSize(C - B);
-    const coord_t width_diff = llabs(B.w - C.w);
+    const coord_t width_diff = std::abs(B.w - C.w);
     if (width_diff > 1)
     {
         // Adjust the width only if there is a difference, or else the rounding errors may produce the wrong
         // weighted average value.
         weighted_average_width = (ab_length * B.w + bc_length * C.w) / vSize(C - A);
-        return llabs(B.w - weighted_average_width) * ab_length + llabs(C.w - weighted_average_width) * bc_length;
+        return std::abs(B.w - weighted_average_width) * ab_length + std::abs(C.w - weighted_average_width) * bc_length;
     }
     else
     {

--- a/src/utils/LinearAlg2D.cpp
+++ b/src/utils/LinearAlg2D.cpp
@@ -208,7 +208,7 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
         return ap_size2;
     }
     const coord_t dott = dot(vab, vap);
-    if (dott != 0 && abs(dott) > SQRT_LLONG_MAX_FLOOR)
+    if (dott != 0 && std::abs(dott) > SQRT_LLONG_MAX_FLOOR)
     { // dott * dott will overflow so calculate px_size2 via its square root
         coord_t px_size = LinearAlg2D::getDistFromLine(p, a, b);
         if (px_size <= SQRT_LLONG_MAX_FLOOR)
@@ -285,7 +285,7 @@ coord_t LinearAlg2D::getDistFromLine(const Point& p, const Point& a, const Point
     {
         return vSize(vap);
     }
-    const coord_t area_times_two = abs((p.X - b.X) * (p.Y - a.Y) + (a.X - p.X) * (p.Y - b.Y)); // Shoelace formula, factored
+    const coord_t area_times_two = std::abs((p.X - b.X) * (p.Y - a.Y) + (a.X - p.X) * (p.Y - b.Y)); // Shoelace formula, factored
     const coord_t px_size = area_times_two / ab_size;
     return px_size;
 }

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -684,7 +684,7 @@ void Polygons::removeSmallAreas(const double min_area_size, const bool remove_ho
         for(auto it = paths.begin(); it < new_end; it++)
         {
             // All polygons smaller than target are removed by replacing them with a polygon from the back of the vector
-            if(fabs(INT2MM2(ClipperLib::Area(*it))) < min_area_size)
+            if(std::abs(INT2MM2(ClipperLib::Area(*it))) < min_area_size)
             {
                 new_end--;
                 *it = std::move(*new_end);
@@ -698,7 +698,7 @@ void Polygons::removeSmallAreas(const double min_area_size, const bool remove_ho
         std::vector<PolygonRef> small_holes;
         for(auto it = paths.begin(); it < new_end; it++) {
             double area = INT2MM2(ClipperLib::Area(*it));
-            if (fabs(area) < min_area_size)
+            if (std::abs(area) < min_area_size)
             {
                 if(area >= 0)
                 {


### PR DESCRIPTION
Some places in the code call the C function `abs`. Unlike the C++ function `std::abs()` which has overloads, C's `abs` cast its argument to `int`, risking overflows.

For example, [this block is dead code](https://github.com/Ultimaker/CuraEngine/blob/385e2ca6ce62af2b4b927d58352f378636418291/src/utils/LinearAlg2D.cpp#L211-L224) since `abs(x) > SQRT_LLONG_MAX_FLOOR` is always false.

The second commit, less important, changes `fabs` and `llabs` to `std::abs`. This is for consistency, but also avoid casting to floats when the argument is a double, like with `PolygonRef::area()`'s return value.

Other mathematical function like cos, sqrt, etc, operate on a double precision float argument, so it is less problematic to use the C variant.