### PR TITLE
writeInt2mm: prevents OOB

### DIFF
--- a/include/utils/string.h
+++ b/include/utils/string.h
@@ -53,7 +53,7 @@ static inline void writeInt2mm(const int32_t coord, std::ostream& ss)
 #endif // DEBUG
     int end_pos = char_count; // the first character not to write any more
     int trailing_zeros = 1;
-    while (trailing_zeros < 4 && buffer[char_count - trailing_zeros] == '0')
+    while (trailing_zeros < 4 && char_count >= trailing_zeros && buffer[char_count - trailing_zeros] == '0')
     {
         trailing_zeros++;
     }


### PR DESCRIPTION
In some case `writeInt2mm` reads a char before the start of the buffer. This is mostly harmless as the buffer is on the stack far from protected memory but might introduce unpredictable behavior depending on the compiler.
This commits adds a check.

Separately, I wrote a [new from scratch implementation of stream writers](https://github.com/Piezoid/CuraEngine/blob/2911cbff9e7d124fbe10f0250dd538b35da88913/src/utils/string.h) that enables changing the fixed point precision at compile time. It also speeds up the gcode writer quite a bit, which is the bottleneck on many core machines.
It is still a work in progress, but if you are interested I could make a PR once edge cases are resolved.