### PR TITLE
Guard against signed overflows in IntPoint.h related code

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2205,7 +2205,7 @@ std::optional<Point> FffGcodeWriter::getSeamAvoidingLocation(const Polygons& fil
         return std::optional<Point>();
     }
     // now go to whichever of those vertices that is closest to where we are now
-    if (vSize2(pa.p() - last_position) < vSize2(pb.p() - last_position))
+    if (compareVSize2(pa.p(), pb.p(), last_position))
     {
         return std::optional<Point>(std::in_place, pa.p());
     }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -740,7 +740,7 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& se
                 Point b0 = bridge[0];
                 Point b1 = bridge[1];
 
-                if (vSize2f(cur_point - b1) < vSize2f(cur_point - b0))
+                if (compareVSize2(b0, b1, cur_point) > 0)
                 {
                     // swap vertex order
                     b0 = bridge[1];
@@ -882,7 +882,7 @@ void LayerPlan::addWall(const ExtrusionLine& wall, int start_idx, const Settings
                         Point b0 = bridge[0];
                         Point b1 = bridge[1];
 
-                        if (vSize2f(p0.p - b1) < vSize2f(p0.p - b0))
+                        if (compareVSize2(b0, b1, p0.p) > 0)
                         {
                             // swap vertex order
                             b0 = bridge[1];

--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -436,7 +436,7 @@ protected:
             ? seam_config.pos
             : Point(0, std::sqrt(std::numeric_limits<coord_t>::max())); //Use sqrt, so the squared size can be used when comparing distances.
         const size_t start_from_pos = std::min_element(simple_poly.begin(), simple_poly.end(), [focus_fixed_point](const Point& a, const Point& b) {
-            return vSize2(a - focus_fixed_point) < vSize2(b - focus_fixed_point);
+            return compareVSize2(a, b, focus_fixed_point) < 0;
         }) - simple_poly.begin();
         const size_t end_before_pos = simple_poly.size() + start_from_pos;
 

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -118,7 +118,8 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
             //Two options to start, both perpendicular to the ironing lines. Which is closer?
             const Point front_side = PolygonUtils::findNearestVert(center + far_away, ironed_areas).p();
             const Point back_side = PolygonUtils::findNearestVert(center - far_away, ironed_areas).p();
-            if (vSize2(layer.getLastPlannedPositionOrStartingPosition() - front_side) < vSize2(layer.getLastPlannedPositionOrStartingPosition() - back_side))
+
+            if (compareVSize2(front_side, back_side, layer.getLastPlannedPositionOrStartingPosition()) < 0)
             {
                 layer.addTravel(front_side);
             }

--- a/src/utils/IntPoint.h
+++ b/src/utils/IntPoint.h
@@ -142,6 +142,13 @@ INLINE double vSizeMM(const Point& p0)
     return sqrt(fx*fx+fy*fy);
 }
 
+//! \returns vSize2(a - c) - vSize2(b - c)
+INLINE coord_t compareVSize2(const Point& a, const Point& b, const Point& c)
+{
+    Point ba = a - b;
+    return vSize2(a) + vSize2(b) - 2 * (c.X * ba.X + c.Y * + ba.Y);
+}
+
 INLINE Point normal(const Point& p0, coord_t len)
 {
     coord_t _len = vSize(p0);

--- a/src/utils/LinearAlg2D.cpp
+++ b/src/utils/LinearAlg2D.cpp
@@ -191,8 +191,6 @@ bool LinearAlg2D::lineSegmentsCollide(const Point& a_from_transformed, const Poi
 
 coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Point& b)
 {
-    constexpr coord_t SQRT_LLONG_MAX_FLOOR = 3037000499;
-
     //  x.......a------------b
     //  :
     //  :
@@ -208,10 +206,15 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
         return ap_size2;
     }
     const coord_t dott = dot(vab, vap);
-    if (dott != 0 && std::abs(dott) > SQRT_LLONG_MAX_FLOOR)
+    if (!squareOverflow(dott))
+    {
+        const coord_t ax_size2 = dott * dott / ab_size2;
+        px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
+    }
+    else
     { // dott * dott will overflow so calculate px_size2 via its square root
         coord_t px_size = LinearAlg2D::getDistFromLine(p, a, b);
-        if (px_size <= SQRT_LLONG_MAX_FLOOR)
+        if (!squareOverflow(px_size))
         {
             // Due to rounding and conversion errors, this multiplication may not be the exact value that would be
             // produced via the dott product, but it should still be close enough
@@ -219,13 +222,8 @@ coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Poin
         }
         else
         {
-            px_size2 = std::numeric_limits<long long>::max();
+            px_size2 = std::numeric_limits<coord_t>::max();
         }
-    }
-    else
-    {
-        const coord_t ax_size2 = dott * dott / ab_size2;
-        px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
     }
     return px_size2;
 }

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -857,7 +857,7 @@ void ConstPolygonRef::smooth_outward_step(const Point p1, const int64_t shortcut
     const bool backward_has_converged = backward_is_blocked || backward_is_too_far;
     const Point p0 = p0_it.p();
     const Point p2 = p2_it.p();
-    bool walk_forward = !forward_has_converged && (backward_has_converged || (vSize2(p2 - p1) < vSize2(p0 - p1))); // whether to walk along the p1-p2 direction or in the p1-p0 direction
+    bool walk_forward = !forward_has_converged && (backward_has_converged || (compareVSize2(p2, p0, p1) < 0)); // whether to walk along the p1-p2 direction or in the p1-p0 direction
 
     if (walk_forward)
     {

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -217,7 +217,7 @@ Point PolygonUtils::moveInsideDiagonally(ClosestPolygonPoint point_on_boundary, 
     ConstPolygonRef poly = **point_on_boundary.poly;
     Point p0 = poly[point_on_boundary.point_idx];
     Point p1 = poly[(point_on_boundary.point_idx + 1) % poly.size()];
-    if (vSize2(p0 - point_on_boundary.location) < vSize2(p1 - point_on_boundary.location))
+    if (compareVSize2(p0, p1, point_on_boundary.location) < 0)
     {
         return point_on_boundary.location + normal(getVertexInwardNormal(poly, point_on_boundary.point_idx), inset);
     }
@@ -754,7 +754,7 @@ ClosestPolygonPoint PolygonUtils::findNearestClosest(Point from, ConstPolygonRef
     }
     ClosestPolygonPoint back = findNearestClosest(from, polygon, start_idx, -1);
     assert(back.isValid());
-    if (vSize2(forth.location - from) < vSize2(back.location - from))
+    if (compareVSize2(forth.location, back.location, from) < 0)
     {
         return forth;
     }


### PR DESCRIPTION
This work was done while investigating overflows when increasing the precision of fixed point `coord_t` coordinates. However some of the overflows happen with the normal micro-metric precision while slicing a Benchy on standard fdmprofile.

- First commit is already present in #1583 ,
- Second commit adds asserts, checking for overflows in `vSize2`. A `saturatingVSize2` is also added,
- Third commit reorders the short-circuiting disjunction in `PolygonRef::_simplify` such that, if the lines intersection is far away, `getDist2FromLine` is not called,
- Last one introduces the function `compareVSize2(a, b, c)` which returns `vSize2(a - c) - vSize2(b - c)` with less risks of overflows. One place where such overflow happens is [here in `findStartLocation`](https://github.com/Ultimaker/CuraEngine/blob/master/src/PathOrderOptimizer.h#L481).

I haven't investigated in depth potential changes of behavior. Since the overflows have gone unnoticed, it is likely that the code "do the right thing" in the presence of overflow. But it is not impossible that fixing them introduces other bugs...

There is other signed overflow cases not addressed by this PR. For example, the triangle [`height_2` computation in `PolygonRef::_simplify`](https://github.com/Ultimaker/CuraEngine/blob/385e2ca6ce62af2b4b927d58352f378636418291/src/utils/polygon.cpp#L532) sometimes overflows and produces a negative value (on most CPUs). A potential solution is to implement proper fixed point multiplication. However with a decimal factor, that would be slower than using floating point ([like so](https://github.com/Piezoid/CuraEngine/commit/d6e740115d4e01d63614addc26a0b921d68937bd#diff-80b19785c1dcfa41e7d311f9ecb5a3470cc66c58e16222613c73c730fd20210aR450-R542)). The overhead would likely be minimal, as the FPU ports were mostly unused in that code.

These issues were investigated using Clang's UndefinedBehaviorSanitizer (`-fsanitize=undefined,implicit-conversion,signed-integer-overflow`). In order to keep the reports minimal I've made [other changes](https://github.com/Piezoid/CuraEngine/commits/fix_ub) that I deemed too pedantic and of little importance to be included in this PR. 