### PR TITLE
Add support for per-object retraction settings.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -80,9 +80,7 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
 
     setConfigFanSpeedLayerTime();
 
-    setConfigRetraction(storage);
-
-    setConfigWipe(storage);
+    setConfigRetractionAndWipe(storage);
 
     if (scene.current_mesh_group == scene.mesh_groups.begin())
     {
@@ -176,7 +174,7 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
 
 
     constexpr bool force = true;
-    gcode.writeRetraction(storage.retraction_config_per_extruder[gcode.getExtruderNr()], force); // retract after finishing each meshgroup
+    gcode.writeRetraction(storage.retraction_wipe_config_per_extruder[gcode.getExtruderNr()].retraction_config, force); // retract after finishing each meshgroup
 }
 
 unsigned int FffGcodeWriter::findSpiralizedLayerSeamVertexIndex(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const int layer_nr, const int last_layer_nr)
@@ -307,63 +305,63 @@ void FffGcodeWriter::setConfigFanSpeedLayerTime()
     }
 }
 
-void FffGcodeWriter::setConfigRetraction(SliceDataStorage& storage) 
-{
-    Scene& scene = Application::getInstance().current_slice->scene;
-    for (size_t extruder_index = 0; extruder_index < scene.extruders.size(); extruder_index++)
-    {
-        ExtruderTrain& train = scene.extruders[extruder_index];
-        RetractionConfig& retraction_config = storage.retraction_config_per_extruder[extruder_index];
-        retraction_config.distance = (train.settings.get<bool>("retraction_enable")) ? train.settings.get<double>("retraction_amount") : 0; //Retraction distance in mm.
-        retraction_config.prime_volume = train.settings.get<double>("retraction_extra_prime_amount"); //Extra prime volume in mm^3.
-        retraction_config.speed = train.settings.get<Velocity>("retraction_retract_speed");
-        retraction_config.primeSpeed = train.settings.get<Velocity>("retraction_prime_speed");
-        retraction_config.zHop = train.settings.get<coord_t>("retraction_hop");
-        retraction_config.retraction_min_travel_distance = train.settings.get<coord_t>("retraction_min_travel");
-        retraction_config.retraction_extrusion_window = train.settings.get<double>("retraction_extrusion_window"); //Window to count retractions in in mm of extruded filament.
-        retraction_config.retraction_count_max = train.settings.get<size_t>("retraction_count_max");
+static void retractionAndWipeConfigFromSettings(const Settings& settings, RetractionAndWipeConfig* config) {
+    RetractionConfig& retraction_config = config->retraction_config;
+    retraction_config.distance = (settings.get<bool>("retraction_enable")) ? settings.get<double>("retraction_amount") : 0; //Retraction distance in mm.
+    retraction_config.prime_volume = settings.get<double>("retraction_extra_prime_amount"); //Extra prime volume in mm^3.
+    retraction_config.speed = settings.get<Velocity>("retraction_retract_speed");
+    retraction_config.primeSpeed = settings.get<Velocity>("retraction_prime_speed");
+    retraction_config.zHop = settings.get<coord_t>("retraction_hop");
+    retraction_config.retraction_min_travel_distance = settings.get<coord_t>("retraction_min_travel");
+    retraction_config.retraction_extrusion_window = settings.get<double>("retraction_extrusion_window"); //Window to count retractions in in mm of extruded filament.
+    retraction_config.retraction_count_max = settings.get<size_t>("retraction_count_max");
 
-        RetractionConfig& switch_retraction_config = storage.extruder_switch_retraction_config_per_extruder[extruder_index];
-        switch_retraction_config.distance = train.settings.get<double>("switch_extruder_retraction_amount"); //Retraction distance in mm.
-        switch_retraction_config.prime_volume = 0.0;
-        switch_retraction_config.speed = train.settings.get<Velocity>("switch_extruder_retraction_speed");
-        switch_retraction_config.primeSpeed = train.settings.get<Velocity>("switch_extruder_prime_speed");
-        switch_retraction_config.zHop = train.settings.get<coord_t>("retraction_hop_after_extruder_switch_height");
-        switch_retraction_config.retraction_min_travel_distance = 0; // no limitation on travel distance for an extruder switch retract
-        switch_retraction_config.retraction_extrusion_window = 99999.9; // so that extruder switch retractions won't affect the retraction buffer (extruded_volume_at_previous_n_retractions)
-        switch_retraction_config.retraction_count_max = 9999999; // extruder switch retraction is never limited
-    }
+    config->retraction_hop_after_extruder_switch = settings.get<bool>("retraction_hop_after_extruder_switch");
+    config->switch_extruder_extra_prime_amount = settings.get<double>("switch_extruder_extra_prime_amount");
+    RetractionConfig& switch_retraction_config = config->extruder_switch_retraction_config;
+    switch_retraction_config.distance = settings.get<double>("switch_extruder_retraction_amount"); //Retraction distance in mm.
+    switch_retraction_config.prime_volume = 0.0;
+    switch_retraction_config.speed = settings.get<Velocity>("switch_extruder_retraction_speed");
+    switch_retraction_config.primeSpeed = settings.get<Velocity>("switch_extruder_prime_speed");
+    switch_retraction_config.zHop = settings.get<coord_t>("retraction_hop_after_extruder_switch_height");
+    switch_retraction_config.retraction_min_travel_distance = 0; // no limitation on travel distance for an extruder switch retract
+    switch_retraction_config.retraction_extrusion_window = 99999.9; // so that extruder switch retractions won't affect the retraction buffer (extruded_volume_at_previous_n_retractions)
+    switch_retraction_config.retraction_count_max = 9999999; // extruder switch retraction is never limited
+
+    WipeScriptConfig& wipe_config = config->wipe_config;
+
+    wipe_config.retraction_enable = settings.get<bool>("wipe_retraction_enable");
+    wipe_config.retraction_config.distance = settings.get<double>("wipe_retraction_amount");
+    wipe_config.retraction_config.speed = settings.get<Velocity>("wipe_retraction_retract_speed");
+    wipe_config.retraction_config.primeSpeed = settings.get<Velocity>("wipe_retraction_prime_speed");
+    wipe_config.retraction_config.prime_volume = settings.get<double>("wipe_retraction_extra_prime_amount");
+    wipe_config.retraction_config.retraction_min_travel_distance = 0;
+    wipe_config.retraction_config.retraction_extrusion_window = std::numeric_limits<double>::max();
+    wipe_config.retraction_config.retraction_count_max = std::numeric_limits<size_t>::max();
+
+    wipe_config.pause = settings.get<Duration>("wipe_pause");
+
+    wipe_config.hop_enable = settings.get<bool>("wipe_hop_enable");
+    wipe_config.hop_amount = settings.get<coord_t>("wipe_hop_amount");
+    wipe_config.hop_speed = settings.get<Velocity>("wipe_hop_speed");
+
+    wipe_config.brush_pos_x = settings.get<coord_t>("wipe_brush_pos_x");
+    wipe_config.repeat_count = settings.get<size_t>("wipe_repeat_count");
+    wipe_config.move_distance = settings.get<coord_t>("wipe_move_distance");
+    wipe_config.move_speed = settings.get<Velocity>("speed_travel");
+    wipe_config.max_extrusion_mm3 = settings.get<double>("max_extrusion_before_wipe");
+    wipe_config.clean_between_layers = settings.get<bool>("clean_between_layers");
 }
-
-void FffGcodeWriter::setConfigWipe(SliceDataStorage& storage)
+void FffGcodeWriter::setConfigRetractionAndWipe(SliceDataStorage& storage)
 {
     Scene& scene = Application::getInstance().current_slice->scene;
     for (size_t extruder_index = 0; extruder_index < scene.extruders.size(); extruder_index++)
     {
         ExtruderTrain& train = scene.extruders[extruder_index];
-        WipeScriptConfig& wipe_config = storage.wipe_config_per_extruder[extruder_index];
-
-        wipe_config.retraction_enable = train.settings.get<bool>("wipe_retraction_enable");
-        wipe_config.retraction_config.distance = train.settings.get<double>("wipe_retraction_amount");
-        wipe_config.retraction_config.speed = train.settings.get<Velocity>("wipe_retraction_retract_speed");
-        wipe_config.retraction_config.primeSpeed = train.settings.get<Velocity>("wipe_retraction_prime_speed");
-        wipe_config.retraction_config.prime_volume = train.settings.get<double>("wipe_retraction_extra_prime_amount");
-        wipe_config.retraction_config.retraction_min_travel_distance = 0;
-        wipe_config.retraction_config.retraction_extrusion_window = std::numeric_limits<double>::max();
-        wipe_config.retraction_config.retraction_count_max = std::numeric_limits<size_t>::max();
-
-        wipe_config.pause = train.settings.get<Duration>("wipe_pause");
-
-        wipe_config.hop_enable = train.settings.get<bool>("wipe_hop_enable");
-        wipe_config.hop_amount = train.settings.get<coord_t>("wipe_hop_amount");
-        wipe_config.hop_speed = train.settings.get<Velocity>("wipe_hop_speed");
-
-        wipe_config.brush_pos_x = train.settings.get<coord_t>("wipe_brush_pos_x");
-        wipe_config.repeat_count = train.settings.get<size_t>("wipe_repeat_count");
-        wipe_config.move_distance = train.settings.get<coord_t>("wipe_move_distance");
-        wipe_config.move_speed = train.settings.get<Velocity>("speed_travel");
-        wipe_config.max_extrusion_mm3 = train.settings.get<double>("max_extrusion_before_wipe");
-        wipe_config.clean_between_layers = train.settings.get<bool>("clean_between_layers");
+        retractionAndWipeConfigFromSettings(train.settings, &storage.retraction_wipe_config_per_extruder[extruder_index]);
+    }
+    for(SliceMeshStorage& mesh: storage.meshes) {
+        retractionAndWipeConfigFromSettings(mesh.settings, &mesh.retraction_wipe_config);
     }
 }
 
@@ -655,7 +653,7 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
         processInitialLayerTemperature(storage, start_extruder_nr);
         gcode.writePrimeTrain(train.settings.get<Velocity>("speed_travel"));
         extruder_prime_layer_nr[start_extruder_nr] = std::numeric_limits<int>::min(); // set to most negative number so that layer processing never primes this extruder any more.
-        const RetractionConfig& retraction_config = storage.retraction_config_per_extruder[start_extruder_nr];
+        const RetractionConfig& retraction_config = storage.retraction_wipe_config_per_extruder[start_extruder_nr].retraction_config;
         gcode.writeRetraction(retraction_config);
     }
     if (mesh_group_settings.get<bool>("relative_extrusion"))
@@ -670,7 +668,7 @@ void FffGcodeWriter::processStartingCode(const SliceDataStorage& storage, const 
             gcode.resetExtrusionValue();
 
             // retract before first travel move
-            gcode.writeRetraction(storage.retraction_config_per_extruder[start_extruder_nr]);
+            gcode.writeRetraction(storage.retraction_wipe_config_per_extruder[start_extruder_nr].retraction_config);
         }
     }
     gcode.setExtruderFanNumber(start_extruder_nr);
@@ -1391,7 +1389,7 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
         return;
     }
 
-    gcode_layer.setMesh(mesh.mesh_name);
+    gcode_layer.setMesh(&mesh);
 
     ZSeamConfig z_seam_config;
     if(mesh.isPrinted()) //"normal" meshes with walls, skin, infill, etc. get the traditional part ordering based on the z-seam settings.
@@ -1414,7 +1412,7 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
     {
         addMeshOpenPolyLinesToGCode(mesh, mesh_config, gcode_layer);
     }
-    gcode_layer.setMesh("NONMESH");
+    gcode_layer.setMesh(nullptr);
 }
 
 void FffGcodeWriter::addMeshPartToGCode(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, LayerPlan& gcode_layer) const

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -150,18 +150,11 @@ private:
     void setConfigCoasting(SliceDataStorage& storage);
 
     /*!
-     * Set the retraction config globally, per extruder and per mesh.
+     * Set the retraction and wipe config globally, per extruder and per mesh.
      * 
      * \param[out] storage The data storage to which to save the configurations
      */
-    void setConfigRetraction(SliceDataStorage& storage);
-
-    /*!
-     * Set the wipe config globally, per extruder.
-     *
-     * \param[out] storage The data storage to which to save the configurations
-     */
-    void setConfigWipe(SliceDataStorage& storage);
+    void setConfigRetractionAndWipe(SliceDataStorage& storage);
 
     /*!
      * Get the extruder with which to start the print.

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -240,7 +240,7 @@ private:
     std::vector<bool> has_prime_tower_planned_per_extruder; //!< For each extruder, whether the prime tower is planned yet or not.
     std::optional<Point> last_planned_position; //!< The last planned XY position of the print head (if known)
 
-    std::string current_mesh; //<! A unique ID for the mesh of the last planned move.
+    const SliceMeshStorage* current_mesh; //!< The mesh of the last planned move.
 
     /*!
      * Whether the skirt or brim polygons have been processed into planned paths
@@ -391,7 +391,7 @@ public:
      * Track the currently printing mesh.
      * \param mesh_id A unique ID indicating the current mesh.
      */
-    void setMesh(const std::string mesh_id);
+    void setMesh(const SliceMeshStorage* mesh_id);
 
     /*!
      * Set bridge_wall_mask.

--- a/src/WipeScriptConfig.h
+++ b/src/WipeScriptConfig.h
@@ -31,6 +31,15 @@ struct WipeScriptConfig
     bool clean_between_layers; // whether to include nozzle wipe g-code between layers
 };
 
+struct RetractionAndWipeConfig {
+    WipeScriptConfig wipe_config;
+
+    RetractionConfig retraction_config;
+    coord_t retraction_hop_after_extruder_switch;
+    double switch_extruder_extra_prime_amount;
+    RetractionConfig extruder_switch_retraction_config;
+};
+
 }//namespace cura
 
 #endif // WIPE_SCRIPT_CONFIG_H

--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -66,7 +66,7 @@ Comb::Comb(const SliceDataStorage& storage, const LayerIndex layer_nr, const Pol
 {
 }
 
-bool Comb::calc(const ExtruderTrain& train, Point start_point, Point end_point, CombPaths& comb_paths, bool _start_inside, bool _end_inside, coord_t max_comb_distance_ignored, bool &unretract_before_last_travel_move)
+bool Comb::calc(bool perform_z_hops, bool perform_z_hops_only_when_collides, Point start_point, Point end_point, CombPaths& comb_paths, bool _start_inside, bool _end_inside, coord_t max_comb_distance_ignored, bool &unretract_before_last_travel_move)
 {
     if(shorterThen(end_point - start_point, max_comb_distance_ignored))
     {
@@ -85,8 +85,6 @@ bool Comb::calc(const ExtruderTrain& train, Point start_point, Point end_point, 
     unsigned int start_part_idx =   (start_inside_poly == NO_INDEX)?    NO_INDEX : partsView_inside_optimal.getPartContaining(start_inside_poly, &start_part_boundary_poly_idx);
     unsigned int end_part_idx =     (end_inside_poly == NO_INDEX)?      NO_INDEX : partsView_inside_optimal.getPartContaining(end_inside_poly, &end_part_boundary_poly_idx);
 
-    const bool perform_z_hops = train.settings.get<bool>("retraction_hop_enabled");
-    const bool perform_z_hops_only_when_collides = train.settings.get<bool>("retraction_hop_only_when_collides");
     const bool fail_on_unavoidable_obstacles = perform_z_hops && perform_z_hops_only_when_collides;
 
     // normal combing within part using optimal comb boundary

--- a/src/pathPlanning/Comb.h
+++ b/src/pathPlanning/Comb.h
@@ -186,7 +186,8 @@ public:
      * alternated with travel paths.
      * 
      * \warning Changes the order of polygons in \ref Comb::comb_boundary_inside
-     * \param train The extruder train to calculate the comb path for.
+     * \param perform_z_hops Whether to Z hop when retracted.
+     * \param perform_z_hops_only_when_collides Whether to Z hop only over printed parts.
      * \param startPoint Where to start moving from.
      * \param endPoint Where to move to.
      * \param[out] combPoints The points along the combing path, excluding the
@@ -199,7 +200,7 @@ public:
      * being introduced due to the unretraction.
      * \return Whether combing has succeeded; otherwise a retraction is needed.
      */
-    bool calc(const ExtruderTrain& train, Point startPoint, Point endPoint, CombPaths& combPaths, bool startInside, bool endInside, coord_t max_comb_distance_ignored, bool &unretract_before_last_travel_move);
+    bool calc(bool perform_z_hops, bool perform_z_hops_only_when_collides, Point startPoint, Point endPoint, CombPaths& combPaths, bool startInside, bool endInside, coord_t max_comb_distance_ignored, bool &unretract_before_last_travel_move);
 };
 
 }//namespace cura

--- a/src/pathPlanning/GCodePath.cpp
+++ b/src/pathPlanning/GCodePath.cpp
@@ -6,9 +6,9 @@
 
 namespace cura
 {
-GCodePath::GCodePath(const GCodePathConfig& config, std::string mesh_id, const SpaceFillType space_fill_type, const Ratio flow, const bool spiralize, const Ratio speed_factor) :
+GCodePath::GCodePath(const GCodePathConfig& config, const SliceMeshStorage* mesh, const SpaceFillType space_fill_type, const Ratio flow, const bool spiralize, const Ratio speed_factor) :
 config(&config),
-mesh_id(mesh_id),
+mesh(mesh),
 space_fill_type(space_fill_type),
 flow(flow),
 speed_factor(speed_factor),

--- a/src/pathPlanning/GCodePath.h
+++ b/src/pathPlanning/GCodePath.h
@@ -5,9 +5,9 @@
 #define PATH_PLANNING_G_CODE_PATH_H
 
 #include "../SpaceFillType.h"
+#include "../sliceDataStorage.h"
 #include "../settings/types/Ratio.h"
 #include "../utils/IntPoint.h"
-
 #include "TimeMaterialEstimates.h"
 
 namespace cura 
@@ -29,7 +29,7 @@ class GCodePath
 {
 public:
     const GCodePathConfig* config; //!< The configuration settings of the path.
-    std::string mesh_id; //!< Which mesh this path belongs to, if any. If it's not part of any mesh, the mesh ID should be 0.
+    const SliceMeshStorage* mesh; //!< Which mesh this path belongs to, if any. If it's not part of any mesh, the mesh should be nullptr;
     SpaceFillType space_fill_type; //!< The type of space filling of which this path is a part
     Ratio flow; //!< A type-independent flow configuration
     Ratio speed_factor; //!< A speed factor that is multiplied with the travel speed. This factor can be used to change the travel speed.
@@ -60,7 +60,7 @@ public:
      * \param speed_factor The factor that the travel speed will be multiplied with
      * this path.
      */
-    GCodePath(const GCodePathConfig& config, std::string mesh_id, const SpaceFillType space_fill_type, const Ratio flow, const bool spiralize, const Ratio speed_factor = 1.0);
+    GCodePath(const GCodePathConfig& config, const SliceMeshStorage* mesh_id, const SpaceFillType space_fill_type, const Ratio flow, const bool spiralize, const Ratio speed_factor = 1.0);
 
     /*!
      * Whether this config is the config of a travel path.

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -269,25 +269,16 @@ Point SliceMeshStorage::getZSeamHint() const
     return pos;
 }
 
-std::vector<RetractionConfig> SliceDataStorage::initializeRetractionConfigs()
+std::vector<RetractionAndWipeConfig> SliceDataStorage::initializeRetractionAndWipeConfigs()
 {
-    std::vector<RetractionConfig> ret;
+    std::vector<RetractionAndWipeConfig> ret;
     ret.resize(Application::getInstance().current_slice->scene.extruders.size()); // initializes with constructor RetractionConfig()
-    return ret;
-}
-
-std::vector<WipeScriptConfig> SliceDataStorage::initializeWipeConfigs()
-{
-    std::vector<WipeScriptConfig> ret;
-    ret.resize(Application::getInstance().current_slice->scene.extruders.size());
     return ret;
 }
 
 SliceDataStorage::SliceDataStorage()
 : print_layer_count(0)
-, wipe_config_per_extruder(initializeWipeConfigs())
-, retraction_config_per_extruder(initializeRetractionConfigs())
-, extruder_switch_retraction_config_per_extruder(initializeRetractionConfigs())
+, retraction_wipe_config_per_extruder(initializeRetractionAndWipeConfigs())
 , max_print_height_second_to_last_extruder(-1)
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -263,6 +263,8 @@ public:
 
     LightningGenerator* lightning_generator; //!< Pre-computed structure for Lightning type infill
 
+    RetractionAndWipeConfig retraction_wipe_config; //!< Per-Object retraction and wipe settings.
+
     /*!
      * \brief Creates a storage space for slice results of a mesh.
      * \param mesh The mesh that the storage space belongs to.
@@ -309,10 +311,7 @@ public:
     AABB3D machine_size; //!< The bounding box with the width, height and depth of the printer.
     std::vector<SliceMeshStorage> meshes;
 
-    std::vector<WipeScriptConfig> wipe_config_per_extruder; //!< Wipe configs per extruder.
-
-    std::vector<RetractionConfig> retraction_config_per_extruder; //!< Retraction config per extruder.
-    std::vector<RetractionConfig> extruder_switch_retraction_config_per_extruder; //!< Retraction config per extruder for when performing an extruder switch
+    std::vector<RetractionAndWipeConfig> retraction_wipe_config_per_extruder; //!< Config for retractions, extruder switch retractions, and wipes, per extruder.
 
     SupportStorage support;
 
@@ -390,14 +389,9 @@ public:
 
 private:
     /*!
-     * Construct the retraction_config_per_extruder
+     * Construct the retraction_wipe_config_per_extruder
      */
-    std::vector<RetractionConfig> initializeRetractionConfigs();
-
-    /*!
-     * Construct the wipe_config_per_extruder
-     */
-    std::vector<WipeScriptConfig> initializeWipeConfigs();
+    std::vector<RetractionAndWipeConfig> initializeRetractionAndWipeConfigs();
 };
 
 }//namespace cura

--- a/tests/ExtruderPlanTest.cpp
+++ b/tests/ExtruderPlanTest.cpp
@@ -84,11 +84,11 @@ public:
             GCodePathConfig::SpeedDerivatives(120, 5000, 30)
         )
     {
-        const std::string mesh_id = "test_mesh";
+        const SliceMeshStorage* mesh = nullptr;
         constexpr Ratio flow_1 = 1.0_r;
         constexpr bool no_spiralize = false;
         constexpr Ratio speed_1 = 1.0_r;
-        square.assign({GCodePath(extrusion_config, mesh_id, SpaceFillType::PolyLines, flow_1, no_spiralize, speed_1)});
+        square.assign({GCodePath(extrusion_config, mesh, SpaceFillType::PolyLines, flow_1, no_spiralize, speed_1)});
         square.back().points = {
             Point(0, 0),
             Point(1000, 0),
@@ -98,11 +98,11 @@ public:
         };
 
         lines.assign({
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1)
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1)
         });
         lines[0].points = {Point(0, 0), Point(1000, 0)};
         lines[1].points = {Point(1000, 0), Point(1000, 400)};
@@ -114,11 +114,11 @@ public:
         constexpr Ratio flow_08 = 0.8_r;
         constexpr Ratio flow_04 = 0.4_r;
         decreasing_flow.assign({
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_12, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_08, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_04, no_spiralize, speed_1)
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_12, no_spiralize, speed_1),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_08, no_spiralize, speed_1),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_04, no_spiralize, speed_1)
         });
         decreasing_flow[0].points = {Point(0, 0), Point(1000, 0)};
         decreasing_flow[1].points = {Point(1000, 0), Point(1000, 400)};
@@ -130,11 +130,11 @@ public:
         constexpr Ratio speed_08 = 0.8_r;
         constexpr Ratio speed_04 = 0.4_r;
         decreasing_speed.assign({
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_12),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_08),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_04)
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_12),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_08),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_04)
         });
         decreasing_speed[0].points = {Point(0, 0), Point(1000, 0)};
         decreasing_speed[1].points = {Point(1000, 0), Point(1000, 400)};
@@ -143,12 +143,12 @@ public:
         decreasing_speed[4].points = {Point(0, 800), Point(1000, 800)};
 
         variable_width.assign({
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.8_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.6_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.4_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.2_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.0_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.8_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.6_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.4_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.2_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.0_r, no_spiralize, speed_1),
         });
         variable_width[0].points = {Point(0, 0), Point(1000, 0)};
         variable_width[1].points = {Point(1000, 0), Point(2000, 0)};

--- a/tests/LayerPlanTest.cpp
+++ b/tests/LayerPlanTest.cpp
@@ -208,7 +208,7 @@ public:
         retraction_config.retraction_count_max = settings->get<size_t>("retraction_count_max");
 
         SliceDataStorage* result = new SliceDataStorage();
-        result->retraction_config_per_extruder[0] = retraction_config;
+        result->retraction_wipe_config_per_extruder[0].retraction_config = retraction_config;
         return result;
     }
 
@@ -355,7 +355,7 @@ public:
         settings->add("retraction_hop_enabled", parameters.hop_enable);
         settings->add("retraction_combing", parameters.combing);
         settings->add("retraction_min_travel", parameters.is_long ? "1" : "10000"); //If disabled, give it a high minimum travel so we're sure that our travel move is shorter.
-        storage->retraction_config_per_extruder[0].retraction_min_travel_distance = settings->get<coord_t>("retraction_min_travel"); //Update the copy that the storage has of this.
+        storage->retraction_wipe_config_per_extruder[0].retraction_config.retraction_min_travel_distance = settings->get<coord_t>("retraction_min_travel"); //Update the copy that the storage has of this.
         settings->add("retraction_combing_max_distance", parameters.is_long_combing ? "1" : "10000");
 
         Polygons slice_data;


### PR DESCRIPTION
This change adds support for per-object retraction settings to CuraEngine.
The main mechanism is through changing the code to track a pointer to the
SliceMeshStorage instead of just storing the mesh name as a string.

Additionally, the code is changed to group together all retraction and
wipe settings into a single object which allows for more easily switching
between the object-specified and the extruder-specified settings, depending
on the context.

Retraction settings will be applied based on the most recent mesh that was
extruded.  As @Ghostkeeper noted, this may cause imperfections on the next
mesh (albeit in a way that the user has control over).  However, in 
one-at-a-time print ordering, this will not be an issue.

For some retractions, occuring as part of setup or teardown, it does not
make sense to apply options from a specific mesh, so settings from the
mesh group or extruder are used instead.

This PR is related to https://github.com/Ultimaker/Cura/issues/3193