### PR TITLE
Fix failure to stitch 0-width lines

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Ultimaker B.V.
+// Copyright (c) 2022 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <algorithm> //For std::partition_copy and std::min_element.
@@ -129,7 +129,7 @@ const VariableWidthPaths& WallToolPaths::generate()
 
 void WallToolPaths::stitchToolPaths(VariableWidthPaths& toolpaths, const Settings& settings)
 {
-    const coord_t stitch_distance = settings.get<coord_t>("wall_line_width_x") / 4;
+    const coord_t stitch_distance = settings.get<coord_t>("wall_line_width_x") / 3 + 1; //In 0-width contours, junctions can cause up to 1-line-width gaps. Don't stitch more than 1 line width.
 
     for (unsigned int wall_idx = 0; wall_idx < toolpaths.size(); wall_idx++)
     {

--- a/src/utils/PolylineStitcher.h
+++ b/src/utils/PolylineStitcher.h
@@ -89,7 +89,7 @@ public:
                             {
                                 return true; // keep looking
                             }
-                            if (nearby.p() == make_point(chain.front()))
+                            if(vSize2(nearby.p() - make_point(chain.front())) < snap_distance * snap_distance)
                             {
                                 if (chain.polylineLength() + dist < 3 * max_stitch_distance // prevent closing of small poly, cause it might be able to continue making a larger polyline
                                     || chain.size() <= 2) // don't make 2 vert polygons

--- a/src/utils/SVG.h
+++ b/src/utils/SVG.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef SVG_H
@@ -7,6 +7,7 @@
 #include <stdio.h> // for file output
 
 #include "AABB.h"
+#include "ExtrusionLine.h" //To accept variable-width paths.
 #include "IntPoint.h"
 #include "NoCopy.h"
 
@@ -141,6 +142,39 @@ public:
     void writePolylines(const Polygons& polys, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
 
     void writePolyline(ConstPolygonRef poly, const ColorObject color = Color::BLACK, const float stroke_width = 1) const;
+
+    /*!
+     * Draw variable-width paths into the image.
+     *
+     * The paths are drawn with the correct line width, as given in the paths,
+     * but there is a multiplicative factor to adjust the width with.
+     * \param paths The paths to draw.
+     * \param color The color to draw the paths with.
+     * \param width_factor A multiplicative factor on the line widths.
+     */
+    void writePaths(const VariableWidthPaths& paths, const ColorObject color = Color::BLACK, const float width_factor = 1.0) const;
+
+    /*!
+     * Draw variable-width lines into the image.
+     *
+     * The lines are drawn with the correct line width, as given in the lines,
+     * but there is a multiplicative factor to adjust the width with.
+     * \param lines The lines to draw.
+     * \param color The color to draw the lines with.
+     * \param width_factor A multiplicative factor on the line widths.
+     */
+    void writeLines(const VariableWidthLines& lines, const ColorObject color = Color::BLACK, const float width_factor = 1.0) const;
+
+    /*!
+     * Draw a variable-width line into the image.
+     *
+     * The line is drawn with the correct line width, as given in the junctions,
+     * but there is a multiplicative factor to adjust the width with.
+     * \param line The line to draw.
+     * \param color The color to draw the line with.
+     * \param width_factor A multiplicative factor on the line width.
+     */
+    void writeLine(const ExtrusionLine& line, const ColorObject color = Color::BLACK, const float width_factor = 1.0) const;
 
     /*!
      * Draws a grid across the image and writes down coordinates.


### PR DESCRIPTION
To find the area inside of the variable-width walls, we generate an extra wall with a line width of 0. This extra wall doesn't get properly stitched in transitions because a transition of 0-width lines is not properly defined. Instead, we've been stitching those lines in post-processing.

However this stitching didn't always succeed, resulting in a crash of CuraEngine. It failed for two separate reasons sometimes (as specified in the commit messages). These two small changes should make it succeed.

I also added some debugging code to output variable-width lines to SVG files. This was the best way to debug this issue, since the testing models where this occurred were all way to big to get a proper stack trace of (GDB gets stuck on listing the variables).

Fixes CURA-8091.