### PR TITLE
Support gap filler fix

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2689,7 +2689,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
             const coord_t support_line_width = default_support_line_width * (combine_idx + 1);
 
             Polygons support_polygons;
-            VariableWidthPaths wall_toolpaths_here;
+            VariableWidthPaths gap_filler_toolpaths; // In case of a zigzag infill pattern the Infill comp generates gap fillers for the initial offset from the outline to where the zigzag connectors will lie
             Polygons support_lines;
             const size_t max_density_idx = part.infill_area_per_combine_per_density.size() - 1;
             for(size_t density_idx = max_density_idx; (density_idx + 1) > 0; --density_idx)
@@ -2718,7 +2718,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                                    max_resolution, max_deviation,
                                    wall_count, infill_origin, support_connect_zigzags,
                                    use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
-                infill_comp.generate(wall_toolpaths_here, support_polygons, support_lines, infill_extruder.settings, storage.support.cross_fill_provider);
+                infill_comp.generate(gap_filler_toolpaths, support_polygons, support_lines, infill_extruder.settings, storage.support.cross_fill_provider);
             }
 
             setExtruder_addPrime(storage, gcode_layer, extruder_nr); // only switch extruder if we're sure we're going to switch

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1726,6 +1726,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                            infill_line_distance_here, overlap, infill_multiplier, infill_angle, gcode_layer.z,
                            infill_shift, max_resolution, max_deviation, wall_line_count_here, infill_origin,
                            connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
+        // TODO: prevent the infill_comp from generating gap filler lines to fill the area which is too narrow to fit the zigzag connectors
         infill_comp.generate(wall_tool_paths.back(), infill_polygons, infill_lines, mesh.settings, mesh.cross_fill_provider, lightning_layer, &mesh);
 
         // Fixme: CURA-7848 for libArachne.


### PR DESCRIPTION
Some support lines had gone missing.

For example the line on the left here.
![image](https://user-images.githubusercontent.com/8895761/156439520-55287fe0-732e-4bf8-a41e-79c0816fa2b7.png)
[zipped 3MF](https://github.com/Ultimaker/CuraEngine/files/8170140/SupportTest.zip)

When the Infill class generates any zigzag pattern then it performs an inset to the area so that the zigzag connectors don't overlap with the area to be filled, but lie half a line width inward. This inset can remove long thin areas which are then not filled anymore, which would be problematic for zizgag skin. The Infill class therefore generates gap filler lines for those areas removed.

However, it is not clear whether such gap filling areas also need to be filled when it comes to infill or support.

For support there could be a case made that if you don't use gap fillers then sometimes a thin overhang would not be supported. That's what this PR fixes.

However, for infill I see no reason to print gap fillers, since infill is generally allowed to be sparse. This is a TODO which is not fixed in this PR.