### PR TITLE
Make Wall Ordering option Center Last into its own setting

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -54,7 +54,7 @@ bool InsetOrderOptimizer::addToLayer()
     // Settings & configs:
     const bool pack_by_inset = ! settings.get<bool>("optimize_wall_printing_order");
     const InsetDirection inset_direction = settings.get<InsetDirection>("inset_direction");
-    const bool center_last = inset_direction == InsetDirection::CENTER_LAST;
+    const bool center_last = settings.get<bool>("wall_order_center_last");
     const bool alternate_walls = settings.get<bool>("material_alternate_walls");
 
     const bool outer_to_inner = inset_direction == InsetDirection::OUTSIDE_IN;

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -569,11 +569,7 @@ template<> SlicingTolerance Settings::get<SlicingTolerance>(const std::string& k
 template<> InsetDirection Settings::get<InsetDirection>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if(value == "center_last")
-    {
-        return InsetDirection::CENTER_LAST;
-    }
-    else if(value == "outside_in")
+    if(value == "outside_in")
     {
         return InsetDirection::OUTSIDE_IN;
     }


### PR DESCRIPTION
Since the Wall Ordering PR was merged the ordering of center lines has changed such that the center is always printed after their enclosing wall.

The only thing that Center Last controls is whether to print all centers bunched up after all even walls have been printed, or interspersed. If we choose a strategy whereby the middle line has more width variation than the even walls then it could be nice to print all those center lines together (rather than interspersed) so that they don't influence the even walls. This choice is independent of which direction we print the walls in.

The difference becomes apparent when a layer has middle lines of different inset index. Even walls ABCDE, Middle Lines 12
![image](https://user-images.githubusercontent.com/8895761/156534704-2ce30769-23a7-459f-95fb-d3c946741cf0.png)


Example orders:
not Optimize Wall Ordering & Inner to Outer & not Middle Last: E**2**DABC**1** (Note that 2 is after E because Middle lines are always printed after their enclosing wall)
not Optimize Wall Ordering & Inner to Outer & Middle Last: EDABC21
Optimize Wall Ordering & Inner to Outer & not Middle Last: E2ADCB1
Optimize Wall Ordering & Inner to Outer & Middle Last: EADCB21
not Optimize Wall Ordering & Outer to Inner & not Middle Last: ABC1DE2
not Optimize Wall Ordering & Outer to Inner & Middle Last: ABCDE12
Optimize Wall Ordering & Outer to Inner & not Middle Last: ACE2B1D
Optimize Wall Ordering & Outer to Inner & Middle Last: ACEBD12

Perhaps we might want each of these different behaviors in different situations, but the reason I introduce this setting change is not because we already have figured out that that's the case, but because we want separation of concerns; we want to be able to define the inset order direction now and look at the Center Last option later.

Frontend setting change: https://github.com/Ultimaker/Cura/pull/11592