### PR TITLE
[CURA-8085] Set the stitch distance to a full line-width instead of 1/3.

### DIFF
--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -433,8 +433,6 @@ void SkeletalTrapezoidation::constructFromPolygons(const Polygons& polys)
     }
 
     separatePointyQuadEndNodes();
-
-    graph.fixNodeDuplication();
     
     graph.collapseSmallEdges();
 

--- a/src/SkeletalTrapezoidationGraph.cpp
+++ b/src/SkeletalTrapezoidationGraph.cpp
@@ -175,39 +175,6 @@ bool STHalfEdgeNode::isLocalMaximum(bool strict) const
     } while (edge = edge->twin->next, edge != incident_edge);
     return true;
 }
-
-void SkeletalTrapezoidationGraph::fixNodeDuplication()
-{
-    for (auto node_it = nodes.begin(); node_it != nodes.end();)
-    {
-        node_t* replacing_node = nullptr;
-        for (edge_t* outgoing = node_it->incident_edge; outgoing != node_it->incident_edge; outgoing = outgoing->twin->next)
-        {
-            assert(outgoing);
-            if (outgoing->from != &*node_it)
-            {
-                replacing_node = outgoing->from;
-            }
-            if (outgoing->twin->to != &*node_it)
-            {
-                replacing_node = outgoing->twin->to;
-            }
-        }
-        if (replacing_node)
-        {
-            for (edge_t* outgoing = node_it->incident_edge; outgoing != node_it->incident_edge; outgoing = outgoing->twin->next)
-            {
-                outgoing->twin->to = replacing_node;
-                outgoing->from = replacing_node;
-            }
-            node_it = nodes.erase(node_it);
-        }
-        else
-        {
-            ++node_it;
-        }
-    }
-}
     
 void SkeletalTrapezoidationGraph::collapseSmallEdges(coord_t snap_dist)
 {

--- a/src/SkeletalTrapezoidationGraph.h
+++ b/src/SkeletalTrapezoidationGraph.h
@@ -70,7 +70,6 @@ class SkeletalTrapezoidationGraph: public HalfEdgeGraph<SkeletalTrapezoidationJo
     using edge_t = STHalfEdge;
     using node_t = STHalfEdgeNode;
 public:
-    void fixNodeDuplication();
 
     /*!
      * If an edge is too small, collapse it and its twin and fix the surrounding edges to ensure a consistent graph.

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -129,7 +129,7 @@ const VariableWidthPaths& WallToolPaths::generate()
 
 void WallToolPaths::stitchToolPaths(VariableWidthPaths& toolpaths, const Settings& settings)
 {
-    const coord_t stitch_distance = settings.get<coord_t>("wall_line_width_x") / 3 + 1; //In 0-width contours, junctions can cause up to 1-line-width gaps. Don't stitch more than 1 line width.
+    const coord_t stitch_distance = settings.get<coord_t>("wall_line_width_x") - 1; //In 0-width contours, junctions can cause up to 1-line-width gaps. Don't stitch more than 1 line width.
 
     for (unsigned int wall_idx = 0; wall_idx < toolpaths.size(); wall_idx++)
     {

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -1510,14 +1510,14 @@ void PolygonUtils::fixSelfIntersections(const coord_t epsilon, Polygons& thiss)
         return;
     }
 
-    const coord_t half_epsilon = (epsilon + 1) / 2;
+    const coord_t half_epsilon = std::max(10LL, (epsilon + 1) / 2);
 
     // Points too close to line segments should be moved a little away from those line segments, but less than epsilon,
     //   so at least half-epsilon distance between points can still be guaranteed.
     constexpr coord_t grid_size = 2000;
     auto query_grid = PolygonUtils::createLocToLineGrid(thiss, grid_size);
 
-    const coord_t move_dist = std::max(2LL, half_epsilon - 2);
+    const coord_t move_dist = half_epsilon - 2;
     const coord_t half_epsilon_sqrd = half_epsilon * half_epsilon;
 
     const size_t n = thiss.size();
@@ -1527,7 +1527,7 @@ void PolygonUtils::fixSelfIntersections(const coord_t epsilon, Polygons& thiss)
         for (size_t point_idx = 0; point_idx < pathlen; ++point_idx)
         {
             Point& pt = thiss[poly_idx][point_idx];
-            for (const auto& line : query_grid->getNearby(pt, epsilon))
+            for (const auto& line : query_grid->getNearby(pt, epsilon * 2))
             {
                 const size_t line_next_idx = (line.point_idx + 1) % thiss[line.poly_idx].size();
                 if (poly_idx == line.poly_idx && (point_idx == line.point_idx || point_idx == line_next_idx))


### PR DESCRIPTION
The whole x 3 thing is w.r.t. the respect of the whole polygon -- that is to say, the stitching procedure will not make polygons out of something that has a chain (or rather, loop) length of less than 3x the stitch distance given. Dividing by 3 here means that we where giving it the chance to produce polygons of the size of the stich width, which is a single line segment. Not only is that unnecessarily small, it will also prevent junctions (in a series) that _are_ more than say, half a line width apart from joining up into a polygon.(Though this shouldn't be a problem _and_ does in fact occur.) This is bad because the algorithm seems to rely on at least 'even' indexed walls to always form polygons further down the line. That said, the comment is still correct, and did in fact help me find the final piece of the puzzle a little more quickly.