### PR TITLE
Set up CodeQL scans and fixed several findings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,70 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '43 10 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    container: ultimaker/cura-build-environment
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    - name: Build and test
+      run: docker/build.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,21 +1,9 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
     branches: [ master ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ master ]
   schedule:
     - cron: '43 10 * * 2'
@@ -34,37 +22,20 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'cpp' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    - name: Build and test
+    - name: Build
       run: docker/build.sh
+      env:
+        TESTS: OFF
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/cmake/FindStb.cmake
+++ b/cmake/FindStb.cmake
@@ -45,7 +45,8 @@ else()
         # Stb's commits in early February seems to cause the engine to fail compilation on Mac.
         ExternalProject_Add(stb
             GIT_REPOSITORY "https://github.com/nothings/stb.git"
-            GIT_TAG d5d052c806eee2ca1f858cb58b2f062d9fa25b90
+            GIT_TAG af1a5bc352164740c1cc1354942b1c6b72eacb8a
+            PATCH_COMMAND git apply ${CMAKE_SOURCE_DIR}/cmake/stb_image.h.patch # This patch fixes several integer overflows in stb_image.h. This can be removed once https://github.com/nothings/stb/pull/1306 is merged.
             UPDATE_DISCONNECTED TRUE
             CONFIGURE_COMMAND "" #We don't want to actually go and build/test/generate it. Just need to download the headers.
             BUILD_COMMAND ""

--- a/cmake/stb_image.h.patch
+++ b/cmake/stb_image.h.patch
@@ -1,0 +1,72 @@
+diff --git a/stb_image.h b/stb_image.h
+index d60371b..16e2158 100644
+--- a/stb_image.h
++++ b/stb_image.h
+@@ -1797,7 +1797,7 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int r
+    if (req_comp == img_n) return data;
+    STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+ 
+-   good = (stbi__uint16 *) stbi__malloc(req_comp * x * y * 2);
++   good = (stbi__uint16 *) stbi__malloc((size_t) req_comp * x * y * 2);
+    if (good == NULL) {
+       STBI_FREE(data);
+       return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+@@ -1872,7 +1872,7 @@ static stbi_uc *stbi__hdr_to_ldr(float   *data, int x, int y, int comp)
+    if (comp & 1) n = comp; else n = comp-1;
+    for (i=0; i < x*y; ++i) {
+       for (k=0; k < n; ++k) {
+-         float z = (float) pow(data[i*comp+k]*stbi__h2l_scale_i, stbi__h2l_gamma_i) * 255 + 0.5f;
++         float z = (float) pow((double) data[i*comp+k]*stbi__h2l_scale_i, stbi__h2l_gamma_i) * 255 + 0.5f;
+          if (z < 0) z = 0;
+          if (z > 255) z = 255;
+          output[i*comp + k] = (stbi_uc) stbi__float2int(z);
+@@ -6123,7 +6123,7 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
+       out = (stbi_uc *) stbi__malloc_mad3(8, w, h, 0);
+       ri->bits_per_channel = 16;
+    } else
+-      out = (stbi_uc *) stbi__malloc(4 * w*h);
++      out = (stbi_uc *) stbi__malloc((size_t) 4 * w*h);
+ 
+    if (!out) return stbi__errpuc("outofmem", "Out of memory");
+    pixelCount = w*h;
+@@ -6446,7 +6446,7 @@ static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_c
+    // intermediate buffer is RGBA
+    result = (stbi_uc *) stbi__malloc_mad3(x, y, 4, 0);
+    if (!result) return stbi__errpuc("outofmem", "Out of memory");
+-   memset(result, 0xff, x*y*4);
++   memset(result, 0xff, (size_t) x*y*4);
+ 
+    if (!stbi__pic_load_core(s,x,y,comp, result)) {
+       STBI_FREE(result);
+@@ -6755,11 +6755,11 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
+       }
+ 
+       // background is what out is after the undoing of the previou frame;
+-      memcpy( g->background, g->out, 4 * g->w * g->h );
++      memcpy( g->background, g->out, (size_t) 4 * g->w * g->h );
+    }
+ 
+    // clear my history;
+-   memset( g->history, 0x00, g->w * g->h );        // pixels that were affected previous frame
++   memset( g->history, 0x00, (size_t) g->w * g->h );        // pixels that were affected previous frame
+ 
+    for (;;) {
+       int tag = stbi__get8(s);
+@@ -6913,7 +6913,7 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
+             stride = g.w * g.h * 4;
+ 
+             if (out) {
+-               void *tmp = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, layers * stride );
++               void *tmp = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, (size_t) layers * stride );
+                if (!tmp)
+                   return stbi__load_gif_main_outofmem(&g, out, delays);
+                else {
+@@ -6929,7 +6929,7 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
+                   delays_size = layers * sizeof(int);
+                }
+             } else {
+-               out = (stbi_uc*)stbi__malloc( layers * stride );
++               out = (stbi_uc*)stbi__malloc((size_t) layers * stride );
+                if (!out)
+                   return stbi__load_gif_main_outofmem(&g, out, delays);
+                out_size = layers * stride;

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -11,6 +11,10 @@ export PATH="${CURA_BUILD_ENV_PATH}/bin:${PATH}"
 export PKG_CONFIG_PATH="${CURA_BUILD_ENV_PATH}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 export LD_LIBRARY_PATH="${CURA_BUILD_ENV_PATH}/lib:${LD_LIBRARY_PATH}"
 
+if [ "${TESTS}" = "" ]; then
+    TESTS="ON"
+fi
+
 cd "${PROJECT_DIR}"
 
 mkdir build
@@ -18,7 +22,10 @@ cd build
 cmake \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_PREFIX_PATH="${CURA_BUILD_ENV_PATH}" \
-    -DBUILD_TESTS=ON \
+    -DBUILD_TESTS=${TESTS} \
     ..
 make
-ctest --output-on-failure -T Test
+
+if [ "${TESTS}" = "ON" ]; then
+    ctest --output-on-failure -T Test
+fi

--- a/src/BeadingStrategy/BeadingStrategyFactory.cpp
+++ b/src/BeadingStrategy/BeadingStrategyFactory.cpp
@@ -74,21 +74,21 @@ BeadingStrategyPtr BeadingStrategyFactory::makeStrategy
     
     if(print_thin_walls)
     {
-        logDebug("Applying the Widening Beading meta-strategy with minimum input width %d and minimum output width %d.\n", min_feature_size, min_bead_width);
+        logDebug("Applying the Widening Beading meta-strategy with minimum input width %lld and minimum output width %lld.\n", min_feature_size, min_bead_width);
         ret = make_unique<WideningBeadingStrategy>(move(ret), min_feature_size, min_bead_width);
     }
     if (max_bead_count > 0)
     {
-        logDebug("Applying the Redistribute meta-strategy with outer-wall width = %d, inner-wall width = %d\n", preferred_bead_width_outer, preferred_bead_width_inner);
+        logDebug("Applying the Redistribute meta-strategy with outer-wall width = %lld, inner-wall width = %lld\n", preferred_bead_width_outer, preferred_bead_width_inner);
         ret = make_unique<RedistributeBeadingStrategy>(preferred_bead_width_outer, preferred_bead_width_inner, minimum_variable_line_width, move(ret));
         //Apply the LimitedBeadingStrategy last, since that adds a 0-width marker wall which other beading strategies shouldn't touch.
-        logDebug("Applying the Limited Beading meta-strategy with maximum bead count = %d.\n", max_bead_count);
+        logDebug("Applying the Limited Beading meta-strategy with maximum bead count = %lld.\n", max_bead_count);
         ret = make_unique<LimitedBeadingStrategy>(max_bead_count, move(ret));
     }
     
     if (outer_wall_offset > 0)
     {
-        logDebug("Applying the OuterWallOffset meta-strategy with offset = %d.\n", outer_wall_offset);
+        logDebug("Applying the OuterWallOffset meta-strategy with offset = %lld.\n", outer_wall_offset);
         ret = make_unique<OuterWallInsetBeadingStrategy>(outer_wall_offset, move(ret));
     }
     return ret;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -911,7 +911,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
 LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, LayerIndex layer_nr, const size_t total_layers) const
 {
-    logDebug("GcodeWriter processing layer %i of %i\n", layer_nr, total_layers);
+    logDebug("GcodeWriter processing layer %i of %lu\n", (int) layer_nr, total_layers);
 
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     coord_t layer_thickness = mesh_group_settings.get<coord_t>("layer_height");

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -103,7 +103,7 @@ bool FffPolygonGenerator::sliceModel(MeshGroup* meshgroup, TimeKeeper& timeKeepe
     coord_t initial_layer_thickness = mesh_group_settings.get<coord_t>("layer_height_0");
     if (initial_layer_thickness <= 0)
     {
-        logError("Initial layer height %i is disallowed.\n", initial_layer_thickness);
+        logError("Initial layer height %lld is disallowed.\n", initial_layer_thickness);
         return false;
     }
 
@@ -111,7 +111,7 @@ bool FffPolygonGenerator::sliceModel(MeshGroup* meshgroup, TimeKeeper& timeKeepe
     const coord_t layer_thickness = mesh_group_settings.get<coord_t>("layer_height");
     if(layer_thickness <= 0)
     {
-        logError("Layer height %i is disallowed.\n", layer_thickness);
+        logError("Layer height %lld is disallowed.\n", layer_thickness);
         return false;
     }
 
@@ -380,7 +380,7 @@ void FffPolygonGenerator::slices2polygons(SliceDataStorage& storage, TimeKeeper&
         removeEmptyFirstLayers(storage, storage.print_layer_count); // changes storage.print_layer_count!
     }
 
-    log("Layer count: %i\n", storage.print_layer_count);
+    log("Layer count: %lu\n", storage.print_layer_count);
 
     //layerparts2HTML(storage, "output/output.html");
 
@@ -466,7 +466,7 @@ void FffPolygonGenerator::processBasicWallsSkinInfill(SliceDataStorage& storage,
     // Use a signed type for the loop counter so MSVC compiles (because it uses OpenMP 2.0, an old version).
     for (int layer_number = 0; layer_number < static_cast<int>(mesh.layers.size()); layer_number++)
     {
-        logDebug("Processing insets for layer %i of %i\n", layer_number, mesh_layer_count);
+        logDebug("Processing insets for layer %i of %lu\n", layer_number, mesh_layer_count);
         processWalls(mesh, layer_number);
 #ifdef _OPENMP
         if (omp_get_thread_num() == 0)
@@ -525,7 +525,7 @@ void FffPolygonGenerator::processBasicWallsSkinInfill(SliceDataStorage& storage,
         // Use a signed type for the loop counter so MSVC compiles (because it uses OpenMP 2.0, an old version).
         for (int layer_number = 0; layer_number < static_cast<int>(mesh.layers.size()); layer_number++)
         {
-            logDebug("Processing skins and infill layer %i of %i\n", layer_number, mesh_layer_count);
+            logDebug("Processing skins and infill layer %i of %lu\n", layer_number, mesh_layer_count);
             if (!mesh_group_settings.get<bool>("magic_spiralize") || layer_number < static_cast<int>(mesh_max_initial_bottom_layer_count))    //Only generate up/downskin and infill for the first X layers when spiralize is choosen.
             {
                 processSkinsAndInfill(mesh, layer_number, process_infill);
@@ -778,7 +778,7 @@ void FffPolygonGenerator::removeEmptyFirstLayers(SliceDataStorage& storage, size
 
     if (n_empty_first_layers > 0)
     {
-        log("Removing %d layers because they are empty\n", n_empty_first_layers);
+        log("Removing %lu layers because they are empty\n", n_empty_first_layers);
         const coord_t layer_height = Application::getInstance().current_slice->scene.current_mesh_group->settings.get<coord_t>("layer_height");
         for (SliceMeshStorage& mesh : storage.meshes)
         {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -595,9 +595,9 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
     }
 }
 
-static constexpr float max_non_bridge_line_volume = MM2INT(100); // limit to accumulated "volume" of non-bridge lines which is proportional to distance x extrusion rate
+static constexpr double max_non_bridge_line_volume = MM2INT(100); // limit to accumulated "volume" of non-bridge lines which is proportional to distance x extrusion rate
 
-void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, float flow, float& non_bridge_line_volume, Ratio speed_factor, double distance_to_bridge_start)
+void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, float flow, double& non_bridge_line_volume, Ratio speed_factor, double distance_to_bridge_start)
 {
     const coord_t min_line_len = 5; // we ignore lines less than 5um long
     const double acceleration_segment_len = MM2INT(1); // accelerate using segments of this length
@@ -672,7 +672,7 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& se
                 addExtrusionMove(segment_end, non_bridge_config, SpaceFillType::Polygons, segment_flow, spiralize,
                     (overhang_mask.empty() || (!overhang_mask.inside(p0, true) && !overhang_mask.inside(p1, true))) ? speed_factor : overhang_speed_factor);
             }
-            non_bridge_line_volume += vSize(cur_point - segment_end) * segment_flow * speed_factor * non_bridge_config.getSpeed();
+            non_bridge_line_volume += (double) vSize(cur_point - segment_end) * segment_flow * speed_factor * non_bridge_config.getSpeed();
             cur_point = segment_end;
             speed_factor = 1 - (1 - speed_factor) * acceleration_factor;
             if (speed_factor >= 0.9)
@@ -814,7 +814,7 @@ void LayerPlan::addWall(const ExtrusionLine& wall, int start_idx, const Settings
         start_idx = locateFirstSupportedVertex(wall, start_idx);
     }
 
-    float non_bridge_line_volume = max_non_bridge_line_volume; // assume extruder is fully pressurised before first non-bridge line is output
+    double non_bridge_line_volume = max_non_bridge_line_volume; // assume extruder is fully pressurised before first non-bridge line is output
     double speed_factor = 1.0; // start first line at normal speed
     coord_t distance_to_bridge_start = 0; // will be updated before each line is processed
 
@@ -1191,7 +1191,7 @@ void LayerPlan::addLinesInGivenOrder(
                 ConstPolygonRef next_polygon = *next_path.vertices;
                 const size_t next_start = next_path.start_vertex;
                 const Point& next_p0 = next_polygon[next_start];
-                if (vSize2(next_p0 - p1) <= line_width * line_width * 4)
+                if (vSize2(next_p0 - p1) <= (long) line_width * line_width * 4)
                 {
                     wipe = false;
                 }

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -520,7 +520,7 @@ public:
      * \param distance_to_bridge_start The distance along the wall from p0 to the first bridge segment
      */
 
-    void addWallLine(const Point& p0, const Point& p1, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, float flow, float& non_bridge_line_volume, Ratio speed_factor, double distance_to_bridge_start);
+    void addWallLine(const Point& p0, const Point& p1, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, float flow, double& non_bridge_line_volume, Ratio speed_factor, double distance_to_bridge_start);
 
     /*!
      * Add a wall to the g-code starting at vertex \p start_idx

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -80,7 +80,7 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
 
     if (!new_layer_destination_state)
     {
-        logWarning("Layer %d is empty (or it has empty extruder plans). Temperature control and cross layer travel moves might suffer!\n", newest_layer->layer_nr);
+        logWarning("Layer %d is empty (or it has empty extruder plans). Temperature control and cross layer travel moves might suffer!\n", (int) newest_layer->layer_nr);
         return;
     }
 

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1925,7 +1925,7 @@ void SkeletalTrapezoidation::connectJunctions(ptr_vector_t<LineJunctions>& edge_
             assert(std::abs(int(from_junctions.size()) - int(to_junctions.size())) <= 1); // at transitions one end has more beads
             if(std::abs(int(from_junctions.size()) - int(to_junctions.size())) > 1)
             {
-                logWarning("Can't create a transition when connecting two perimeters where the number of beads differs too much! %i vs. %i", from_junctions.size(), to_junctions.size());
+                logWarning("Can't create a transition when connecting two perimeters where the number of beads differs too much! %lu vs. %lu", from_junctions.size(), to_junctions.size());
             }
 
             size_t segment_count = std::min(from_junctions.size(), to_junctions.size());
@@ -1936,7 +1936,7 @@ void SkeletalTrapezoidation::connectJunctions(ptr_vector_t<LineJunctions>& edge_
                 assert(from.perimeter_index == to.perimeter_index);
                 if(from.perimeter_index != to.perimeter_index)
                 {
-                    logWarning("Connecting two perimeters with different indices! Perimeter %i and %i", from.perimeter_index, to.perimeter_index);
+                    logWarning("Connecting two perimeters with different indices! Perimeter %lu and %lu", from.perimeter_index, to.perimeter_index);
                 }
                 const bool from_is_odd = 
                     quad_start->to->data.bead_count > 0 && quad_start->to->data.bead_count % 2 == 1 // quad contains single bead segment

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1635,9 +1635,9 @@ SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beadin
         }
         else
         {
-            ret.bead_widths[inset_idx] = ratio_left_to_whole * left.bead_widths[inset_idx] + ratio_right_to_whole * right.bead_widths[inset_idx];
+            ret.bead_widths[inset_idx] = ratio_left_to_whole * left.bead_widths[inset_idx] + (double) ratio_right_to_whole * right.bead_widths[inset_idx];
         }
-        ret.toolpath_locations[inset_idx] = ratio_left_to_whole * left.toolpath_locations[inset_idx] + ratio_right_to_whole * right.toolpath_locations[inset_idx];
+        ret.toolpath_locations[inset_idx] = ratio_left_to_whole * left.toolpath_locations[inset_idx] + (double) ratio_right_to_whole * right.toolpath_locations[inset_idx];
     }
     return ret;
 }

--- a/src/Weaver.cpp
+++ b/src/Weaver.cpp
@@ -30,7 +30,7 @@ void Weaver::weave(MeshGroup* meshgroup)
     const size_t layer_count = (maxz - initial_layer_thickness) / connection_height + 1;
     std::vector<AdaptiveLayer> layer_thicknesses;
 
-    log("Layer count: %i\n", layer_count);
+    log("Layer count: %lu\n", layer_count);
 
     std::vector<cura::Slicer*> slicerList;
 
@@ -54,7 +54,7 @@ void Weaver::weave(MeshGroup* meshgroup)
         }
         if (starting_layer_idx > 0)
         {
-            logWarning("First %i layers are empty!\n", starting_layer_idx);
+            logWarning("First %i layers are empty!\n", (int) starting_layer_idx);
         }
     }
 

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -396,11 +396,11 @@ void ArcusCommunication::sendOptimizedLayerData()
     {
         return;
     }
-    log("Sending %d layers.", data.current_layer_count);
+    log("Sending %lu layers.", data.current_layer_count);
 
     for (std::pair<const int, std::shared_ptr<proto::LayerOptimized>> entry : data.slice_data) //Note: This is in no particular order!
     {
-        logDebug("Sending layer data for layer %i of %i.\n", entry.first, data.slice_data.size());
+        logDebug("Sending layer data for layer %i of %lu.\n", entry.first, data.slice_data.size());
         private_data->socket->sendMessage(entry.second); //Send the actual layers.
     }
     data.sliced_objects = 0;

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1399,7 +1399,7 @@ void GCodeExport::finalize(const char* endCode)
     writeCode(endCode);
     int64_t print_time = getSumTotalPrintTimes();
     int mat_0 = getTotalFilamentUsed(0);
-    log("Print time (s): %d\n", print_time);
+    log("Print time (s): %l\n", print_time);
     log("Print time (hr|min|s): %dh %dm %ds\n", int(print_time / 60 / 60), int((print_time / 60) % 60), int(print_time % 60));
     log("Filament (mm^3): %d\n", mat_0);
     for(int n=1; n<MAX_EXTRUDERS; n++)

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -462,7 +462,7 @@ void Infill::addLineInfill(Polygons& result, const PointMatrix& rotation_matrix,
     assert(!connect_lines && "connectLines() should add the infill lines, not addLineInfill");
 
     unsigned int scanline_idx = 0;
-    for(coord_t x = scanline_min_idx * line_distance + shift; x < boundary.max.X; x += line_distance)
+    for(coord_t x = (long) scanline_min_idx * line_distance + shift; x < boundary.max.X; x += line_distance)
     {
         if (scanline_idx >= cut_list.size())
         {
@@ -624,8 +624,8 @@ void Infill::generateLinearBasedInfill(Polygons& result, const int line_distance
 
             for(int scanline_idx = scanline_idx0; scanline_idx != scanline_idx1 + direction; scanline_idx += direction)
             {
-                int x = scanline_idx * line_distance + shift;
-                int y = p1.Y + (p0.Y - p1.Y) * (x - p1.X) / (p0.X - p1.X);
+                long x = (long) scanline_idx * line_distance + shift;
+                long y = p1.Y + (p0.Y - p1.Y) * (x - p1.X) / (p0.X - p1.X);
                 assert(scanline_idx - scanline_min_idx >= 0 && scanline_idx - scanline_min_idx < int(cut_list.size()) && "reading infill cutlist index out of bounds!");
                 cut_list[scanline_idx - scanline_min_idx].push_back(y);
                 Point scanline_linesegment_intersection(x, y);

--- a/src/infill/SierpinskiFill.cpp
+++ b/src/infill/SierpinskiFill.cpp
@@ -722,7 +722,7 @@ Polygon SierpinskiFill::generateCross() const
     float realized_length = INT2MM(ret.polygonLength());
     float requested_length = root.requested_length;
     float error = (realized_length - requested_length) / requested_length;
-    logDebug("realized_length: %f, requested_length: %f  :: %f% error\n", realized_length, requested_length, .01 * static_cast<int>(10000 * error));
+    logDebug("realized_length: %f, requested_length: %f  :: %f error\n", realized_length, requested_length, .01 * static_cast<int>(10000 * error));
     return ret;
 }
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -183,7 +183,7 @@ int Mesh::getFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx, int notFaceVe
 
     if (candidateFaces.size() % 2 == 0)
     {
-        cura::logDebug("Warning! Edge with uneven number of faces connecting it!(%i)\n", candidateFaces.size()+1);
+        cura::logDebug("Warning! Edge with uneven number of faces connecting it!(%lu)\n", candidateFaces.size()+1);
         if (!has_disconnected_faces)
         {
             cura::logWarning("Mesh has disconnected faces!\n");

--- a/src/utils/IntPoint.h
+++ b/src/utils/IntPoint.h
@@ -160,12 +160,12 @@ INLINE const Point& make_point(const Point& p)
 namespace std {
 template <>
 struct hash<cura::Point> {
-    size_t operator()(const cura::Point & pp) const
+    signed long long operator()(const cura::Point & pp) const
     {
         static int prime = 31;
-        int result = 89;
-        result = result * prime + pp.X;
-        result = result * prime + pp.Y;
+        signed long long result = 89;
+        result = (long) result * prime + pp.X;
+        result = (long) result * prime + pp.Y;
         return result;
     }
 };

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -271,7 +271,7 @@ ClosestPolygonPoint PolygonUtils::_moveInside2(const ClosestPolygonPoint& closes
     const Point v_boundary_result = result - closest_polygon_point.location;
     if (dot(v_boundary_result, v_boundary_from) > 0)
     { // point was already on the correct side of the polygon
-        if (vSize2(v_boundary_from) > distance * distance)
+        if (vSize2(v_boundary_from) > (long) distance * distance)
         { // [from] was already on the correct side of the boudary by enough distance
             // don't change [from]
             return closest_polygon_point;
@@ -394,7 +394,7 @@ unsigned int PolygonUtils::moveInside(const Polygons& polygons, Point& from, int
     }
     if (is_already_on_correct_side_of_boundary) // when the best point is already inside and we're moving inside, or when the best point is already outside and we're moving outside
     {
-        if (bestDist2 < distance * distance)
+        if (bestDist2 < (long) distance * distance)
         {
             from = ret;
         }
@@ -519,7 +519,7 @@ unsigned int PolygonUtils::moveInside(const ConstPolygonRef polygon, Point& from
 
     if (is_already_on_correct_side_of_boundary) // when the best point is already inside and we're moving inside, or when the best point is already outside and we're moving outside
     {
-        if (bestDist2 < distance * distance)
+        if (bestDist2 < (long) distance * distance)
         {
             from = ret;
         }
@@ -1092,7 +1092,7 @@ std::vector<std::pair<ClosestPolygonPoint, ClosestPolygonPoint>> PolygonUtils::f
         int dist_to_p1 = vSize(p0p1);
         for (unsigned int middle_point_nr = 1; dist_to_p1 > grid_size * 2; ++middle_point_nr)
         {
-            Point x = p0 + normal(p0p1, middle_point_nr * grid_size);
+            Point x = p0 + normal(p0p1, (long) middle_point_nr * grid_size);
             dist_to_p1 -= grid_size;
 
             std::optional<ClosestPolygonPoint> best_here = findClose(x, destination, destination_loc_to_line, penalty_function);

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -44,11 +44,11 @@ static inline void writeInt2mm(const int32_t coord, std::ostream& ss)
 #ifdef DEBUG
     if (char_count + 1 >= int(buffer_size)) // + 1 for the null character
     {
-        logError("Cannot write %ld to buffer of size %i", coord, buffer_size);
+        logError("Cannot write %d to buffer of size %lu", coord, buffer_size);
     }
     if (char_count < 0)
     {
-        logError("Encoding error while writing %ld", coord);
+        logError("Encoding error while writing %d", coord);
     }
 #endif // DEBUG
     int end_pos = char_count; // the first character not to write any more
@@ -131,7 +131,7 @@ static inline void writeDoubleToStream(const unsigned int precision, const doubl
 #ifdef DEBUG
     if (char_count + 1 >= int(buffer_size)) // + 1 for the null character
     {
-        logError("Cannot write %f to buffer of size %i", coord, buffer_size);
+        logError("Cannot write %f to buffer of size %lu", coord, buffer_size);
     }
     if (char_count < 0)
     {


### PR DESCRIPTION
I'd like to suggest setting CodeQL scans for `CuraEngine`. [CodeQL](https://codeql.github.com/) is a static-analysis engine that can help with detecting security and other issues. It can be easily run in a GitHub [workflow](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository#setting-up-code-scanning-using-actions). The suggested config runs scans on PRs and the main branch. Findings are going to be posted as comments in pull requests. Or, they can also be found in the `Security` tab.

Here is an [example](https://github.com/artem-smotrakov/CuraEngine/actions/runs/1973004996) workflow run for CodeQL.

CodeQL reported several findings, mostly multiplication overflows and wrong format strings. I've looked into them and tried to fix them but this definitely needs a review because I have not writtten C code for a long time :) If this PR is accepted, the baseline is going to be 0 findings.

Several findings have been reported in `stb_image.h` that is pulled while building `CuraEngine`. I've updated `stb_image.h` to the latest commit and added a patch that addresses findings at build time. This can be removed once these issues are [fixed](https://github.com/nothings/stb/pull/1306) in the upstream repository.

