### PR TITLE
Added a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting vulnerabilities
+
+If you discover a vulnerability, please let us know as soon as possible via `security@ultimaker.com`.
+Please do not take advantage of the vulnerability and do not reveal the problem to others.
+To allow us to resolve the issue, please do provide us with sufficient information to reproduce the problem.


### PR DESCRIPTION
I'd like to propose adding a security policy file for the project. The policy describes how to report security issues. I copied it from here

https://support.ultimaker.com/hc/en-us/articles/360012009799-Ultimaker-security

The process of reporting security issues should be documented and easy to find. Security policy in the repository makes it easier to find the docs that describe how security issues should be reported. It can be seen in the `Security` tab. Also, when someone creates an issue the repository, they will see a link to the security policy.

https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository
