### PR TITLE
Fix: Don't stitch zigzag lines when enforcing monotonic order

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2410,6 +2410,7 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage, La
     coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
     coord_t max_deviation = mesh.settings.get<coord_t>("meshfix_maximum_deviation");
     const Point infill_origin;
+    const bool skip_line_stitching = monotonic;
     constexpr bool connected_zigzags = false;
     constexpr bool use_endpieces = true;
     constexpr bool skip_some_zags = false;
@@ -2420,6 +2421,7 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage, La
         pattern, zig_zaggify_infill, connect_polygons, area, config.getLineWidth(), config.getLineWidth() / skin_density, skin_overlap, infill_multiplier, skin_angle, gcode_layer.z, extra_infill_shift
         , max_resolution, max_deviation
         , wall_line_count, infill_origin,
+        skip_line_stitching,
         connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
         );
     infill_comp.generate(skin_paths, skin_polygons, skin_lines, mesh.settings);

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -62,6 +62,10 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
     const coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
     const coord_t max_deviation = mesh.settings.get<coord_t>("meshfix_maximum_deviation");
     const Ratio ironing_flow = mesh.settings.get<Ratio>("ironing_flow");
+    const bool enforce_monotonic_order = mesh.settings.get<bool>("ironing_monotonic");
+    constexpr size_t wall_line_count = 0;
+    const Point infill_origin = Point();
+    const bool skip_line_stitching = enforce_monotonic_order;
 
     coord_t ironing_inset = -mesh.settings.get<coord_t>("ironing_inset");
     if (pattern == EFillMethod::ZIG_ZAG)
@@ -81,7 +85,7 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
     }
     Polygons ironed_areas = areas.offset(ironing_inset);
 
-    Infill infill_generator(pattern, zig_zaggify_infill, connect_polygons, ironed_areas, line_width, line_spacing, infill_overlap, infill_multiplier, direction, layer.z - 10, shift, max_resolution, max_deviation);
+    Infill infill_generator(pattern, zig_zaggify_infill, connect_polygons, ironed_areas, line_width, line_spacing, infill_overlap, infill_multiplier, direction, layer.z - 10, shift, max_resolution, max_deviation, wall_line_count, infill_origin, skip_line_stitching);
     VariableWidthPaths ironing_paths;
     Polygons ironing_polygons;
     Polygons ironing_lines;
@@ -124,7 +128,7 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
             }
         }
 
-        if(!mesh.settings.get<bool>("ironing_monotonic"))
+        if( ! enforce_monotonic_order)
         {
             layer.addLinesByOptimizer(ironing_lines, line_config, SpaceFillType::PolyLines);
         }

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -248,8 +248,8 @@ void Infill::_generate(VariableWidthPaths& toolpaths, Polygons& result_polygons,
 
     result_polygons.simplify(max_resolution, max_deviation);
 
-    if (zig_zaggify ||
-        pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D || pattern == EFillMethod::CUBICSUBDIV || pattern == EFillMethod::GYROID || pattern == EFillMethod::ZIG_ZAG)
+    if ( ! skip_line_stitching && (zig_zaggify ||
+        pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D || pattern == EFillMethod::CUBICSUBDIV || pattern == EFillMethod::GYROID || pattern == EFillMethod::ZIG_ZAG))
     { // don't stich for non-zig-zagged line infill types
         Polygons stiched_lines;
         PolylineStitcher<Polygons, Polygon, Point>::stitch(result_lines, stiched_lines, result_polygons, infill_line_width);

--- a/src/infill.h
+++ b/src/infill.h
@@ -40,6 +40,7 @@ class Infill
     coord_t max_deviation; //!< Max deviation fro the original poly when enforcing max_resolution
     size_t wall_line_count; //!< Number of walls to generate at the boundary of the infill region, spaced \ref infill_line_width apart
     const Point infill_origin; //!< origin of the infill pattern
+    bool skip_line_stitching; //!< Whether to bypass the line stitching normally performed for polyline type infills
     bool connected_zigzags; //!< (ZigZag) Whether endpieces of zigzag infill should be connected to the nearest infill line on both sides of the zigzag connector
     bool use_endpieces; //!< (ZigZag) Whether to include endpieces: zigzag connector segments from one infill line to itself
     bool skip_some_zags;  //!< (ZigZag) Whether to skip some zags
@@ -64,6 +65,7 @@ public:
         , coord_t max_deviation
         , size_t wall_line_count = 0
         , const Point& infill_origin = Point()
+        , bool skip_line_stitching = false
         , bool connected_zigzags = false
         , bool use_endpieces = false
         , bool skip_some_zags = false
@@ -85,6 +87,7 @@ public:
     , max_deviation(max_deviation)
     , wall_line_count(wall_line_count)
     , infill_origin(infill_origin)
+    , skip_line_stitching(skip_line_stitching)
     , connected_zigzags(connected_zigzags)
     , use_endpieces(use_endpieces)
     , skip_some_zags(skip_some_zags)


### PR DESCRIPTION
Connecting the zigzags into long polylines foregoes the monotonic order.
LayerPlan::addLinesMonotonic doesn't consider breaking up polylines.

Fixes CURA-8983