### PR TITLE
Don't remove surface mode both cutting mesh areas.

### DIFF
--- a/src/multiVolumes.cpp
+++ b/src/multiVolumes.cpp
@@ -184,7 +184,6 @@ void MultiVolumes::carveCuttingMeshes(std::vector<Slicer*>& volumes, const std::
             if (cutting_mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
             {
                 cutting_mesh_polylines.clear();
-                cutting_mesh_polygons.clear();
                 PolylineStitcher<Polygons, Polygon, Point>::stitch(new_polylines, cutting_mesh_polylines, cutting_mesh_polygons, surface_line_width);
             }
         }


### PR DESCRIPTION
The polylines are recomputed by the stitching, so they should be cleared.
However, the polygons should not be cleared for surface mode BOTH.
They are already cleared for surface mode SURFACE, 35 lines above at line 150.