### PR TITLE
Remove the epsilon from the findStartLocation

### DIFF
--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -431,10 +431,6 @@ protected:
         // Paths, other than polygons, can be either clockwise or counterclockwise. Make sure this is detected.
         const bool clockwise = simple_poly.orientation();
 
-        //Find most extreme point in one direction. For the "actual loop" (see below), start from this point,
-        //so it can act as a "tie breaker" if all differences in dist-score for a polygon fall within epsilon.
-        //Direction/point should be the user-specified point if available, or an arbitrary point away from polygon otherwise.
-        constexpr coord_t EPSILON = 25;
         const Point focus_fixed_point = (seam_config.type == EZSeamType::USER_SPECIFIED)
             ? seam_config.pos
             : Point(0, std::sqrt(std::numeric_limits<coord_t>::max())); //Use sqrt, so the squared size can be used when comparing distances.
@@ -505,8 +501,7 @@ protected:
                     score += 1000; //1 meter penalty.
                 }
             }
-
-            if(score - EPSILON < best_score)
+            if(score < best_score)
             {
                 best_point = here;
                 best_score = score;


### PR DESCRIPTION
Although this was originally needed to fix CURA-8149, removing this code
doesn't re-introduce the behavior that it was supposed to fix (which makes sense;
We didn't really knew what caused that in the first place and Arachne already makes
a lot of things different).

The reason that this was causing issues is because it could, depending on the order,
take a worse point due to cascading. Eg:
Say that you have 3 lines in a row:
scores 100, 124, 148
So first the best score will be 100 (since that is lower than MAX).
Then it will accept 124 as the lowest score (because 124-25 < 100)
Then it will accept 145 as the lowest score (because 148-25 < 148)

You would end up with the 148 score even though the first point is a lot better.

All in all this should fix CURA-7950 and I expect it to also solve CURA-8875