### PR TITLE
[CURA-9027] Make Beading Strategies Behave

### DIFF
--- a/src/BeadingStrategy/BeadingStrategy.cpp
+++ b/src/BeadingStrategy/BeadingStrategy.cpp
@@ -8,13 +8,31 @@
 namespace cura
 {
 
-BeadingStrategy::BeadingStrategy(coord_t optimal_width, coord_t default_transition_length, float transitioning_angle)
-    : optimal_width(optimal_width)
-    , default_transition_length(default_transition_length)
-    , transitioning_angle(transitioning_angle)
+BeadingStrategy::BeadingStrategy
+(
+    coord_t optimal_width,
+    Ratio wall_split_middle_threshold,
+    Ratio wall_add_middle_threshold,
+    coord_t default_transition_length,
+    float transitioning_angle
+) :
+    optimal_width(optimal_width),
+    wall_split_middle_threshold(wall_split_middle_threshold),
+    wall_add_middle_threshold(wall_add_middle_threshold),
+    default_transition_length(default_transition_length),
+    transitioning_angle(transitioning_angle)
 {
     name = "Unknown";
 }
+
+BeadingStrategy::BeadingStrategy(const BeadingStrategy& other) :
+    optimal_width(other.optimal_width),
+    wall_split_middle_threshold(other.wall_split_middle_threshold),
+    wall_add_middle_threshold(other.wall_add_middle_threshold),
+    default_transition_length(other.default_transition_length),
+    transitioning_angle(other.transitioning_angle),
+    name(other.name)
+{}
 
 coord_t BeadingStrategy::getTransitioningLength(coord_t lower_bead_count) const
 {

--- a/src/BeadingStrategy/BeadingStrategy.cpp
+++ b/src/BeadingStrategy/BeadingStrategy.cpp
@@ -71,6 +71,16 @@ coord_t BeadingStrategy::getOptimalWidth() const
     return optimal_width;
 }
 
+Ratio BeadingStrategy::getSplitMiddleThreshold() const
+{
+    return wall_split_middle_threshold;
+}
+
+Ratio BeadingStrategy::getAddMiddleThreshold() const
+{
+    return wall_add_middle_threshold;
+}
+
 AngleRadians BeadingStrategy::getTransitioningAngle() const
 {
     return transitioning_angle;

--- a/src/BeadingStrategy/BeadingStrategy.cpp
+++ b/src/BeadingStrategy/BeadingStrategy.cpp
@@ -86,5 +86,17 @@ AngleRadians BeadingStrategy::getTransitioningAngle() const
     return transitioning_angle;
 }
 
+coord_t BeadingStrategy::getOptimalThickness(coord_t bead_count) const
+{
+    return optimal_width * bead_count;
+}
+
+coord_t BeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
+{
+    const coord_t lower_ideal_width = getOptimalThickness(lower_bead_count);
+    const coord_t higher_ideal_width = getOptimalThickness(lower_bead_count + 1);
+    const Ratio threshold = lower_bead_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold;
+    return lower_ideal_width + threshold * (higher_ideal_width - lower_ideal_width);
+}
 
 } // namespace cura

--- a/src/BeadingStrategy/BeadingStrategy.h
+++ b/src/BeadingStrategy/BeadingStrategy.h
@@ -9,6 +9,7 @@
 #include "../utils/IntPoint.h"
 #include "../utils/logoutput.h"
 #include "../settings/types/Angle.h"
+#include "../settings/types/Ratio.h" //For the wall transition threshold.
 
 namespace cura
 {
@@ -36,7 +37,16 @@ public:
         coord_t left_over; //! The distance not covered by any bead; gap area.
     };
 
-    BeadingStrategy(coord_t optimal_width, coord_t default_transition_length, float transitioning_angle = pi_div(3));
+    BeadingStrategy
+    (
+        coord_t optimal_width,
+        Ratio wall_split_middle_threshold,
+        Ratio wall_add_middle_threshold,
+        coord_t default_transition_length,
+        float transitioning_angle = pi_div(3)
+    );
+
+    BeadingStrategy(const BeadingStrategy& other);
 
     virtual ~BeadingStrategy() {}
 
@@ -96,6 +106,10 @@ protected:
     std::string name;
 
     coord_t optimal_width; //! Optimal bead width, nominal width off the walls in 'ideal' circumstances.
+
+    Ratio wall_split_middle_threshold; //! Threshold when a middle wall should be split into two, as a ratio of the optimal wall width.
+
+    Ratio wall_add_middle_threshold; //! Threshold when a new middle wall should be added between an even number of walls, as a ratio of the optimal wall width.
 
     coord_t default_transition_length; //! The length of the region to smoothly transfer between bead counts
 

--- a/src/BeadingStrategy/BeadingStrategy.h
+++ b/src/BeadingStrategy/BeadingStrategy.h
@@ -62,12 +62,12 @@ public:
     /*!
      * The ideal thickness for a given \param bead_count
      */
-    virtual coord_t getOptimalThickness(coord_t bead_count) const = 0;
+    virtual coord_t getOptimalThickness(coord_t bead_count) const;
 
     /*!
      * The model thickness at which \ref BeadingStrategy::optimal_bead_count transitions from \p lower_bead_count to \p lower_bead_count + 1
      */
-    virtual coord_t getTransitionThickness(coord_t lower_bead_count) const = 0;
+    virtual coord_t getTransitionThickness(coord_t lower_bead_count) const;
 
     /*!
      * The number of beads should we ideally usefor a given model thickness

--- a/src/BeadingStrategy/BeadingStrategy.h
+++ b/src/BeadingStrategy/BeadingStrategy.h
@@ -99,6 +99,8 @@ public:
     virtual std::string toString() const;
 
     coord_t getOptimalWidth() const;
+    Ratio getSplitMiddleThreshold() const;
+    Ratio getAddMiddleThreshold() const;
     coord_t getDefaultTransitionLength() const;
     AngleRadians getTransitioningAngle() const;
 

--- a/src/BeadingStrategy/BeadingStrategyFactory.cpp
+++ b/src/BeadingStrategy/BeadingStrategyFactory.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "BeadingStrategyFactory.h"

--- a/src/BeadingStrategy/BeadingStrategyFactory.cpp
+++ b/src/BeadingStrategy/BeadingStrategyFactory.cpp
@@ -30,7 +30,7 @@ BeadingStrategyPtr BeadingStrategyFactory::makeStrategy
     const coord_t max_bead_count,
     const coord_t outer_wall_offset,
     const int inward_distributed_center_wall_count,
-    const double minimum_variable_line_width
+    const Ratio minimum_variable_line_ratio
 )
 {
     using std::make_unique;
@@ -52,7 +52,7 @@ BeadingStrategyPtr BeadingStrategyFactory::makeStrategy
             return nullptr;
     }
     logDebug("Applying the Redistribute meta-strategy with outer-wall width = %d, inner-wall width = %d\n", preferred_bead_width_outer, preferred_bead_width_inner);
-    ret = make_unique<RedistributeBeadingStrategy>(preferred_bead_width_outer, minimum_variable_line_width, move(ret));
+    ret = make_unique<RedistributeBeadingStrategy>(preferred_bead_width_outer, minimum_variable_line_ratio, move(ret));
 
     if(print_thin_walls)
     {

--- a/src/BeadingStrategy/BeadingStrategyFactory.cpp
+++ b/src/BeadingStrategy/BeadingStrategyFactory.cpp
@@ -15,25 +15,6 @@
 namespace cura
 {
 
-coord_t getWeightedAverage(const coord_t preferred_bead_width_outer, const coord_t preferred_bead_width_inner, const coord_t max_bead_count)
-{
-    if(max_bead_count > preferred_bead_width_outer - preferred_bead_width_inner)
-    {
-        //The difference between outer and inner bead width would be spread out across so many lines that rounding errors would destroy the difference.
-        //Also catches the case of max_bead_count being "infinite" (max integer).
-        return (preferred_bead_width_outer + preferred_bead_width_inner) / 2;
-    }
-    if (max_bead_count > 2)
-    {
-        return ((preferred_bead_width_outer * 2) + preferred_bead_width_inner * (max_bead_count - 2)) / max_bead_count;
-    }
-    if (max_bead_count <= 0)
-    {
-        return preferred_bead_width_inner;
-    }
-    return preferred_bead_width_outer;
-}
-
 BeadingStrategyPtr BeadingStrategyFactory::makeStrategy
 (
     const StrategyType type,
@@ -54,43 +35,39 @@ BeadingStrategyPtr BeadingStrategyFactory::makeStrategy
 {
     using std::make_unique;
     using std::move;
-    const coord_t bar_preferred_wall_width = getWeightedAverage(preferred_bead_width_outer, preferred_bead_width_inner, max_bead_count);
     BeadingStrategyPtr ret;
     switch (type)
     {
         case StrategyType::Center:
-            ret = make_unique<CenterDeviationBeadingStrategy>(bar_preferred_wall_width, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold);
+            ret = make_unique<CenterDeviationBeadingStrategy>(preferred_bead_width_inner, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold);
             break;
         case StrategyType::Distributed:
-            ret = make_unique<DistributedBeadingStrategy>(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold, std::numeric_limits<int>::max());
+            ret = make_unique<DistributedBeadingStrategy>(preferred_bead_width_inner, preferred_transition_length, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold, std::numeric_limits<int>::max());
             break;
         case StrategyType::InwardDistributed:
-            ret = make_unique<DistributedBeadingStrategy>(bar_preferred_wall_width, preferred_transition_length, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold, inward_distributed_center_wall_count);
+            ret = make_unique<DistributedBeadingStrategy>(preferred_bead_width_inner, preferred_transition_length, transitioning_angle, wall_split_middle_threshold, wall_add_middle_threshold, inward_distributed_center_wall_count);
             break;
         default:
             logError("Cannot make strategy!\n");
             return nullptr;
     }
-    
+    logDebug("Applying the Redistribute meta-strategy with outer-wall width = %d, inner-wall width = %d\n", preferred_bead_width_outer, preferred_bead_width_inner);
+    ret = make_unique<RedistributeBeadingStrategy>(preferred_bead_width_outer, minimum_variable_line_width, move(ret));
+
     if(print_thin_walls)
     {
         logDebug("Applying the Widening Beading meta-strategy with minimum input width %d and minimum output width %d.\n", min_feature_size, min_bead_width);
         ret = make_unique<WideningBeadingStrategy>(move(ret), min_feature_size, min_bead_width);
     }
-    if (max_bead_count > 0)
-    {
-        logDebug("Applying the Redistribute meta-strategy with outer-wall width = %d, inner-wall width = %d\n", preferred_bead_width_outer, preferred_bead_width_inner);
-        ret = make_unique<RedistributeBeadingStrategy>(preferred_bead_width_outer, preferred_bead_width_inner, minimum_variable_line_width, move(ret));
-        //Apply the LimitedBeadingStrategy last, since that adds a 0-width marker wall which other beading strategies shouldn't touch.
-        logDebug("Applying the Limited Beading meta-strategy with maximum bead count = %d.\n", max_bead_count);
-        ret = make_unique<LimitedBeadingStrategy>(max_bead_count, move(ret));
-    }
-    
     if (outer_wall_offset > 0)
     {
         logDebug("Applying the OuterWallOffset meta-strategy with offset = %d.\n", outer_wall_offset);
         ret = make_unique<OuterWallInsetBeadingStrategy>(outer_wall_offset, move(ret));
     }
+
+    //Apply the LimitedBeadingStrategy last, since that adds a 0-width marker wall which other beading strategies shouldn't touch.
+    logDebug("Applying the Limited Beading meta-strategy with maximum bead count = %d.\n", max_bead_count);
+    ret = make_unique<LimitedBeadingStrategy>(max_bead_count, move(ret));
     return ret;
 }
 } // namespace cura

--- a/src/BeadingStrategy/BeadingStrategyFactory.h
+++ b/src/BeadingStrategy/BeadingStrategyFactory.h
@@ -37,7 +37,7 @@ public:
         const coord_t max_bead_count = 0,
         const coord_t outer_wall_offset = 0,
         const int inward_distributed_center_wall_count = 2,
-        const double minimum_variable_line_width = 0.5
+        const Ratio minimum_variable_line_ratio = 0.5
     );
 };
 

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -68,7 +68,7 @@ CenterDeviationBeadingStrategy::Beading CenterDeviationBeadingStrategy::compute(
 
 coord_t CenterDeviationBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
-    const coord_t naive_count = thickness / optimal_width; // How many lines we can fit in for sure. (Note difference with Distributed.)
+    const coord_t naive_count = thickness / optimal_width; // How many lines we can fit in for sure.
     const coord_t remainder = thickness - naive_count * optimal_width; // Space left after fitting that many lines.
     const coord_t minimum_line_width = optimal_width * (naive_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold);
     return naive_count + (remainder >= minimum_line_width); // If there's enough space, fit an extra one.

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -66,16 +66,6 @@ CenterDeviationBeadingStrategy::Beading CenterDeviationBeadingStrategy::compute(
     return ret;
 }
 
-coord_t CenterDeviationBeadingStrategy::getOptimalThickness(coord_t bead_count) const
-{
-    return bead_count * optimal_width;
-}
-
-coord_t CenterDeviationBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
-{
-    return optimal_width * (lower_bead_count + (lower_bead_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold));
-}
-
 coord_t CenterDeviationBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
     const coord_t naive_count = thickness / optimal_width; // How many lines we can fit in for sure. (Note difference with Distributed.)

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Ultimaker B.V.
+// Copyright (c) 2022 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher.
 #include <algorithm>
 

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -6,19 +6,23 @@
 
 namespace cura
 {
-CenterDeviationBeadingStrategy::CenterDeviationBeadingStrategy(const coord_t pref_bead_width,
-                                                               const AngleRadians transitioning_angle,
-                                                               const Ratio wall_split_middle_threshold,
-                                                               const Ratio wall_add_middle_threshold)
-  : BeadingStrategy(pref_bead_width, pref_bead_width / 2, transitioning_angle),
-    minimum_line_width_split(pref_bead_width * wall_split_middle_threshold),
-    minimum_line_width_add(pref_bead_width * wall_add_middle_threshold)
+CenterDeviationBeadingStrategy::CenterDeviationBeadingStrategy
+(
+    const coord_t pref_bead_width,
+    const AngleRadians transitioning_angle,
+    const Ratio wall_split_middle_threshold,
+    const Ratio wall_add_middle_threshold
+) :
+    BeadingStrategy(pref_bead_width, wall_split_middle_threshold, wall_add_middle_threshold, pref_bead_width / 2, transitioning_angle)
 {
     name = "CenterDeviationBeadingStrategy";
 }
 
 CenterDeviationBeadingStrategy::Beading CenterDeviationBeadingStrategy::compute(coord_t thickness, coord_t bead_count) const
 {
+    const coord_t minimum_line_width_split = optimal_width * wall_split_middle_threshold;
+    const coord_t minimum_line_width_add = optimal_width * wall_add_middle_threshold;
+
     Beading ret;
 
     ret.total_thickness = thickness;
@@ -74,14 +78,14 @@ coord_t CenterDeviationBeadingStrategy::getOptimalThickness(coord_t bead_count) 
 
 coord_t CenterDeviationBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
 {
-    return lower_bead_count * optimal_width + (lower_bead_count % 2 == 1 ? minimum_line_width_split : minimum_line_width_add);
+    return optimal_width * (lower_bead_count + (lower_bead_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold));
 }
 
 coord_t CenterDeviationBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
     const coord_t naive_count = thickness / optimal_width; // How many lines we can fit in for sure.
     const coord_t remainder = thickness - naive_count * optimal_width; // Space left after fitting that many lines.
-    const coord_t minimum_line_width = naive_count % 2 == 1 ? minimum_line_width_split : minimum_line_width_add;
+    const coord_t minimum_line_width = optimal_width * (naive_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold);
     return naive_count + (remainder > minimum_line_width); // If there's enough space, fit an extra one.
 }
 

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.cpp
@@ -69,7 +69,7 @@ CenterDeviationBeadingStrategy::Beading CenterDeviationBeadingStrategy::compute(
 coord_t CenterDeviationBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
     const coord_t naive_count = thickness / optimal_width; // How many lines we can fit in for sure.
-    const coord_t remainder = thickness - naive_count * optimal_width; // Space left after fitting that many lines.
+    const coord_t remainder = thickness % optimal_width; // Space left after fitting that many lines.
     const coord_t minimum_line_width = optimal_width * (naive_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold);
     return naive_count + (remainder >= minimum_line_width); // If there's enough space, fit an extra one.
 }

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
@@ -1,6 +1,5 @@
-// Copyright (c) 2021 Ultimaker B.V.
+// Copyright (c) 2022 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher.
-
 
 #ifndef CENTER_DEVIATION_BEADING_STRATEGY_H
 #define CENTER_DEVIATION_BEADING_STRATEGY_H

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
@@ -36,8 +36,6 @@ class CenterDeviationBeadingStrategy : public BeadingStrategy
 
     ~CenterDeviationBeadingStrategy() override{};
     Beading compute(coord_t thickness, coord_t bead_count) const override;
-    coord_t getOptimalThickness(coord_t bead_count) const override;
-    coord_t getTransitionThickness(coord_t lower_bead_count) const override;
     coord_t getOptimalBeadCount(coord_t thickness) const override;
 };
 

--- a/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
+++ b/src/BeadingStrategy/CenterDeviationBeadingStrategy.h
@@ -26,18 +26,14 @@ class CenterDeviationBeadingStrategy : public BeadingStrategy
     FRIEND_TEST(CenterDeviationBeadingStrategy, Construction);
 #endif
 
-  private:
-    // For uneven numbers of lines: Minimum line width for which the middle line will be split into two lines.
-    coord_t minimum_line_width_split;
-
-    // For even numbers of lines: Minimum line width for which a new middle line will be added between the two innermost lines.
-    coord_t minimum_line_width_add;
-
   public:
-    CenterDeviationBeadingStrategy(coord_t pref_bead_width,
-                                   AngleRadians transitioning_angle,
-                                   Ratio wall_split_middle_threshold,
-                                   Ratio wall_add_middle_threshold);
+    CenterDeviationBeadingStrategy
+    (
+        coord_t pref_bead_width,
+        AngleRadians transitioning_angle,
+        Ratio wall_split_middle_threshold,
+        Ratio wall_add_middle_threshold
+    );
 
     ~CenterDeviationBeadingStrategy() override{};
     Beading compute(coord_t thickness, coord_t bead_count) const override;

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -95,7 +95,7 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
 
 coord_t DistributedBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
-    const coord_t naive_count = (thickness + optimal_width / 2) / optimal_width; // How many lines do we _want_ to fit in here. (Note difference with Central.)
+    const coord_t naive_count = thickness / optimal_width; // How many lines we can fit in for sure.
     const coord_t remainder = thickness - naive_count * optimal_width; // Space left after fitting that many lines.
     const coord_t minimum_line_width = optimal_width * (naive_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold);
     return naive_count + (remainder >= minimum_line_width); // If there's enough space, fit an extra one.

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Ultimaker B.V.
+// Copyright (c) 2022 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher.
 #include <numeric>
 #include "DistributedBeadingStrategy.h"

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -93,16 +93,6 @@ DistributedBeadingStrategy::Beading DistributedBeadingStrategy::compute(coord_t 
     return ret;
 }
 
-coord_t DistributedBeadingStrategy::getOptimalThickness(coord_t bead_count) const
-{
-    return bead_count * optimal_width;
-}
-
-coord_t DistributedBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
-{
-    return optimal_width * (lower_bead_count + (lower_bead_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold));
-}
-
 coord_t DistributedBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
     const coord_t naive_count = (thickness + optimal_width / 2) / optimal_width; // How many lines do we _want_ to fit in here. (Note difference with Central.)

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -105,6 +105,10 @@ coord_t DistributedBeadingStrategy::getTransitionThickness(coord_t lower_bead_co
 
 coord_t DistributedBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
+    if (thickness < wall_add_middle_threshold * optimal_width)
+    {
+        return 0;
+    }
     return (thickness + optimal_width / 2) / optimal_width;
 }
 

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -105,11 +105,10 @@ coord_t DistributedBeadingStrategy::getTransitionThickness(coord_t lower_bead_co
 
 coord_t DistributedBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
-    if (thickness < wall_add_middle_threshold * optimal_width)
-    {
-        return 0;
-    }
-    return (thickness + optimal_width / 2) / optimal_width;
+    const coord_t naive_count = (thickness + optimal_width / 2) / optimal_width; // How many lines do we _want_ to fit in here. (Note difference with Central.)
+    const coord_t remainder = thickness - naive_count * optimal_width; // Space left after fitting that many lines.
+    const coord_t minimum_line_width = optimal_width * (naive_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold);
+    return naive_count + (remainder >= minimum_line_width); // If there's enough space, fit an extra one.
 }
 
 } // namespace cura

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -100,7 +100,7 @@ coord_t DistributedBeadingStrategy::getOptimalThickness(coord_t bead_count) cons
 
 coord_t DistributedBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
 {
-    return lower_bead_count * optimal_width + optimal_width * (lower_bead_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold);
+    return optimal_width * (lower_bead_count + (lower_bead_count % 2 == 1 ? wall_split_middle_threshold : wall_add_middle_threshold));
 }
 
 coord_t DistributedBeadingStrategy::getOptimalBeadCount(coord_t thickness) const

--- a/src/BeadingStrategy/DistributedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.cpp
@@ -6,15 +6,16 @@
 namespace cura
 {
 
-DistributedBeadingStrategy::DistributedBeadingStrategy(const coord_t optimal_width,
-                                const coord_t default_transition_length,
-                                const AngleRadians transitioning_angle,
-                                const Ratio wall_split_middle_threshold,
-                                const Ratio wall_add_middle_threshold,
-                                const int distribution_radius)
-    : BeadingStrategy(optimal_width, default_transition_length, transitioning_angle)
-    , wall_split_middle_threshold(wall_split_middle_threshold)
-    , wall_add_middle_threshold(wall_add_middle_threshold)
+DistributedBeadingStrategy::DistributedBeadingStrategy
+(
+    const coord_t optimal_width,
+    const coord_t default_transition_length,
+    const AngleRadians transitioning_angle,
+    const Ratio wall_split_middle_threshold,
+    const Ratio wall_add_middle_threshold,
+    const int distribution_radius
+) :
+    BeadingStrategy(optimal_width, wall_split_middle_threshold, wall_add_middle_threshold, default_transition_length, transitioning_angle)
 {
     if(distribution_radius >= 2)
     {

--- a/src/BeadingStrategy/DistributedBeadingStrategy.h
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.h
@@ -37,8 +37,6 @@ public:
     virtual ~DistributedBeadingStrategy() override {}
 
     Beading compute(coord_t thickness, coord_t bead_count) const override;
-    coord_t getOptimalThickness(coord_t bead_count) const override;
-    coord_t getTransitionThickness(coord_t lower_bead_count) const override;
     coord_t getOptimalBeadCount(coord_t thickness) const override;
 };
 

--- a/src/BeadingStrategy/DistributedBeadingStrategy.h
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Ultimaker B.V.
+// Copyright (c) 2022 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef DISTRIBUTED_BEADING_STRATEGY_H

--- a/src/BeadingStrategy/DistributedBeadingStrategy.h
+++ b/src/BeadingStrategy/DistributedBeadingStrategy.h
@@ -18,24 +18,21 @@ namespace cura
 class DistributedBeadingStrategy : public BeadingStrategy
 {
 protected:
-     // For uneven numbers of lines: Minimum factor of the optimal width for which the middle line will be split into two lines.
-    Ratio wall_split_middle_threshold;
-    
-    // For even numbers of lines: Minimum factor of the optimal width for which a new middle line will be added between the two innermost lines.
-    Ratio wall_add_middle_threshold;
-
     float one_over_distribution_radius_squared; // (1 / distribution_radius)^2
 
 public:
     /*!
     * \param distribution_radius the radius (in number of beads) over which to distribute the discrepancy between the feature size and the optimal thickness
     */
-    DistributedBeadingStrategy( const coord_t optimal_width,
-                                const coord_t default_transition_length,
-                                const AngleRadians transitioning_angle,
-                                const Ratio wall_split_middle_threshold,
-                                const Ratio wall_add_middle_threshold,
-                                const int distribution_radius);
+    DistributedBeadingStrategy
+    (
+        const coord_t optimal_width,
+        const coord_t default_transition_length,
+        const AngleRadians transitioning_angle,
+        const Ratio wall_split_middle_threshold,
+        const Ratio wall_add_middle_threshold,
+        const int distribution_radius
+    );
 
     virtual ~DistributedBeadingStrategy() override {}
 

--- a/src/BeadingStrategy/LimitedBeadingStrategy.cpp
+++ b/src/BeadingStrategy/LimitedBeadingStrategy.cpp
@@ -24,7 +24,7 @@ float LimitedBeadingStrategy::getTransitionAnchorPos(coord_t lower_bead_count) c
 }
 
 LimitedBeadingStrategy::LimitedBeadingStrategy(const coord_t max_bead_count, BeadingStrategyPtr parent)
-    : BeadingStrategy(parent->getOptimalWidth(), /*default_transition_length=*/-1, parent->getTransitioningAngle())
+    : BeadingStrategy(*parent)
     , max_bead_count(max_bead_count)
     , parent(std::move(parent))
 {

--- a/src/BeadingStrategy/OuterWallInsetBeadingStrategy.cpp
+++ b/src/BeadingStrategy/OuterWallInsetBeadingStrategy.cpp
@@ -8,9 +8,9 @@
 namespace cura
 {
 OuterWallInsetBeadingStrategy::OuterWallInsetBeadingStrategy(coord_t outer_wall_offset, BeadingStrategyPtr parent) :
-            BeadingStrategy(parent->getOptimalWidth(), parent->getDefaultTransitionLength(), parent->getTransitioningAngle()),
-            parent(std::move(parent)),
-            outer_wall_offset(outer_wall_offset)
+    BeadingStrategy(*parent),
+    parent(std::move(parent)),
+    outer_wall_offset(outer_wall_offset)
 {
     name = "OuterWallOfsetBeadingStrategy";
 }

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -32,14 +32,23 @@ coord_t RedistributeBeadingStrategy::getOptimalThickness(coord_t bead_count) con
 
 coord_t RedistributeBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
 {
-    return parent->getTransitionThickness(lower_bead_count);
+    switch (lower_bead_count)
+    {
+        case 0: return minimum_variable_line_width * optimal_width_outer;
+        case 1: return (1.0 + parent->getSplitMiddleThreshold()) * optimal_width_outer;
+        default: return parent->getTransitionThickness(lower_bead_count);
+    }
 }
 
 coord_t RedistributeBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
+    if (thickness < minimum_variable_line_width * optimal_width_outer)
+    {
+        return 0;
+    }
     if (thickness <= 2 * optimal_width_outer)
     {
-        return thickness / 2 >= minimum_variable_line_width * optimal_width_outer ? 2 : 1;
+        return thickness > (1.0 + parent->getSplitMiddleThreshold()) * optimal_width_outer ? 2 : 1;
     }
     return parent->getOptimalBeadCount(thickness - 2 * optimal_width_outer) + 2;
 }

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -9,24 +9,24 @@
 namespace cura
 {
 
-RedistributeBeadingStrategy::RedistributeBeadingStrategy(   const coord_t optimal_width_outer,
-                                                            const coord_t optimal_width_inner,
-                                                            const double minimum_variable_line_width,
-                                                            BeadingStrategyPtr parent) :
-        BeadingStrategy(parent->getOptimalWidth(), parent->getDefaultTransitionLength(), parent->getTransitioningAngle()),
-        parent(std::move(parent)),
-        optimal_width_outer(optimal_width_outer),
-        optimal_width_inner(optimal_width_inner),
-        minimum_variable_line_width(minimum_variable_line_width)
+RedistributeBeadingStrategy::RedistributeBeadingStrategy
+(
+    const coord_t optimal_width_outer,
+    const double minimum_variable_line_width,
+    BeadingStrategyPtr parent
+) :
+    BeadingStrategy(parent->getOptimalWidth(), parent->getDefaultTransitionLength(), parent->getTransitioningAngle()),
+    parent(std::move(parent)),
+    optimal_width_outer(optimal_width_outer),
+    minimum_variable_line_width(minimum_variable_line_width)
 {
     name = "RedistributeBeadingStrategy";
 }
 
 coord_t RedistributeBeadingStrategy::getOptimalThickness(coord_t bead_count) const
 {
-    const coord_t inner_bead_count = bead_count > 2 ? bead_count - 2 : 0;
+    const coord_t inner_bead_count = std::max(static_cast<coord_t>(0), bead_count - 2);
     const coord_t outer_bead_count = bead_count - inner_bead_count;
-
     return parent->getOptimalThickness(inner_bead_count) + optimal_width_outer * outer_bead_count;
 }
 
@@ -37,7 +37,11 @@ coord_t RedistributeBeadingStrategy::getTransitionThickness(coord_t lower_bead_c
 
 coord_t RedistributeBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
-    return parent->getOptimalBeadCount(thickness);
+    if (thickness <= 2 * optimal_width_outer)
+    {
+        return thickness / 2 >= minimum_variable_line_width * optimal_width_outer ? 2 : 1;
+    }
+    return parent->getOptimalBeadCount(thickness - 2 * optimal_width_outer) + 2;
 }
 
 coord_t RedistributeBeadingStrategy::getTransitioningLength(coord_t lower_bead_count) const
@@ -58,123 +62,41 @@ std::string RedistributeBeadingStrategy::toString() const
 BeadingStrategy::Beading RedistributeBeadingStrategy::compute(coord_t thickness, coord_t bead_count) const
 {
     Beading ret;
-    if (bead_count > 2)
+
+    // Take care of all situations in which no lines are actually produced:
+    if (bead_count == 0 || thickness < minimum_variable_line_width * optimal_width_outer)
     {
-        const coord_t inner_transition_width = optimal_width_inner * minimum_variable_line_width;
-        const coord_t outer_bead_width =
-            getOptimalOuterBeadWidth(thickness, optimal_width_outer, inner_transition_width);
-
-        // Outer wall is locked in size and position for wall regions of 3 and higher which have at least a
-        // thickness equal to two times the optimal outer width and the minimal inner wall width.
-        const coord_t virtual_thickness = thickness - outer_bead_width * 2;
-        const coord_t virtual_bead_count = bead_count - 2;
-
-        // Calculate the beads and widths of the inner walls only
-        ret = parent->compute(virtual_thickness, virtual_bead_count);
-
-        // Insert the outer beads
-        ret.bead_widths.insert(ret.bead_widths.begin(), outer_bead_width);
-        ret.bead_widths.emplace_back(outer_bead_width);
-    }
-    else
-    {
-        ret = parent->compute(thickness, bead_count);
+        ret.left_over = thickness;
+        ret.total_thickness = thickness;
+        return ret;
     }
 
-    // Filter out beads that violate the minimum inner wall widths and recompute if necessary
-    const coord_t outer_transition_width = optimal_width_inner * minimum_variable_line_width;
-    const bool removed_inner_beads = validateInnerBeadWidths(ret, outer_transition_width);
-    if (removed_inner_beads)
+    // Compute the beadings of the inner walls, if any:
+    const coord_t inner_bead_count = bead_count - 2;
+    const coord_t inner_thickness = thickness - 2 * optimal_width_outer;
+    if (inner_bead_count > 0 && inner_thickness > 0)
     {
-        ret = compute(thickness, bead_count - 1);
+        ret = parent->compute(inner_thickness, inner_bead_count);
+        for (auto& toolpath_location : ret.toolpath_locations)
+        {
+            toolpath_location += optimal_width_outer;
+        }
     }
 
-    // Ensure that the positions of the beads are distributed over the thickness
-    resetToolPathLocations(ret, thickness);
+    // Insert the outer wall(s) around the previously computed inner wall(s), which may be empty:
+    const coord_t actual_outer_thickness = bead_count > 2 ? std::min(thickness / 2, optimal_width_outer) : thickness / bead_count;
+    ret.bead_widths.insert(ret.bead_widths.begin(), actual_outer_thickness);
+    ret.toolpath_locations.insert(ret.toolpath_locations.begin(), actual_outer_thickness / 2);
+    if (bead_count > 1)
+    {
+        ret.bead_widths.push_back(actual_outer_thickness);
+        ret.toolpath_locations.push_back(thickness - actual_outer_thickness / 2);
+    }
 
+    // Ensure correct total and left over thickness.
+    ret.total_thickness = thickness;
+    ret.left_over = thickness - std::accumulate(ret.bead_widths.cbegin(), ret.bead_widths.cend(), static_cast<coord_t>(0));
     return ret;
 }
-
-coord_t RedistributeBeadingStrategy::getOptimalOuterBeadWidth(const coord_t thickness, const coord_t optimal_width_outer, const coord_t minimum_width_inner)
-{
-    const coord_t total_outer_optimal_width = optimal_width_outer * 2;
-    coord_t outer_bead_width = thickness / 2;
-    if (total_outer_optimal_width < thickness)
-    {
-        if (total_outer_optimal_width + minimum_width_inner > thickness)
-        {
-            outer_bead_width -= minimum_width_inner / 2;
-        }
-        else
-        {
-            outer_bead_width = optimal_width_outer;
-        }
-    }
-    return outer_bead_width;
-}
-
-void RedistributeBeadingStrategy::resetToolPathLocations(BeadingStrategy::Beading& beading, const coord_t thickness)
-{
-    const size_t bead_count = beading.bead_widths.size();
-    beading.toolpath_locations.resize(bead_count);
-
-    if (bead_count < 1)
-    {
-        beading.toolpath_locations.resize(0);
-        beading.total_thickness = thickness;
-        beading.left_over = thickness;
-        return;
-    }
-
-    // Update the first half of the toolpath-locations with the updated bead-widths (starting from 0, up to half):
-    coord_t last_coord = 0;
-    coord_t last_width = 0;
-    for (size_t i_location = 0; i_location < bead_count / 2; ++i_location)
-    {
-        beading.toolpath_locations[i_location] = last_coord + (last_width + beading.bead_widths[i_location]) / 2;
-        last_coord = beading.toolpath_locations[i_location];
-        last_width = beading.bead_widths[i_location];
-    }
-
-    // Handle the position of any middle wall (note that the width will already have been set correctly):
-    if (bead_count % 2 == 1)
-    {
-        beading.toolpath_locations[bead_count / 2] = thickness / 2;
-    }
-
-    // Update the last half of the toolpath-locations with the updated bead-widths (starting from thickness, down to half):
-    last_coord = thickness;
-    last_width = 0;
-    for (size_t i_location = bead_count - 1; i_location >= bead_count - (bead_count / 2); --i_location)
-    {
-        beading.toolpath_locations[i_location] = last_coord - (last_width + beading.bead_widths[i_location]) / 2;
-        last_coord = beading.toolpath_locations[i_location];
-        last_width = beading.bead_widths[i_location];
-    }
-
-    // Ensure correct total and left over thickness
-    beading.total_thickness = thickness;
-    beading.left_over = thickness - std::accumulate(beading.bead_widths.cbegin(), beading.bead_widths.cend(), static_cast<coord_t>(0));
-}
-
-bool RedistributeBeadingStrategy::validateInnerBeadWidths(BeadingStrategy::Beading& beading, const coord_t minimum_width_inner)
-{
-    // Filter out bead_widths that violate the transition width and recalculate if needed
-    const size_t unfiltered_beads = beading.bead_widths.size();
-    if(unfiltered_beads <= 2) //Outer walls are exempt. If there are 2 walls the range below will be empty. If there is 1 or 0 walls it would be invalid.
-    {
-        return false;
-    }
-    auto inner_begin = std::next(beading.bead_widths.begin());
-    auto inner_end = std::prev(beading.bead_widths.end());
-    beading.bead_widths.erase(
-        std::remove_if(inner_begin, inner_end,
-        [&minimum_width_inner](const coord_t width)
-        {
-            return width < minimum_width_inner;
-        }),
-        inner_end);
-    return unfiltered_beads != beading.bead_widths.size();
-    }
 
 } // namespace cura

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "RedistributeBeadingStrategy.h"

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -12,10 +12,10 @@ namespace cura
 RedistributeBeadingStrategy::RedistributeBeadingStrategy
 (
     const coord_t optimal_width_outer,
-    const double minimum_variable_line_width,
+    const Ratio minimum_variable_line_width,
     BeadingStrategyPtr parent
 ) :
-    BeadingStrategy(parent->getOptimalWidth(), parent->getDefaultTransitionLength(), parent->getTransitioningAngle()),
+    BeadingStrategy(*parent),
     parent(std::move(parent)),
     optimal_width_outer(optimal_width_outer),
     minimum_variable_line_width(minimum_variable_line_width)

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -12,13 +12,13 @@ namespace cura
 RedistributeBeadingStrategy::RedistributeBeadingStrategy
 (
     const coord_t optimal_width_outer,
-    const Ratio minimum_variable_line_width,
+    const Ratio minimum_variable_line_ratio,
     BeadingStrategyPtr parent
 ) :
     BeadingStrategy(*parent),
     parent(std::move(parent)),
     optimal_width_outer(optimal_width_outer),
-    minimum_variable_line_width(minimum_variable_line_width)
+    minimum_variable_line_ratio(minimum_variable_line_ratio)
 {
     name = "RedistributeBeadingStrategy";
 }
@@ -34,7 +34,7 @@ coord_t RedistributeBeadingStrategy::getTransitionThickness(coord_t lower_bead_c
 {
     switch (lower_bead_count)
     {
-        case 0: return minimum_variable_line_width * optimal_width_outer;
+        case 0: return minimum_variable_line_ratio * optimal_width_outer;
         case 1: return (1.0 + parent->getSplitMiddleThreshold()) * optimal_width_outer;
         default: return parent->getTransitionThickness(lower_bead_count - 2) + 2 * optimal_width_outer;
     }
@@ -42,7 +42,7 @@ coord_t RedistributeBeadingStrategy::getTransitionThickness(coord_t lower_bead_c
 
 coord_t RedistributeBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
 {
-    if (thickness < minimum_variable_line_width * optimal_width_outer)
+    if (thickness < minimum_variable_line_ratio * optimal_width_outer)
     {
         return 0;
     }
@@ -73,7 +73,7 @@ BeadingStrategy::Beading RedistributeBeadingStrategy::compute(coord_t thickness,
     Beading ret;
 
     // Take care of all situations in which no lines are actually produced:
-    if (bead_count == 0 || thickness < minimum_variable_line_width * optimal_width_outer)
+    if (bead_count == 0 || thickness < minimum_variable_line_ratio * optimal_width_outer)
     {
         ret.left_over = thickness;
         ret.total_thickness = thickness;

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -36,7 +36,7 @@ coord_t RedistributeBeadingStrategy::getTransitionThickness(coord_t lower_bead_c
     {
         case 0: return minimum_variable_line_width * optimal_width_outer;
         case 1: return (1.0 + parent->getSplitMiddleThreshold()) * optimal_width_outer;
-        default: return parent->getTransitionThickness(lower_bead_count - 2) + (optimal_width_outer * 2);
+        default: return parent->getTransitionThickness(lower_bead_count - 2) + 2 * optimal_width_outer;
     }
 }
 

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.cpp
@@ -36,7 +36,7 @@ coord_t RedistributeBeadingStrategy::getTransitionThickness(coord_t lower_bead_c
     {
         case 0: return minimum_variable_line_width * optimal_width_outer;
         case 1: return (1.0 + parent->getSplitMiddleThreshold()) * optimal_width_outer;
-        default: return parent->getTransitionThickness(lower_bead_count);
+        default: return parent->getTransitionThickness(lower_bead_count - 2) + (optimal_width_outer * 2);
     }
 }
 

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.h
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.h
@@ -37,7 +37,7 @@ namespace cura
         RedistributeBeadingStrategy
         (
             const coord_t optimal_width_outer,
-            const double minimum_variable_line_width,
+            const Ratio minimum_variable_line_width,
             BeadingStrategyPtr parent
         );
 
@@ -91,7 +91,6 @@ namespace cura
 
         BeadingStrategyPtr parent;
         coord_t optimal_width_outer;
-        coord_t optimal_width_inner;
         double minimum_variable_line_width;
     };
 

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.h
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2020 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef REDISTRIBUTE_DISTRIBUTED_BEADING_STRATEGY_H

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.h
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.h
@@ -32,12 +32,12 @@ namespace cura
          * /param optimal_width_outer         Outer wall width, guaranteed to be the actual (save rounding errors) at a
          *                                    bead count if the parent strategies' optimum bead width is a weighted
          *                                    average of the outer and inner walls at that bead count.
-         * /param minimum_variable_line_width Minimum factor that the variable line might deviate from the optimal width.
+         * /param minimum_variable_line_ratio Minimum factor that the variable line might deviate from the optimal width.
          */
         RedistributeBeadingStrategy
         (
             const coord_t optimal_width_outer,
-            const Ratio minimum_variable_line_width,
+            const Ratio minimum_variable_line_ratio,
             BeadingStrategyPtr parent
         );
 
@@ -91,7 +91,7 @@ namespace cura
 
         BeadingStrategyPtr parent;
         coord_t optimal_width_outer;
-        double minimum_variable_line_width;
+        Ratio minimum_variable_line_ratio;
     };
 
 } // namespace cura

--- a/src/BeadingStrategy/RedistributeBeadingStrategy.h
+++ b/src/BeadingStrategy/RedistributeBeadingStrategy.h
@@ -32,15 +32,14 @@ namespace cura
          * /param optimal_width_outer         Outer wall width, guaranteed to be the actual (save rounding errors) at a
          *                                    bead count if the parent strategies' optimum bead width is a weighted
          *                                    average of the outer and inner walls at that bead count.
-         * /param optimal_width_outer         Inner wall width, guaranteed to be the actual (save rounding errors) at a
-         *                                    bead count if the parent strategies' optimum bead width is a weighted
-         *                                    average of the outer and inner walls at that bead count.
          * /param minimum_variable_line_width Minimum factor that the variable line might deviate from the optimal width.
          */
-        RedistributeBeadingStrategy(const coord_t optimal_width_outer,
-                                    const coord_t optimal_width_inner,
-                                    const double minimum_variable_line_width,
-                                    BeadingStrategyPtr parent);
+        RedistributeBeadingStrategy
+        (
+            const coord_t optimal_width_outer,
+            const double minimum_variable_line_width,
+            BeadingStrategyPtr parent
+        );
 
         virtual ~RedistributeBeadingStrategy() override = default;
 

--- a/src/BeadingStrategy/WideningBeadingStrategy.cpp
+++ b/src/BeadingStrategy/WideningBeadingStrategy.cpp
@@ -7,7 +7,7 @@ namespace cura
 {
 
 WideningBeadingStrategy::WideningBeadingStrategy(BeadingStrategyPtr parent, const coord_t min_input_width, const coord_t min_output_width)
-    : BeadingStrategy(parent->getOptimalWidth(), /*default_transition_length=*/-1, parent->getTransitioningAngle())
+    : BeadingStrategy(*parent)
     , parent(std::move(parent))
     , min_input_width(min_input_width)
     , min_output_width(min_output_width)

--- a/tests/beading_strategy/CenterDeviationBeadingStrategyTest.cpp
+++ b/tests/beading_strategy/CenterDeviationBeadingStrategyTest.cpp
@@ -14,14 +14,9 @@ namespace cura
  */
 TEST(CenterDeviationBeadingStrategy, Construction)
 {
-    CenterDeviationBeadingStrategy strategy(400, 0.6, 0.5, 0.5); //Pretty standard settings.
-    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 200) << "Since the transition threshold was 50%, the minimum line width should be 0.5 times the preferred width.";
-    strategy = CenterDeviationBeadingStrategy(400, 0.6, 0, 0);
-    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 0) << "Since the transition threshold was 0%, the minimum line width should be 0.";
-    strategy = CenterDeviationBeadingStrategy(0, 0.6, 0.5, 0.5);
-    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 0) << "Since the line width was 0%, the minimum line width should also be 0.";
-    strategy = CenterDeviationBeadingStrategy(400, 0.6, 1, 1);
-    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 400) << "Since the transition threshold was 100%, the minimum line width equals the preferred width.";
+    CenterDeviationBeadingStrategy strategy(400, 0.6, 0.5, 0.75);
+    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 0.5) << "Split-middle threshold should be the one it's constructed with.";
+    EXPECT_EQ(strategy.getAddMiddleThreshold(), 0.75) << "Add-middle threshold should be the one it's constructed with.";
 }
 
 /*!

--- a/tests/beading_strategy/CenterDeviationBeadingStrategyTest.cpp
+++ b/tests/beading_strategy/CenterDeviationBeadingStrategyTest.cpp
@@ -15,13 +15,13 @@ namespace cura
 TEST(CenterDeviationBeadingStrategy, Construction)
 {
     CenterDeviationBeadingStrategy strategy(400, 0.6, 0.5, 0.5); //Pretty standard settings.
-    EXPECT_EQ(strategy.minimum_line_width_split, 200) << "Since the transition threshold was 50%, the minimum line width should be 0.5 times the preferred width.";
+    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 200) << "Since the transition threshold was 50%, the minimum line width should be 0.5 times the preferred width.";
     strategy = CenterDeviationBeadingStrategy(400, 0.6, 0, 0);
-    EXPECT_EQ(strategy.minimum_line_width_split, 0) << "Since the transition threshold was 0%, the minimum line width should be 0.";
+    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 0) << "Since the transition threshold was 0%, the minimum line width should be 0.";
     strategy = CenterDeviationBeadingStrategy(0, 0.6, 0.5, 0.5);
-    EXPECT_EQ(strategy.minimum_line_width_split, 0) << "Since the line width was 0%, the minimum line width should also be 0.";
+    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 0) << "Since the line width was 0%, the minimum line width should also be 0.";
     strategy = CenterDeviationBeadingStrategy(400, 0.6, 1, 1);
-    EXPECT_EQ(strategy.minimum_line_width_split, 400) << "Since the transition threshold was 100%, the minimum line width equals the preferred width.";
+    EXPECT_EQ(strategy.getSplitMiddleThreshold(), 400) << "Since the transition threshold was 100%, the minimum line width equals the preferred width.";
 }
 
 /*!


### PR DESCRIPTION
Make the Beading Strategies conform to current expected behaviour. (See image, helpfully provided by a colleague.)

![5340f88c-0eff-474a-a5ea-c5cdec47a6ca](https://user-images.githubusercontent.com/41987080/159503076-97ffe843-caa1-4580-99c7-38d9691d5e59.png)

Please use a recent front-end when testing this!

Also solves internal ticket(s): CURA-8699, ...