### PR TITLE
Fix ironing path generation

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -356,8 +356,8 @@ void Infill::generateConcentricInfill(VariableWidthPaths& toolpaths, const Setti
     const coord_t min_area = infill_line_width * infill_line_width;
     coord_t line_width_to_use = infill_line_width;
 
-    // Special case for ironing. The line distance will often be much smaller than the line width.
-    // In that case we should add the lines based on that spacing (and not the line width). See CURA-8090
+    // Special case that currently only triggers when using ironing. The line distance will often be much smaller than
+    // the line width. In that case we should add the lines based on that spacing (and not the line width). See CURA-8090
     // for more information
     if(infill_line_width > line_distance)
     {

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -354,6 +354,16 @@ void Infill::generateConcentricInfill(VariableWidthPaths& toolpaths, const Setti
     constexpr coord_t wall_0_inset = 0; // Don't apply any outer wall inset for these. That's just for the outer wall.
     const bool iterative = line_distance > infill_line_width; // Do it all at once if there is not need for a gap, otherwise, iterate.
     const coord_t min_area = infill_line_width * infill_line_width;
+    coord_t line_width_to_use = infill_line_width;
+
+    // Special case for ironing. The line distance will often be much smaller than the line width.
+    // In that case we should add the lines based on that spacing (and not the line width). See CURA-8090
+    // for more information
+    if(infill_line_width > line_distance)
+    {
+        line_width_to_use = line_distance;
+    }
+
     Polygons current_inset = inner_contour.offset(infill_line_width / 2);
     do
     {
@@ -368,7 +378,7 @@ void Infill::generateConcentricInfill(VariableWidthPaths& toolpaths, const Setti
         }
 
         const coord_t inset_wall_count = iterative ? 1 : std::numeric_limits<coord_t>::max();
-        WallToolPaths wall_toolpaths(current_inset, infill_line_width, inset_wall_count, wall_0_inset, settings);
+        WallToolPaths wall_toolpaths(current_inset, line_width_to_use, inset_wall_count, wall_0_inset, settings);
         const VariableWidthPaths inset_paths = wall_toolpaths.getToolPaths();
 
         toolpaths.insert(toolpaths.end(), inset_paths.begin(), inset_paths.end());

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -79,7 +79,6 @@ void Infill::generate(VariableWidthPaths& toolpaths, Polygons& result_polygons, 
     //The lines along the edge must lie next to the border, not on it.
     //This makes those algorithms a lot simpler.
     if (pattern == EFillMethod::ZIG_ZAG //Zig-zag prints the zags along the walls.
-        || pattern == EFillMethod::CONCENTRIC //Concentric at high densities needs to print alongside the walls, not overlapping them.
         || (zig_zaggify && (pattern == EFillMethod::LINES //Zig-zaggified infill patterns print their zags along the walls.
             || pattern == EFillMethod::TRIANGLES
             || pattern == EFillMethod::GRID
@@ -351,22 +350,27 @@ void Infill::generateLightningInfill(const LightningLayer* trees, Polygons& resu
 
 void Infill::generateConcentricInfill(VariableWidthPaths& toolpaths, const Settings& settings)
 {
-    constexpr coord_t wall_0_inset = 0; // Don't apply any outer wall inset for these. That's just for the outer wall.
     const coord_t min_area = infill_line_width * infill_line_width;
 
-    Polygons current_inset = inner_contour.offset(infill_line_width / 2);
-    while(current_inset.area() >= min_area) //Stop when lower than min_area.
+    Polygons current_inset = inner_contour;
+    while(true)
     {
-        current_inset.simplify();
+        //If line_distance is 0, start from the same contour as the previous line, except where the previous line closed up the shape.
+        //So we add the whole nominal line width first (to allow lines to be closer together than 1 line width if the line distance is smaller) and then subtract line_distance.
+        current_inset = current_inset.offset(infill_line_width - line_distance);
+        current_inset.simplify(); //Many insets lead to increasingly detailed shapes. Simplify to speed up processing.
+        if(current_inset.area() < min_area) //So small that it's inconsequential. Stop here.
+        {
+            break;
+        }
 
-        constexpr size_t inset_wall_count = 1;
+        constexpr size_t inset_wall_count = 1; //1 wall at a time.
+        constexpr coord_t wall_0_inset = 0; //Don't apply any outer wall inset for these. That's just for the outer wall.
         WallToolPaths wall_toolpaths(current_inset, infill_line_width, inset_wall_count, wall_0_inset, settings);
         const VariableWidthPaths inset_paths = wall_toolpaths.getToolPaths();
         toolpaths.insert(toolpaths.end(), inset_paths.begin(), inset_paths.end());
 
-        //If line_distance is 0, start from the same contour as the previous line, except where the previous line closed up the shape.
-        //So we add the whole nominal line width first (to allow lines to be closer together than 1 line width if the line distance is smaller) and then subtract line_distance.
-        current_inset = wall_toolpaths.getInnerContour().offset(infill_line_width - line_distance);
+        current_inset = wall_toolpaths.getInnerContour();
     }
 }
 

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -355,21 +355,18 @@ void Infill::generateConcentricInfill(VariableWidthPaths& toolpaths, const Setti
     const coord_t min_area = infill_line_width * infill_line_width;
 
     Polygons current_inset = inner_contour.offset(infill_line_width / 2);
-    while(true)
+    while(current_inset.area() >= min_area) //Stop when lower than min_area.
     {
-        current_inset = current_inset.offset(-infill_line_width * 2).offset(infill_line_width * 2);
         current_inset.simplify();
-        if (current_inset.area() <= min_area)
-        {
-            break;
-        }
 
         constexpr size_t inset_wall_count = 1;
         WallToolPaths wall_toolpaths(current_inset, infill_line_width, inset_wall_count, wall_0_inset, settings);
         const VariableWidthPaths inset_paths = wall_toolpaths.getToolPaths();
         toolpaths.insert(toolpaths.end(), inset_paths.begin(), inset_paths.end());
 
-        current_inset = wall_toolpaths.getInnerContour().offset((infill_line_width / 2) - line_distance);
+        //If line_distance is 0, start from the same contour as the previous line, except where the previous line closed up the shape.
+        //So we add the whole nominal line width first (to allow lines to be closer together than 1 line width if the line distance is smaller) and then subtract line_distance.
+        current_inset = wall_toolpaths.getInnerContour().offset(infill_line_width - line_distance);
     }
 }
 


### PR DESCRIPTION
When the line_width is larger than the spacing, it would plan everything in one go
but it would us the linewidth to do so. In the case of ironing it would mean that the
spacing would be ignored (as it would be printed without overlaps). This makes sense
for infill, but that is not what we want for ironing

CURA-8090