### PR TITLE
Failures to stitch

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -138,18 +138,6 @@ void WallToolPaths::stitchToolPaths(VariableWidthPaths& toolpaths, const Setting
         VariableWidthLines stitched_polylines;
         VariableWidthLines closed_polygons;
         PolylineStitcher<VariableWidthLines, ExtrusionLine, ExtrusionJunction>::stitch(wall_lines, stitched_polylines, closed_polygons, stitch_distance);
-#ifdef DEBUG
-        for (const ExtrusionLine& line : stitched_polylines)
-        {
-            if ( ! line.is_odd &&
-                line.polylineLength() > 3 * stitch_distance && line.size() > 3)
-            {
-                logError("Some even contour lines could not be closed into polygons!\n");
-                assert(false && "Some even contour lines could not be closed into polygons!");
-                // NOTE: if this assertion fails then revert the debugging code removed in this commit (git blame on this line)
-            }
-        }
-#endif // DEBUG
         wall_lines = stitched_polylines; // replace input toolpaths with stitched polylines
 
         for (ExtrusionLine& wall_polygon : closed_polygons)

--- a/src/utils/PolylineStitcher.cpp
+++ b/src/utils/PolylineStitcher.cpp
@@ -40,5 +40,17 @@ bool PolylineStitcher<Polygons, Polygon, Point>::canConnect(const Polygon&, cons
     return true;
 }
 
+template<>
+bool PolylineStitcher<VariableWidthLines, ExtrusionLine, ExtrusionJunction>::isOdd(const ExtrusionLine& line)
+{
+    return line.is_odd;
+}
+
+template<>
+bool PolylineStitcher<Polygons, Polygon, Point>::isOdd(const Polygon&)
+{
+    return false;
+}
+
 }//namespace cura
 


### PR DESCRIPTION
This branch contains a few small changes:

* It will make CuraEngine prefer to stitch walls of the same oddity together: Odd walls to odd walls, even to even. This helps to close loops more often where possible.
* It removes an assertion that was faulty. It is intended that lines that start off even can be connected to odd lines, and in those cases the line will often be marked as even while actually being a polyline.
* A minor performance improvement when stitching highly detailed polygons.

Fixes CURA-8091, hopefully once and for all.