### PR TITLE
Fix combing skipping small distances

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -976,12 +976,13 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, LayerIn
     coord_t max_inner_wall_width = 0;
     for (const SliceMeshStorage& mesh : storage.meshes)
     {
-        max_inner_wall_width = std::max(max_inner_wall_width, mesh.settings.get<coord_t>((mesh.settings.get<size_t>("wall_line_count") > 1) ? "wall_line_width_x" : "wall_line_width_0"));
-        if (layer_nr == 0)
+        coord_t mesh_inner_wall_width = mesh.settings.get<coord_t>((mesh.settings.get<size_t>("wall_line_count") > 1) ? "wall_line_width_x" : "wall_line_width_0");
+        if(layer_nr == 0)
         {
             const ExtruderTrain& train = mesh.settings.get<ExtruderTrain&>((mesh.settings.get<size_t>("wall_line_count") > 1) ? "wall_0_extruder_nr" : "wall_x_extruder_nr");
-            max_inner_wall_width *= train.settings.get<Ratio>("initial_layer_line_width_factor");
+            mesh_inner_wall_width *= train.settings.get<Ratio>("initial_layer_line_width_factor");
         }
+        max_inner_wall_width = std::max(max_inner_wall_width, mesh_inner_wall_width);
     }
     const coord_t comb_offset_from_outlines = max_inner_wall_width * 2;
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1453,7 +1453,7 @@ void FffGcodeWriter::addMeshPartToGCode(const SliceDataStorage& storage, const S
         {
             innermost_wall_line_width *= mesh.settings.get<Ratio>("initial_layer_line_width_factor");
         }
-        gcode_layer.moveInsideCombBoundary(innermost_wall_line_width);
+        gcode_layer.moveInsideCombBoundary(innermost_wall_line_width, part);
     }
 
     gcode_layer.setIsInside(false);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -301,16 +301,17 @@ void LayerPlan::setMesh(const std::string mesh_id)
     current_mesh = mesh_id;
 }
 
-void LayerPlan::moveInsideCombBoundary(const coord_t distance)
+void LayerPlan::moveInsideCombBoundary(const coord_t distance, const std::optional<SliceLayerPart>& part)
 {
     constexpr coord_t max_dist2 = MM2INT(2.0) * MM2INT(2.0); // if we are further than this distance, we conclude we are not inside even though we thought we were.
-    // this function is to be used to move from the boudary of a part to inside the part
+    // this function is to be used to move from the boundary of a part to inside the part
     Point p = getLastPlannedPositionOrStartingPosition(); // copy, since we are going to move p
     if (PolygonUtils::moveInside(comb_boundary_preferred, p, distance, max_dist2) != NO_INDEX)
     {
         //Move inside again, so we move out of tight 90deg corners
         PolygonUtils::moveInside(comb_boundary_preferred, p, distance, max_dist2);
-        if (comb_boundary_preferred.inside(p))
+        if (comb_boundary_preferred.inside(p) &&
+            (part == std::nullopt || part->outline.inside(p)))
         {
             addTravel_simple(p);
             //Make sure the that any retraction happens after this move, not before it by starting a new move path.

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -758,12 +758,17 @@ public:
     void processFanSpeedAndMinimalLayerTime(Point starting_position);
     
     /*!
-     * Add a travel move to the layer plan to move inside the current layer part by a given distance away from the outline.
-     * This is supposed to be called when the nozzle is around the boundary of a layer part, not when the nozzle is in the middle of support, or in the middle of the air.
-     * 
-     * \param distance The distance to the comb boundary after we moved inside it.
+     * Add a travel move to the layer plan to move inside the current layer part
+     * by a given distance away from the outline.
+     *
+     * This is supposed to be called when the nozzle is around the boundary of a
+     * layer part, not when the nozzle is in the middle of support, or in the
+     * middle of the air.
+     * \param distance The distance to the comb boundary after we moved inside
+     * it.
+     * \param part If given, stay within the boundary of this part.
      */
-    void moveInsideCombBoundary(const coord_t distance);
+    void moveInsideCombBoundary(const coord_t distance, const std::optional<SliceLayerPart>& part = std::nullopt);
 
     /*!
      * Apply back-pressure compensation to this layer-plan.

--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -33,7 +33,7 @@ Comb::Comb(const SliceDataStorage& storage, const LayerIndex layer_nr, const Pol
 : storage(storage)
 , layer_nr(layer_nr)
 , offset_from_outlines(comb_boundary_offset) // between second wall and infill / other walls
-, max_moveInside_distance2(offset_from_outlines * 2 * offset_from_outlines * 2)
+, max_moveInside_distance2(offset_from_outlines * offset_from_outlines)
 , offset_from_inside_to_outside(offset_from_outlines + travel_avoid_distance)
 , max_crossing_dist2(offset_from_inside_to_outside * offset_from_inside_to_outside * 2) // so max_crossing_dist = offset_from_inside_to_outside * sqrt(2) =approx 1.5 to allow for slightly diagonal crossings and slightly inaccurate crossing computation
 , boundary_inside_minimum( comb_boundary_inside_minimum ) // copy the boundary, because the partsView_inside will reorder the polygons
@@ -80,7 +80,7 @@ bool Comb::calc(const ExtruderTrain& train, Point start_point, Point end_point, 
     unsigned int end_inside_poly = NO_INDEX;
     const bool end_inside = moveInside(boundary_inside_optimal, _end_inside, inside_loc_to_line_optimal.get(), end_point, end_inside_poly);
 
-    unsigned int start_part_boundary_poly_idx = NO_INDEX;		// Added initial value to stop MSVC throwing an exception in debug mode
+    unsigned int start_part_boundary_poly_idx = NO_INDEX; // Added initial value to stop MSVC throwing an exception in debug mode
     unsigned int end_part_boundary_poly_idx = NO_INDEX;
     unsigned int start_part_idx =   (start_inside_poly == NO_INDEX)?    NO_INDEX : partsView_inside_optimal.getPartContaining(start_inside_poly, &start_part_boundary_poly_idx);
     unsigned int end_part_idx =     (end_inside_poly == NO_INDEX)?      NO_INDEX : partsView_inside_optimal.getPartContaining(end_inside_poly, &end_part_boundary_poly_idx);


### PR DESCRIPTION
There were two moveInside operations being done around the combing code that both have the possibility to jump between parts, causing a travel move without ooze protection (retraction/hop/etc) to occur there. The distances are small, but plausible.

1. The moveInside operation after finishing a part was attempting to move to the optimal combing boundary, if it was within 2mm. I added an additional constraint to that move to force it to stay within the same part if possible. It's still limited to 2mm which is kind of far, but it should be more safe. In theory, it's possible to have cases here where it crosses the boundary of a single part twice, in which case it will still travel through the outer wall, but hopefully that is sufficiently rare.
2. Combing itself also had a moveInside operation. That was set to limit to twice the `offset_from_outlines`, which itself is set to twice the innermost wall line width, making it limit to 4 line widths. Since the optimal combing boundary is set to 1.5 line widths, it should be no more than 3 line widths maximum distance (the case when two opposite outer walls exactly touch). I set it to 2 instead via `offset_from_outlines`, because that fits better semantically. This has the danger that the move-inside to get away from the outer wall fails in sharp outer corners. However in a sharp outer corner the only direction it can travel in is towards that same inside anyway, so it shouldn't be that bad when it goes wrong.

Fixes CURA-8131.