### PR TITLE
[CURA-9036] Fix using wrong junctions when calculating areas.

### DIFF
--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -225,8 +225,10 @@ coord_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A,
     {
         // Adjust the width only if there is a difference, or else the rounding errors may produce the wrong
         // weighted average value.
-        weighted_average_width = (ab_length * (A.w + B.w) / 2 + bc_length * (B.w + C.w) / 2) / vSize(C - A);
-        return std::abs(A.w - weighted_average_width) * ab_length + std::abs(B.w - weighted_average_width) * bc_length;
+        const coord_t ab_weight = (A.w + B.w) / 2;
+        const coord_t bc_weight = (B.w + C.w) / 2;
+        weighted_average_width = (ab_length * ab_weight + bc_length * bc_weight) / vSize(C - A);
+        return std::abs(ab_weight - weighted_average_width) * ab_length + std::abs(bc_weight - weighted_average_width) * bc_length;
     }
     else
     {

--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -220,18 +220,18 @@ coord_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A,
      * */
     const coord_t ab_length = vSize(B - A);
     const coord_t bc_length = vSize(C - B);
-    const coord_t width_diff = llabs(B.w - C.w);
+    const coord_t width_diff = llabs(B.w - A.w);
     if (width_diff > 1)
     {
         // Adjust the width only if there is a difference, or else the rounding errors may produce the wrong
         // weighted average value.
-        weighted_average_width = (ab_length * B.w + bc_length * C.w) / vSize(C - A);
-        return llabs(B.w - weighted_average_width) * ab_length + llabs(C.w - weighted_average_width) * bc_length;
+        weighted_average_width = (ab_length * A.w + bc_length * B.w) / vSize(C - A);
+        return llabs(A.w - weighted_average_width) * ab_length + llabs(B.w - weighted_average_width) * bc_length;
     }
     else
     {
         // If the width difference is very small, then select the width of the segment that is longer
-        weighted_average_width = ab_length > bc_length ? B.w : C.w;
+        weighted_average_width = ab_length > bc_length ? A.w : B.w;
         return ab_length > bc_length ? width_diff * bc_length : width_diff * ab_length;
     }
 }

--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -128,9 +128,7 @@ void ExtrusionLine::simplify(const coord_t smallest_line_segment_squared, const 
             // We shouldn't remove middle junctions of colinear segments if the area changed for the C-P segment is exceeding the maximum allowed
              && extrusion_area_error <= maximum_extrusion_area_deviation)
         {
-            // Adjust the width of the entire P-N line as a weighted average of the widths of the P-C and C-N lines and
-            // then remove the current junction (vertex).
-            next.w = weighted_average_width;
+            // Remove the current junction (vertex).
             continue;
         }
 
@@ -220,7 +218,7 @@ coord_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A,
      * */
     const coord_t ab_length = vSize(B - A);
     const coord_t bc_length = vSize(C - B);
-    const coord_t width_diff = std::abs(B.w - A.w);
+    const coord_t width_diff = std::max(std::abs(B.w - A.w), std::abs(C.w - B.w));
     if (width_diff > 1)
     {
         // Adjust the width only if there is a difference, or else the rounding errors may produce the wrong

--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -210,8 +210,8 @@ coord_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A,
      * |             |--------------------------|              |            |***************************|
      * |             |                                         ------------------------------------------
      * ---------------             ^                           **************
-     *       ^                    C.w                                             ^
-     *      B.w                                                     new_width = weighted_average_width
+     *       ^                B.w + C.w / 2                                       ^
+     *  A.w + B.w / 2                                               new_width = weighted_average_width
      *
      *
      * ******** denote the total extrusion area deviation error in the consecutive segments as a result of using the
@@ -225,7 +225,7 @@ coord_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A,
     {
         // Adjust the width only if there is a difference, or else the rounding errors may produce the wrong
         // weighted average value.
-        weighted_average_width = (ab_length * A.w + bc_length * B.w) / vSize(C - A);
+        weighted_average_width = (ab_length * (A.w + B.w) / 2 + bc_length * (B.w + C.w) / 2) / vSize(C - A);
         return std::abs(A.w - weighted_average_width) * ab_length + std::abs(B.w - weighted_average_width) * bc_length;
     }
     else

--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -220,13 +220,13 @@ coord_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A,
      * */
     const coord_t ab_length = vSize(B - A);
     const coord_t bc_length = vSize(C - B);
-    const coord_t width_diff = llabs(B.w - A.w);
+    const coord_t width_diff = std::abs(B.w - A.w);
     if (width_diff > 1)
     {
         // Adjust the width only if there is a difference, or else the rounding errors may produce the wrong
         // weighted average value.
         weighted_average_width = (ab_length * A.w + bc_length * B.w) / vSize(C - A);
-        return llabs(A.w - weighted_average_width) * ab_length + llabs(B.w - weighted_average_width) * bc_length;
+        return std::abs(A.w - weighted_average_width) * ab_length + std::abs(B.w - weighted_average_width) * bc_length;
     }
     else
     {

--- a/tests/utils/ExtrusionLineTest.cpp
+++ b/tests/utils/ExtrusionLineTest.cpp
@@ -406,31 +406,13 @@ namespace cura
     TEST(ExtrusionLineTest, simplifyLineWidthVariance)
     {
         //Generate a line with several vertices halfway.
-        constexpr coord_t spacing = 100;
         ExtrusionLine colinear_polylines(0, false);
         auto& colinear = colinear_polylines.junctions;
         colinear.emplace_back(Point(0, 0), 200, 0);
-        colinear.emplace_back(Point(spacing / 4, 0), 200, 0);
-        colinear.emplace_back(Point(spacing / 2, 0), 400, 0);
-        colinear.emplace_back(Point(spacing / 2 + spacing / 4, 0), 600, 0);
-        colinear.emplace_back(Point(spacing, 0), 800, 0);
-
-        colinear_polylines.simplify(25 * 25, 25 * 25, std::numeric_limits<coord_t>::max());
-
-        ASSERT_EQ(colinear_polylines.junctions.size(), 2) << "The degenerate vertices should have been removed.";
-    }
-
-    TEST(ExtrusionLineTest, simplifyNoLineWidthVariance)
-    {
-        //Generate a line with several vertices halfway.
-        constexpr coord_t spacing = 100;
-        ExtrusionLine colinear_polylines(0, false);
-        auto& colinear = colinear_polylines.junctions;
-        colinear.emplace_back(Point(0, 0), 200, 0);
-        colinear.emplace_back(Point(spacing / 4, 0), 200, 0);
-        colinear.emplace_back(Point(spacing / 2, 0), 400, 0);
-        colinear.emplace_back(Point(spacing / 2 + spacing / 4, 0), 600, 0);
-        colinear.emplace_back(Point(spacing, 0), 800, 0);
+        colinear.emplace_back(Point(500, 0), 200, 0);
+        colinear.emplace_back(Point(1000, 0), 400, 0);
+        colinear.emplace_back(Point(1500, 0), 600, 0);
+        colinear.emplace_back(Point(2000, 0), 800, 0);
 
         // Get 'before' average width:
         coord_t averge_width_before = 0;
@@ -439,9 +421,25 @@ namespace cura
             averge_width_before += ((colinear[i_junction].w + colinear[i_junction + 1].w) / 2) * vSize(colinear[i_junction].p - colinear[i_junction + 1].p);
         }
 
-        colinear_polylines.simplify(5 * 5, 5 * 5, 5 * 5);
+        colinear_polylines.simplify(20 * 20, 5 * 5, std::numeric_limits<coord_t>::max()); //Regardless of parameters, it should always remove those middle vertices.
+
+        ASSERT_EQ(colinear_polylines.junctions.size(), 2) << "The degenerate vertices should have been removed.";
+        ASSERT_EQ(colinear[0].w + colinear[1].w / 2, averge_width_before) << "The average width of the line should be the same before and after.";
+    }
+
+    TEST(ExtrusionLineTest, simplifyNoLineWidthVariance)
+    {
+        //Generate a line with several vertices halfway.
+        ExtrusionLine colinear_polylines(0, false);
+        auto& colinear = colinear_polylines.junctions;
+        colinear.emplace_back(Point(0, 0), 200, 0);
+        colinear.emplace_back(Point(500, 0), 200, 0);
+        colinear.emplace_back(Point(1000, 0), 400, 0);
+        colinear.emplace_back(Point(1500, 0), 600, 0);
+        colinear.emplace_back(Point(2000, 0), 800, 0);
+
+        colinear_polylines.simplify(20 * 20, 5 * 5, 1);  // Now it should _not_ remove the vertices, since the total width altered will be more than the max area ...
 
         ASSERT_EQ(colinear_polylines.junctions.size(), 5) << "No junctions should have been removed."; // ... even though they are co-linear!
-        ASSERT_EQ(colinear[0].w + colinear[1].w / 2, averge_width_before) << "The average width of the line should be the same before and after.";
     }
 }

--- a/tests/utils/ExtrusionLineTest.cpp
+++ b/tests/utils/ExtrusionLineTest.cpp
@@ -424,7 +424,6 @@ namespace cura
         colinear_polylines.simplify(20 * 20, 5 * 5, std::numeric_limits<coord_t>::max()); //Regardless of parameters, it should always remove those middle vertices.
 
         ASSERT_EQ(colinear_polylines.junctions.size(), 2) << "The degenerate vertices should have been removed.";
-        ASSERT_EQ(colinear[0].w + colinear[1].w / 2, averge_width_before) << "The average width of the line should be the same before and after.";
     }
 
     TEST(ExtrusionLineTest, simplifyNoLineWidthVariance)


### PR DESCRIPTION
The code as it was assumed that each junction specified the width for the _previous_ line it was connected to, but it actually specifies the width for the _next_ line it's connected to.

This caused an issue where it could make the symmetrical beadings so far out of kilter that it's easily visible in the preview.

Technically this still can happen, but only because the Maximum Extrusion Area Deviation is set to a very large value in the front-end, so the simplification doesn't really care about the weights. We should probably put it back to 2000 square micron, as it was.

Also remove that we re-set the width of the next-vertex when simplifying out the current, since this can have repercussions for line-segments that have very little to do with the removal of the current vertex in the loop. (Namely the next-next.)

See also frontend PR https://github.com/Ultimaker/Cura/pull/11709 since we need the maximum area deviation back at a somewhat more reasonable figure to make this work at all.