### PR TITLE
Remove Center Last option from Wall Ordering

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -54,7 +54,6 @@ bool InsetOrderOptimizer::addToLayer()
     // Settings & configs:
     const bool pack_by_inset = ! settings.get<bool>("optimize_wall_printing_order");
     const InsetDirection inset_direction = settings.get<InsetDirection>("inset_direction");
-    const bool center_last = settings.get<bool>("wall_order_center_last");
     const bool alternate_walls = settings.get<bool>("material_alternate_walls");
 
     const bool outer_to_inner = inset_direction == InsetDirection::OUTSIDE_IN;
@@ -128,23 +127,6 @@ bool InsetOrderOptimizer::addToLayer()
         pack_by_inset?
         getInsetOrder(walls_to_be_added, outer_to_inner)
         : getRegionOrder(walls_to_be_added, outer_to_inner);
-    
-    if (center_last)
-    {
-        for (const ExtrusionLine* line : walls_to_be_added)
-        {
-            if (line->is_odd)
-            {
-                for (const ExtrusionLine* other_line : walls_to_be_added)
-                {
-                    if ( ! other_line->is_odd)
-                    {
-                        order.emplace(std::make_pair(other_line, line));
-                    }
-                }
-            }
-        }
-    }
     
     constexpr Ratio flow = 1.0_r;
     

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -54,7 +54,7 @@ bool InsetOrderOptimizer::addToLayer()
     // Settings & configs:
     const bool pack_by_inset = ! settings.get<bool>("optimize_wall_printing_order");
     const InsetDirection inset_direction = settings.get<InsetDirection>("inset_direction");
-    const bool center_last = inset_direction == InsetDirection::CENTER_LAST;
+    const bool center_last = settings.get<bool>("wall_order_center_last");
     const bool alternate_walls = settings.get<bool>("material_alternate_walls");
 
     const bool outer_to_inner = inset_direction == InsetDirection::OUTSIDE_IN;

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -569,11 +569,7 @@ template<> SlicingTolerance Settings::get<SlicingTolerance>(const std::string& k
 template<> InsetDirection Settings::get<InsetDirection>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if(value == "center_last")
-    {
-        return InsetDirection::CENTER_LAST;
-    }
-    else if(value == "outside_in")
+    if(value == "outside_in")
     {
         return InsetDirection::OUTSIDE_IN;
     }


### PR DESCRIPTION
The current (expected, intended) behavior is that the center lines / gap fillers / middle odd walls are printed after their enclosing wall.

The Center Last option postponed the printing of the center wall to after all (polygonal) walls had been printed, rather than only their enclosing wall.

Hypothetically there would be an advantage to printing all gap fillers after all walls, because the odd walls can get more line width range depending on the threshold settings. However, we're not configuring the line width settings as such and the expected benefits are unclear and expected not to be big.

The Print Process team and the Cura team agreed that the option should be removed.

See also https://github.com/Ultimaker/CuraEngine/pull/1597