### PR TITLE
CURA-8875 Add tie-breaker to seam score calculations

### DIFF
--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -503,7 +503,7 @@ protected:
             }
 
             constexpr float EPSILON = 25.0;
-            if(best_score - EPSILON <= score && score <= best_score + EPSILON)
+            if (fabs(best_score - score) <= EPSILON)
             {
                 // add breaker for two candidate starting location with similar score
                 // if we don't do this then we (can) get an un-even seam

--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -507,10 +507,13 @@ protected:
             {
                 // add breaker for two candidate starting location with similar score
                 // if we don't do this then we (can) get an un-even seam
-                Point tie_breaker_point = target_pos != Point(0, 0)
-                    ? Point(0, 0)       // break ties by picking the point that is closest to the origin
-                    : Point(0, 100000); // unless the target position is the origin, then pick some other location
-                best_point = vSize2(best_point - tie_breaker_point) < vSize2(here - tie_breaker_point) ? best_point : here;
+                // ties are broken by favouring points with lower x-coord
+                // if x-coord for both points are equal then break ties by
+                // favouring points with lower y-coord
+                if (here.X != best_point.X ? here.X < best_point.X : here.Y < best_point.Y)
+                {
+                    best_point = here;
+                }
                 best_score = std::min(best_score, score);
             }
             else if(score < best_score)

--- a/src/PathOrderOptimizer.h
+++ b/src/PathOrderOptimizer.h
@@ -510,7 +510,7 @@ protected:
                 Point tie_breaker_point = target_pos != Point(0, 0)
                     ? Point(0, 0)       // break ties by picking the point that is closest to the origin
                     : Point(0, 100000); // unless the target position is the origin, then pick some other location
-                best_point = vSize2(best_point - tie_breaker_point) < vSize2(best_point - tie_breaker_point) ? best_point : here;
+                best_point = vSize2(best_point - tie_breaker_point) < vSize2(here - tie_breaker_point) ? best_point : here;
                 best_score = std::min(best_score, score);
             }
             else if(score < best_score)


### PR DESCRIPTION
to create an even seem in the case where multiple candidate starting positions get the same score.

CURA-8875