### PR TITLE
Fix computation of Y-axis coordinate of intersection in LinearAlg2D::lineLineIntersection().

### DIFF
--- a/src/utils/linearAlg2D.h
+++ b/src/utils/linearAlg2D.h
@@ -88,7 +88,7 @@ public:
         const double c2 = a2 * (c.X) + b2 * (c.Y);
 
         const Point result((b2 * c1 - b1 * c2) / determinant,
-                     (a1 * c1 - a2 * c1) / determinant);
+                     (a1 * c2 - a2 * c1) / determinant);
         if(std::abs(result.X) > std::numeric_limits<int32_t>::max() || std::abs(result.Y) > std::numeric_limits<int32_t>::max())
         {
             //Intersection is so far away that it could lead to integer overflows.


### PR DESCRIPTION
I think that function `LinearAlg2D::lineLineIntersection()` contains an issue in computing the Y-axis coordinate of the intersection on the following line: https://github.com/Ultimaker/CuraEngine/blob/2a371868662d6eb73cef3dfdea24ded0feb872ea/src/utils/linearAlg2D.h#L91
Instead of `a1 * c1`, there should be `a1 * c2`, so now this function computes the wrong Y-axis coordinate of the intersection.
A simple case to verify that `LinearAlg2D::lineLineIntersection()` is returning the wrong intersection between two lines is the following:
```
Line_1: {(0, 0), (1000, 1000)}
Line_2: {(1000, 0), (0, 1000)}
```
So when `LinearAlg2D::lineLineIntersection()` is called on the two lines defined above (`LinearAlg2D::lineLineIntersection(Point(0, 0), Point(1000, 1000), Point(1000, 0), Point(0, 1000), res))`, the result intersection that this function computes is `(500, 0)`, which is wrong. The correct intersection should be `(500, 500)`.
This issue was introduced with the commit 618a8ab75f828776fef36ee845ba53713c9e7311.