### PR TITLE
Separate flow ratio from line width factor

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <cstring>
@@ -85,25 +85,24 @@ void ExtruderPlan::applyBackPressureCompensation(const Ratio back_pressure_compe
     constexpr double epsilon_speed_factor = 0.001; // Don't put on actual 'limit double minimum', because we don't want printers to stall.
     for (auto& path : paths)
     {
-        const Ratio nominal_flow_for_path = path.config->getFlowRatio();
         const double nominal_width_for_path = static_cast<double>(path.config->getLineWidth());
-        if (path.flow <= 0.0 || nominal_flow_for_path <= 0.0 || nominal_width_for_path <= 0.0 || path.config->isTravelPath() || path.config->isBridgePath())
+        if(path.width_factor <= 0.0 || nominal_width_for_path <= 0.0 || path.config->isTravelPath() || path.config->isBridgePath())
         {
             continue;
         }
-        const double line_width_for_path = path.flow * nominal_flow_for_path * nominal_width_for_path;
+        const double line_width_for_path = path.width_factor * nominal_width_for_path;
         path.speed_back_pressure_factor = std::max(epsilon_speed_factor, 1.0 + (nominal_width_for_path / line_width_for_path - 1.0) * back_pressure_compensation);
     }
 }
 
-GCodePath* LayerPlan::getLatestPathWithConfig(const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio flow, bool spiralize, const Ratio speed_factor)
+GCodePath* LayerPlan::getLatestPathWithConfig(const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio flow, const Ratio width_factor, bool spiralize, const Ratio speed_factor)
 {
     std::vector<GCodePath>& paths = extruder_plans.back().paths;
-    if (paths.size() > 0 && paths.back().config == &config && !paths.back().done && paths.back().flow == flow && paths.back().speed_factor == speed_factor && paths.back().mesh_id == current_mesh) // spiralize can only change when a travel path is in between
+    if(paths.size() > 0 && paths.back().config == &config && !paths.back().done && paths.back().flow == flow && paths.back().width_factor == width_factor && paths.back().speed_factor == speed_factor && paths.back().mesh_id == current_mesh) // spiralize can only change when a travel path is in between
     {
         return &paths.back();
     }
-    paths.emplace_back(config, current_mesh, space_fill_type, flow, spiralize, speed_factor);
+    paths.emplace_back(config, current_mesh, space_fill_type, flow, width_factor, spiralize, speed_factor);
     GCodePath* ret = &paths.back();
     ret->skip_agressive_merge_hint = mode_skip_agressive_merge;
     return ret;
@@ -510,9 +509,9 @@ void LayerPlan::planPrime(const float& prime_blob_wipe_length)
     forceNewPathStart();
 }
 
-void LayerPlan::addExtrusionMove(Point p, const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio& flow, bool spiralize, Ratio speed_factor, double fan_speed)
+void LayerPlan::addExtrusionMove(Point p, const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio& flow, const Ratio width_factor, bool spiralize, Ratio speed_factor, double fan_speed)
 {
-    GCodePath* path = getLatestPathWithConfig(config, space_fill_type, flow, spiralize, speed_factor);
+    GCodePath* path = getLatestPathWithConfig(config, space_fill_type, flow, width_factor, spiralize, speed_factor);
     path->points.push_back(p);
     path->setFanSpeed(fan_speed);
     last_planned_position = p;
@@ -520,19 +519,20 @@ void LayerPlan::addExtrusionMove(Point p, const GCodePathConfig& config, SpaceFi
 
 void LayerPlan::addPolygon(ConstPolygonRef polygon, int start_idx, const bool backwards, const GCodePathConfig& config, coord_t wall_0_wipe_dist, bool spiralize, const Ratio& flow_ratio, bool always_retract)
 {
+    constexpr Ratio width_ratio = 1.0_r; //Not printed with variable line width.
     Point p0 = polygon[start_idx];
     addTravel(p0, always_retract);
     const int direction = backwards ? -1 : 1;
     for(size_t point_idx = 1; point_idx < polygon.size(); point_idx++)
     {
         Point p1 = polygon[(start_idx + point_idx * direction + polygon.size()) % polygon.size()];
-        addExtrusionMove(p1, config, SpaceFillType::Polygons, flow_ratio, spiralize);
+        addExtrusionMove(p1, config, SpaceFillType::Polygons, flow_ratio, width_ratio, spiralize);
         p0 = p1;
     }
     if(polygon.size() > 2)
     {
         const Point& p1 = polygon[start_idx];
-        addExtrusionMove(p1, config, SpaceFillType::Polygons, flow_ratio, spiralize);
+        addExtrusionMove(p1, config, SpaceFillType::Polygons, flow_ratio, width_ratio, spiralize);
 
         if(wall_0_wipe_dist > 0)
         { // apply outer wall wipe
@@ -597,7 +597,7 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons, const GCodePath
 
 static constexpr float max_non_bridge_line_volume = MM2INT(100); // limit to accumulated "volume" of non-bridge lines which is proportional to distance x extrusion rate
 
-void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, float flow, float& non_bridge_line_volume, Ratio speed_factor, double distance_to_bridge_start)
+void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, float flow, const Ratio width_factor, float& non_bridge_line_volume, Ratio speed_factor, double distance_to_bridge_start)
 {
     const coord_t min_line_len = 5; // we ignore lines less than 5um long
     const double acceleration_segment_len = MM2INT(1); // accelerate using segments of this length
@@ -652,15 +652,16 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& se
                     if ((len - coast_dist) > min_line_len)
                     {
                         // segment is longer than coast distance so extrude using non-bridge config to start of coast
-                        addExtrusionMove(segment_end + coast_dist * (cur_point - segment_end) / len, non_bridge_config, SpaceFillType::Polygons, segment_flow, spiralize, speed_factor);
+                        addExtrusionMove(segment_end + coast_dist * (cur_point - segment_end) / len, non_bridge_config, SpaceFillType::Polygons, segment_flow, width_factor, spiralize, speed_factor);
                     }
                     // then coast to start of bridge segment
-                    addExtrusionMove(segment_end, non_bridge_config, SpaceFillType::Polygons, 0, spiralize, speed_factor);
+                    constexpr Ratio flow = 0.0_r; //Coasting has no flow rate.
+                    addExtrusionMove(segment_end, non_bridge_config, SpaceFillType::Polygons, flow, width_factor, spiralize, speed_factor);
                 }
                 else
                 {
                     // no coasting required, just normal segment using non-bridge config
-                    addExtrusionMove(segment_end, non_bridge_config, SpaceFillType::Polygons, segment_flow, spiralize,
+                    addExtrusionMove(segment_end, non_bridge_config, SpaceFillType::Polygons, segment_flow, width_factor, spiralize,
                         (overhang_mask.empty() || (!overhang_mask.inside(p0, true) && !overhang_mask.inside(p1, true))) ? speed_factor : overhang_speed_factor);
                 }
 
@@ -669,10 +670,10 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& se
             else
             {
                 // no coasting required, just normal segment using non-bridge config
-                addExtrusionMove(segment_end, non_bridge_config, SpaceFillType::Polygons, segment_flow, spiralize,
+                addExtrusionMove(segment_end, non_bridge_config, SpaceFillType::Polygons, segment_flow, width_factor, spiralize,
                     (overhang_mask.empty() || (!overhang_mask.inside(p0, true) && !overhang_mask.inside(p1, true))) ? speed_factor : overhang_speed_factor);
             }
-            non_bridge_line_volume += vSize(cur_point - segment_end) * segment_flow * speed_factor * non_bridge_config.getSpeed();
+            non_bridge_line_volume += vSize(cur_point - segment_end) * segment_flow * width_factor * speed_factor * non_bridge_config.getSpeed();
             cur_point = segment_end;
             speed_factor = 1 - (1 - speed_factor) * acceleration_factor;
             if (speed_factor >= 0.9)
@@ -686,7 +687,7 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& se
     if (bridge_wall_mask.empty())
     {
         // no bridges required
-        addExtrusionMove(p1, non_bridge_config, SpaceFillType::Polygons, flow, spiralize,
+        addExtrusionMove(p1, non_bridge_config, SpaceFillType::Polygons, flow, width_factor, spiralize,
             (overhang_mask.empty() || (!overhang_mask.inside(p0, true) && !overhang_mask.inside(p1, true))) ? 1.0_r : overhang_speed_factor);
     }
     else
@@ -744,7 +745,7 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& se
 
                     if (bridge_line_len > min_line_len)
                     {
-                        addExtrusionMove(b1, bridge_config, SpaceFillType::Polygons, flow);
+                        addExtrusionMove(b1, bridge_config, SpaceFillType::Polygons, flow, width_factor);
                         non_bridge_line_volume = 0;
                         cur_point = b1;
                         // after a bridge segment, start slow and accelerate to avoid under-extrusion due to extruder lag
@@ -768,7 +769,7 @@ void LayerPlan::addWallLine(const Point& p0, const Point& p1, const Settings& se
         else if (bridge_wall_mask.inside(p0, true) && vSize(p0 - p1) >= min_bridge_line_len)
         {
             // both p0 and p1 must be above air (the result will be ugly!)
-            addExtrusionMove(p1, bridge_config, SpaceFillType::Polygons, flow);
+            addExtrusionMove(p1, bridge_config, SpaceFillType::Polygons, flow, width_factor);
             non_bridge_line_volume = 0;
         }
         else
@@ -968,12 +969,12 @@ void LayerPlan::addWall(const ExtrusionLine& wall, int start_idx, const Settings
             if(is_small_feature)
             {
                 constexpr bool spiralize = false;
-                addExtrusionMove(destination, non_bridge_config, SpaceFillType::Polygons, flow_ratio * (line_width * nominal_line_width_multiplier), spiralize, small_feature_speed_factor);
+                addExtrusionMove(destination, non_bridge_config, SpaceFillType::Polygons, flow_ratio, line_width * nominal_line_width_multiplier, spiralize, small_feature_speed_factor);
             }
             else
             {
                 const Point origin = p0.p + normal(line_vector, piece_length * piece);
-                addWallLine(origin, destination, settings, non_bridge_config, bridge_config, flow_ratio * (line_width * nominal_line_width_multiplier), non_bridge_line_volume, speed_factor, distance_to_bridge_start);
+                addWallLine(origin, destination, settings, non_bridge_config, bridge_config, flow_ratio, line_width * nominal_line_width_multiplier, non_bridge_line_volume, speed_factor, distance_to_bridge_start);
             }
         }
 
@@ -1031,9 +1032,10 @@ void LayerPlan::addInfillWall(const ExtrusionLine& wall, const GCodePathConfig& 
 
     for (const auto &junction_n : wall)
     {
-        const double flow = junction_n.w / Ratio(path_config.getLineWidth());
+        const Ratio width_factor = junction_n.w / Ratio(path_config.getLineWidth());
         constexpr SpaceFillType space_fill_type = SpaceFillType::Polygons;
-        addExtrusionMove(junction_n.p, path_config, space_fill_type, flow);
+        constexpr Ratio flow = 1.0_r;
+        addExtrusionMove(junction_n.p, path_config, space_fill_type, flow, width_factor);
         junction = junction_n;
     }
 }
@@ -1134,7 +1136,11 @@ void LayerPlan::addLinesInGivenOrder(
         {
             // Instead of doing a small travel that is shorter than the line width (which is generally done at pretty high jerk & move) do a
             // "fake" extrusion move
-            addExtrusionMove(start, config, space_fill_type, 0, false, 1.0, fan_speed);
+            constexpr Ratio flow = 0.0_r;
+            constexpr Ratio width_factor = 1.0_r;
+            constexpr bool spiralize = false;
+            constexpr Ratio speed_factor = 1.0_r;
+            addExtrusionMove(start, config, space_fill_type, flow, width_factor, spiralize, speed_factor, fan_speed);
         }
         else
         {
@@ -1163,7 +1169,10 @@ void LayerPlan::addLinesInGivenOrder(
             // ignore line segments that are less than 5uM long
             if (vSize2(p1 - p0) >= MINIMUM_SQUARED_LINE_LENGTH)
             {
-                addExtrusionMove(p1, config, space_fill_type, flow_ratio, false, 1.0, fan_speed);
+                constexpr Ratio width_factor = 1.0_r;
+                constexpr bool spiralize = false;
+                constexpr Ratio speed_factor = 1.0_r;
+                addExtrusionMove(p1, config, space_fill_type, flow_ratio, width_factor, spiralize, speed_factor, fan_speed);
                 p0 = p1;
             }
         }
@@ -1199,7 +1208,11 @@ void LayerPlan::addLinesInGivenOrder(
 
             if (wipe)
             {
-                addExtrusionMove(p1 + normal(p1 - p0, wipe_dist), config, space_fill_type, 0.0, false, 1.0, fan_speed);
+                constexpr Ratio flow = 0.0_r;
+                constexpr Ratio width_factor = 1.0_r;
+                constexpr bool spiralize = false;
+                constexpr Ratio speed_factor = 1.0_r;
+                addExtrusionMove(p1 + normal(p1 - p0, wipe_dist), config, space_fill_type, flow, width_factor, spiralize, speed_factor, fan_speed);
             }
         }
     }
@@ -1268,6 +1281,8 @@ void LayerPlan::addLinesMonotonic
 void LayerPlan::spiralizeWallSlice(const GCodePathConfig& config, ConstPolygonRef wall, ConstPolygonRef last_wall, const int seam_vertex_idx, const int last_seam_vertex_idx, const bool is_top_layer, const bool is_bottom_layer)
 {
     const bool smooth_contours = Application::getInstance().current_slice->scene.current_mesh_group->settings.get<bool>("smooth_spiralized_contours");
+    constexpr bool spiralize = true; //In addExtrusionMove calls, enable spiralize and use nominal line width.
+    constexpr Ratio width_factor = 1.0_r;
 
     // once we are into the spiral we always start at the end point of the last layer (if any)
     const Point origin = (last_seam_vertex_idx >= 0 && !is_bottom_layer) ? last_wall[last_seam_vertex_idx] : wall[seam_vertex_idx];
@@ -1280,7 +1295,8 @@ void LayerPlan::spiralizeWallSlice(const GCodePathConfig& config, ConstPolygonRe
         Point join_first_wall_at = LinearAlg2D::getClosestOnLineSegment(origin, wall[seam_vertex_idx], wall[(seam_vertex_idx + 1) % wall.size()]);
         if (vSize(join_first_wall_at - origin) > 10)
         {
-            addExtrusionMove(join_first_wall_at, config, SpaceFillType::Polygons, 1.0, true);
+            constexpr Ratio flow = 1.0_r;
+            addExtrusionMove(join_first_wall_at, config, SpaceFillType::Polygons, flow, width_factor, spiralize);
         }
     }
 
@@ -1363,18 +1379,18 @@ void LayerPlan::spiralizeWallSlice(const GCodePathConfig& config, ConstPolygonRe
             if (cpp.isValid() && vSize2(cpp.location - p) <= max_dist2)
             {
                 // interpolate between cpp.location and p depending on how far we have progressed along wall
-                addExtrusionMove(cpp.location + (p - cpp.location) * (wall_length / total_length), config, SpaceFillType::Polygons, flow, true, speed_factor);
+                addExtrusionMove(cpp.location + (p - cpp.location) * (wall_length / total_length), config, SpaceFillType::Polygons, flow, width_factor, spiralize, speed_factor);
             }
             else
             {
                 // no point in the last wall was found close enough to the current wall point so don't interpolate
-                addExtrusionMove(p, config, SpaceFillType::Polygons, flow, true, speed_factor);
+                addExtrusionMove(p, config, SpaceFillType::Polygons, flow, width_factor, spiralize, speed_factor);
             }
         }
         else
         {
             // no smoothing, use point verbatim
-            addExtrusionMove(p, config, SpaceFillType::Polygons, flow, true, speed_factor);
+            addExtrusionMove(p, config, SpaceFillType::Polygons, flow, width_factor, spiralize, speed_factor);
         }
     }
 
@@ -1398,7 +1414,8 @@ void LayerPlan::spiralizeWallSlice(const GCodePathConfig& config, ConstPolygonRe
                 distance_coasted += seg_length;
             }
             // reduce number of paths created when polygon has many points by limiting precision of flow
-            addExtrusionMove(p, config, SpaceFillType::Polygons, ((int)(flow * 20)) / 20.0, false, speed_factor);
+            constexpr bool no_spiralize = false;
+            addExtrusionMove(p, config, SpaceFillType::Polygons, ((int)(flow * 20)) / 20.0, width_factor, no_spiralize, speed_factor);
         }
     }
 }

--- a/src/LayerPlan.h
+++ b/src/LayerPlan.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef LAYER_PLAN_H
@@ -283,7 +283,7 @@ private:
      * \param speed_factor (optional) a factor which the speed will be multiplied by.
      * \return A path with the given config which is now the last path in LayerPlan::paths
      */
-    GCodePath* getLatestPathWithConfig(const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio flow = 1.0_r, bool spiralize = false, const Ratio speed_factor = 1.0_r);
+    GCodePath* getLatestPathWithConfig(const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio flow = 1.0_r, const Ratio width_factor = 1.0_r, bool spiralize = false, const Ratio speed_factor = 1.0_r);
 
 public:
     /*!
@@ -456,13 +456,20 @@ public:
      * 
      * \param p The point to extrude to
      * \param config The config with which to extrude
-     * \param space_fill_type Of what space filling type this extrusion move is a part
-     * \param flow A modifier of the extrusion width which would follow from the \p config
-     * \param speed_factor (optional) A factor the travel speed will be multipled by.
-     * \param spiralize Whether to gradually increase the z while printing. (Note that this path may be part of a sequence of spiralized paths, forming one polygon)
-     * \param fan_speed fan speed override for this path
+     * \param space_fill_type Of what space filling type this extrusion move is
+     * a part.
+     * \param flow A modifier of the flow rate which would follow from the
+     * \p config.
+     * \param width_factor A modifier of the line width which would follow from
+     * the \p config.
+     * \param speed_factor (optional) A factor the travel speed will be
+     * multiplied by.
+     * \param spiralize Whether to gradually increase the z while printing.
+     * (Note that this path may be part of a sequence of spiralized paths,
+     * forming one polygon.)
+     * \param fan_speed Fan speed override for this path.
      */
-    void addExtrusionMove(Point p, const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio& flow = 1.0_r, bool spiralize = false, Ratio speed_factor = 1.0_r, double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
+    void addExtrusionMove(Point p, const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio& flow = 1.0_r, const Ratio width_factor = 1.0_r, bool spiralize = false, Ratio speed_factor = 1.0_r, double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT);
 
     /*!
      * Add polygon to the gcode starting at vertex \p startIdx
@@ -509,18 +516,25 @@ public:
 
     /*!
      * Add a single line that is part of a wall to the gcode.
-     * \param p0 The start vertex of the line
-     * \param p1 The end vertex of the line
-     * \param settings The settings which should apply to this line added to the layer plan.
-     * \param non_bridge_config The config with which to print the wall lines that are not spanning a bridge
-     * \param bridge_config The config with which to print the wall lines that are spanning a bridge
-     * \param flow The ratio with which to multiply the extrusion amount
-     * \param non_bridge_line_volume A pseudo-volume that is derived from the print speed and flow of the non-bridge lines that have preceeded this line
-     * \param speed_factor This modifies the print speed when accelerating after a bridge line
-     * \param distance_to_bridge_start The distance along the wall from p0 to the first bridge segment
+     * \param p0 The start vertex of the line.
+     * \param p1 The end vertex of the line.
+     * \param settings The settings which should apply to this line added to the
+     * layer plan.
+     * \param non_bridge_config The config with which to print the wall lines
+     * that are not spanning a bridge.
+     * \param bridge_config The config with which to print the wall lines that
+     * are spanning a bridge.
+     * \param flow The ratio with which to multiply the extrusion amount.
+     * \param width_ratio The ratio with which to multiply the line width.
+     * \param non_bridge_line_volume A pseudo-volume that is derived from the
+     * print speed and flow of the non-bridge lines that have preceded this
+     * line.
+     * \param speed_factor This modifies the print speed when accelerating after
+     * a bridge line.
+     * \param distance_to_bridge_start The distance along the wall from p0 to
+     * the first bridge segment.
      */
-
-    void addWallLine(const Point& p0, const Point& p1, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, float flow, float& non_bridge_line_volume, Ratio speed_factor, double distance_to_bridge_start);
+    void addWallLine(const Point& p0, const Point& p1, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, float flow, const Ratio width_factor, float& non_bridge_line_volume, Ratio speed_factor, double distance_to_bridge_start);
 
     /*!
      * Add a wall to the g-code starting at vertex \p start_idx

--- a/src/pathPlanning/GCodePath.cpp
+++ b/src/pathPlanning/GCodePath.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "GCodePath.h"
@@ -6,11 +6,12 @@
 
 namespace cura
 {
-GCodePath::GCodePath(const GCodePathConfig& config, std::string mesh_id, const SpaceFillType space_fill_type, const Ratio flow, const bool spiralize, const Ratio speed_factor) :
+GCodePath::GCodePath(const GCodePathConfig& config, std::string mesh_id, const SpaceFillType space_fill_type, const Ratio flow, const Ratio width_factor, const bool spiralize, const Ratio speed_factor) :
 config(&config),
 mesh_id(mesh_id),
 space_fill_type(space_fill_type),
 flow(flow),
+width_factor(width_factor),
 speed_factor(speed_factor),
 speed_back_pressure_factor(1.0),
 retract(false),
@@ -33,12 +34,12 @@ bool GCodePath::isTravelPath() const
 
 double GCodePath::getExtrusionMM3perMM() const
 {
-    return flow * config->getExtrusionMM3perMM();
+    return flow * width_factor * config->getExtrusionMM3perMM();
 }
 
 coord_t GCodePath::getLineWidthForLayerView() const
 {
-    return flow * config->getLineWidth() * config->getFlowRatio();
+    return flow * width_factor * config->getLineWidth() * config->getFlowRatio();
 }
 
 void GCodePath::setFanSpeed(double fan_speed)

--- a/src/pathPlanning/GCodePath.h
+++ b/src/pathPlanning/GCodePath.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef PATH_PLANNING_G_CODE_PATH_H
@@ -32,6 +32,7 @@ public:
     std::string mesh_id; //!< Which mesh this path belongs to, if any. If it's not part of any mesh, the mesh ID should be 0.
     SpaceFillType space_fill_type; //!< The type of space filling of which this path is a part
     Ratio flow; //!< A type-independent flow configuration
+    Ratio width_factor; //!< Adjustment to the line width. Similar to flow, but causes the speed_back_pressure_factor to be adjusted.
     Ratio speed_factor; //!< A speed factor that is multiplied with the travel speed. This factor can be used to change the travel speed.
     Ratio speed_back_pressure_factor; // <! The factor the (non-travel) speed should be multiplied with as a consequence of back pressure compensation.
     bool retract; //!< Whether the path is a move path preceded by a retraction move; whether the path is a retracted move path. 
@@ -56,11 +57,12 @@ public:
      * \param space_fill_type The type of space filling of which this path is a
      * part.
      * \param flow The flow rate to print this path with.
+     * \param width_factor A multiplier on the line width.
      * \param spiralize Gradually increment the z-coordinate while traversing
      * \param speed_factor The factor that the travel speed will be multiplied with
      * this path.
      */
-    GCodePath(const GCodePathConfig& config, std::string mesh_id, const SpaceFillType space_fill_type, const Ratio flow, const bool spiralize, const Ratio speed_factor = 1.0);
+    GCodePath(const GCodePathConfig& config, std::string mesh_id, const SpaceFillType space_fill_type, const Ratio flow, const Ratio width_factor, const bool spiralize, const Ratio speed_factor = 1.0);
 
     /*!
      * Whether this config is the config of a travel path.

--- a/tests/ExtruderPlanTest.cpp
+++ b/tests/ExtruderPlanTest.cpp
@@ -86,9 +86,10 @@ public:
     {
         const std::string mesh_id = "test_mesh";
         constexpr Ratio flow_1 = 1.0_r;
+        constexpr Ratio width_1 = 1.0_r;
         constexpr bool no_spiralize = false;
         constexpr Ratio speed_1 = 1.0_r;
-        square.assign({GCodePath(extrusion_config, mesh_id, SpaceFillType::PolyLines, flow_1, no_spiralize, speed_1)});
+        square.assign({GCodePath(extrusion_config, mesh_id, SpaceFillType::PolyLines, flow_1, width_1, no_spiralize, speed_1)});
         square.back().points = {
             Point(0, 0),
             Point(1000, 0),
@@ -98,11 +99,11 @@ public:
         };
 
         lines.assign({
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1)
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(travel_config   , mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(travel_config   , mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1)
         });
         lines[0].points = {Point(0, 0), Point(1000, 0)};
         lines[1].points = {Point(1000, 0), Point(1000, 400)};
@@ -114,11 +115,11 @@ public:
         constexpr Ratio flow_08 = 0.8_r;
         constexpr Ratio flow_04 = 0.4_r;
         decreasing_flow.assign({
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_12, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_08, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_04, no_spiralize, speed_1)
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_12, width_1, no_spiralize, speed_1),
+            GCodePath(travel_config   , mesh_id, SpaceFillType::Lines, flow_1 , width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_08, width_1, no_spiralize, speed_1),
+            GCodePath(travel_config   , mesh_id, SpaceFillType::Lines, flow_1 , width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_04, width_1, no_spiralize, speed_1)
         });
         decreasing_flow[0].points = {Point(0, 0), Point(1000, 0)};
         decreasing_flow[1].points = {Point(1000, 0), Point(1000, 400)};
@@ -130,11 +131,11 @@ public:
         constexpr Ratio speed_08 = 0.8_r;
         constexpr Ratio speed_04 = 0.4_r;
         decreasing_speed.assign({
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_12),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_08),
-            GCodePath(travel_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_04)
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_12),
+            GCodePath(travel_config   , mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_08),
+            GCodePath(travel_config   , mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_04)
         });
         decreasing_speed[0].points = {Point(0, 0), Point(1000, 0)};
         decreasing_speed[1].points = {Point(1000, 0), Point(1000, 400)};
@@ -143,12 +144,12 @@ public:
         decreasing_speed[4].points = {Point(0, 800), Point(1000, 800)};
 
         variable_width.assign({
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.8_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.6_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.4_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.2_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, 0.0_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, 0.8_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, 0.6_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, 0.4_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, 0.2_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh_id, SpaceFillType::Lines, flow_1, 0.0_r, no_spiralize, speed_1),
         });
         variable_width[0].points = {Point(0, 0), Point(1000, 0)};
         variable_width[1].points = {Point(1000, 0), Point(2000, 0)};
@@ -194,13 +195,15 @@ public:
     {}
 
     /*!
-     * Helper method to calculate the flow rate of a path in mm3 per second, ignoring any user specified speed alteration other than the back pressure compensation.
+     * Helper method to calculate the flow rate of a path in mm3 per second,
+     * minus the influence of flow rate and ignoring any user specified speed
+     * alteration other than the back pressure compensation.
      * \param path The path to calculate the flow rate of.
-     * \return The flow rate, in cubic millimeters per second (ignoring any user specified speed alteration other than back-pressure compensation).
+     * \return The flow rate, in cubic millimeters per second.
      */
-    double calculatePathFlow(const GCodePath& path)
+    double calculatePathWidth(const GCodePath& path)
     {
-        return path.getExtrusionMM3perMM() * path.config->getSpeed() * path.speed_back_pressure_factor;
+        return path.getExtrusionMM3perMM() / path.config->getFlowRatio() / path.flow * path.config->getSpeed() * path.speed_back_pressure_factor;
     }
 
     bool shouldCountPath(const GCodePath& path) const
@@ -260,10 +263,10 @@ TEST_P(ExtruderPlanPathsParameterizedTest, BackPressureCompensationZeroIsUncompe
 
     extruder_plan.applyBackPressureCompensation(0.0_r);
 
-    ASSERT_EQ(extruder_plan.paths.size(), original_flows.size()) << "Number of paths may not have changed.";
+    ASSERT_EQ(extruder_plan.paths.size(), original_widths.size()) << "Number of paths may not have changed.";
     for(size_t i = 0; i < extruder_plan.paths.size(); ++i)
     {
-        EXPECT_NEAR(original_flows[i], extruder_plan.paths[i].width_factor, error_margin) << "The flow rate did not change. Back pressure compensation doesn't adjust flow.";
+        EXPECT_NEAR(original_widths[i], extruder_plan.paths[i].width_factor, error_margin) << "The width did not change. Back pressure compensation doesn't adjust line width.";
         EXPECT_NEAR(original_speeds[i], extruder_plan.paths[i].speed_factor, error_margin) << "The speed factor did not change, since the compensation factor was 0.";
     }
 }
@@ -285,7 +288,7 @@ TEST_P(ExtruderPlanPathsParameterizedTest, BackPressureCompensationFull)
         return;
     }
     //All flow rates must be equal to this one.
-    const double first_flow_mm3_per_sec = calculatePathFlow(*first_extrusion);
+    const double first_flow_mm3_per_sec = calculatePathWidth(*first_extrusion);
 
     for(GCodePath& path : extruder_plan.paths)
     {
@@ -293,7 +296,7 @@ TEST_P(ExtruderPlanPathsParameterizedTest, BackPressureCompensationFull)
         {
             continue; //Ignore travel moves.
         }
-        const double flow_mm3_per_sec = calculatePathFlow(path);
+        const double flow_mm3_per_sec = calculatePathWidth(path);
         EXPECT_NEAR(flow_mm3_per_sec, first_flow_mm3_per_sec, error_margin) << "Every path must have a flow rate equal to the first, since the flow changes were completely compensated for.";
     }
 }
@@ -313,7 +316,7 @@ TEST_P(ExtruderPlanPathsParameterizedTest, BackPressureCompensationHalf)
         {
             continue; //Ignore travel moves.
         }
-        original_flows.push_back(calculatePathFlow(path));
+        original_flows.push_back(calculatePathWidth(path));
     }
     const double original_average = std::accumulate(original_flows.begin(), original_flows.end(), 0.0) / original_flows.size();
 
@@ -328,7 +331,7 @@ TEST_P(ExtruderPlanPathsParameterizedTest, BackPressureCompensationHalf)
         {
             continue; //Ignore travel moves.
         }
-        new_flows.push_back(calculatePathFlow(path));
+        new_flows.push_back(calculatePathWidth(path));
     }
     const double new_average = std::accumulate(new_flows.begin(), new_flows.end(), 0.0) / new_flows.size();
     //Note that the new average doesn't necessarily need to be the same average! It is most likely a higher average in real-world scenarios.
@@ -337,7 +340,7 @@ TEST_P(ExtruderPlanPathsParameterizedTest, BackPressureCompensationHalf)
     ASSERT_EQ(original_flows.size(), new_flows.size()) << "We need to have the same number of extrusion moves.";
     for(size_t i = 0; i < new_flows.size(); ++i)
     {
-        EXPECT_NEAR((original_flows[i] - original_average) / 2.0, new_flows[i] - new_average, error_margin);
+        EXPECT_NEAR((original_flows[i] - original_average) / 2.0, new_flows[i] - new_average, error_margin) << "The differences in flow rate needs to be approximately halved, within margin of rounding errors.";
     }
 }
 

--- a/tests/ExtruderPlanTest.cpp
+++ b/tests/ExtruderPlanTest.cpp
@@ -205,7 +205,7 @@ public:
 
     bool shouldCountPath(const GCodePath& path) const
     {
-        return path.flow > 0.0 && path.config->getFlowRatio() > 0.0 && path.config->getLineWidth() > 0.0 && ! path.config->isTravelPath() && ! path.config->isBridgePath();
+        return path.flow > 0.0 && path.width_factor > 0.0 && path.config->getFlowRatio() > 0.0 && path.config->getLineWidth() > 0.0 && ! path.config->isTravelPath() && ! path.config->isBridgePath();
     }
 };
 
@@ -250,11 +250,11 @@ public:
 TEST_P(ExtruderPlanPathsParameterizedTest, BackPressureCompensationZeroIsUncompensated)
 {
     extruder_plan.paths = GetParam();
-    std::vector<Ratio> original_flows;
+    std::vector<Ratio> original_widths;
     std::vector<Ratio> original_speeds;
     for(const GCodePath& path : extruder_plan.paths)
     {
-        original_flows.push_back(path.flow);
+        original_widths.push_back(path.width_factor);
         original_speeds.push_back(path.speed_factor);
     }
 
@@ -263,7 +263,7 @@ TEST_P(ExtruderPlanPathsParameterizedTest, BackPressureCompensationZeroIsUncompe
     ASSERT_EQ(extruder_plan.paths.size(), original_flows.size()) << "Number of paths may not have changed.";
     for(size_t i = 0; i < extruder_plan.paths.size(); ++i)
     {
-        EXPECT_NEAR(original_flows[i], extruder_plan.paths[i].flow, error_margin) << "The flow rate did not change. Back pressure compensation doesn't adjust flow.";
+        EXPECT_NEAR(original_flows[i], extruder_plan.paths[i].width_factor, error_margin) << "The flow rate did not change. Back pressure compensation doesn't adjust flow.";
         EXPECT_NEAR(original_speeds[i], extruder_plan.paths[i].speed_factor, error_margin) << "The speed factor did not change, since the compensation factor was 0.";
     }
 }


### PR DESCRIPTION
We want two multipliers on the amount of extrusion here: One to reduce the flow rate out the nozzle, and another to reduce the flow rate but possibly get compensated for by changing the print speed.

So the paths need to contain an extra field. I'm calling it width_factor. It's a multiplier on the line width that gets compensated for by applyBackPressureCompensation. That function now no longer takes the flow ratio into account, just the line width.

Because of this extra field, a bunch of function calls to addExtrusionLine need to have that extra parameter too, so that applyBackPressureCompensation can separate the width from the flow still. This is a bit of a hassle!

Fixes issue CURA-8737.