### PR TITLE
Retracted unnecessary travel moves

### DIFF
--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -213,10 +213,28 @@ bool Comb::calc(const ExtruderTrain& train, Point start_point, Point end_point, 
         }
         else
         {
-            bool combing_succeeded = LinePolygonsCrossings::comb(*boundary_outside, getOutsideLocToLine(), start_crossing.out, end_crossing.out, comb_paths.back(), offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored, fail_on_unavoidable_obstacles);
-            if (!combing_succeeded)
+            CombPath tmp_comb_path;
+            bool combing_succeeded = LinePolygonsCrossings::comb(*boundary_outside, getOutsideLocToLine(), start_crossing.out, end_crossing.out, tmp_comb_path, offset_dist_to_get_from_on_the_polygon_to_outside, max_comb_distance_ignored, true);
+
+            if (combing_succeeded)
+            {
+                // add combing travel moves if the combing was successful
+                comb_paths.push_back(tmp_comb_path);
+            }
+            else if (fail_on_unavoidable_obstacles)
             {
                 return false;
+            }
+            else
+            {
+                // if combing is not possible then move directly to the target destination
+                // this happens for instance when trying to avoid skin-regions and combing from
+                // an origin that is on a hole-boundary to a destination that is on the outline-border
+                comb_paths.emplace_back();
+                comb_paths.throughAir = true;
+                comb_paths.back().cross_boundary = true;
+                comb_paths.back().push_back(start_crossing.in_or_mid);
+                comb_paths.back().push_back(end_crossing.in_or_mid);
             }
         }
     }


### PR DESCRIPTION
### Overview
This PR changes the combing behavior from
![Screenshot 2022-03-29 at 11 28 23](https://user-images.githubusercontent.com/6638028/160580533-7b62e988-22f6-4484-ae4d-2d16e3b29b8c.png)
To
![Screenshot 2022-03-29 at 11 27 40](https://user-images.githubusercontent.com/6638028/160580562-e8c8c910-9cb7-4fd0-a479-a8f1640f8989.png)

### Analysis
Problem arises when trying to comb from one part of the model to an unconnected other part. See image below. We try to transition from a start location `a` to a target destination `d`. As we try to comb outside of the model we first move points `a` and `d` to points `b` and `c` respectively, and then try to comb from `b` to `c` avoiding the polygon. This is impossible as point `b` is within a hole.
![Untitled Diagram](https://user-images.githubusercontent.com/6638028/160580643-4bca55b2-dd96-4361-9c48-cd39b3e0c0d3.png)

### Solution
The proposed solution detects such cases and instead of applying the incorrect combing move travels directly from point `a` to point `d`. This combing move is not ideal as we try to avoid combing over the outer surface/skin. However there is no combing move possible that would avoid traveling over the outer surface.

CURA-8694