### PR TITLE
Feat/Fix: transition filter limit

### DIFF
--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -796,7 +796,7 @@ void SkeletalTrapezoidation::generateTransitionMids(ptr_vector_t<std::list<Trans
                 edge.data.setTransitions(edge_transitions.back());  // initialization
                 transitions = edge.data.getTransitions();
             }
-            transitions->emplace_back(mid_pos, transition_lower_bead_count);
+            transitions->emplace_back(mid_pos, transition_lower_bead_count, mid_R);
         }
         assert((edge.from->data.bead_count == edge.to->data.bead_count) || edge.data.hasTransitions());
     }

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -898,7 +898,10 @@ std::list<SkeletalTrapezoidation::TransitionMidRef> SkeletalTrapezoidation::diss
 
         const coord_t origin_radius = origin_transition.feature_radius;
         const coord_t radius_here = edge->from->data.distance_to_boundary;
-        if (std::abs(origin_radius - radius_here) > allowed_filter_deviation / 2) // divide by two because the deviation happens at both sides of the significant edge
+        const bool dissolve_result_is_odd = bool(origin_transition.lower_bead_count % 2) == going_up;
+        const coord_t width_deviation = std::abs(origin_radius - radius_here) * 2; // times by two because the deviation happens at both sides of the significant edge
+        const coord_t line_width_deviation = dissolve_result_is_odd? width_deviation : width_deviation / 2; // assume the deviation will be split over either 1 or 2 lines, i.e. assume wall_distribution_count = 1
+        if (line_width_deviation > allowed_filter_deviation)
         {
             should_dissolve = false;
         }

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -897,7 +897,7 @@ std::list<SkeletalTrapezoidation::TransitionMidRef> SkeletalTrapezoidation::diss
         bool seen_transition_on_this_edge = false;
 
         const coord_t origin_radius = origin_transition.feature_radius;
-        const coord_t radius_here = edge->to->data.distance_to_boundary;
+        const coord_t radius_here = edge->from->data.distance_to_boundary;
         if (std::abs(origin_radius - radius_here) > allowed_filter_deviation / 2) // divide by two because the deviation happens at both sides of the significant edge
         {
             should_dissolve = false;

--- a/src/SkeletalTrapezoidation.h
+++ b/src/SkeletalTrapezoidation.h
@@ -99,10 +99,10 @@ public:
     SkeletalTrapezoidation(const Polygons& polys, 
                            const BeadingStrategy& beading_strategy,
                            AngleRadians transitioning_angle
-    , coord_t discretization_step_size = MM2INT(0.8)
-    , coord_t transition_filter_dist = MM2INT(1)
-    , coord_t allowed_filter_deviation = MM2INT(0.2)
-    , coord_t beading_propagation_transition_dist = MM2INT(0.4));
+    , coord_t discretization_step_size
+    , coord_t transition_filter_dist
+    , coord_t allowed_filter_deviation
+    , coord_t beading_propagation_transition_dist);
 
     /*!
      * A skeletal graph through the polygons that we need to fill with beads.

--- a/src/SkeletalTrapezoidation.h
+++ b/src/SkeletalTrapezoidation.h
@@ -61,6 +61,7 @@ class SkeletalTrapezoidation
     AngleRadians transitioning_angle; //!< How pointy a region should be before we apply the method. Equals 180* - limit_bisector_angle
     coord_t discretization_step_size; //!< approximate size of segments when parabolic VD edges get discretized (and vertex-vertex edges)
     coord_t transition_filter_dist; //!< Filter transition mids (i.e. anchors) closer together than this
+    coord_t allowed_filter_deviation; //!< The allowed line width deviation induced by filtering
     coord_t beading_propagation_transition_dist; //!< When there are different beadings propagated from below and from above, use this transitioning distance
     static constexpr coord_t central_filter_dist = 20; //!< Filter areas marked as 'central' smaller than this
     static constexpr coord_t snap_dist = 20; //!< Generic arithmatic inaccuracy. Only used to determine whether a transition really needs to insert an extra edge.
@@ -100,6 +101,7 @@ public:
                            AngleRadians transitioning_angle
     , coord_t discretization_step_size = MM2INT(0.8)
     , coord_t transition_filter_dist = MM2INT(1)
+    , coord_t allowed_filter_deviation = MM2INT(0.2)
     , coord_t beading_propagation_transition_dist = MM2INT(0.4));
 
     /*!

--- a/src/SkeletalTrapezoidationEdge.h
+++ b/src/SkeletalTrapezoidationEdge.h
@@ -26,8 +26,10 @@ public:
     {
         coord_t pos; // Position along edge as measure from edge.from.p
         int lower_bead_count;
-        TransitionMiddle(coord_t pos, int lower_bead_count)
+        coord_t feature_radius; // The feature radius at which this transition is placed
+        TransitionMiddle(coord_t pos, int lower_bead_count, coord_t feature_radius)
             : pos(pos), lower_bead_count(lower_bead_count)
+            , feature_radius(feature_radius)
         {}
     };
 

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -97,6 +97,7 @@ const VariableWidthPaths& WallToolPaths::generate()
             wall_distribution_count
         );
     const coord_t transition_filter_dist = settings.get<coord_t>("wall_transition_filter_distance");
+    const coord_t allowed_filter_deviation = settings.get<coord_t>("wall_transition_filter_deviation");
     SkeletalTrapezoidation wall_maker
     (
         prepared_outline,
@@ -104,6 +105,7 @@ const VariableWidthPaths& WallToolPaths::generate()
         beading_strat->getTransitioningAngle(),
         discretization_step_size,
         transition_filter_dist,
+        allowed_filter_deviation,
         wall_transition_length
     );
     wall_maker.generateToolpaths(toolpaths);

--- a/tests/WallsComputationTest.cpp
+++ b/tests/WallsComputationTest.cpp
@@ -88,6 +88,7 @@ public:
         settings.add("wall_line_width_x", "0.4");
         settings.add("wall_transition_angle", "10");
         settings.add("wall_transition_filter_distance", "1");
+        settings.add("wall_transition_filter_deviation", ".2");
         settings.add("wall_transition_length", "1");
         settings.add("wall_split_middle_threshold", "50");
         settings.add("wall_add_middle_threshold", "50");


### PR DESCRIPTION
In some cases the transition filtering could introduce very large deviations in extrusion width.
The bug was introduced because the LimitedBeadingStrategy could cause large portions of a region to get the same bead count value. E.g. the gray area here:
![image](https://user-images.githubusercontent.com/8895761/160593530-fc8beda6-7dad-4494-9476-d939e41e5933.png)

With a high value for the filter distance such regions could then collapse as a whole. Meaning that the extrusion width would get ridiculously large:
![image](https://user-images.githubusercontent.com/8895761/160593755-141d84d0-a112-40d2-9e03-c6d5632366c2.png)

However, the problem is more general: we have no control over the bead width variation induced by the filtering.

This PR adds a setting to limit the allowed bead width deviation induced by filtering.
![image](https://user-images.githubusercontent.com/8895761/160594129-c9729c0d-7891-4431-918c-9c1fddf7fbf6.png)
![image](https://user-images.githubusercontent.com/8895761/160594066-0289a3d8-a649-4bef-a39e-65bfab07659c.png)
![image](https://user-images.githubusercontent.com/8895761/160594220-c505d792-7ec6-4845-9f42-cc756b57354f.png)

This fixes CURA-9080