### PR TITLE
[CURA-8694] retracted unnecessary travel moves part ii return of the comb

### DIFF
--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -62,7 +62,27 @@ Comb::Comb(const SliceDataStorage& storage, const LayerIndex layer_nr, const Pol
         , this
         , offset_from_inside_to_outside
     )
-, move_inside_distance(move_inside_distance)
+, model_boundary(
+          [&storage, layer_nr]()
+          {
+              const std::vector<bool> extruder_is_used = storage.getExtrudersUsed();
+              bool travel_avoid_supports = false;
+              for (const ExtruderTrain& extruder : Application::getInstance().current_slice->scene.extruders)
+              {
+                  travel_avoid_supports |= extruder_is_used[extruder.extruder_nr] && extruder.settings.get<bool>("travel_avoid_other_parts") && extruder.settings.get<bool>("travel_avoid_supports");
+              }
+              return storage.getLayerOutlines(layer_nr, travel_avoid_supports, travel_avoid_supports);
+          }
+      )
+, model_boundary_loc_to_line(
+          [](Comb* comber, const int64_t offset_from_inside_to_outside)
+          {
+              return PolygonUtils::createLocToLineGrid(*comber->model_boundary, offset_from_inside_to_outside * 3 / 2);
+          }
+          , this
+          , offset_from_inside_to_outside
+      )
+    , move_inside_distance(move_inside_distance)
 {
 }
 
@@ -256,7 +276,7 @@ bool Comb::calc(const ExtruderTrain& train, Point start_point, Point end_point, 
             }
             else
             { // both start and end are outside
-                comb_paths.back().cross_boundary = PolygonUtils::polygonCollidesWithLineSegment(start_point, end_point, getOutsideLocToLine());
+                comb_paths.back().cross_boundary = PolygonUtils::polygonCollidesWithLineSegment(start_point, end_point, **model_boundary_loc_to_line);
             }
         }
         else

--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -228,6 +228,11 @@ bool Comb::calc(const ExtruderTrain& train, Point start_point, Point end_point, 
         comb_paths.throughAir = true;
         if ( vSize(start_crossing.in_or_mid - end_crossing.in_or_mid) < vSize(start_crossing.in_or_mid - start_crossing.out) + vSize(end_crossing.in_or_mid - end_crossing.out) )
         { // via outside is moving more over the in-between zone
+            comb_paths.emplace_back();
+            // we are not sure if these paths travel through air or cross a boundary
+            // but, they might be so set it to be certain (error on the safe side).
+            comb_paths.throughAir = true;
+            comb_paths.back().cross_boundary = true;
             comb_paths.back().push_back(start_crossing.in_or_mid);
             comb_paths.back().push_back(end_crossing.in_or_mid);
         }

--- a/src/pathPlanning/Comb.h
+++ b/src/pathPlanning/Comb.h
@@ -132,7 +132,9 @@ private:
     std::unique_ptr<LocToLineGrid> inside_loc_to_line_minimum; //!< The SparsePointGridInclusive mapping locations to line segments of the inner boundary.
     std::unique_ptr<LocToLineGrid> inside_loc_to_line_optimal; //!< The SparsePointGridInclusive mapping locations to line segments of the inner boundary.
     LazyInitialization<Polygons> boundary_outside; //!< The boundary outside of which to stay to avoid collision with other layer parts. This is a pointer cause we only compute it when we move outside the boundary (so not when there is only a single part in the layer)
+    LazyInitialization<Polygons> model_boundary; //!< The boundary of the model itself
     LazyInitialization<std::unique_ptr<LocToLineGrid>, Comb*, const coord_t> outside_loc_to_line; //!< The SparsePointGridInclusive mapping locations to line segments of the outside boundary.
+    LazyInitialization<std::unique_ptr<LocToLineGrid>, Comb*, const coord_t> model_boundary_loc_to_line; //!< The SparsePointGridInclusive mapping locations to line segments of the model boundary
     coord_t move_inside_distance; //!< When using comb_boundary_inside_minimum for combing it tries to move points inside by this amount after calculating the path to move it from the border a bit.
 
     /*!


### PR DESCRIPTION
Main issue remaining of the CURA-8694 ticket was solved in https://github.com/Ultimaker/CuraEngine/commit/d696b2dd036bc63e19c32a1159d838c1004fbd33.

Problem was with the `cross_boundary`. In this situation we only retract if the travel path intersects with a outer boundary. The outer boundary used here was the `travel_avoid_distance` offset of the model polygon (green polygon). Some paths that were crossing the boundary of the model where thus not retracted as it didn't cross the green boundary. Solved the issue by performing the check on the boundary of the model itself.

<img width="543" alt="Screenshot 2022-04-06 at 23 15 55" src="https://user-images.githubusercontent.com/6638028/162160614-639bb2e9-e764-4afd-a8ff-84ff72a9a1f9.png">

After this fix there were still some unredacted travel moves crossing the outer boundary of the model. that was fixed here: https://github.com/Ultimaker/CuraEngine/commit/ade72656ec16931fd750759ce39203b03d5ea19f. In this situation we would very bluntly travel from the start location to the end destination without any combing move. We do not know whether or not we would cross a boundary here. As a precaution i did set the `cross_boundary` and `through_air` flags here as we _might_ cross a boundary. However this change might be too aggressive; it could set `cross_boundary` for travel moves that don't intersect with the models boundary. This might introduce additional retractions.

(see https://ultimaker.atlassian.net/browse/CURA-8694 for a more in-depth analysis)