### PR TITLE
Fix missing infill layers

### DIFF
--- a/src/infill/LightningLayer.cpp
+++ b/src/infill/LightningLayer.cpp
@@ -260,16 +260,9 @@ Polygons LightningLayer::convertToLines(const Polygons& limit_to_outline, const 
 
     for (const auto& tree : tree_roots)
     {
-        // If even the furthest location in the tree is inside the polygon, the entire tree must be inside of the polygon.
-        // (Don't take the root as that may be on the edge and cause rounding errors to register as 'outside'.)
-        constexpr coord_t epsilon = 5;
-        Point should_be_inside = tree->getLocation();
-        PolygonUtils::moveInside(limit_to_outline, should_be_inside, epsilon, epsilon * epsilon);
-        if (limit_to_outline.inside(should_be_inside))
-        {
-            tree->convertToPolylines(result_lines, line_width);
-        }
+        tree->convertToPolylines(result_lines, line_width);
     }
+    result_lines = limit_to_outline.intersectionPolyLines(result_lines);
 
     return result_lines;
 }


### PR DESCRIPTION
## Overview
This PR fix the behavior of lightning infill where certain infill regions are skipped

### Before
![Screenshot 2022-04-13 at 16 41 51](https://user-images.githubusercontent.com/6638028/163206087-217ecfd7-9a58-4549-8e8b-5ed9b421f700.png)
### After
![Screenshot 2022-04-13 at 16 42 10](https://user-images.githubusercontent.com/6638028/163206482-b5a5f35b-5f89-4162-abb6-000e723c81cf.png)

## Analysis
Previously there was logic in the Lighting Infill implementation that would check of the root of the lighting node was inside the polygon-part. https://github.com/Ultimaker/CuraEngine/blob/7e3a0a5988e291d176a31f594854d8df908f644a/src/infill/LightningLayer.cpp#L268 This was needed because otherwise the lightning infill would be printed multiple times, once for every "polygon-island" (see CURA-8702).

Problem with this implementation was that the root of this node was ever so slightly outside of this outer boundary-shape (see image: outline, and tree lightning-root highlighted). As the root is outside the shape the complete infill would be skipped for this particular example.
![Screenshot 2022-04-13 at 15 13 49](https://user-images.githubusercontent.com/6638028/163206598-8f0de717-8951-41d6-8a4b-a15653fe18c0.png)

Moving the point slightly inside this polygon appears not to be enough. https://github.com/Ultimaker/CuraEngine/blob/7e3a0a5988e291d176a31f594854d8df908f644a/src/infill/LightningLayer.cpp#L265-L267

## Solution
Initially all lightning paths are added to the result. To make sure we only use the infill lines that are inside the relevant polygon island (and prevent CURA-8702) I propose to do a `intersectionPolyLines` with the outline and the result lines.

CURA-9088