### PR TITLE
fix a bug in supports

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1236,7 +1236,6 @@ void AreaSupport::moveUpFromModel(const SliceDataStorage& storage, Polygons& sta
     }
     else
     {
-        to_be_removed = stair_removal.unionPolygons(bottom_outline);
         if (layer_idx % bottom_stair_step_layer_count == 0)
         { // update stairs for next step
             const Polygons supporting_bottom = storage.getLayerOutlines(bottom_layer_nr - 1, no_support, no_prime_tower);
@@ -1253,6 +1252,7 @@ void AreaSupport::moveUpFromModel(const SliceDataStorage& storage, Polygons& sta
                 stair_removal = allowed_step_width;
             }
         }
+        to_be_removed = stair_removal.unionPolygons(bottom_outline);
     }
     support_areas = support_areas.difference(to_be_removed);
 }


### PR DESCRIPTION
This PR fixes Ultimaker/Cura#11190, which is a support generation bug present in (at least) 4.12, 4.13, and master/5.0.

Without this fix (the current situation) there is a consistent problematic behavior that shows up in many situation.  Here's a 3mf file that demonstrates the issue using an Ultimaker S5 printer and several different models: [supports.zip](https://github.com/Ultimaker/CuraEngine/files/8491864/supports.zip).  The settings are close to the "Default / Fast" profile, but with Supports enabled and "Support Z Distance" set to 0.

Here's an overview picture with problems highlighted (details below):
![Screenshot from 2022-04-14 15-57-10](https://user-images.githubusercontent.com/46073098/163466948-b9b3d475-20b3-4cbc-8f9d-c845cfe2e803.png)

The problem manifests as incorrect support geometry in the uppermost layer of the support (whether or not Support Interface is enabled), and *different* incorrect support geometry in every layer of the support below that.

## @Doccos's part

The big curved part on the left is from @Doccos's original bug report. This closeup *from below* shows the uppermost layer of the support, and ("behind" that) the layer of the model just above that.  It clearly shows that there are gaps in the support that leave part of the edge of the model unsupported:
![Screenshot from 2022-04-14 16-21-11](https://user-images.githubusercontent.com/46073098/163469689-fe89874e-6a12-409b-80b5-5a9bafe36ab1.png)

This closeup *from above* shows the top layer of the support, and the layer just below that, and shows that the support geometry is partially but not completely healed (the errors present on the second-from-the-top layer of the support propagate all the way down the support with no further "healing", as indicated by the "streaks" visible in the overview picture at the top):
![Screenshot from 2022-04-14 16-21-44](https://user-images.githubusercontent.com/46073098/163470118-397a3db5-617d-4d5d-a7d0-4e2598841e06.png)

## My part

I ran in to the same issue while slicing a different part (the middle part in the overview picture above).

The uppermost layer of support, and the model above it, seen from below:
![Screenshot from 2022-04-14 16-32-47](https://user-images.githubusercontent.com/46073098/163471052-32bd99fc-e75f-417d-889a-c7238e74744d.png)

Top layer and the second-from-top layer of the support, seen from above: 
![Screenshot from 2022-04-14 16-33-17](https://user-images.githubusercontent.com/46073098/163471054-089e9cec-29da-4878-98c1-5161beec385b.png)

## A third simple part

And finally, the part on the right-hand side of the overview picture.  The simple geometry of this part led me to the bug.

Again we see the same pattern of errors, which leave part of the model unsupported:
![Screenshot from 2022-04-14 16-39-15](https://user-images.githubusercontent.com/46073098/163471813-e1f2d860-b7f5-469a-ae6f-5a923487475d.png)
![Screenshot from 2022-04-14 16-39-33](https://user-images.githubusercontent.com/46073098/163471934-2a6ec87f-cdbe-4bfa-b55c-40a8ffba25ac.png)
 
## The bug and the fix

I believe this PR has the correct fix.  It correctly computes the supports in all three of the cases that are shown above to be buggy in 4.13.1:

![Screenshot from 2022-04-14 17-01-51](https://user-images.githubusercontent.com/46073098/163474597-c34e5482-c3a8-41d2-8602-c17b83d4c3ba.png)
![Screenshot from 2022-04-14 17-01-24](https://user-images.githubusercontent.com/46073098/163474600-92f55356-b9db-4a99-a5a5-176b65ef410e.png)
![Screenshot from 2022-04-14 17-01-09](https://user-images.githubusercontent.com/46073098/163474601-57d4a322-fb00-4a62-84a6-6e4c8adce384.png)

The bug is in the code that computes support stairs.  On layers where the stair-step geometry changes, the support areas need to respond to the new stair geometry immediately, instead of deferring it to the next layer down.