### PR TITLE
[Cura] 9096 - Tree Support branches not being generated

### DIFF
--- a/src/TreeModelVolumes.h
+++ b/src/TreeModelVolumes.h
@@ -4,6 +4,7 @@
 #ifndef TREEMODELVOLUMES_H
 #define TREEMODELVOLUMES_H
 
+#include <mutex>
 #include <unordered_map>
 
 #include "settings/EnumSettings.h" //To store whether X/Y or Z distance gets priority.
@@ -20,7 +21,7 @@ class Settings;
 /*!
  * \brief Lazily generates tree guidance volumes.
  *
- * \warning This class is not currently thread-safe and should not be accessed in OpenMP blocks
+ * \warning This class blocks on thread access. Use calls to this in threaded blocks sparingly.
  */
 class TreeModelVolumes
 {
@@ -195,6 +196,11 @@ private:
     mutable std::unordered_map<RadiusLayerPair, Polygons> collision_cache_;
     mutable std::unordered_map<RadiusLayerPair, Polygons> avoidance_cache_;
     mutable std::unordered_map<RadiusLayerPair, Polygons> internal_model_cache_;
+
+    /*!
+     * \brief Used to make the class thread-safe.
+     */
+    mutable std::mutex object_mutex_;
 };
 
 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -31,10 +31,9 @@
 namespace cura
 {
 
-TreeSupport::TreeSupport(const SliceDataStorage& storage)
+TreeSupport::TreeSupport(const SliceDataStorage& storage) :
+    volumes_(storage, Application::getInstance().current_slice->scene.current_mesh_group->settings)
 {
-    const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-    volumes_ = TreeModelVolumes(storage, mesh_group_settings);
 }
 
 void TreeSupport::generateSupportAreas(SliceDataStorage& storage)

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -381,13 +381,13 @@ void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
                     }();
 
                     const ClosestPolygonPoint to_outside = PolygonUtils::findClosest(node.position, collision);
-                    bool node_is_tip = node.distance_to_top <= tip_layers;
+                    const bool node_is_tip = node.distance_to_top <= tip_layers;
                     coord_t max_inside_dist = branch_radius_node;
                     if (node_is_tip) {
                         // if the node is part of the tip allow the branch to travel through the support xy distance
                         max_inside_dist += (tip_layers - node.distance_to_top) * maximum_move_distance;
                     }
-                    if (vSize2(node.position - to_outside.location) >= max_inside_dist * max_inside_dist) //Too far inside.
+                    if (vSize2(node.position - to_outside.location) >= max_inside_dist * max_inside_dist) // Too far inside.
                     {
                         if (! support_rests_on_model)
                         {
@@ -429,9 +429,10 @@ void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
                 }();
 
                 //Avoid collisions.
-                const coord_t maximum_move_between_samples = maximum_move_distance + radius_sample_resolution + 100; //100 micron extra for rounding errors.
-                Polygons avoidance = group_index == 0 ? volumes_.getAvoidance(branch_radius_node, layer_nr - 1) : volumes_.getCollision(branch_radius_node, layer_nr - 1);
-                PolygonUtils::moveOutside(avoidance, next_layer_vertex, radius_sample_resolution + 100, maximum_move_between_samples * maximum_move_between_samples);
+                constexpr size_t rounding_compensation = 100;
+                const coord_t maximum_move_between_samples = maximum_move_distance + radius_sample_resolution + rounding_compensation;
+                const Polygons avoidance = group_index == 0 ? volumes_.getAvoidance(branch_radius_node, layer_nr - 1) : volumes_.getCollision(branch_radius_node, layer_nr - 1);
+                PolygonUtils::moveOutside(avoidance, next_layer_vertex, radius_sample_resolution + rounding_compensation, maximum_move_between_samples * maximum_move_between_samples);
 
                 const bool to_buildplate = !volumes_.getAvoidance(branch_radius_node, layer_nr - 1).inside(next_layer_vertex);
                 Node* next_node = new Node(next_layer_vertex, node.distance_to_top + 1, node.skin_direction, node.support_roof_layers_below - 1, to_buildplate, p_node);

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -366,7 +366,7 @@ void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
                 }
                 //If the branch falls completely inside a collision area (the entire branch would be removed by the X/Y offset), delete it.
 
-                Polygons collision = volumes_.getCollision(0, layer_nr);
+                const Polygons collision = volumes_.getCollision(0, layer_nr);
                 if (group_index > 0 && collision.inside(node.position))
                 {
                     const coord_t branch_radius_node = [&]() -> coord_t

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -318,12 +318,11 @@ void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
                              return branch_radius * (node.distance_to_top + 1) / tip_layers;
                         }
                     }();
-                    if (group_index == 0)
-                    {
-                        //Avoid collisions.
-                        const coord_t maximum_move_between_samples = maximum_move_distance + radius_sample_resolution + 100; //100 micron extra for rounding errors.
-                        PolygonUtils::moveOutside(volumes_.getAvoidance(branch_radius_node, layer_nr - 1), next_position, radius_sample_resolution + 100, maximum_move_between_samples * maximum_move_between_samples); //Some extra offset to prevent rounding errors with the sample resolution.
-                    }
+
+                    //Avoid collisions.
+                    const coord_t maximum_move_between_samples = maximum_move_distance + radius_sample_resolution + 100; //100 micron extra for rounding errors.
+                    Polygons avoidance = group_index == 0 ? volumes_.getAvoidance(branch_radius_node, layer_nr - 1) : volumes_.getCollision(branch_radius_node, layer_nr - 1);
+                    PolygonUtils::moveOutside(avoidance, next_position, radius_sample_resolution + 100, maximum_move_between_samples * maximum_move_between_samples);
 
                     Node* neighbour = nodes_per_part[group_index][neighbours[0]];
                     size_t new_distance_to_top = std::max(node.distance_to_top, neighbour->distance_to_top) + 1;
@@ -428,12 +427,11 @@ void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
                         return branch_radius * (node.distance_to_top + 1) / tip_layers;
                     }
                 }();
-                if (group_index == 0)
-                {
-                    //Avoid collisions.
-                    const coord_t maximum_move_between_samples = maximum_move_distance + radius_sample_resolution + 100; //100 micron extra for rounding errors.
-                    PolygonUtils::moveOutside(volumes_.getAvoidance(branch_radius_node, layer_nr - 1), next_layer_vertex, radius_sample_resolution + 100, maximum_move_between_samples * maximum_move_between_samples); //Some extra offset to prevent rounding errors with the sample resolution.
-                }
+
+                //Avoid collisions.
+                const coord_t maximum_move_between_samples = maximum_move_distance + radius_sample_resolution + 100; //100 micron extra for rounding errors.
+                Polygons avoidance = group_index == 0 ? volumes_.getAvoidance(branch_radius_node, layer_nr - 1) : volumes_.getCollision(branch_radius_node, layer_nr - 1);
+                PolygonUtils::moveOutside(avoidance, next_layer_vertex, radius_sample_resolution + 100, maximum_move_between_samples * maximum_move_between_samples);
 
                 const bool to_buildplate = !volumes_.getAvoidance(branch_radius_node, layer_nr - 1).inside(next_layer_vertex);
                 Node* next_node = new Node(next_layer_vertex, node.distance_to_top + 1, node.skin_direction, node.support_roof_layers_below - 1, to_buildplate, p_node);

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -320,9 +320,10 @@ void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
                     }();
 
                     //Avoid collisions.
-                    const coord_t maximum_move_between_samples = maximum_move_distance + radius_sample_resolution + 100; //100 micron extra for rounding errors.
-                    Polygons avoidance = group_index == 0 ? volumes_.getAvoidance(branch_radius_node, layer_nr - 1) : volumes_.getCollision(branch_radius_node, layer_nr - 1);
-                    PolygonUtils::moveOutside(avoidance, next_position, radius_sample_resolution + 100, maximum_move_between_samples * maximum_move_between_samples);
+                    constexpr size_t rounding_compensation = 100;
+                    const coord_t maximum_move_between_samples = maximum_move_distance + radius_sample_resolution + rounding_compensation;
+                    const Polygons avoidance = group_index == 0 ? volumes_.getAvoidance(branch_radius_node, layer_nr - 1) : volumes_.getCollision(branch_radius_node, layer_nr - 1);
+                    PolygonUtils::moveOutside(avoidance, next_position, radius_sample_resolution + rounding_compensation, maximum_move_between_samples * maximum_move_between_samples);
 
                     Node* neighbour = nodes_per_part[group_index][neighbours[0]];
                     size_t new_distance_to_top = std::max(node.distance_to_top, neighbour->distance_to_top) + 1;


### PR DESCRIPTION
# Overview

Some of the required tree-support failed to generate. For these instances the tree-support contact points were generated, but there were no supporting tree branches attached.

This PR aims to fix this issue.

**Before**<img width="1680" alt="Screenshot 2022-04-19 at 20 13 36" src="https://user-images.githubusercontent.com/6638028/164069369-a2209d95-cdb4-46de-a1cb-f8611f416a8d.png">

**After**<img width="1680" alt="Screenshot 2022-04-19 at 20 12 39" src="https://user-images.githubusercontent.com/6638028/164069391-c0dbea0f-ce18-4ee3-bbf3-3ed42f8d689b.png">

# Analysis

As stated previously the tree-support contact points were correctly generated. These points are created on overhanging areas, and are as a result almost always located within the xy support distance of the polygon. This can be seen in the image below (contact point tree-support: black dot, shape-outline: green, xy support distance: Red).
<img width="486" alt="Screenshot 2022-04-19 at 20 20 21" src="https://user-images.githubusercontent.com/6638028/164069975-bd0719c6-a80d-4357-9a45-f7e6e9f8fa59.png">

This situation would trigger the following piece of code: If the support branch would fall within this xy support distance polygon
https://github.com/Ultimaker/CuraEngine/blob/1a7667832f918781ca7d2e2e008f02708b6be07c/src/TreeSupport.cpp#L368-L369 _and_ the distance to the boundary is less then the branch's diameter https://github.com/Ultimaker/CuraEngine/blob/1a7667832f918781ca7d2e2e008f02708b6be07c/src/TreeSupport.cpp#L382-L390 _then_ the branch would be removed in it's entirely.

The rational behind this piece of code is optimization; if a branch polygon is completely within the xy distance offsetted polygon then it would be removed anyway in the finalization stage of the tree support generation. Removing the support branches preemptively prevents unnecessary branches from being maintained throughout the support generation.

This is the crux of the issue; as the support branch contact point is at the far end of the tip it's diameter is very small, only 100 microns for this example. This would in almost all cases be less then the distance to the xy distance offsetted polygon, and thus the support branch is removed.

# Solution
The solution is fairly simple; in this PR I propose to allow (the tip of the) support branches to travel through the xy distance.

## Asterisk

The original insensitive to remove the polygons still holds, the branches fall within the xy support distance and they should be removed here. 
https://github.com/Ultimaker/CuraEngine/blob/1a7667832f918781ca7d2e2e008f02708b6be07c/src/TreeSupport.cpp#L145-L146
I did not do anything to prevent this from happening, but the generated support seems correct... so not sure whats going on here.

Additionally, the behavior of the tree support seems to have changed between cura 4.13 and current master, while there has not been any changes to the relevant code. This is a bit suspicious and I started investigation what has changed between these versions. I compared some of the relevant setting values and compared the generated polygons, but I could not determine what has changed. I'm a bit puzzled how this has worked before.

CURA-9096