### PR TITLE
[CURA-9159] Fix occasional crash due to unsafe threading in tree support.

### DIFF
--- a/src/TreeModelVolumes.h
+++ b/src/TreeModelVolumes.h
@@ -4,6 +4,7 @@
 #ifndef TREEMODELVOLUMES_H
 #define TREEMODELVOLUMES_H
 
+#include <mutex>
 #include <unordered_map>
 
 #include "settings/EnumSettings.h" //To store whether X/Y or Z distance gets priority.
@@ -20,7 +21,7 @@ class Settings;
 /*!
  * \brief Lazily generates tree guidance volumes.
  *
- * \warning This class is not currently thread-safe and should not be accessed in OpenMP blocks
+ * \warning This class blocks on thread access. Use calls to this in threaded blocks sparingly.
  */
 class TreeModelVolumes
 {
@@ -195,6 +196,11 @@ private:
     mutable std::unordered_map<RadiusLayerPair, Polygons> collision_cache_;
     mutable std::unordered_map<RadiusLayerPair, Polygons> avoidance_cache_;
     mutable std::unordered_map<RadiusLayerPair, Polygons> internal_model_cache_;
+
+    /*!
+     * \brief Used to make the class thread-safe.
+     */
+    mutable std::mutex object_mutex_;
 };
 
 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -31,10 +31,9 @@
 namespace cura
 {
 
-TreeSupport::TreeSupport(const SliceDataStorage& storage)
+TreeSupport::TreeSupport(const SliceDataStorage& storage) :
+    volumes_(storage, Application::getInstance().current_slice->scene.current_mesh_group->settings)
 {
-    const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-    volumes_ = TreeModelVolumes(storage, mesh_group_settings);
 }
 
 void TreeSupport::generateSupportAreas(SliceDataStorage& storage)


### PR DESCRIPTION
It explicitly said the class was not thread safe in the comments -- but we used it within a threaded for anyway. This caused crashes in at least one particular model with tree-support roughly about one in five times (at least on some PC's).