### PR TITLE
Print wall_toolpaths_here, which has the thin toolpaths of support

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2796,7 +2796,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                 const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, gcode_layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE, simplify_curvature);
                 InsetOrderOptimizer wall_orderer(*this, storage, gcode_layer, infill_extruder.settings, extruder_nr,
                                                 config, config, config, config,
-                                                retract_before_outer_wall, wipe_dist, wipe_dist, extruder_nr, extruder_nr, z_seam_config, wall_toolpaths);
+                                                retract_before_outer_wall, wipe_dist, wipe_dist, extruder_nr, extruder_nr, z_seam_config, wall_toolpaths_here);
                 added_something |= wall_orderer.addToLayer();
             }
         }

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -865,7 +865,7 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage, const S
             if (use_xy_distance_overhang) //Z overrides XY distance.
             {
                 // we also want to use the min XY distance when the support is resting on a sloped surface so we calculate the area of the
-                // layer below that protudes beyond the current layer's area and combine it with the current layer's overhang disallowed area
+                // layer below that protrudes beyond the current layer's area and combine it with the current layer's overhang disallowed area
 
                 Polygons larger_area_below; // the areas in the layer below that protrude beyond the area of the current layer
                 if (layer_idx > 1)
@@ -875,7 +875,7 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage, const S
 
                     if (larger_area_below.size())
                     {
-                        // if the layer below protudes sufficiently such that a normal support at xy_distance could be placed there,
+                        // if the layer below protrudes sufficiently such that a normal support at xy_distance could be placed there,
                         // we don't want to use the min XY distance in that area and so we remove the wide area from larger_area_below
 
                         // assume that a minimal support structure would be one line spaced at xy_distance from the model (verified by experiment)


### PR DESCRIPTION
It was re-printing the same thing that was already printed earlier: wall_toolpaths. In this code block it was checking if wall_toolpaths_here was empty and then proceeded to print wall_toolpaths (not _here) if it wasn't. That was clearly a mistake.

Also fixed some spelling mistakes in the other file since I noticed them. Just in documentation.

Contributes to issue CURA-9077.