### PR TITLE
Retracted unnecessary travel moves

### DIFF
--- a/src/pathPlanning/Comb.cpp
+++ b/src/pathPlanning/Comb.cpp
@@ -228,11 +228,6 @@ bool Comb::calc(const ExtruderTrain& train, Point start_point, Point end_point, 
         comb_paths.throughAir = true;
         if ( vSize(start_crossing.in_or_mid - end_crossing.in_or_mid) < vSize(start_crossing.in_or_mid - start_crossing.out) + vSize(end_crossing.in_or_mid - end_crossing.out) )
         { // via outside is moving more over the in-between zone
-            comb_paths.emplace_back();
-            // we are not sure if these paths travel through air or cross a boundary
-            // but, they might be so set it to be certain (error on the safe side).
-            comb_paths.throughAir = true;
-            comb_paths.back().cross_boundary = true;
             comb_paths.back().push_back(start_crossing.in_or_mid);
             comb_paths.back().push_back(end_crossing.in_or_mid);
         }


### PR DESCRIPTION
This was a bit of a tricky one. Before this PR there were a lot of un-retracted travel moves that would scar the object.

![Screenshot 2022-05-02 at 14 46 27](https://user-images.githubusercontent.com/6638028/166238184-323263ae-4f92-4dc6-ba3a-8a6bb725bf9c.png)

In this particular model there are a lot of travel moves, which correctly would be labeled as _retracted travel moves_. As the support for this model has PVA support the amount of retractions is limited to a great extend. Some of the retracted travel moves would thus be overridden by this limiter and printed as un retracted travel moves.

We did end-up reverting one commit from https://github.com/Ultimaker/CuraEngine/pull/1636. Part of this PR read

> After this fix there were still some unredacted travel moves crossing the outer boundary of the model. that was fixed here: https://github.com/Ultimaker/CuraEngine/commit/ade72656ec16931fd750759ce39203b03d5ea19f. In this situation we would very bluntly travel from the start location to the end destination without any combing move. We do not know whether or not we would cross a boundary here. As a precaution i did set the cross_boundary and through_air flags here as we might cross a boundary. However this change might be too aggressive; it could set cross_boundary for travel moves that don't intersect with the models boundary. This might introduce additional retractions.

Now that we retract less aggressively this problem is _slightly less likely_ to occur. 

![Screenshot 2022-05-02 at 15 03 39](https://user-images.githubusercontent.com/6638028/166238202-4c323c3a-2065-489d-8058-a5d1d5e67d89.png)

CURA-9163

Co-authored-by: @Joeydelarago 