### PR TITLE
Don't use zig-zag endpieces when using gradual infill

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1632,7 +1632,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
     const auto pocket_size = mesh.settings.get<coord_t>("cross_infill_pocket_size");
     constexpr bool skip_stitching = false;
     constexpr bool connected_zigzags = false;
-    constexpr bool use_endpieces = true;
+    const bool use_endpieces = part.infill_area_per_combine_per_density.size() == 1; //Only use endpieces when not using gradual infill, since they will then overlap.
     constexpr bool skip_some_zags = false;
     constexpr int zag_skip_count = 0;
 


### PR DESCRIPTION
The endpieces will connect the endpoint of the zigzag pattern up to the last real line along the edge, but this causes massive overlaps when the pattern is used at different densities next to each other for gradual infill.

Most likely fixes CURA-9288.