### PR TITLE
[CURA-9293] Define 'too long' line segments as twice the length of smallest.

### DIFF
--- a/src/utils/ExtrusionLine.cpp
+++ b/src/utils/ExtrusionLine.cpp
@@ -136,7 +136,7 @@ void ExtrusionLine::simplify(const coord_t smallest_line_segment_squared, const 
             && height_2 <= allowed_error_distance_squared) // Removing the junction (vertex) doesn't introduce too much error.
         {
             const coord_t next_length2 = vSize2(current - next);
-            if (next_length2 > smallest_line_segment_squared)
+            if (next_length2 > 4 * smallest_line_segment_squared)
             {
                 // Special case; The next line is long. If we were to remove this, it could happen that we get quite noticeable artifacts.
                 // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -540,7 +540,7 @@ void PolygonRef::_simplify(const coord_t smallest_line_segment_squared, const co
                 && height_2 <= allowed_error_distance_squared) // removing the vertex doesn't introduce too much error.)
             {
                 const coord_t next_length2 = vSize2(current - next);
-                if (next_length2 > smallest_line_segment_squared)
+                if (next_length2 > 4 * smallest_line_segment_squared)
                 {
                     // Special case; The next line is long. If we were to remove this, it could happen that we get quite noticeable artifacts.
                     // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.


### PR DESCRIPTION
Should fix microsegemtns for occurrences of 'line segments slightly longer than the minimum' and 'small line segments but longer than 5 micron' occurring together often. Which in turn should fix those microsegments that still cause blobs at least on UM printers.