### PR TITLE
[CURA-9085] Unretracted moves on top layer of top skin. 

### DIFF
--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -648,7 +648,7 @@ void SkinInfillAreaComputation::generateTopAndBottomMostSkinSurfaces(SliceLayerP
 
     for (SkinPart& skin_part : part.skin_parts) {
         Polygons no_air_above = generateNoAirAbove(part, 1);
-        skin_part.top_most_surface_fill = skin_part.roofing_fill.difference(no_air_above);
+        skin_part.top_most_surface_fill = skin_part.outline.difference(no_air_above);
 
         Polygons no_air_below = generateNoAirBelow(part, 1);
         skin_part.bottom_most_surface_fill = skin_part.skin_fill.difference(no_air_below);

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -648,7 +648,7 @@ void SkinInfillAreaComputation::generateTopAndBottomMostSkinSurfaces(SliceLayerP
 
     for (SkinPart& skin_part : part.skin_parts) {
         Polygons no_air_above = generateNoAirAbove(part, 1);
-        skin_part.top_most_surface_fill = skin_part.skin_fill.difference(no_air_above);
+        skin_part.top_most_surface_fill = skin_part.roofing_fill.difference(no_air_above);
 
         Polygons no_air_below = generateNoAirBelow(part, 1);
         skin_part.bottom_most_surface_fill = skin_part.skin_fill.difference(no_air_below);


### PR DESCRIPTION
This fixes travels being unretracted on the top most surface skin layer(s) when using CombingMode::NO_OUTER_SURFACES.

The top_most_surface_fill polygon being used for the combing boundary was defined incorrectly.
skin_part.top_most_surface_fill = skin_part.skin_fill.difference(no_air_above);
The skin_part.skin_fill was empty on the surface skin layers. Causing this statement to return an empty polygon for combing.
This is because the skin_fill is the fill for the bottom skin rather than the top.

This fix is to use roofing_fill, which has the correct polygon for the top surface skin fill.

CURA-9083