### PR TITLE
CMake: Correcting minimum version for Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ endif()
 
 find_package(stb REQUIRED)
 
-find_package(Boost REQUIRED 1.75.0)
+find_package(Boost 1.75.0 REQUIRED)
 if (NOT TARGET Boost::boost)  # Workaround for different namespace in non Conan find_packages
     add_library(boost::boost ALIAS Boost::boost)
 endif ()


### PR DESCRIPTION
This is the wrong position in find_package. Components are listed after the REQUIRED statement.