### PR TITLE
CMake: Correcting alias'ing of Boost::boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ find_package(stb REQUIRED)
 
 find_package(Boost REQUIRED 1.75.0)
 if (NOT TARGET Boost::boost)  # Workaround for different namespace in non Conan find_packages
-    add_library(boost::boost ALIAS Boost::boost)
+    add_library(Boost::boost ALIAS boost::boost)
 endif ()
 
 target_link_libraries(_CuraEngine PRIVATE clipper::clipper rapidjson::rapidjson stb::stb boost::boost)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ if (NOT TARGET Boost::boost)  # Workaround for different namespace in non Conan 
     add_library(Boost::boost ALIAS boost::boost)
 endif ()
 
-target_link_libraries(_CuraEngine PRIVATE clipper::clipper rapidjson::rapidjson stb::stb boost::boost)
+target_link_libraries(_CuraEngine PRIVATE clipper::clipper rapidjson::rapidjson stb::stb Boost::boost)
 
 if (WIN32)
     message(STATUS "Using windres")


### PR DESCRIPTION
add_library takes <name> and as option after ALIAS the <target>.
Let's do it the correct way! (If I get the point of the section correct..)