### PR TITLE
Don't fill gaps more than once when using gradual infill

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1694,8 +1694,6 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                                infill_shift, max_resolution, max_deviation, skin_below_wall_count, infill_origin,
                                skip_stitching, fill_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
             infill_comp.generate(wall_tool_paths.back(), infill_polygons, infill_lines, mesh.settings, mesh.cross_fill_provider, lightning_layer, &mesh);
-
-            // Fixme: CURA-7848 for libArachne.
             if (density_idx < last_idx)
             {
                 const coord_t cut_offset =
@@ -1732,8 +1730,6 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage, L
                            infill_shift, max_resolution, max_deviation, wall_line_count_here, infill_origin,
                            skip_stitching, fill_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size);
         infill_comp.generate(wall_tool_paths.back(), infill_polygons, infill_lines, mesh.settings, mesh.cross_fill_provider, lightning_layer, &mesh);
-
-        // Fixme: CURA-7848 for libArachne.
         if (density_idx < last_idx)
         {
             const coord_t cut_offset = get_cut_offset(zig_zaggify_infill, infill_line_width, wall_line_count);

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -117,7 +117,10 @@ void Infill::generate(std::vector<VariableWidthLines>& toolpaths, Polygons& resu
                     if(path.polygonLength() >= infill_line_width * 4) //Don't fill gaps that are very small (with paths less than 2 line widths long, 4 back and forth).
                     {
                         gap_filled_areas.add(path);
-                        thin_walls_only.push_back(extrusion);
+                        if(fill_gaps)
+                        {
+                            thin_walls_only.push_back(extrusion);
+                        }
                     }
                 }
             }

--- a/src/infill.h
+++ b/src/infill.h
@@ -41,6 +41,7 @@ class Infill
     size_t wall_line_count; //!< Number of walls to generate at the boundary of the infill region, spaced \ref infill_line_width apart
     const Point infill_origin; //!< origin of the infill pattern
     bool skip_line_stitching; //!< Whether to bypass the line stitching normally performed for polyline type infills
+    bool fill_gaps; //!< Whether to fill gaps in strips of infill that would be too thin to fit the infill lines. If disabled, those areas are left empty.
     bool connected_zigzags; //!< (ZigZag) Whether endpieces of zigzag infill should be connected to the nearest infill line on both sides of the zigzag connector
     bool use_endpieces; //!< (ZigZag) Whether to include endpieces: zigzag connector segments from one infill line to itself
     bool skip_some_zags;  //!< (ZigZag) Whether to skip some zags
@@ -66,6 +67,7 @@ public:
         , size_t wall_line_count = 0
         , const Point& infill_origin = Point()
         , bool skip_line_stitching = false
+        , bool fill_gaps = true
         , bool connected_zigzags = false
         , bool use_endpieces = false
         , bool skip_some_zags = false
@@ -88,6 +90,7 @@ public:
     , wall_line_count(wall_line_count)
     , infill_origin(infill_origin)
     , skip_line_stitching(skip_line_stitching)
+    , fill_gaps(fill_gaps)
     , connected_zigzags(connected_zigzags)
     , use_endpieces(use_endpieces)
     , skip_some_zags(skip_some_zags)


### PR DESCRIPTION
When using gradual infill or gradual support, the infill algorithm is called multiple times, once for each density index. If the infill pattern is one that keeps half-line-width distance from the boundary (such as concentric, or connected infill lines) then it will fill gaps smaller than 1 line width with a variable-width path. This gap filling was occurring for each density, because there was no check on whether it was already done by a previous density index.

I added a parameter to the infill constructor (the 19th parameter! such params, much config, wowzers) that tells the infill generator to fill gaps or not. For the infill pattern usage that has multiple densities (infill and support), this is only enabled for the lowest density parameter, so that the gap filling only happens once for all of the densities. This prevents overextruding in those areas.

Unfortunately, if the infill gaps are not filled, it still needs to calculate the area for those gaps, in order to leave them open specifically. Otherwise the normal infill pattern will still fill those areas and fill them badly that way.

Contributes to issue CURA-9295.