### PR TITLE
[CURA-9247] Fix for negative indices in threading.

### DIFF
--- a/src/utils/ThreadPool.h
+++ b/src/utils/ThreadPool.h
@@ -300,7 +300,7 @@ class MultipleProducersOrderedConsumer
     ptrdiff_t produce(lock_t& lock)
     {
         ptrdiff_t produced_idx = write_idx++;
-        item_t* slot = &queue[produced_idx % max_pending];
+        item_t* slot = &queue[(produced_idx + max_pending) % max_pending];
         assert(produced_idx < last_idx);
 
         // Unlocks global mutex while producing an item
@@ -319,7 +319,7 @@ class MultipleProducersOrderedConsumer
     void consume_many(lock_t& lock)
     {
         assert(read_idx < write_idx);
-        for (item_t* slot = &queue[read_idx % max_pending]; *slot ; slot = &queue[read_idx % max_pending])
+        for (item_t* slot = &queue[(read_idx + max_pending) % max_pending]; *slot ; slot = &queue[(read_idx + max_pending) % max_pending])
         {
             // Unlocks global mutex while consuming an item
             lock.unlock();


### PR DESCRIPTION
Start pointer can be negative. This actually happens for real use when we use a raft, then 'negative' numbered layers are created under the model, so all the other math works out. This gave a crash when combining raft with support.