### PR TITLE
[CURA-9225] 'Prime' for mutliple extruders in Raft

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -754,7 +754,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         }
         raft_outline_paths.emplace_back(storage.raftOutline);
 
-        for (const auto& raft_outline_path : raft_outline_paths)
+        for (const Polygons& raft_outline_path : raft_outline_paths)
         {
             Infill infill_comp(
                 EFillMethod::LINES, zig_zaggify_infill, connect_polygons, raft_outline_path, gcode_layer.configs_storage.raft_base_config.getLineWidth(), line_spacing,
@@ -846,7 +846,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr int zag_skip_count = 0;
         constexpr coord_t pocket_size = 0;
 
-        for (const auto& raft_outline_path : raft_outline_paths)
+        for (const Polygons& raft_outline_path : raft_outline_paths)
         {
             Infill infill_comp(
                 EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, infill_outline_width, interface_line_spacing,
@@ -921,7 +921,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr size_t zag_skip_count = 0;
         constexpr coord_t pocket_size = 0;
 
-        for (const auto& raft_outline_path : raft_outline_paths)
+        for (const Polygons& raft_outline_path : raft_outline_paths)
         {
             Infill infill_comp(
                 EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, infill_outline_width, surface_line_spacing,

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -747,24 +747,37 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         const coord_t max_resolution = base_settings.get<coord_t>("meshfix_maximum_resolution");
         const coord_t max_deviation = base_settings.get<coord_t>("meshfix_maximum_deviation");
 
-        Infill infill_comp(
-            EFillMethod::LINES, zig_zaggify_infill, connect_polygons, storage.raftOutline, gcode_layer.configs_storage.raft_base_config.getLineWidth(), line_spacing,
-            fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
-            max_resolution, max_deviation,
-            wall_line_count, infill_origin, skip_stitching, fill_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
-            );
-        std::vector<VariableWidthLines> raft_paths;
-        infill_comp.generate(raft_paths, raft_polygons, raftLines, base_settings);
-        if(!raft_paths.empty())
+        std::vector<Polygons> raft_outline_paths;
+        if (storage.primeRaftOutline.area() > 0)
         {
-            const GCodePathConfig& config = gcode_layer.configs_storage.raft_base_config;
-            const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, gcode_layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE, false);
-            InsetOrderOptimizer wall_orderer(*this, storage, gcode_layer, base_settings, base_extruder_nr,
-                                             config, config, config, config,
-                                             retract_before_outer_wall, wipe_dist, wipe_dist, base_extruder_nr, base_extruder_nr, z_seam_config, raft_paths);
-            wall_orderer.addToLayer();
+            raft_outline_paths.emplace_back(storage.primeRaftOutline);
         }
-        gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_base_config, SpaceFillType::Lines);
+        raft_outline_paths.emplace_back(storage.raftOutline);
+
+        for (const auto& raft_outline_path : raft_outline_paths)
+        {
+            Infill infill_comp(
+                EFillMethod::LINES, zig_zaggify_infill, connect_polygons, raft_outline_path, gcode_layer.configs_storage.raft_base_config.getLineWidth(), line_spacing,
+                fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
+                max_resolution, max_deviation,
+                wall_line_count, infill_origin, skip_stitching, fill_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
+            );
+            std::vector<VariableWidthLines> raft_paths;
+            infill_comp.generate(raft_paths, raft_polygons, raftLines, base_settings);
+            if (!raft_paths.empty())
+            {
+                const GCodePathConfig& config = gcode_layer.configs_storage.raft_base_config;
+                const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, gcode_layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE, false);
+                InsetOrderOptimizer wall_orderer(*this, storage, gcode_layer, base_settings, base_extruder_nr,
+                    config, config, config, config,
+                    retract_before_outer_wall, wipe_dist, wipe_dist, base_extruder_nr, base_extruder_nr, z_seam_config, raft_paths);
+                wall_orderer.addToLayer();
+            }
+            gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_base_config, SpaceFillType::Lines);
+
+            raft_polygons.clear();
+            raftLines.clear();
+        }
 
         // When we use raft, we need to make sure that all used extruders for this print will get primed on the first raft layer,
         // and then switch back to the original extruder.
@@ -809,10 +822,17 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
         Application::getInstance().communication->sendLayerComplete(layer_nr, z, interface_layer_height);
 
-        Polygons raft_outline_path = storage.raftOutline.offset(-gcode_layer.configs_storage.raft_interface_config.getLineWidth() / 2); //Do this manually because of micron-movement created in corners when insetting a polygon that was offset with round joint type.
-        raft_outline_path = Simplify(interface_settings).polygon(raft_outline_path); //Remove those micron-movements.
+        std::vector<Polygons> raft_outline_paths;
+        const coord_t small_offset = gcode_layer.configs_storage.raft_interface_config.getLineWidth() / 2; //Do this manually because of micron-movement created in corners when insetting a polygon that was offset with round joint type.
+        if (storage.primeRaftOutline.area() > 0)
+        {
+            raft_outline_paths.emplace_back(storage.primeRaftOutline.offset(-small_offset));
+            raft_outline_paths.back() = Simplify(interface_settings).polygon(raft_outline_paths.back()); //Remove those micron-movements.
+        }
+        raft_outline_paths.emplace_back(storage.raftOutline.offset(-small_offset));
+        raft_outline_paths.back() = Simplify(interface_settings).polygon(raft_outline_paths.back()); //Remove those micron-movements.
         const coord_t infill_outline_width = gcode_layer.configs_storage.raft_interface_config.getLineWidth();
-        Polygons raftLines;
+        Polygons raft_lines;
         AngleDegrees fill_angle = (num_surface_layers + num_interface_layers - raft_interface_layer) % 2 ? 45 : 135; //90 degrees rotated from the first top layer.
         constexpr bool zig_zaggify_infill = true;
         constexpr bool connect_polygons = true; // why not?
@@ -826,15 +846,21 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr int zag_skip_count = 0;
         constexpr coord_t pocket_size = 0;
 
-        Infill infill_comp(
-            EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, infill_outline_width, interface_line_spacing,
-            fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
-            interface_max_resolution, interface_max_deviation,
-            wall_line_count, infill_origin, skip_stitching, fill_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
+        for (const auto& raft_outline_path : raft_outline_paths)
+        {
+            Infill infill_comp(
+                EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, infill_outline_width, interface_line_spacing,
+                fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
+                interface_max_resolution, interface_max_deviation,
+                wall_line_count, infill_origin, skip_stitching, fill_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
             );
-        std::vector<VariableWidthLines> raft_paths; //Should remain empty, since we have no walls.
-        infill_comp.generate(raft_paths, raft_polygons, raftLines, interface_settings);
-        gcode_layer.addLinesByOptimizer(raftLines, gcode_layer.configs_storage.raft_interface_config, SpaceFillType::Lines, false, 0, 1.0, last_planned_position);
+            std::vector<VariableWidthLines> raft_paths; //Should remain empty, since we have no walls.
+            infill_comp.generate(raft_paths, raft_polygons, raft_lines, interface_settings);
+            gcode_layer.addLinesByOptimizer(raft_lines, gcode_layer.configs_storage.raft_interface_config, SpaceFillType::Lines, false, 0, 1.0, last_planned_position);
+
+            raft_polygons.clear();
+            raft_lines.clear();
+        }
 
         layer_plan_buffer.handle(gcode_layer, gcode);
         last_planned_position = gcode_layer.getLastPlannedPositionOrStartingPosition();
@@ -871,8 +897,15 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
         Application::getInstance().communication->sendLayerComplete(layer_nr, z, surface_layer_height);
 
-        Polygons raft_outline_path = storage.raftOutline.offset(-gcode_layer.configs_storage.raft_surface_config.getLineWidth() / 2); //Do this manually because of micron-movement created in corners when insetting a polygon that was offset with round joint type.
-        raft_outline_path = Simplify(surface_settings).polygon(raft_outline_path); //Remove those micron-movements.
+        std::vector<Polygons> raft_outline_paths;
+        const coord_t small_offset = gcode_layer.configs_storage.raft_interface_config.getLineWidth() / 2; //Do this manually because of micron-movement created in corners when insetting a polygon that was offset with round joint type.
+        if (storage.primeRaftOutline.area() > 0)
+        {
+            raft_outline_paths.emplace_back(storage.primeRaftOutline.offset(-small_offset));
+            raft_outline_paths.back() = Simplify(interface_settings).polygon(raft_outline_paths.back()); //Remove those micron-movements.
+        }
+        raft_outline_paths.emplace_back(storage.raftOutline.offset(-small_offset));
+        raft_outline_paths.back() = Simplify(interface_settings).polygon(raft_outline_paths.back()); //Remove those micron-movements.
         const coord_t infill_outline_width = gcode_layer.configs_storage.raft_interface_config.getLineWidth();
         Polygons raft_lines;
         AngleDegrees fill_angle = (num_surface_layers - raft_surface_layer) % 2 ? 45 : 135; //Alternate between -45 and +45 degrees, ending up 90 degrees rotated from the default skin angle.
@@ -888,15 +921,21 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr size_t zag_skip_count = 0;
         constexpr coord_t pocket_size = 0;
 
-        Infill infill_comp(
-            EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, infill_outline_width, surface_line_spacing,
-            fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
-            surface_max_resolution, surface_max_deviation,
-            wall_line_count, infill_origin, skip_stitching, fill_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
+        for (const auto& raft_outline_path : raft_outline_paths)
+        {
+            Infill infill_comp(
+                EFillMethod::ZIG_ZAG, zig_zaggify_infill, connect_polygons, raft_outline_path, infill_outline_width, surface_line_spacing,
+                fill_overlap, infill_multiplier, fill_angle, z, extra_infill_shift,
+                surface_max_resolution, surface_max_deviation,
+                wall_line_count, infill_origin, skip_stitching, fill_gaps, connected_zigzags, use_endpieces, skip_some_zags, zag_skip_count, pocket_size
             );
-        std::vector<VariableWidthLines> raft_paths; //Should remain empty, since we have no walls.
-        infill_comp.generate(raft_paths, raft_polygons, raft_lines, surface_settings);
-        gcode_layer.addLinesByOptimizer(raft_lines, gcode_layer.configs_storage.raft_surface_config, SpaceFillType::Lines, false, 0, 1.0, last_planned_position);
+            std::vector<VariableWidthLines> raft_paths; //Should remain empty, since we have no walls.
+            infill_comp.generate(raft_paths, raft_polygons, raft_lines, surface_settings);
+            gcode_layer.addLinesByOptimizer(raft_lines, gcode_layer.configs_storage.raft_surface_config, SpaceFillType::Lines, false, 0, 1.0, last_planned_position);
+
+            raft_polygons.clear();
+            raft_lines.clear();
+        }
 
         layer_plan_buffer.handle(gcode_layer, gcode);
     }

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -44,6 +44,7 @@ PrimeTower::PrimeTower()
     enabled = scene.current_mesh_group->settings.get<bool>("prime_tower_enable")
            && scene.current_mesh_group->settings.get<coord_t>("prime_tower_min_volume") > 10
            && scene.current_mesh_group->settings.get<coord_t>("prime_tower_size") > 10;
+    would_have_actual_tower = enabled;  // Assume so for now.
 
     extruder_count = scene.extruders.size();
     extruder_order.resize(extruder_count);
@@ -92,8 +93,8 @@ void PrimeTower::generateGroundpoly()
 
 void PrimeTower::generatePaths(const SliceDataStorage& storage)
 {
-    enabled &= storage.max_print_height_second_to_last_extruder >= 0; //Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
-    if (enabled)
+    would_have_actual_tower = storage.max_print_height_second_to_last_extruder >= 0; //Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
+    if (would_have_actual_tower && enabled)
     {
         generatePaths_denseInfill();
         generateStartLocations();
@@ -168,7 +169,7 @@ void PrimeTower::generateStartLocations()
 
 void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_layer, const size_t prev_extruder, const size_t new_extruder) const
 {
-    if (!enabled)
+    if (! (enabled && would_have_actual_tower))
     {
         return;
     }

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -179,7 +179,7 @@ void PrimeTower::addToGcode(const SliceDataStorage& storage, LayerPlan& gcode_la
     }
 
     const LayerIndex layer_nr = gcode_layer.getLayerNr();
-    if (layer_nr > storage.max_print_height_second_to_last_extruder + 1)
+    if (layer_nr < 0 || layer_nr > storage.max_print_height_second_to_last_extruder + 1)
     {
         return;
     }

--- a/src/PrimeTower.h
+++ b/src/PrimeTower.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef PRIME_TOWER_H
@@ -44,6 +44,7 @@ private:
 
 public:
     bool enabled; //!< Whether the prime tower is enabled.
+    bool would_have_actual_tower; //!< Whether there is an actual tower.
     bool multiple_extruders_on_first_layer; //!< Whether multiple extruders are allowed on the first layer of the prime tower (e.g. when a raft is there)
     Polygons outer_poly; //!< The outline of the outermost prime tower.
     Polygons outer_poly_first_layer; //!< The outermost outline, plus optional brim on 'brim for prime tower' is enabled.

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -21,41 +21,32 @@ void Raft::generate(SliceDataStorage& storage)
     const Settings& settings = Application::getInstance().current_slice->scene.current_mesh_group->settings.get<ExtruderTrain&>("adhesion_extruder_nr").settings;
     const coord_t distance = settings.get<coord_t>("raft_margin");
     constexpr bool include_support = true;
-    constexpr bool include_prime_tower = true;
-    Polygons global_raft_outlines{ storage.getLayerOutlines(0, include_support, include_prime_tower).offset(distance, ClipperLib::jtRound) };
+    constexpr bool dont_include_prime_tower = false;  // Prime tower raft will be handled separately in 'storage.primeRaftOutline'; see below.
+    storage.raftOutline = storage.getLayerOutlines(0, include_support, dont_include_prime_tower).offset(distance, ClipperLib::jtRound);
     const coord_t shield_line_width_layer0 = settings.get<coord_t>("skirt_brim_line_width");
     if (storage.draft_protection_shield.size() > 0)
     {
         Polygons draft_shield_raft = storage.draft_protection_shield.offset(shield_line_width_layer0) // start half a line width outside shield
                                         .difference(storage.draft_protection_shield.offset(-distance - shield_line_width_layer0 / 2, ClipperLib::jtRound)); // end distance inside shield
-        global_raft_outlines = global_raft_outlines.unionPolygons(draft_shield_raft);
+        storage.raftOutline = storage.raftOutline.unionPolygons(draft_shield_raft);
     }
     if (storage.oozeShield.size() > 0 && storage.oozeShield[0].size() > 0)
     {
         const Polygons& ooze_shield = storage.oozeShield[0];
         Polygons ooze_shield_raft = ooze_shield.offset(shield_line_width_layer0) // start half a line width outside shield
                                         .difference(ooze_shield.offset(-distance - shield_line_width_layer0 / 2, ClipperLib::jtRound)); // end distance inside shield
-        global_raft_outlines = global_raft_outlines.unionPolygons(ooze_shield_raft);
+        storage.raftOutline = storage.raftOutline.unionPolygons(ooze_shield_raft);
     }
 
     if(settings.get<bool>("raft_remove_inside_corners"))
     {
-        global_raft_outlines.makeConvex();
+        storage.raftOutline.makeConvex();
     }
     else
     {
         const coord_t smoothing = settings.get<coord_t>("raft_smoothing");
-        global_raft_outlines = global_raft_outlines.offset(smoothing, ClipperLib::jtRound).offset(-smoothing, ClipperLib::jtRound); // remove small holes and smooth inward corners
+        storage.raftOutline = storage.raftOutline.offset(smoothing, ClipperLib::jtRound).offset(-smoothing, ClipperLib::jtRound); // remove small holes and smooth inward corners
     }
-
-    constexpr bool dont_include_prime_tower = false;
-    Polygons raw_raft_without_prime{ storage.getLayerOutlines(0, include_support, dont_include_prime_tower).offset(distance, ClipperLib::jtRound) };
-    if (settings.get<bool>("raft_remove_inside_corners"))
-    {
-        raw_raft_without_prime.makeConvex();
-    }
-    storage.primeRaftOutline = global_raft_outlines.difference(raw_raft_without_prime);
-    storage.raftOutline = global_raft_outlines.difference(storage.primeRaftOutline);
 
     if (storage.primeTower.enabled && ! storage.primeTower.would_have_actual_tower)
     {
@@ -67,9 +58,17 @@ void Raft::generate(SliceDataStorage& storage)
         const size_t surface_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").extruder_nr;
         if (base_extruder_nr == interface_extruder_nr && base_extruder_nr == surface_extruder_nr)
         {
-            storage.primeRaftOutline.clear();
+            return;
         }
     }
+
+    storage.primeRaftOutline = storage.primeTower.outer_poly_first_layer.offset(distance, ClipperLib::jtRound);
+    if (settings.get<bool>("raft_remove_inside_corners"))
+    {
+        storage.primeRaftOutline = storage.primeRaftOutline.unionPolygons(storage.raftOutline);
+        storage.primeRaftOutline.makeConvex();
+    }
+    storage.primeRaftOutline = storage.primeRaftOutline.difference(storage.raftOutline); // In case of overlaps.
 }
 
 coord_t Raft::getTotalThickness()

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -49,7 +49,11 @@ void Raft::generate(SliceDataStorage& storage)
     }
 
     constexpr bool dont_include_prime_tower = false;
-    const Polygons raw_raft_without_prime{ storage.getLayerOutlines(0, include_support, dont_include_prime_tower).offset(distance, ClipperLib::jtRound) };
+    Polygons raw_raft_without_prime{ storage.getLayerOutlines(0, include_support, dont_include_prime_tower).offset(distance, ClipperLib::jtRound) };
+    if (settings.get<bool>("raft_remove_inside_corners"))
+    {
+        raw_raft_without_prime.makeConvex();
+    }
     storage.primeRaftOutline = global_raft_outlines.difference(raw_raft_without_prime);
     storage.raftOutline = global_raft_outlines.difference(storage.primeRaftOutline);
 

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2021 Ultimaker B.V.
+//Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef SLICE_DATA_STORAGE_H

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -319,6 +319,7 @@ public:
     Polygons skirt_brim[MAX_EXTRUDERS]; //!< Skirt and brim polygons per extruder, ordered from inner to outer polygons.
     size_t skirt_brim_max_locked_part_order[MAX_EXTRUDERS]; //!< Some parts (like skirt) always need to be printed before parts like support-brim, so lock 0..n for each extruder, where n is the value saved in this array.
     Polygons raftOutline;               //Storage for the outline of the raft. Will be filled with lines when the GCode is generated.
+    Polygons primeRaftOutline;          // ... the raft underneath the prime-tower will have to be printed first, if there is one. (When the raft has top layers with a different extruder for example.)
 
     int max_print_height_second_to_last_extruder; //!< Used in multi-extrusion: the layer number beyond which all models are printed with the same extruder
     std::vector<int> max_print_height_per_extruder; //!< For each extruder the highest layer number at which it is used.

--- a/src/sliceDataStorage.h
+++ b/src/sliceDataStorage.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2022 Ultimaker B.V.
+//Copyright (c) 2021 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef SLICE_DATA_STORAGE_H

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -500,8 +500,8 @@ Polygons AreaSupport::join(const SliceDataStorage& storage, const Polygons& supp
                 break;
             case EPlatformAdhesion::RAFT:
             {
-                const ExtruderTrain& raft_extruder = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr");
-                adhesion_size = raft_extruder.settings.get<coord_t>("raft_margin");
+                const ExtruderTrain& raft_base_extruder = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr");
+                adhesion_size = raft_base_extruder.settings.get<coord_t>("raft_margin");
                 break;
             }
             case EPlatformAdhesion::SKIRT:

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -500,8 +500,8 @@ Polygons AreaSupport::join(const SliceDataStorage& storage, const Polygons& supp
                 break;
             case EPlatformAdhesion::RAFT:
             {
-                const ExtruderTrain& raft_base_extruder = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr");
-                adhesion_size = raft_base_extruder.settings.get<coord_t>("raft_margin");
+                const ExtruderTrain& raft_extruder = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr");
+                adhesion_size = raft_extruder.settings.get<coord_t>("raft_margin");
                 break;
             }
             case EPlatformAdhesion::SKIRT:


### PR DESCRIPTION
__The problem:__
Since the raft can have multiple extruders now, the also need to be primed. However, extending the prime tower to the bottom would be problematic as well.

It was decided that printing a prime-tower raft first (on each layer) would sufficiently prime each nozzle. However, the raft before this PR was monolithic, meaning it was calculated for the entire build-plate at once.

(Priming with a blob was also a problem, since for certain materials the time between the blob and, say, the printing of the top layer, given that the bottom layers of the raft use an other extruder was too large.)

__The resolution:__
This PR splits the raft into a 'model' and a 'prime tower' part. Also, it guarantees printing the prime tower part of the raft if the prime tower is enabled, but not required for the actual model on top of the raft _if_ there are different extruders used for different layers of the raft.

_A note with regards to the raft convexity setting/requirement for certain materials:_
The 'model', as well as the raft _as a whole_ can still be made convex with the 'remove inside corners' option as required. The convexity specifically of the 'prime tower part' of the raft is only guaranteed if the rafts don't overlap in that case. If they do overlap, it is hoped that the convexity of the raft as a whole is enough to sufficiently reduce shearing effects and the like.

_A note w.r.t. code review:_
Hiding whitespace changes may make this easier. (One of the options when you click on the gear-menu in github when viewed with 'files changed', or `-w` on the command-line when viewed with `git diff`, so `git diff -w`.)