### PR TITLE
[CURA-9425] Distance to moved point should be w.r.t. segment.

### DIFF
--- a/src/utils/Simplify.h
+++ b/src/utils/Simplify.h
@@ -322,7 +322,7 @@ protected:
         {
             return; //Cannot remove edge without shifting a long edge. Don't remove anything.
         }
-        const coord_t intersection_deviation = LinearAlg2D::getDist2FromLine(intersection, before_to, after_from);
+        const coord_t intersection_deviation = LinearAlg2D::getDist2FromLineSegment(before_to, intersection, after_from);
         if(intersection_deviation <= max_deviation * max_deviation) //Intersection point doesn't deviate too much. Use it!
         {
             to_delete[vertex] = true;


### PR DESCRIPTION
Before this fix, the distance to the intersection was measured by the distance to the _line_ going through some points A and C on the poly-like in question. However, only the _line-segment_ is of course on the poly-like, anything 'just' on the line could be very far indeed from the intended location. Luckily there was already a method that checks this, so it was just a question of swapping out the line method for the line-segment method.

(As an aside: Note the parameter-ordering -- that has to be different between the two methods for some reason, since the method now used has the point in the middle instead of at the beginning?)