### PR TITLE
[CURA-9472] Fix crash on Windows (Gyroid/Simplify/5.1-beta)

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -25,8 +25,6 @@
 #include "utils/Simplify.h" //Removing micro-segments created by offsetting.
 #include "WallToolPaths.h"
 
-#define OMP_MAX_ACTIVE_LAYERS_PROCESSED 30 // TODO: hardcoded-value for the max number of layers being in the pipeline while writing away and destroying layers in a multi-threaded context
-
 namespace cura
 {
 

--- a/src/utils/Simplify.cpp
+++ b/src/utils/Simplify.cpp
@@ -26,7 +26,7 @@ Polygons Simplify::polygon(const Polygons& polygons) const
     Polygons result;
     for(size_t i = 0; i < polygons.size(); ++i)
     {
-        result.add(polygon(polygons[i]));
+        result.addIfNotEmpty(polygon(polygons[i]));
     }
     return result;
 }
@@ -48,7 +48,7 @@ Polygons Simplify::polyline(const Polygons& polylines) const
     Polygons result;
     for(size_t i = 0; i < polylines.size(); ++i)
     {
-        result.add(polyline(polylines[i]));
+        result.addIfNotEmpty(polyline(polylines[i]));
     }
     return result;
 }

--- a/src/utils/polygon.h
+++ b/src/utils/polygon.h
@@ -836,6 +836,27 @@ public:
     {
         std::copy(other.paths.begin(), other.paths.end(), std::back_inserter(paths));
     }
+    void addIfNotEmpty(ConstPolygonRef& poly)
+    {
+        if (! poly.empty())
+        {
+            paths.push_back(*poly.path);
+        }
+    }
+    void addIfNotEmpty(const ConstPolygonRef& poly)
+    {
+        if (! poly.empty())
+        {
+            paths.push_back(*poly.path);
+        }
+    }
+    void addIfNotEmpty(Polygon&& other_poly)
+    {
+        if (! other_poly.empty())
+        {
+            paths.emplace_back(std::move(*other_poly));
+        }
+    }
     /*!
      * Add a 'polygon' consisting of two points
      */


### PR DESCRIPTION
Degenerate polygons where converted to empty ones by simplification. Leaving the empty polygons in crashes the engine on Windows on certain model(s?) with Gyroid infill.