### PR TITLE
Cura 9031 add and send slice UUID

### DIFF
--- a/Cura.proto
+++ b/Cura.proto
@@ -139,5 +139,9 @@ message GCodePrefix {
     bytes data = 2; //Header string to be prepended before the rest of the g-code sent from the engine.
 }
 
+message SliceUUID {
+    string slice_uuid = 1; //The UUID of the slice.
+}
+
 message SlicingFinished {
 }

--- a/Cura.proto
+++ b/Cura.proto
@@ -140,7 +140,7 @@ message GCodePrefix {
 }
 
 message SliceUUID {
-    string slice_uuid = 1; //The UUID of the slice.
+    string slice_uuid = 1; //An ID to link the slice in the printer to a statistical data point in the anonymous slice data.
 }
 
 message SlicingFinished {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1,20 +1,21 @@
-//Copyright (c) 2022 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "FffGcodeWriter.h"
 #include "Application.h"
-#include "bridge.h"
-#include "communication/Communication.h" //To send layer view data.
 #include "ExtruderTrain.h"
-#include "FffGcodeWriter.h"
 #include "FffProcessor.h"
-#include "utils/ThreadPool.h"
-#include "infill.h"
 #include "InsetOrderOptimizer.h"
 #include "LayerPlan.h"
+#include "Slice.h"
+#include "WallToolPaths.h"
+#include "bridge.h"
+#include "communication/Communication.h" //To send layer view data.
+#include "infill.h"
 #include "progress/Progress.h"
 #include "raft.h"
-#include "Slice.h"
+#include "utils/Simplify.h" //Removing micro-segments created by offsetting.
+#include "utils/ThreadPool.h"
 #include "utils/linearAlg2D.h"
 #include "utils/math.h"
 #include "utils/orderOptimizer.h"
@@ -67,6 +68,7 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
 {
     const size_t start_extruder_nr = getStartExtruder(storage);
     gcode.preSetup(start_extruder_nr);
+    gcode.setSliceUUID(slice_uuid);
 
     Scene& scene = Application::getInstance().current_slice->scene;
     if (scene.current_mesh_group == scene.mesh_groups.begin()) //First mesh group.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3137,6 +3137,7 @@ void FffGcodeWriter::finalize()
     if (!Application::getInstance().communication->isSequential())
     {
         Application::getInstance().communication->sendGCodePrefix(prefix);
+        Application::getInstance().communication->sendSliceUUID(slice_uuid);
     }
     else
     {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1,11 +1,7 @@
 //Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
-#include <list>
-#include <limits> // numeric_limits
-#include <algorithm>
-#include <optional>
-
+#include "FffGcodeWriter.h"
 #include "Application.h"
 #include "bridge.h"
 #include "communication/Communication.h" //To send layer view data.
@@ -22,15 +18,18 @@
 #include "utils/linearAlg2D.h"
 #include "utils/math.h"
 #include "utils/orderOptimizer.h"
-#include "utils/Simplify.h" //Removing micro-segments created by offsetting.
-#include "WallToolPaths.h"
+#include <algorithm>
+#include <boost/uuid/random_generator.hpp> //For generating a UUID.
+#include <boost/uuid/uuid_io.hpp> //For generating a UUID.
+#include <limits> // numeric_limits
+#include <list>
+#include <optional>
 
 namespace cura
 {
 
 FffGcodeWriter::FffGcodeWriter()
-: max_object_height(0)
-, layer_plan_buffer(gcode)
+  : max_object_height(0), layer_plan_buffer(gcode), slice_uuid(boost::uuids::to_string(boost::uuids::random_generator()()))
 {
     for (unsigned int extruder_nr = 0; extruder_nr < MAX_EXTRUDERS; extruder_nr++)
     { // initialize all as max layer_nr, so that they get updated to the lowest layer on which they are used.

--- a/src/FffGcodeWriter.h
+++ b/src/FffGcodeWriter.h
@@ -1,5 +1,5 @@
-//Copyright (c) 2022 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef GCODE_WRITER_H
 #define GCODE_WRITER_H
@@ -73,16 +73,18 @@ private:
     /*!
      * For each extruder on which layer the prime will be planned,
      * or a large negative number if it's already planned outside of \ref FffGcodeWriter::processLayer
-     * 
+     *
      * Depending on whether we need to prime on the first layer, or anywhere in the print,
      * the layer numbers are all zero (or less in case of raft)
      * or they are the first layer at which the extruder is needed
      */
     LayerIndex extruder_prime_layer_nr[MAX_EXTRUDERS];
 
-    std::vector<FanSpeedLayerTimeSettings> fan_speed_layer_time_settings_per_extruder; //!< The settings used relating to minimal layer time and fan speeds. Configured for each extruder.
+    std::vector<FanSpeedLayerTimeSettings> fan_speed_layer_time_settings_per_extruder; //!< The settings used relating to minimal layer time
+                                                                                       //!< and fan speeds. Configured for each extruder.
 
-public:
+    std::string slice_uuid; //!< The UUID of the current slice.
+  public:
     /*
      * \brief Construct a g-code writer.
      *
@@ -93,9 +95,9 @@ public:
 
     /*!
      * Set the target to write gcode to: to a file.
-     * 
+     *
      * Used when CuraEngine is used as command line tool.
-     * 
+     *
      * \param filename The filename of the file to which to write the gcode.
      */
     bool setTargetFile(const char* filename);

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -1,5 +1,5 @@
-//Copyright (c) 2022 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifdef ARCUS
 
@@ -369,6 +369,13 @@ void ArcusCommunication::sendGCodePrefix(const std::string& prefix) const
 {
     std::shared_ptr<proto::GCodePrefix> message = std::make_shared<proto::GCodePrefix>();
     message->set_data(prefix);
+    private_data->socket->sendMessage(message);
+}
+
+void ArcusCommunication::sendSliceUUID(const std::string& slice_uuid) const
+{
+    std::shared_ptr<proto::SliceUUID> message = std::make_shared<proto::SliceUUID>();
+    message->set_slice_uuid(slice_uuid);
     private_data->socket->sendMessage(message);
 }
 

--- a/src/communication/ArcusCommunication.h
+++ b/src/communication/ArcusCommunication.h
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019-2022 Ultimaker B.V.
+//  Copyright (c) 2022 Ultimaker B.V.
 //  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef ARCUSCOMMUNICATION_H

--- a/src/communication/ArcusCommunication.h
+++ b/src/communication/ArcusCommunication.h
@@ -1,5 +1,5 @@
-//Copyright (c) 2019 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2019-2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef ARCUSCOMMUNICATION_H
 #define ARCUSCOMMUNICATION_H
@@ -99,6 +99,12 @@ public:
      * the front-end for its replacement variables.
      */
     void sendGCodePrefix(const std::string& prefix) const override;
+
+    /*
+     * \brief Send the uuid of the generated slice so that it may be processed by
+     * the front-end.
+     */
+    void sendSliceUUID(const std::string& slice_uuid) const override;
 
     /*
      * \brief Indicate to the front-end that a layer is complete and send a

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -1,5 +1,5 @@
-//Copyright (c) 2020 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2020-2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <cstring> //For strtok and strcopy.
 #include <fstream> //To check if files exist.
@@ -48,12 +48,17 @@ bool CommandLine::hasSlice() const
 
 bool CommandLine::isSequential() const
 {
-    return true; //We have to receive the g-code in sequential order. Start g-code before the rest and so on.
+    return true; // We have to receive the g-code in sequential order. Start g-code before the rest and so on.
 }
 
 void CommandLine::sendGCodePrefix(const std::string&) const
 {
-    //TODO: Right now this is done directly in the g-code writer. For consistency it should be moved here?
+    // TODO: Right now this is done directly in the g-code writer. For consistency it should be moved here?
+}
+
+void CommandLine::sendSliceUUID(const std::string& slice_uuid) const
+{
+    // pass
 }
 
 void CommandLine::sendPrintTimeMaterialEstimates() const

--- a/src/communication/CommandLine.h
+++ b/src/communication/CommandLine.h
@@ -1,5 +1,5 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2018-2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef COMMANDLINE_H
 #define COMMANDLINE_H
@@ -73,6 +73,12 @@ public:
      * \brief Output the g-code header.
      */
     void sendGCodePrefix(const std::string&) const override;
+
+    /*
+     * \brief Send the uuid of the generated slice so that it may be processed by
+     * the front-end.
+     */
+    void sendSliceUUID(const std::string& slice_uuid) const override;
 
     /*
      * \brief Indicate that the layer has been completely sent.

--- a/src/communication/Communication.h
+++ b/src/communication/Communication.h
@@ -1,5 +1,5 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2018-2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef COMMUNICATION_H
 #define COMMUNICATION_H
@@ -158,6 +158,12 @@ public:
      * the front-end for its replacement variables.
      */
     virtual void sendGCodePrefix(const std::string& prefix) const = 0;
+
+    /*
+     * \brief Send the uuid of the generated slice so that it may be processed by
+     * the front-end.
+     */
+    virtual void sendSliceUUID(const std::string& slice_uuid) const = 0;
 
     /*
      * \brief Sends a message to indicate that all the slicing is done.

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1,5 +1,5 @@
-//  Copyright (c) 2021-2022 Ultimaker B.V.
-//  CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2022 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <assert.h>
 #include <cmath>

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1,5 +1,5 @@
-//Copyright (c) 2021 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2021-2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <assert.h>
 #include <cmath>
@@ -226,6 +226,7 @@ std::string GCodeExport::getFileHeader(const std::vector<bool>& extruder_is_used
         prefix << ";PRINT.SIZE.MAX.X:" << INT2MM(total_bounding_box.max.x) << new_line;
         prefix << ";PRINT.SIZE.MAX.Y:" << INT2MM(total_bounding_box.max.y) << new_line;
         prefix << ";PRINT.SIZE.MAX.Z:" << INT2MM(total_bounding_box.max.z) << new_line;
+        prefix << ";SLICE_UUID:" << slice_uuid_ << new_line;
         prefix << ";END_OF_HEADER" << new_line;
         break;
     default:
@@ -1461,5 +1462,10 @@ void GCodeExport::insertWipeScript(const WipeScriptConfig& wipe_config)
     writeComment("WIPE_SCRIPT_END");
 }
 
-}//namespace cura
+void GCodeExport::setSliceUUID(const std::string& slice_uuid)
+{
+    slice_uuid_ = slice_uuid;
+}
+
+} // namespace cura
 

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -235,8 +235,7 @@ public:
 
     void setOutputStream(std::ostream* stream);
 
-    bool getExtruderIsUsed(
-      const int extruder_nr) const; //!< return whether the extruder has been used throughout printing all meshgroup up till now
+    bool getExtruderIsUsed(const int extruder_nr) const; //!< return whether the extruder has been used throughout printing all meshgroup up till now
 
     Point getGcodePos(const coord_t x, const coord_t y, const int extruder_train) const;
 

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -1,5 +1,5 @@
-//  Copyright (c) 2021-2022 Ultimaker B.V.
-//  CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2022 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef GCODEEXPORT_H
 #define GCODEEXPORT_H

--- a/src/gcodeExport.h
+++ b/src/gcodeExport.h
@@ -1,5 +1,5 @@
-//Copyright (c) 2021 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2021-2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef GCODEEXPORT_H
 #define GCODEEXPORT_H
@@ -99,17 +99,16 @@ private:
         , currentTemperature(0)
         , waited_for_temperature(false)
         , initial_temp(0)
-        , retraction_e_amount_current(0.0)
-        , retraction_e_amount_at_e_start(0.0)
-        , prime_volume(0.0)
-        , last_retraction_prime_speed(0.0)
-        , fan_number(0)
-        { }
+        , retraction_e_amount_current(0.0), retraction_e_amount_at_e_start(0.0),
+            prime_volume(0.0), last_retraction_prime_speed(0.0), fan_number(0)
+        {
+        }
     };
     ExtruderTrainAttributes extruder_attr[MAX_EXTRUDERS];
     bool use_extruder_offset_to_offset_coords;
     std::string machine_name;
     std::string machine_buildplate_type;
+    std::string slice_uuid_; //!< The UUID of the current slice.
 
     std::ostream* output_stream;
     std::string new_line;
@@ -218,23 +217,29 @@ public:
 
     /*!
      * Get the gcode file header (e.g. ";FLAVOR:UltiGCode\n")
-     * 
+     *
      * \param extruder_is_used For each extruder whether it is used in the print
      * \param print_time The total print time in seconds of the whole gcode (if known)
      * \param filament_used The total mm^3 filament used for each extruder or a vector of the wrong size of unknown
      * \param mat_ids The material GUIDs for each material.
      * \return The string representing the file header
      */
-    std::string getFileHeader(const std::vector<bool>& extruder_is_used, const Duration* print_time = nullptr, const std::vector<double>& filament_used = std::vector<double>(), const std::vector<std::string>& mat_ids = std::vector<std::string>());
+    std::string getFileHeader(const std::vector<bool>& extruder_is_used,
+                              const Duration* print_time = nullptr,
+                              const std::vector<double>& filament_used = std::vector<double>(),
+                              const std::vector<std::string>& mat_ids = std::vector<std::string>());
+
+    void setSliceUUID(const std::string& slice_uuid);
 
     void setLayerNr(unsigned int layer_nr);
 
     void setOutputStream(std::ostream* stream);
 
-    bool getExtruderIsUsed(const int extruder_nr) const; //!< return whether the extruder has been used throughout printing all meshgroup up till now
+    bool getExtruderIsUsed(
+      const int extruder_nr) const; //!< return whether the extruder has been used throughout printing all meshgroup up till now
 
     Point getGcodePos(const coord_t x, const coord_t y, const int extruder_train) const;
-    
+
     void setFlavor(EGCodeFlavor flavor);
     EGCodeFlavor getFlavor() const;
     

--- a/tests/arcus/MockCommunication.h
+++ b/tests/arcus/MockCommunication.h
@@ -1,13 +1,13 @@
-//Copyright (c) 2019 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+//  Copyright (c) 2022 Ultimaker B.V.
+//  CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef MOCKCOMMUNICATION_H
 #define MOCKCOMMUNICATION_H
 
+#include "communication/Communication.h" //The interface we're implementing.
+#include "utils/Coord_t.h"
+#include "utils/polygon.h" //In the signature of Communication.
 #include <gmock/gmock.h>
-
-#include "../../src/communication/Communication.h" //The interface we're implementing.
-#include "../../src/utils/polygon.h" //In the signature of Communication.
 
 namespace cura
 {
@@ -17,14 +17,29 @@ namespace cura
  */
 class MockCommunication : public Communication
 {
-public:
+  public:
     MOCK_CONST_METHOD0(hasSlice, bool());
     MOCK_CONST_METHOD0(isSequential, bool());
     MOCK_CONST_METHOD1(sendProgress, void(const float& progress));
     MOCK_METHOD3(sendLayerComplete, void(const LayerIndex& layer_nr, const coord_t& z, const coord_t& thickness));
-    MOCK_METHOD5(sendPolygons, void(const PrintFeatureType& type, const Polygons& polygons, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity));
-    MOCK_METHOD5(sendPolygon, void(const PrintFeatureType& type, const ConstPolygonRef& polygon, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity));
-    MOCK_METHOD5(sendLineTo, void(const PrintFeatureType& type, const Point& to, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity));
+    MOCK_METHOD5(sendPolygons,
+                 void(const PrintFeatureType& type,
+                      const Polygons& polygons,
+                      const coord_t& line_width,
+                      const coord_t& line_thickness,
+                      const Velocity& velocity));
+    MOCK_METHOD5(sendPolygon,
+                 void(const PrintFeatureType& type,
+                      const ConstPolygonRef& polygon,
+                      const coord_t& line_width,
+                      const coord_t& line_thickness,
+                      const Velocity& velocity));
+    MOCK_METHOD5(sendLineTo,
+                 void(const PrintFeatureType& type,
+                      const Point& to,
+                      const coord_t& line_width,
+                      const coord_t& line_thickness,
+                      const Velocity& velocity));
     MOCK_METHOD1(sendCurrentPosition, void(const Point& position));
     MOCK_METHOD1(setExtruderForSend, void(const ExtruderTrain& extruder));
     MOCK_METHOD1(setLayerForSend, void(const LayerIndex& layer_nr));
@@ -33,10 +48,11 @@ public:
     MOCK_METHOD0(beginGCode, void());
     MOCK_METHOD0(flushGCode, void());
     MOCK_CONST_METHOD1(sendGCodePrefix, void(const std::string& prefix));
+    MOCK_CONST_METHOD1(sendSliceUUID, void(const std::string& slice_uuid));
     MOCK_CONST_METHOD0(sendFinishedSlicing, void());
     MOCK_METHOD0(sliceNext, void());
 };
 
-} //namespace cura
+} // namespace cura
 
-#endif //MOCKCOMMUNICATION_H
+#endif // MOCKCOMMUNICATION_H

--- a/tests/arcus/MockCommunication.h
+++ b/tests/arcus/MockCommunication.h
@@ -1,5 +1,5 @@
-//  Copyright (c) 2022 Ultimaker B.V.
-//  CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2022 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef MOCKCOMMUNICATION_H
 #define MOCKCOMMUNICATION_H
@@ -17,7 +17,7 @@ namespace cura
  */
 class MockCommunication : public Communication
 {
-  public:
+public:
     MOCK_CONST_METHOD0(hasSlice, bool());
     MOCK_CONST_METHOD0(isSequential, bool());
     MOCK_CONST_METHOD1(sendProgress, void(const float& progress));


### PR DESCRIPTION
This PR is the backend part of Ultimaker/Cura#12881

Generate a UUID for a slice add it to the Griffin header in the GCode and make sure that the front-end is aware of that UUID,
by sending an newly created Arcus message.

