### PR TITLE
Correctly cast `wall_split_middle_threshold` and `wall_add_middle_theshold` settings to a `Ratio`

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -76,14 +76,14 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     const coord_t wall_transition_length = settings.get<coord_t>("wall_transition_length");
 
     // When to split the middle wall into two:
-    const double min_even_wall_line_width = static_cast<double>(settings.get<int>("min_even_wall_line_width"));
-    const double wall_line_width_0 = static_cast<double>(settings.get<int>("wall_line_width_0"));
-    const Ratio wall_split_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * (2.0 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0));
+    const double min_even_wall_line_width = settings.get<double>("min_even_wall_line_width");
+    const double wall_line_width_0 = settings.get<double>("wall_line_width_0");
+    const Ratio wall_split_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * (2.0 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0)) / 100.;
 
     // When to add a new middle in between the innermost two walls:
-    const double min_odd_wall_line_width = static_cast<double>(settings.get<int>("min_odd_wall_line_width"));
-    const double wall_line_width_x = static_cast<double>(settings.get<int>("wall_line_width_x"));    
-    const Ratio wall_add_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * min_odd_wall_line_width / wall_line_width_x));
+    const double min_odd_wall_line_width = settings.get<double>("min_odd_wall_line_width");
+    const double wall_line_width_x = settings.get<double>("wall_line_width_x");
+    const Ratio wall_add_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * min_odd_wall_line_width / wall_line_width_x)) / 100.;
 
     const int wall_distribution_count = settings.get<int>("wall_distribution_count");
     const size_t max_bead_count = (inset_count < std::numeric_limits<coord_t>::max() / 2) ? 2 * inset_count : std::numeric_limits<coord_t>::max();

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -78,12 +78,12 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     // When to split the middle wall into two:
     const double min_even_wall_line_width = settings.get<double>("min_even_wall_line_width");
     const double wall_line_width_0 = settings.get<double>("wall_line_width_0");
-    const Ratio wall_split_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * (2.0 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0)) / 100.;
+    const Ratio wall_split_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * (2.0 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0)) / 100.0;
 
     // When to add a new middle in between the innermost two walls:
     const double min_odd_wall_line_width = settings.get<double>("min_odd_wall_line_width");
     const double wall_line_width_x = settings.get<double>("wall_line_width_x");
-    const Ratio wall_add_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * min_odd_wall_line_width / wall_line_width_x)) / 100.;
+    const Ratio wall_add_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * min_odd_wall_line_width / wall_line_width_x)) / 100.0;
 
     const int wall_distribution_count = settings.get<int>("wall_distribution_count");
     const size_t max_bead_count = (inset_count < std::numeric_limits<coord_t>::max() / 2) ? 2 * inset_count : std::numeric_limits<coord_t>::max();

--- a/tests/WallsComputationTest.cpp
+++ b/tests/WallsComputationTest.cpp
@@ -81,6 +81,8 @@ public:
         settings.add("wall_line_count", "2");
         settings.add("wall_line_width_0", "0.4");
         settings.add("wall_line_width_x", "0.4");
+        settings.add("min_even_wall_line_width", "0.34");
+        settings.add("min_odd_wall_line_width", "0.34");
         settings.add("wall_transition_angle", "10");
         settings.add("wall_transition_filter_distance", "1");
         settings.add("wall_transition_filter_deviation", ".2");


### PR DESCRIPTION
The settings `min_even_wall_line_width`, `wall_line_width_0`, `min_odd_wall_line_width` and `wall_line_width_x` were fractional values. By casting these to an integer first they were always rounded down to 0.

Divide `wall_split_middle_threshold` and `wall_add_middle_threshold` by 100 to make it a proper `Ratio`

CURA-9357