### PR TITLE
[CURA-9087] Re-fix brim line ordering.

### DIFF
--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -504,7 +504,7 @@ protected:
             }
 
             constexpr float EPSILON = 25.0;
-            if (fabs(best_score - score) <= EPSILON)
+            if (seam_config.type != EZSeamType::SKIRT_BRIM && fabs(best_score - score) <= EPSILON)
             {
                 // add breaker for two candidate starting location with similar score
                 // if we don't do this then we (can) get an un-even seam

--- a/include/settings/EnumSettings.h
+++ b/include/settings/EnumSettings.h
@@ -65,7 +65,12 @@ enum class EZSeamType
     RANDOM,
     SHORTEST,
     USER_SPECIFIED,
-    SHARPEST_CORNER
+    SHARPEST_CORNER,
+
+    /* The 'Skirt/brim' type behaves like shortest, except it doesn't try to do tie-breaking for similar locations to
+     * the last attempt, as that gives a different result when the seams are next to each other instead of on top.
+     */
+    SKIRT_BRIM
 };
 
 enum class EZSeamCornerPrefType

--- a/include/settings/ZSeamConfig.h
+++ b/include/settings/ZSeamConfig.h
@@ -43,21 +43,19 @@ struct ZSeamConfig
     coord_t simplify_curvature;
 
     /*!
-     * Default constructor for use when memory must be allocated before it gets
-     * filled (like with some data structures).
-     *
-     * This will select the "shortest" seam strategy.
-     */
-    ZSeamConfig();
-
-    /*!
      * Create a seam configuration with a custom configuration.
      * \param type The strategy to place the seam.
      * \param pos The position of a user-specified seam.
      * \param corner_pref The corner preference, when using the sharpest corner strategy.
      * \param by how much to simplify the curvature (when detecting corners), as otherwise 'smooth' corners are penalized.
      */
-    ZSeamConfig(const EZSeamType type, const Point pos, const EZSeamCornerPrefType corner_pref, const coord_t simplify_curvature);
+    ZSeamConfig
+    (
+        const EZSeamType type = EZSeamType::SHORTEST,
+        const Point pos = Point(0, 0),
+        const EZSeamCornerPrefType corner_pref = EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE,
+        const coord_t simplify_curvature = 0
+    );
 };
 
 } //Cura namespace.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1194,10 +1194,12 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
         }
     }
 
+    const auto brim_zseam_config = ZSeamConfig(EZSeamType::SKIRT_BRIM);
+
     if (! first_skirt_brim.empty())
     {
         gcode_layer.addTravel(first_skirt_brim.back().closestPointTo(start_close_to));
-        gcode_layer.addPolygonsByOptimizer(first_skirt_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr]);
+        gcode_layer.addPolygonsByOptimizer(first_skirt_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr], brim_zseam_config);
     }
 
     if (skirt_brim.empty())
@@ -1208,7 +1210,7 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
     if (train.settings.get<bool>("brim_outside_only"))
     {
         gcode_layer.addTravel(skirt_brim.back().closestPointTo(start_close_to));
-        gcode_layer.addPolygonsByOptimizer(skirt_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr]);
+        gcode_layer.addPolygonsByOptimizer(skirt_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr], brim_zseam_config);
     }
     else
     {
@@ -1229,7 +1231,7 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
         if (! outer_brim.empty())
         {
             gcode_layer.addTravel(outer_brim.back().closestPointTo(start_close_to));
-            gcode_layer.addPolygonsByOptimizer(outer_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr]);
+            gcode_layer.addPolygonsByOptimizer(outer_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr], brim_zseam_config);
         }
 
         if (! inner_brim.empty())
@@ -1240,7 +1242,7 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
             const float flow_ratio = 1.0;
             const bool always_retract = false;
             const bool reverse_order = true;
-            gcode_layer.addPolygonsByOptimizer(inner_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr], ZSeamConfig(), wall_0_wipe_dist, spiralize, flow_ratio, always_retract, reverse_order);
+            gcode_layer.addPolygonsByOptimizer(inner_brim, gcode_layer.configs_storage.skirt_brim_config_per_extruder[extruder_nr], brim_zseam_config, wall_0_wipe_dist, spiralize, flow_ratio, always_retract, reverse_order);
         }
     }
 }

--- a/src/settings/ZSeamConfig.cpp
+++ b/src/settings/ZSeamConfig.cpp
@@ -6,14 +6,6 @@
 namespace cura
 {
 
-ZSeamConfig::ZSeamConfig()
-: type(EZSeamType::SHORTEST)
-, pos(Point(0, 0))
-, corner_pref(EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE)
-, simplify_curvature(0)
-{
-}
-
 ZSeamConfig::ZSeamConfig(const EZSeamType type, const Point pos, const EZSeamCornerPrefType corner_pref, const coord_t simplify_curvature)
 : type(type)
 , pos(pos)


### PR DESCRIPTION
Add a stealth 'z' seam type for skirt/brim.

Despite the fact that skirt/brim currently doesn't have layers, it still got taken along with the 'tie-breaker' for seams that are very similar. See the explanation given in the original PR #1610. This will (also) fix Cura#11936.