### PR TITLE
Fix sharpest corner seam placement

### DIFF
--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -453,8 +453,8 @@ protected:
                 : getCombingDistance(here, target_pos);
             const float score_distance = (seam_config.type == EZSeamType::SHARPEST_CORNER && seam_config.corner_pref != EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE) ? 0 : static_cast<float>(distance) / 1000000;
             const float corner_angle = LinearAlg2D::getAngleLeft(previous, here, next) / M_PI - 1; //Between -1 and 1.
-            // angles < 0 are convex (left turning)
-            // angles > 0 are concave (right turning)
+            // angles < 0 are concave (left turning)
+            // angles > 0 are convex (right turning)
 
             float score;
             const float corner_shift = seam_config.type != EZSeamType::USER_SPECIFIED ? 10000 : 0; //Allow up to 20mm shifting of the seam to find a good location. For SHARPEST_CORNER, this shift is the only factor. For USER_SPECIFIED, don't allow shifting.

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -429,9 +429,6 @@ protected:
             simple_poly = Polygon(*path.converted); //Restore the original. We have to output a vertex as the seam position, so there needs to be a vertex.
         }
 
-        // Paths, other than polygons, can be either clockwise or counterclockwise. Make sure this is detected.
-        const bool clockwise = simple_poly.orientation();
-
         const Point focus_fixed_point = (seam_config.type == EZSeamType::USER_SPECIFIED)
             ? seam_config.pos
             : Point(0, std::sqrt(std::numeric_limits<coord_t>::max())); //Use sqrt, so the squared size can be used when comparing distances.
@@ -455,7 +452,7 @@ protected:
                 ? getDirectDistance(here, target_pos)
                 : getCombingDistance(here, target_pos);
             const float score_distance = (seam_config.type == EZSeamType::SHARPEST_CORNER && seam_config.corner_pref != EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE) ? 0 : static_cast<float>(distance) / 1000000;
-            const float corner_angle = (clockwise ? LinearAlg2D::getAngleLeft(previous, here, next) : LinearAlg2D::getAngleLeft(next, here, previous)) / M_PI - 1; //Between -1 and 1.
+            const float corner_angle = LinearAlg2D::getAngleLeft(previous, here, next) / M_PI - 1; //Between -1 and 1.
 
             float score;
             const float corner_shift = seam_config.type != EZSeamType::USER_SPECIFIED ? 10000 : 0; //Allow up to 20mm shifting of the seam to find a good location. For SHARPEST_CORNER, this shift is the only factor. For USER_SPECIFIED, don't allow shifting.


### PR DESCRIPTION
The suggestion from the ticket was somewhat in the right direction of the issue. 

>We might've found that the placement only goes wrong when there is a hole-polygon (with of course the opposite winding ... but also all notions of exposre/hide reversed, because it is a hole, so on the 'bump' of a polygon is hiding it instead of exposing it, and vice-versa, on a concave part of the polygon would be exposing it instead of hiding it). This being the reason the ticket was cloned.

Turns out, we did already compensate for this winding order
https://github.com/Ultimaker/CuraEngine/blob/41d3cce06b6d36c8e450c79b870e22bfdea3ab51/include/PathOrderOptimizer.h#L458

However, there is no need for such compensation

consider the following image
![Untitled Diagram drawio](https://user-images.githubusercontent.com/6638028/188647077-572acd35-b039-478a-ba06-8115b8a0a5b6.png)

In this case both corners $\alpha$ and $\beta$ are sharpest, where $\alpha$ is the sharpest corner of the outer polygon and $\beta$ is the sharpest corner of the inner polygon. Due to the difference in winding order of these polygon both $\langle \alpha_{\text{prev}}, \alpha_{\text{curr}}, \alpha_{\text{next}} \rangle$ and $\langle \beta_{\text{prev}}, \beta_{\text{curr}}, \beta_{\text{next}} \rangle$ are left-turning vertices. Hense, there is no need to compensate by negating the angle if depending if the corner is part of a clock/anti-clockwise polygon.

CURA-8600