### PR TITLE
Fix seam placement if fuzzy skin is enabled

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1050,8 +1050,7 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
                     continue;
                 }
 
-                result_paths.emplace_back();
-                auto& result_lines = result_paths.back();
+                auto& result_lines = result_paths.emplace_back();
 
                 if (apply_outside_only)
                 {
@@ -1066,9 +1065,10 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
                         continue;
                     }
 
-                    result_lines.emplace_back();
-                    auto& result = result_lines.back();
+                    auto& result = result_lines.emplace_back();
                     result.inset_idx = line.inset_idx;
+                    result.is_odd = line.is_odd;
+                    result.is_closed = line.is_closed;
 
                     // generate points in between p0 and p1
                     int64_t dist_left_over = (min_dist_between_points / 4) + rand() % (min_dist_between_points / 4); // the distance to be traversed on the line before making the first new point


### PR DESCRIPTION
If fuzzy skin is enabled then the wall tool paths were overwritten by new "fuzzy" wall tool paths. As the properties `is_odd` and `is_closed` weren't properly copied to these new tool paths, these properties would default to `false`. As the new wall tool paths were not closed the start vertex property would be ignored.

CURA-9343