### PR TITLE
Avoid moving iterators out of range

### DIFF
--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1321,8 +1321,8 @@ bool SkeletalTrapezoidation::isEndOfCentral(const edge_t& edge_to) const
 
 void SkeletalTrapezoidation::generateExtraRibs()
 {
-    auto end_edge_it = --graph.edges.end(); // Don't check newly introduced edges
-    for (auto edge_it = graph.edges.begin(); std::prev(edge_it) != end_edge_it; ++edge_it)
+    const auto end_edge_it = graph.edges.end(); // Don't check newly introduced edges
+    for (auto edge_it = graph.edges.begin(); edge_it != end_edge_it; ++edge_it)
     {
         edge_t& edge = *edge_it;
 

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -527,33 +527,35 @@ void Polygons::removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& 
 void Polygons::removeSmallAreas(const double min_area_size, const bool remove_holes)
 {
     auto new_end = paths.end();
-    if(remove_holes)
+    if (remove_holes)
     {
-        for(auto it = paths.begin(); it < new_end; it++)
+        for (auto it = paths.begin(); it < new_end;)
         {
             // All polygons smaller than target are removed by replacing them with a polygon from the back of the vector
-            if(std::abs(INT2MM2(ClipperLib::Area(*it))) < min_area_size)
+            if (std::abs(INT2MM2(ClipperLib::Area(*it))) < min_area_size)
             {
-                new_end--;
-                *it = std::move(*new_end);
-                it--; // wind back the iterator such that the polygon just swaped in is checked next
+                *it = std::move(*--new_end);
+                continue;
             }
+            it++; // Skipped on removal such that the polygon just swaped in is checked next
         }
     }
     else
     {
         // For each polygon, computes the signed area, move small outlines at the end of the vector and keep references on small holes
         std::vector<PolygonRef> small_holes;
-        for(auto it = paths.begin(); it < new_end; it++) {
+        for (auto it = paths.begin(); it < new_end;)
+        {
             double area = INT2MM2(ClipperLib::Area(*it));
             if (std::abs(area) < min_area_size)
             {
-                if(area >= 0)
+                if (area >= 0)
                 {
-                    new_end--;
-                    if(it < new_end) {
+                    --new_end;
+                    if (it < new_end)
+                    {
                         std::swap(*new_end, *it);
-                        it--;
+                        continue;
                     }
                     else
                     { // Don't self-swap the last Path
@@ -565,24 +567,25 @@ void Polygons::removeSmallAreas(const double min_area_size, const bool remove_ho
                     small_holes.push_back(*it);
                 }
             }
+            it++; // Skipped on removal such that the polygon just swaped in is checked next
         }
 
         // Removes small holes that have their first point inside one of the removed outlines
         // Iterating in reverse ensures that unprocessed small holes won't be moved
         const auto removed_outlines_start = new_end;
-        for(auto hole_it = small_holes.rbegin(); hole_it < small_holes.rend(); hole_it++)
+        for (auto hole_it = small_holes.rbegin(); hole_it < small_holes.rend(); hole_it++)
         {
-            for(auto outline_it = removed_outlines_start; outline_it < paths.end() ; outline_it++)
+            for (auto outline_it = removed_outlines_start; outline_it < paths.end(); outline_it++)
             {
-                if(PolygonRef(*outline_it).inside(*hole_it->begin())) {
-                    new_end--;
-                    **hole_it = std::move(*new_end);
+                if (PolygonRef(*outline_it).inside(*hole_it->begin()))
+                {
+                    **hole_it = std::move(*--new_end);
                     break;
                 }
             }
         }
     }
-    paths.resize(new_end-paths.begin());
+    paths.resize(new_end - paths.begin());
 }
 
 void Polygons::removeDegenerateVerts()

--- a/tests/utils/PolygonTest.cpp
+++ b/tests/utils/PolygonTest.cpp
@@ -382,11 +382,11 @@ TEST_F(PolygonTest, convexHullRemoveDuplicatePoints)
 TEST_F(PolygonTest, removeSmallAreas_simple)
 {
     // basic set of polygons
-    auto square_2 = test_square;
-    square_2.translate(Point(0, 500));
+    auto test_square_2 = test_square;
+    test_square_2.translate(Point(0, 500));
     auto d_polygons = Polygons{};
     d_polygons.add(test_square);
-    d_polygons.add(square_2);
+    d_polygons.add(test_square_2);
     d_polygons.add(triangle);
 
     // for the simple case there should be no change.
@@ -407,24 +407,24 @@ TEST_F(PolygonTest, removeSmallAreas_simple)
 TEST_F(PolygonTest, removeSmallAreas_small_area)
 {
     // make some areas.
-    auto sa1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
-    sa1.translate(Point(350, 450));
-    auto sa2 = small_area;
-    sa2.translate(Point(450, 350));
-    auto tri = triangle; // area = 10000 micron^2 = 1e-2 mm^2
-    tri.translate(Point(50, 0));
+    auto small_area_1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
+    small_area_1.translate(Point(350, 450));
+    auto small_area_2 = small_area;
+    small_area_2.translate(Point(450, 350));
+    auto triangle_1 = triangle; // area = 10000 micron^2 = 1e-2 mm^2
+    triangle_1.translate(Point(50, 0));
 
     // add areas to polygons
     auto d_polygons = Polygons{};
-    d_polygons.add(sa1);
-    d_polygons.add(sa2);
+    d_polygons.add(small_area_1);
+    d_polygons.add(small_area_2);
     d_polygons.add(test_square); // area = 10000 micron^2 = 1e-2 mm^2
-    d_polygons.add(tri);
+    d_polygons.add(triangle_1);
 
     // make an expected Polygons
     auto exp_polygons = Polygons{};
     exp_polygons.add(test_square);
-    exp_polygons.add(tri);
+    exp_polygons.add(triangle_1);
 
     // for remove_holes == false, 2 poly removed
     auto act_polygons = d_polygons;
@@ -444,14 +444,14 @@ TEST_F(PolygonTest, removeSmallAreas_small_area)
 TEST_F(PolygonTest, removeSmallAreas_hole)
 {
     // make some areas.
-    auto sh1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
-    sh1.reverse();
-    sh1.translate(Point(10, 10));
+    auto small_hole_1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
+    small_hole_1.reverse();
+    small_hole_1.translate(Point(10, 10));
 
     // add areas to polygons
     auto d_polygons = Polygons{};
     d_polygons.add(test_square); // area = 10000 micron^2 = 1e-2 mm^2
-    d_polygons.add(sh1);
+    d_polygons.add(small_hole_1);
 
 
     // for remove_holes == false there should be no change.
@@ -474,31 +474,31 @@ TEST_F(PolygonTest, removeSmallAreas_hole)
 TEST_F(PolygonTest, removeSmallAreas_hole_2)
 {
     // make some areas.
-    auto sh1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
-    sh1.reverse();
-    auto sh2 = sh1;
-    sh1.translate(Point(10, 10));
-    sh2.translate(Point(160, 160));
-    auto small_square = Polygon{}; // area = 2500 micron^2 = 2.5e-3 mm^2
-    small_square.add(Point(0, 0));
-    small_square.add(Point(50, 0));
-    small_square.add(Point(50, 50));
-    small_square.add(Point(0, 50));
-    small_square.translate(Point(150, 150));
+    auto small_hole_1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
+    small_hole_1.reverse();
+    auto small_hole_2 = small_hole_1;
+    small_hole_1.translate(Point(10, 10));
+    small_hole_2.translate(Point(160, 160));
+    auto med_square_1 = Polygon{}; // area = 2500 micron^2 = 2.5e-3 mm^2
+    med_square_1.add(Point(0, 0));
+    med_square_1.add(Point(50, 0));
+    med_square_1.add(Point(50, 50));
+    med_square_1.add(Point(0, 50));
+    med_square_1.translate(Point(150, 150));
 
     // add areas to polygons
     auto d_polygons = Polygons{};
     d_polygons.add(test_square); // area = 10000 micron^2 = 1e-2 mm^2
-    d_polygons.add(sh1);
-    d_polygons.add(small_square);
-    d_polygons.add(sh2);
+    d_polygons.add(small_hole_1);
+    d_polygons.add(med_square_1);
+    d_polygons.add(small_hole_2);
 
     // for remove_holes == false, two polygons removed.
     auto act_polygons = d_polygons;
     // make an expected Polygons
     auto exp_polygons = Polygons{};
     exp_polygons.add(test_square);
-    exp_polygons.add(sh1);
+    exp_polygons.add(small_hole_1);
     act_polygons.removeSmallAreas(3e-3, false);
     twoPolygonsAreEqual(act_polygons, exp_polygons);
 
@@ -520,35 +520,35 @@ TEST_F(PolygonTest, removeSmallAreas_hole_2)
 TEST_F(PolygonTest, removeSmallAreas_complex)
 {
     // make some areas.
-    auto sa1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
-    sa1.translate(Point(350, 450));
-    auto sa2 = small_area;
-    sa2.translate(Point(450, 350));
-    auto sh1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
-    sh1.reverse();
-    auto sh2 = sh1;
-    sh1.translate(Point(3, 3));
-    sh2.translate(Point(22, 50));
-    auto tri = triangle; // area = 10000 micron^2 = 1e-2 mm^2
-    tri.translate(Point(600, 0));
+    auto small_area_1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
+    small_area_1.translate(Point(350, 450));
+    auto small_area_2 = small_area;
+    small_area_2.translate(Point(450, 350));
+    auto small_hole_1 = small_area; // Area = 100 micron^2 = 1e-4 mm^2
+    small_hole_1.reverse();
+    auto small_hole_2 = small_hole_1;
+    small_hole_1.translate(Point(3, 3));
+    small_hole_2.translate(Point(22, 50));
+    auto triangle_1 = triangle; // area = 10000 micron^2 = 1e-2 mm^2
+    triangle_1.translate(Point(600, 0));
 
     // add areas to polygons
     auto d_polygons = Polygons{};
-    d_polygons.add(sa1);
-    d_polygons.add(sa2);
+    d_polygons.add(small_area_1);
+    d_polygons.add(small_area_2);
     d_polygons.add(test_square); // area = 10000 micron^2 = 1e-2 mm^2
-    d_polygons.add(sh1);
-    d_polygons.add(sh2);
-    d_polygons.add(tri);
+    d_polygons.add(small_hole_1);
+    d_polygons.add(small_hole_2);
+    d_polygons.add(triangle_1);
 
     // for remove_holes == false there should be 2 small areas removed.
     auto act_polygons = d_polygons;
     // make an expected Polygons
     auto exp_polygons = Polygons{};
     exp_polygons.add(test_square); // area = 10000 micron^2 = 1e-2 mm^2
-    exp_polygons.add(sh1);
-    exp_polygons.add(sh2);
-    exp_polygons.add(tri);
+    exp_polygons.add(small_hole_1);
+    exp_polygons.add(small_hole_2);
+    exp_polygons.add(triangle_1);
     act_polygons.removeSmallAreas(1e-3, false);
     twoPolygonsAreEqual(act_polygons, exp_polygons);
 
@@ -557,7 +557,7 @@ TEST_F(PolygonTest, removeSmallAreas_complex)
     // make an expected Polygons
     exp_polygons = Polygons{};
     exp_polygons.add(test_square);
-    exp_polygons.add(tri); // area = 10000 micron^2 = 1e-2 mm^2
+    exp_polygons.add(triangle_1); // area = 10000 micron^2 = 1e-2 mm^2
     act_polygons.removeSmallAreas(1e-3, true);
     twoPolygonsAreEqual(act_polygons, exp_polygons);
 }


### PR DESCRIPTION
Superseeds #1593 and #1662, resolve #1663.

As noticed in discussion of #1432, this PR introduced another case of iterators decremented before `begin()`.
While it is not an issue with release builds on platforms using pointer wrapper as iterators, it is undefined behavior after all. More practically, debug builds catches this which is annoying (iterator checking is enabled by default on mscv).

This PR resolves two cases: one in `Polygons::removeSmallAreas` and one in `SkeletalTrapezoidation::isEndOfCentral`.

I cherry-picked the `removeSmallAreas` tests from #1593 by @plaintoothpaste. I found that the implementation was working as intended but the tests were not expecting reordering of the `Polygons` path entries.

@rburema I investigated the erase-remove idiom in this application but found that it likely doesn't work for the case `remove_holes=false`. The reference given to the predicate is not stable since even kept elements can be shifted. This forbids keeping a reference to small holes for latter filtering. 
Beside, without the order-preserving requirement of `remove_if`, we can do a move per removed element instead of shifting the tail of the vector like `remove_if` does. This might be slightly more efficient for the common case with lot of polygons but few filtered out.