### PR TITLE
WallToolPaths: simplify outlines

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -120,9 +120,9 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     
     removeSmallLines(toolpaths);
 
-    separateOutInnerContour();
-    
     simplifyToolPaths(toolpaths, settings);
+
+    separateOutInnerContour();
 
     removeEmptyToolPaths(toolpaths);
     assert(std::is_sorted(toolpaths.cbegin(), toolpaths.cend(),


### PR DESCRIPTION
When reducing `discretization_step_size` to smaller values (btw, I think it should scale with nozzle size or line widht), I noticed that lightning infill was getting a lot slower, even with drastic simplification settings.

It turns out that the outlines generated by `WallToolPaths` are not simplified, unlike the toolpaths.

The easiest solution is to extract the outlines after simplifying the toolpaths. 

I'm not completely sure, some simplifications may be removed after this change, like [in Infill](https://github.com/Ultimaker/CuraEngine/blob/main/src/infill.cpp#L137).