### PR TITLE
[CURA-7926] Spiralize Outer Contour bottom layers all walls

### DIFF
--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -61,7 +61,7 @@ void WallsComputation::generateWalls(SliceLayerPart* part)
         generateSpiralInsets(part, line_width_0, wall_0_inset, recompute_outline_based_on_outer_wall);
         if (layer_nr <= static_cast<LayerIndex>(settings.get<size_t>("bottom_layers")))
         {
-            WallToolPaths wall_tool_paths(part->outline, line_width_0, line_width_x, wall_count, settings);
+            WallToolPaths wall_tool_paths(part->outline, line_width_0, line_width_x, wall_count, wall_0_inset, settings);
             part->wall_toolpaths = wall_tool_paths.getToolPaths();
             part->inner_area = wall_tool_paths.getInnerContour();
         }


### PR DESCRIPTION
Fix typo, call was being made to the incorrect constructor causing some of the input values to be flipped.

line\_width\_x was being passed in for inset count, wall\_count was being passed as wall\_0\_instet etc.