### PR TITLE
[CURA-9559] Fix Cura crashing on certain models

### DIFF
--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -162,7 +162,9 @@ std::vector<Point> VoronoiUtils::discretizeParabola(const Point& p, const Segmen
     bool add_marking_end = mex * dir > (sx - px) * dir && mex * dir < (ex - px) * dir;
 
     const Point apex = rot.unapply(Point(0, d / 2)) + pxx;
-    bool add_apex = (sx - px) * dir < 0 && (ex - px) * dir > 0;
+    // Only at the apex point if the projected start and end points
+    // are more than 10 microns away from the projected apex
+    bool add_apex = (sx - px) * dir < -10 && (ex - px) * dir > 10;
 
     assert(! (add_marking_start && add_marking_end) || add_apex);
     if (add_marking_start && add_marking_end && ! add_apex)


### PR DESCRIPTION
We had some instances where slicing certain models gave a slice error. 

In a Voronoi diagram we can have straight and curved edges. We have a curved edge if one of the support lines is formed from a point and an edge. To be precise the curve formed here is a parabola. Our algorithms can't handle curved edges, so these curved edges are discretization into straight line segments.

For the discretization we get parameters for the parabola, an `start_point` and `end_point`, an `approximate_step_size` and a `transition_angle`. The start and end points are always added to the parabola. In between this start and end point at an interval approximately equal to "approximate step size" points are added. In addition to the start, end and interval points three special points are added (if applicable). These are
- transition start point
- apex
- transition end point
The apex is the point at the extreme point of the parabola, where the transition points are points that are located at the `transition angle` from the the input arguments (for both the negative, and positive angle). These points are not always added; if either of these points fall outside of the range `start_point` to `end_point` then they are omitted from the discretization.

![Untitled Diagram drawio](https://user-images.githubusercontent.com/6638028/193582143-88ac7087-fb46-4b18-b41e-8f5fc11ff5bf.png)

I did found when playing around in the code that by removing the apex of the parabola the model sliced correctly. After some investigation I did notice that the start and end points would sometimes be very close around the apex point (within a few millimeters. With this fix the apex is only added if $|sx| > 10$ and $|ex| > 10$.