### PR TITLE
Simplify: fix scaling of maximum area deviation setting

### DIFF
--- a/src/utils/Simplify.cpp
+++ b/src/utils/Simplify.cpp
@@ -18,7 +18,7 @@ Simplify::Simplify(const coord_t max_resolution, const coord_t max_deviation, co
 Simplify::Simplify(const Settings& settings)
     : max_resolution(settings.get<coord_t>("meshfix_maximum_resolution"))
     , max_deviation(settings.get<coord_t>("meshfix_maximum_deviation"))
-    , max_area_deviation(settings.get<coord_t>("meshfix_maximum_extrusion_area_deviation"))
+    , max_area_deviation(settings.get<size_t>("meshfix_maximum_extrusion_area_deviation"))
 {}
 
 Polygons Simplify::polygon(const Polygons& polygons) const


### PR DESCRIPTION
`meshfix_maximum_extrusion_area_deviation` is already in millimeters. Using `get<coord_t>` divides the value by 1000, instead the setting should be acceded with `get<size_t>` or `get<int>`.

I've already signaled and fixed this in #1710, but maybe this simple fix has a chance of making it into the 5.2 release?

The frontend commits that recently changed the default value Ultimaker/Cura@03c88c18e6523ad370f094730d43f85e90d3a390 should probably be re-evaluated.