### PR TITLE
Use drop_last to loop over ranges

### DIFF
--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -4,7 +4,6 @@
 #include "SkeletalTrapezoidation.h"
 
 #include <spdlog/spdlog.h>
-#include <range/v3/view/drop_last.hpp>
 
 #include "settings/types/Ratio.h"
 #include <functional>

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -4,6 +4,7 @@
 #include "SkeletalTrapezoidation.h"
 
 #include <spdlog/spdlog.h>
+#include <range/v3/view/drop_last.hpp>
 
 #include "settings/types/Ratio.h"
 #include <functional>
@@ -1321,21 +1322,19 @@ bool SkeletalTrapezoidation::isEndOfCentral(const edge_t& edge_to) const
 
 void SkeletalTrapezoidation::generateExtraRibs()
 {
-    auto end_edge_it = --graph.edges.end(); // Don't check newly introduced edges
-    for (auto edge_it = graph.edges.begin(); std::prev(edge_it) != end_edge_it; ++edge_it)
+    for (auto edge : graph.edges | ranges::views::drop_last(1))
     {
-        edge_t& edge = *edge_it;
-
         if (! edge.data.isCentral() || shorterThen(edge.to->p - edge.from->p, discretization_step_size) || edge.from->data.distance_to_boundary >= edge.to->data.distance_to_boundary)
         {
             continue;
         }
 
-
         std::vector<coord_t> rib_thicknesses = beading_strategy.getNonlinearThicknesses(edge.from->data.bead_count);
 
         if (rib_thicknesses.empty())
+        {
             continue;
+        }
 
         // Preload some variables before [edge] gets changed
         node_t* from = edge.from;

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1322,7 +1322,7 @@ bool SkeletalTrapezoidation::isEndOfCentral(const edge_t& edge_to) const
 
 void SkeletalTrapezoidation::generateExtraRibs()
 {
-    for (auto edge : graph.edges | ranges::views::drop_last(1))
+    for (auto edge : graph.edges)
     {
         if (! edge.data.isCentral() || shorterThen(edge.to->p - edge.from->p, discretization_step_size) || edge.from->data.distance_to_boundary >= edge.to->data.distance_to_boundary)
         {


### PR DESCRIPTION
More robust method to loop over the graph.edges

While helping out @rijkvanmanen with a crash in one of his mini-spike branches we ran across a situation where the Engine crashed, when the graph.edges weren't filled as expected. It is unlikely that this would happen in the wild. But it can't hurt to do some defensive programming imo.

> [views::drop_last](https://ericniebler.github.io/range-v3/structranges_1_1views_1_1drop__last__fn.html)
Given a source range and an integral count, return a range consisting of all but the last count elements from the source range, or an empty range if it has fewer elements.