### PR TITLE
Add Point fmt formatter

### DIFF
--- a/include/utils/format.h
+++ b/include/utils/format.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2022 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef CURAENGINE_UTILS_FORMAT_H
+#define CURAENGINE_UTILS_FORMAT_H
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+namespace ClipperLib {
+    class IntPoint; // Forward declaration
+}
+
+template<>
+struct [[maybe_unused]] fmt::formatter<ClipperLib::IntPoint> {
+    constexpr auto parse(fmt::format_parse_context &ctx) -> decltype(ctx.begin()) {
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}') {
+            throw fmt::format_error("invalid format");
+        }
+        return ctx.begin();
+    }
+
+    /** fmt formatter for IntPoints
+     * This allows spdlog and/or fmt to output a single point as [X, Y].
+     * With the inclusion of the fmt/ranges.h a container of points will be: [[X_0, Y_0], [X_1, Y_1], ..., [X_n, Y_n]]
+     * Usage as:
+     * \code{.cpp}
+     * std::vector<Point> points {{100, 200}, {300, 400}, {500, 600}};
+     * spdlog:debug("points: {}", points};
+     * auto fmt::format("{}", points};
+     * \endcode
+     **/
+    template<typename FormatContext>
+    auto format(const ClipperLib::IntPoint &point, FormatContext &ctx) const -> decltype(ctx.out()) {
+        return fmt::format_to(ctx.out(), "[{}, {}]", point.X, point.Y);
+    }
+};
+
+
+#endif //CURAENGINE_UTILS_FORMAT_H

--- a/include/utils/format.h
+++ b/include/utils/format.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2022 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef CURAENGINE_UTILS_FORMAT_H
 #define CURAENGINE_UTILS_FORMAT_H
@@ -7,14 +7,18 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
-namespace ClipperLib {
-    class IntPoint; // Forward declaration
+namespace ClipperLib
+{
+class IntPoint; // Forward declaration
 }
 
 template<>
-struct [[maybe_unused]] fmt::formatter<ClipperLib::IntPoint> {
-    constexpr auto parse(fmt::format_parse_context &ctx) -> decltype(ctx.begin()) {
-        if (ctx.begin() != ctx.end() && *ctx.begin() != '}') {
+struct [[maybe_unused]] fmt::formatter<ClipperLib::IntPoint>
+{
+    constexpr auto parse(fmt::format_parse_context& ctx) -> decltype(ctx.begin())
+    {
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
             throw fmt::format_error("invalid format");
         }
         return ctx.begin();
@@ -31,10 +35,11 @@ struct [[maybe_unused]] fmt::formatter<ClipperLib::IntPoint> {
      * \endcode
      **/
     template<typename FormatContext>
-    auto format(const ClipperLib::IntPoint &point, FormatContext &ctx) const -> decltype(ctx.out()) {
+    auto format(const ClipperLib::IntPoint& point, FormatContext& ctx) const -> decltype(ctx.out())
+    {
         return fmt::format_to(ctx.out(), "[{}, {}]", point.X, point.Y);
     }
 };
 
 
-#endif //CURAENGINE_UTILS_FORMAT_H
+#endif // CURAENGINE_UTILS_FORMAT_H

--- a/include/utils/format/ExtrusionLine.h
+++ b/include/utils/format/ExtrusionLine.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher
+
+#ifndef CURAENGINE_EXTRUSIONLINE_H
+#define CURAENGINE_EXTRUSIONLINE_H
+
+#include "utils/ExtrusionLine.h"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+
+template<>
+struct [[maybe_unused]] fmt::formatter<cura::ExtrusionLine>
+{
+    constexpr auto parse(fmt::format_parse_context& ctx) -> decltype(ctx.begin())
+    {
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw fmt::format_error("invalid format");
+        }
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const cura::ExtrusionLine& extrusion_line, FormatContext& ctx) const -> decltype(ctx.out())
+    {
+        return fmt::format_to(ctx.out(), "ExtrusionLine: <idx: {}, odd: {}, closed: {}>", extrusion_line.inset_idx, extrusion_line.is_odd, extrusion_line.is_closed);
+    }
+};
+
+
+#endif // CURAENGINE_EXTRUSIONLINE_H

--- a/include/utils/format/IntPoint.h
+++ b/include/utils/format/IntPoint.h
@@ -4,16 +4,14 @@
 #ifndef CURAENGINE_UTILS_FORMAT_H
 #define CURAENGINE_UTILS_FORMAT_H
 
+#include "utils/IntPoint.h"
+
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
-namespace ClipperLib
-{
-class IntPoint; // Forward declaration
-}
 
 template<>
-struct [[maybe_unused]] fmt::formatter<ClipperLib::IntPoint>
+struct [[maybe_unused]] fmt::formatter<cura::Point>
 {
     constexpr auto parse(fmt::format_parse_context& ctx) -> decltype(ctx.begin())
     {
@@ -35,7 +33,7 @@ struct [[maybe_unused]] fmt::formatter<ClipperLib::IntPoint>
      * \endcode
      **/
     template<typename FormatContext>
-    auto format(const ClipperLib::IntPoint& point, FormatContext& ctx) const -> decltype(ctx.out())
+    auto format(const cura::Point& point, FormatContext& ctx) const -> decltype(ctx.out())
     {
         return fmt::format_to(ctx.out(), "[{}, {}]", point.X, point.Y);
     }


### PR DESCRIPTION
This allows spdlog and/or fmt to output a single point as [X, Y]. With the inclusion of the fmt/ranges.h a container of points will be: [[X_0, Y_0], [X_1, Y_1], ..., [X_n, Y_n]] Usage as:

```c++
std::vector<Point> points {{100, 200}, {300, 400}, {500, 600}};
spdlog:debug("points: {}", points};
auto fmt::format("{}", points};
```

Easy debugging commence!

Created while working on: CURA-9377 💥 Slicing error with Top/Bottom line width, which I'm dropping in favor of other tickets.

Although the file currently isn't used, I still believe we should merge, because it is a helpful class to say the least.