### PR TITLE
[CURA-7800] Properly detect and handle 'conflicting' TreeNodes.

### DIFF
--- a/include/TreeSupport.h
+++ b/include/TreeSupport.h
@@ -186,7 +186,7 @@ private:
      *
      * If a node is already at that position in the layer, the nodes are merged.
      */
-    void insertDroppedNode(std::vector<Node*>& nodes_layer, Node* node);
+    Node* insertDroppedNode(std::vector<Node*>& nodes_layer, Node* node);
 };
 
 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -334,7 +334,7 @@ void TreeSupport::dropNodes(std::vector<std::vector<Node*>>& contact_nodes)
 
                     const bool to_buildplate = ! volumes_.getAvoidance(branch_radius_node, layer_nr - 1).inside(next_position);
                     Node* next_node = new Node(next_position, new_distance_to_top, node.skin_direction, new_support_roof_layers_below, to_buildplate, p_node);
-                    insertDroppedNode(contact_nodes[layer_nr - 1], next_node); // Insert the node, resolving conflicts of the two colliding nodes.
+                    next_node = insertDroppedNode(contact_nodes[layer_nr - 1], next_node); // Insert the node, resolving conflicts of the two colliding nodes.
 
                     // Make sure the next pass doesn't drop down either of these (since that already happened).
                     node.merged_neighbours.push_front(neighbour);
@@ -596,18 +596,32 @@ void TreeSupport::generateContactPoints(const SliceMeshStorage& mesh, std::vecto
     }
 }
 
-void TreeSupport::insertDroppedNode(std::vector<Node*>& nodes_layer, Node* p_node)
+TreeSupport::Node* TreeSupport::insertDroppedNode(std::vector<Node*>& nodes_layer, Node* p_node)
 {
-    std::vector<Node*>::iterator conflicting_node_it = std::find(nodes_layer.begin(), nodes_layer.end(), p_node);
+    const std::function<bool(Node*)> node_ptr_eq{ [&p_node](Node* p_other) { return p_node->position == p_other->position; } };
+    std::vector<Node*>::iterator conflicting_node_it = std::find_if(nodes_layer.begin(), nodes_layer.end(), node_ptr_eq);
     if (conflicting_node_it == nodes_layer.end()) // No conflict.
     {
         nodes_layer.emplace_back(p_node);
-        return;
+        return p_node;
     }
 
     Node* conflicting_node = *conflicting_node_it;
     conflicting_node->distance_to_top = std::max(conflicting_node->distance_to_top, p_node->distance_to_top);
     conflicting_node->support_roof_layers_below = std::max(conflicting_node->support_roof_layers_below, p_node->support_roof_layers_below);
+    if (p_node->parent != nullptr && p_node->parent != conflicting_node->parent)
+    {
+        if (conflicting_node->parent != nullptr)
+        {
+            conflicting_node->parent->merged_neighbours.push_front(p_node->parent);
+        }
+        else
+        {
+            conflicting_node->parent = p_node->parent;
+        }
+    }
+    delete p_node;
+    return conflicting_node;
 }
 
 } // namespace cura


### PR DESCRIPTION
This was not been done properly since the move to pointer-based nodes (instead of value based). The comparison to the value in the 'find' would never compare to true, since while the value could be equal in the eyes of the overriden == operator in Node itself, it would instead compare pointers, which would _always_ be different, since all Nodes _are_ different instances here.

Since Nodes where considered to be unique w.r.t. their position, the non-resolution lead to hard-to diagnose problems.

Now that conflicting nodes _are_ resolved properly however, they should also 'play-nice' with the pruning mechanism that was introduced at the same time the conflict resolution became defunct by mistake. (W.r.t. 'parents' and 'merged neighbours'.