### PR TITLE
[CURA-9625] Top skin does not apply skin overlap.

### DIFF
--- a/include/skin.h
+++ b/include/skin.h
@@ -169,7 +169,7 @@ protected:
      * \param skin_part The part where the skin outline information (input) is stored and
      * where the inner infill and roofing infill areas (output) is stored.
      */
-    void regenerateRoofingFillAndInnerInfill(SliceLayerPart& part, SkinPart& skin_part);
+    void generateRoofingFillAndInnerInfill(SliceLayerPart& part, SkinPart& skin_part);
 
 protected:
     LayerIndex layer_nr; //!< The index of the layer for which to generate the skins and infill.

--- a/include/skin.h
+++ b/include/skin.h
@@ -151,7 +151,7 @@ protected:
      * \param part Where to get the SkinParts to get the outline info from
      * \param roofing_layer_count The number of layers above the layer which we are looking into
      */
-    Polygons generateNoAirAbove(SliceLayerPart& part, size_t roofing_layer_count);
+    Polygons generateFilledAreaAbove(SliceLayerPart& part, size_t roofing_layer_count);
 
     /*!
      * Helper function to calculate and return the areas which are 'directly' above air.

--- a/include/skin.h
+++ b/include/skin.h
@@ -133,7 +133,7 @@ protected:
      * 
      * \param[in,out] part Where to get the SkinParts to get the outline info from and to store the roofing areas
      */
-    void generateRoofing(SliceLayerPart& part);
+    void generateRoofingFillAndSkinFill(SliceLayerPart& part);
 
     /*!
      * Remove the areas which are directly under air in the top-most surface and directly above air in bottom-most
@@ -143,7 +143,7 @@ protected:
      * \param[in,out] part Where to get the SkinParts to get the outline info from and to store the top and bottom-most
      * infill areas
      */
-    void generateTopAndBottomMostSkinSurfaces(SliceLayerPart& part);
+    void generateTopAndBottomMostSkinFill(SliceLayerPart& part);
 
     /*!
      * Helper function to calculate and return the areas which are 'directly' under air.

--- a/include/skin.h
+++ b/include/skin.h
@@ -159,7 +159,7 @@ protected:
      * \param part Where to get the SkinParts to get the outline info from
      * \param flooring_layer_count The number of layers below the layer which we are looking into
      */
-    Polygons generateNoAirBelow(SliceLayerPart& part, size_t flooring_layer_count);
+    Polygons generateFilledAreaBelow(SliceLayerPart& part, size_t flooring_layer_count);
 
     /*!
      * Helper function to recalculate the roofing fill and inner infill in roofing layers where the 

--- a/include/skin.h
+++ b/include/skin.h
@@ -161,16 +161,6 @@ protected:
      */
     Polygons generateFilledAreaBelow(SliceLayerPart& part, size_t flooring_layer_count);
 
-    /*!
-     * Helper function to recalculate the roofing fill and inner infill in roofing layers where the 
-     * insets have to be changed.
-     *
-     * \param part Where to get the SkinParts to get the outline info from
-     * \param skin_part The part where the skin outline information (input) is stored and
-     * where the inner infill and roofing infill areas (output) is stored.
-     */
-    void generateRoofingFillAndInnerInfill(SliceLayerPart& part, SkinPart& skin_part);
-
 protected:
     LayerIndex layer_nr; //!< The index of the layer for which to generate the skins and infill.
     SliceMeshStorage& mesh; //!< The storage where the layer outline information (input) is stored and where the skin insets and fill areas (output) are stored.

--- a/include/sliceDataStorage.h
+++ b/include/sliceDataStorage.h
@@ -40,7 +40,6 @@ class SkinPart
 {
 public:
     PolygonsPart outline;           //!< The skinOutline is the area which needs to be 100% filled to generate a proper top&bottom filling. It's filled by the "skin" module. Includes both roofing and non-roofing.
-    std::vector<VariableWidthLines> inset_paths;       //!< The insets represented as variable line-width paths. The insets are also known as perimeters or the walls. Binned by inset_idx.
     Polygons skin_fill; //!< The part of the skin which is not roofing.
     Polygons roofing_fill; //!< The inner infill which has air directly above
     Polygons top_most_surface_fill; //!< The inner infill of the uppermost top layer which has air directly above.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2383,7 +2383,7 @@ void FffGcodeWriter::processRoofing(const SliceDataStorage& storage,
     }
 
     const Ratio skin_density = 1.0;
-    const coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");
+    const coord_t skin_overlap = 0; // skinfill already expanded over the roofing areas; don't overlap with perimeters
     const bool monotonic = mesh.settings.get<bool>("roofing_monotonic");
     processSkinPrintFeature(storage, gcode_layer, mesh, mesh_config, extruder_nr, skin_part.roofing_fill, mesh_config.roofing_config, pattern, roofing_angle, skin_overlap, skin_density, monotonic, added_something);
 }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2383,7 +2383,7 @@ void FffGcodeWriter::processRoofing(const SliceDataStorage& storage,
     }
 
     const Ratio skin_density = 1.0;
-    const coord_t skin_overlap = 0; // skinfill already expanded over the roofing areas; don't overlap with perimeters
+    const coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");
     const bool monotonic = mesh.settings.get<bool>("roofing_monotonic");
     processSkinPrintFeature(storage, gcode_layer, mesh, mesh_config, extruder_nr, skin_part.roofing_fill, mesh_config.roofing_config, pattern, roofing_angle, skin_overlap, skin_density, monotonic, added_something);
 }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2420,8 +2420,8 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage,
     // generate skin_polygons and skin_lines
     const GCodePathConfig* skin_config = &mesh_config.skin_config;
     Ratio skin_density = 1.0;
-    coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");
-    const coord_t more_skin_overlap = std::max(skin_overlap, (coord_t)(mesh_config.insetX_config.getLineWidth() / 2)); // force a minimum amount of skin_overlap
+    const coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");
+    coord_t extra_skin_overlap = 0;
     const bool bridge_settings_enabled = mesh.settings.get<bool>("bridge_settings_enabled");
     const bool bridge_enable_more_layers = bridge_settings_enabled && mesh.settings.get<bool>("bridge_enable_more_layers");
     const Ratio support_threshold = bridge_settings_enabled ? mesh.settings.get<Ratio>("bridge_skin_support_threshold") : 0.0_r;
@@ -2487,7 +2487,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage,
             if (bridge_settings_enabled)
             {
                 skin_config = config;
-                skin_overlap = more_skin_overlap;
+                extra_skin_overlap = std::max(skin_overlap, (coord_t)(mesh_config.insetX_config.getLineWidth() / 2)) - skin_overlap; // Skin overlap offset is applied in skin.cpp only extra overlap is applied here
                 skin_density = density;
             }
             return true;
@@ -2554,7 +2554,7 @@ void FffGcodeWriter::processTopBottom(const SliceDataStorage& storage,
         }
     }
     const bool monotonic = mesh.settings.get<bool>("skin_monotonic");
-    processSkinPrintFeature(storage, gcode_layer, mesh, mesh_config, extruder_nr, skin_part.skin_fill, *skin_config, pattern, skin_angle, skin_overlap, skin_density, monotonic, added_something, fan_speed);
+    processSkinPrintFeature(storage, gcode_layer, mesh, mesh_config, extruder_nr, skin_part.skin_fill, *skin_config, pattern, skin_angle, extra_skin_overlap, skin_density, monotonic, added_something, fan_speed);
 }
 
 void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage,

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -363,14 +363,9 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
         else if (!skin_part.skin_fill.empty() && !skin_part.roofing_fill.empty())
         {
             // Find the intersection of roofing and skin offset (skin_overlap_mm) areas.
-            Polygons skin_overlap_area = skin_part.skin_fill.offset(skin_overlap).difference(skin_part.skin_fill); // skin_overlap offset area around the skin
-            Polygons roofing_overlap_area = skin_part.roofing_fill.offset(skin_overlap).difference(skin_part.roofing_fill); // skin_overlap offset area around the roofing
-            Polygons skin_roofing_overlap_intersection = skin_overlap_area.intersection(roofing_overlap_area);
-
-            // If we offset to both the roofing_fill and skin_fill, when adjacent they would have a doubled offset area. Since they would both offset towards each other.
-            // We only apply the intersecting offset areas to skin_fill.
-            skin_part.roofing_fill = skin_part.roofing_fill.unionPolygons(roofing_overlap_area.difference(skin_roofing_overlap_intersection));
-            skin_part.skin_fill = skin_part.skin_fill.unionPolygons(skin_roofing_overlap_intersection);
+            skin_part.skin_fill = skin_part.skin_fill.offset(skin_overlap);
+            skin_part.roofing_fill =
+ skin_part.roofing_fill.offset(skin_overlap).difference(skin_part.skin_fill);
         }
     }
 }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -305,6 +305,7 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
 void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
 {
     const size_t roofing_layer_count = std::min(mesh.settings.get<size_t>("roofing_layer_count"), mesh.settings.get<size_t>("top_layers"));
+    const coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");
 
     for(SkinPart& skin_part : part.skin_parts)
     {
@@ -349,6 +350,27 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
                 skin_part.inset_paths.clear();
                 regenerateRoofingFillAndInnerInfill(part, skin_part);
             }
+        }
+
+        if (!skin_part.roofing_fill.empty() && skin_part.skin_fill.empty()) // There is no skin_fill on this layer skin_overlap offset only needs to be applied to the roofing_fill
+        {
+            skin_part.roofing_fill = skin_part.roofing_fill.offset(skin_overlap);
+        }
+        else if (skin_part.roofing_fill.empty() && !skin_part.skin_fill.empty()) // There is no roofing_fill on this layer skin_overlap offset only needs to be applied to the skin_fill
+        {
+            skin_part.skin_fill = skin_part.skin_fill.offset(skin_overlap);
+        }
+        else if (!skin_part.skin_fill.empty() && !skin_part.roofing_fill.empty())
+        {
+            // Find the intersection of roofing and skin offset (skin_overlap_mm) areas.
+            Polygons skin_overlap_area = skin_part.skin_fill.offset(skin_overlap).difference(skin_part.skin_fill); // skin_overlap offset area around the skin
+            Polygons roofing_overlap_area = skin_part.roofing_fill.offset(skin_overlap).difference(skin_part.roofing_fill); // skin_overlap offset area around the roofing
+            Polygons skin_roofing_overlap_intersection = skin_overlap_area.intersection(roofing_overlap_area);
+
+            // If we offset to both the roofing_fill and skin_fill, when adjacent they would have a doubled offset area. Since they would both offset towards each other.
+            // We only apply the intersecting offset areas to skin_fill.
+            skin_part.roofing_fill = skin_part.roofing_fill.unionPolygons(roofing_overlap_area.difference(skin_roofing_overlap_intersection));
+            skin_part.skin_fill = skin_part.skin_fill.unionPolygons(skin_roofing_overlap_intersection);
         }
     }
 }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -362,10 +362,10 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
         }
         else if (!skin_part.skin_fill.empty() && !skin_part.roofing_fill.empty())
         {
-            // Find the intersection of roofing and skin offset (skin_overlap_mm) areas.
             skin_part.skin_fill = skin_part.skin_fill.offset(skin_overlap);
-            skin_part.roofing_fill =
- skin_part.roofing_fill.offset(skin_overlap).difference(skin_part.skin_fill);
+            // If we offset to both the roofing_fill and skin_fill, when adjacent they would have a doubled offset area. Since they would both offset towards each other.
+            // To avoid the doubled offset area, the overlapping areas are removed from the roofing_fill.
+            skin_part.roofing_fill = skin_part.roofing_fill.offset(skin_overlap).difference(skin_part.skin_fill);
         }
     }
 }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -89,9 +89,9 @@ void SkinInfillAreaComputation::generateSkinsAndInfill()
 
     for (SliceLayerPart& part : layer->parts)
     {
-        generateRoofing(part);
+        generateRoofingFillAndSkinFill(part);
 
-        generateTopAndBottomMostSkinSurfaces(part);
+        generateTopAndBottomMostSkinFill(part);
     }
 }
 
@@ -301,7 +301,7 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
  *
  * this function may only read/write the skin and infill from the *current* layer.
  */
-void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
+void SkinInfillAreaComputation::generateRoofingFillAndSkinFill(SliceLayerPart& part)
 {
     for(SkinPart& skin_part : part.skin_parts)
     {
@@ -592,7 +592,7 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
  * this function may only read/write the skin and infill from the *current* layer.
  */
 
-void SkinInfillAreaComputation::generateTopAndBottomMostSkinSurfaces(SliceLayerPart &part) {
+void SkinInfillAreaComputation::generateTopAndBottomMostSkinFill(SliceLayerPart &part) {
 
     for (SkinPart& skin_part : part.skin_parts) {
         Polygons filled_area_above = generateFilledAreaAbove(part, 1);

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -388,28 +388,10 @@ void SkinInfillAreaComputation::generateRoofingFillAndInnerInfill(SliceLayerPart
     const coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");
 
     Polygons filled_area_above = generateFilledAreaAbove(part, roofing_layer_count);
+    Polygons outline = skin_part.outline.offset(skin_overlap);
 
-    skin_part.skin_fill = skin_part.outline.intersection(filled_area_above);
-    skin_part.roofing_fill = skin_part.outline.difference(filled_area_above);
-
-    if (skin_overlap != 0)
-    {
-        if (!skin_part.roofing_fill.empty() && skin_part.skin_fill.empty()) // There is no skin_fill on this layer skin_overlap offset only needs to be applied to the roofing_fill
-        {
-            skin_part.roofing_fill = skin_part.roofing_fill.offset(skin_overlap);
-        }
-        else if (skin_part.roofing_fill.empty() && !skin_part.skin_fill.empty()) // There is no roofing_fill on this layer skin_overlap offset only needs to be applied to the skin_fill
-        {
-            skin_part.skin_fill = skin_part.skin_fill.offset(skin_overlap);
-        }
-        else if (!skin_part.skin_fill.empty() && !skin_part.roofing_fill.empty())
-        {
-            skin_part.skin_fill = skin_part.skin_fill.offset(skin_overlap);
-            // If we offset to both the roofing_fill and skin_fill, when adjacent they would have a doubled offset area. Since they would both offset towards each other.
-            // To avoid the doubled offset area, the overlapping areas are removed from the roofing_fill.
-            skin_part.roofing_fill = skin_part.roofing_fill.offset(skin_overlap).difference(skin_part.skin_fill);
-        }
-    }
+    skin_part.skin_fill = outline.intersection(filled_area_above);
+    skin_part.roofing_fill = outline.difference(filled_area_above);
 }
 
 void SkinInfillAreaComputation::generateInfillSupport(SliceMeshStorage& mesh)

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -397,7 +397,7 @@ Polygons SkinInfillAreaComputation::generateFilledAreaAbove(SliceLayerPart& part
  *
  * this function may only read the skin and infill from the *current* layer.
  */
-    Polygons SkinInfillAreaComputation::generateNoAirBelow(SliceLayerPart& part, size_t flooring_layer_count)
+    Polygons SkinInfillAreaComputation::generateFilledAreaBelow(SliceLayerPart& part, size_t flooring_layer_count)
     {
         if (layer_nr < flooring_layer_count)
         {
@@ -405,7 +405,7 @@ Polygons SkinInfillAreaComputation::generateFilledAreaAbove(SliceLayerPart& part
         }
         constexpr size_t min_wall_line_count = 2;
         const int lowest_flooring_layer = layer_nr - flooring_layer_count;
-        Polygons no_air_below = getOutlineOnLayer(part, lowest_flooring_layer);
+        Polygons filled_area_below = getOutlineOnLayer(part, lowest_flooring_layer);
 
         if (!no_small_gaps_heuristic)
         {
@@ -413,10 +413,10 @@ Polygons SkinInfillAreaComputation::generateFilledAreaAbove(SliceLayerPart& part
             for (int layer_nr_below = next_lowest_flooring_layer; layer_nr_below < layer_nr; layer_nr_below++)
             {
                 Polygons outlines_below = getOutlineOnLayer(part, layer_nr_below);
-                no_air_below = no_air_below.intersection(outlines_below);
+                filled_area_below = filled_area_below.intersection(outlines_below);
             }
         }
-        return no_air_below;
+        return filled_area_below;
     }
 
 /*
@@ -429,9 +429,9 @@ void SkinInfillAreaComputation::regenerateRoofingFillAndInnerInfill(SliceLayerPa
 {
     const size_t roofing_layer_count = std::min(mesh.settings.get<size_t>("roofing_layer_count"), mesh.settings.get<size_t>("top_layers"));
 
-    Polygons no_air_above = generateFilledAreaAbove(part, roofing_layer_count);
-    skin_part.roofing_fill = skin_part.outline.difference(no_air_above);
-    skin_part.skin_fill = skin_part.outline.intersection(no_air_above);
+    Polygons filled_area_above = generateFilledAreaAbove(part, roofing_layer_count);
+    skin_part.roofing_fill = skin_part.outline.difference(filled_area_above);
+    skin_part.skin_fill = skin_part.outline.intersection(filled_area_above);
 }
 
 void SkinInfillAreaComputation::generateInfillSupport(SliceMeshStorage& mesh)
@@ -647,11 +647,11 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
 void SkinInfillAreaComputation::generateTopAndBottomMostSkinSurfaces(SliceLayerPart &part) {
 
     for (SkinPart& skin_part : part.skin_parts) {
-        Polygons no_air_above = generateFilledAreaAbove(part, 1);
-        skin_part.top_most_surface_fill = skin_part.outline.difference(no_air_above);
+        Polygons filled_area_above = generateFilledAreaAbove(part, 1);
+        skin_part.top_most_surface_fill = skin_part.outline.difference(filled_area_above);
 
-        Polygons no_air_below = generateNoAirBelow(part, 1);
-        skin_part.bottom_most_surface_fill = skin_part.skin_fill.difference(no_air_below);
+        Polygons filled_area_below = generateFilledAreaBelow(part, 1);
+        skin_part.bottom_most_surface_fill = skin_part.skin_fill.difference(filled_area_below);
     }
 }
 

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -309,10 +309,14 @@ void SkinInfillAreaComputation::generateRoofingFillAndSkinFill(SliceLayerPart& p
         const coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");
 
         Polygons filled_area_above = generateFilledAreaAbove(part, roofing_layer_count);
-        Polygons outline = skin_part.outline.offset(skin_overlap);
 
-        skin_part.skin_fill = outline.intersection(filled_area_above);
-        skin_part.roofing_fill = outline.difference(filled_area_above);
+        skin_part.roofing_fill = skin_part.outline.difference(filled_area_above);
+        skin_part.skin_fill = skin_part.outline.intersection(filled_area_above);
+
+        // We remove offsets areas from roofing_fill anywhere they overlap with skin_fill.
+        // Otherwise, adjacent skin_fill and roofing_fill would have doubled offset areas. Since they both offset into each other.
+        skin_part.roofing_fill = skin_part.roofing_fill.offset(skin_overlap).difference(skin_part.skin_fill);
+        skin_part.skin_fill = skin_part.skin_fill.offset(skin_overlap);
     }
 }
 

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -306,7 +306,7 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
 {
     for(SkinPart& skin_part : part.skin_parts)
     {
-        regenerateRoofingFillAndInnerInfill(part, skin_part);
+        generateRoofingFillAndInnerInfill(part, skin_part);
     }
 }
 
@@ -382,7 +382,7 @@ Polygons SkinInfillAreaComputation::generateFilledAreaAbove(SliceLayerPart& part
  *
  * this function may only read/write the skin and infill from the *current* layer.
  */
-void SkinInfillAreaComputation::regenerateRoofingFillAndInnerInfill(SliceLayerPart& part, SkinPart& skin_part)
+void SkinInfillAreaComputation::generateRoofingFillAndInnerInfill(SliceLayerPart& part, SkinPart& skin_part)
 {
     const size_t roofing_layer_count = std::min(mesh.settings.get<size_t>("roofing_layer_count"), mesh.settings.get<size_t>("top_layers"));
     const coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -307,44 +307,6 @@ void SkinInfillAreaComputation::generateRoofing(SliceLayerPart& part)
     for(SkinPart& skin_part : part.skin_parts)
     {
         regenerateRoofingFillAndInnerInfill(part, skin_part);
-
-        // Insets are NOT generated for any layer if the top/bottom pattern is concentric.
-        // In this case, we still want to generate insets for the roofing layers based on the extra skin wall count,
-        // if the roofing pattern is not concentric.
-        if (!skin_part.roofing_fill.empty()
-            && layer_nr > 0
-            && mesh.settings.get<EFillMethod>("roofing_pattern") != EFillMethod::CONCENTRIC
-            && mesh.settings.get<EFillMethod>("top_bottom_pattern") == EFillMethod::CONCENTRIC)
-        {
-            regenerateRoofingFillAndInnerInfill(part, skin_part);
-
-            const bool concentric_skinfill_pattern =
-                   mesh.settings.get<EFillMethod>("roofing_pattern") == EFillMethod::CONCENTRIC
-                && mesh.settings.get<EFillMethod>("top_bottom_pattern") != EFillMethod::CONCENTRIC;
-
-            // If the pattern is concentric, ONLY use insets.
-            // In this case, we still want to generate skinfill for the roofing layers,
-            // but only if the roofing pattern is not concentric.
-            if(!skin_part.roofing_fill.empty() && layer_nr > 0)
-            {
-                // Regenerate the filled_area_above, and recalculate the inner and roofing infills,
-                // taking into account the extra skin wall count (only for the roofing layers).
-                if(!concentric_skinfill_pattern)
-                {
-                    regenerateRoofingFillAndInnerInfill(part, skin_part);
-                }
-            }
-            // On the contrary, unwanted insets are generated for roofing layers because of the non-concentric top/bottom pattern.
-            // In such cases we want to clear the skin insets first and then regenerate the proper roofing fill and inner infill
-            // in the concentric roofing_pattern.
-            else if(!skin_part.roofing_fill.empty() && skin_part.skin_fill.empty() && layer_nr > 0 && concentric_skinfill_pattern)
-            {
-                // Clear the skin insets for the roofing layers and regenerate the roofing fill and inner infill without taking into
-                // account the Extra Skin Wall Count.
-                skin_part.inset_paths.clear();
-                regenerateRoofingFillAndInnerInfill(part, skin_part);
-            }
-        }
     }
 }
 

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -182,13 +182,6 @@ bool SliceMeshStorage::getExtruderIsUsed(const size_t extruder_nr, const LayerIn
             {
                 return true;
             }
-            for (const SkinPart& skin_part : part.skin_parts)
-            {
-                if (! skin_part.inset_paths.empty())
-                {
-                    return true;
-                }
-            }
         }
     }
     if (settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL && settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr == extruder_nr && layer.openPolyLines.size() > 0)


### PR DESCRIPTION
We were previously not applying skin\_overlap offsets to roofing areas. I assume this was because it was causing doubled overlap areas on adjacent roofing and skin.

This is fixed by applying offset areas to roofing, but only where it would not intersect with offset areas from skin.