### PR TITLE
CURA-9074 fix tower support

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -259,7 +259,7 @@ private:
      * \param settings The settings to use for towers.
      * \param supportLayer_this The support areas in the layer for which we are
      * creating towers/struts
-     * \param towerRoofs The parts of roofs which need to expand downward until
+     * \param tower_roofs The parts of roofs which need to expand downward until
      * they have the required diameter
      * \param overhang_points stores overhang_points of each layer
      * \param layer_idx The index of the layer at which to handle towers
@@ -268,7 +268,7 @@ private:
     static void handleTowers(
         const Settings& settings,
         Polygons& supportLayer_this,
-        std::vector<Polygons>& towerRoofs,
+        std::vector<Polygons>& tower_roofs,
         std::vector<std::vector<Polygons>>& overhang_points,
         LayerIndex layer_idx,
         size_t layer_count

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1313,7 +1313,7 @@ void AreaSupport::detectOverhangPoints(const SliceDataStorage& storage, SliceMes
 }
 
 
-void AreaSupport::handleTowers(const Settings& settings, Polygons& supportLayer_this, std::vector<Polygons>& towerRoofs, std::vector<std::vector<Polygons>>& overhang_points, LayerIndex layer_idx, size_t layer_count)
+void AreaSupport::handleTowers(const Settings& settings, Polygons& supportLayer_this, std::vector<Polygons>& tower_roofs, std::vector<std::vector<Polygons>>& overhang_points, LayerIndex layer_idx, size_t layer_count)
 {
     LayerIndex layer_overhang_point = layer_idx + 1; // Start tower 1 layer below overhang point.
     if (layer_overhang_point >= static_cast<LayerIndex>(layer_count) - 1)
@@ -1321,7 +1321,7 @@ void AreaSupport::handleTowers(const Settings& settings, Polygons& supportLayer_
         return;
     }
     std::vector<Polygons>& overhang_points_here = overhang_points[layer_overhang_point]; // may be changed if an overhang point has a (smaller) overhang point directly below
-    // handle new tower roof tops
+    // handle new tower rooftops
     if (overhang_points_here.size() > 0)
     {
         { // make sure we have the lowest point (make polys empty if they have small parts below)
@@ -1342,7 +1342,7 @@ void AreaSupport::handleTowers(const Settings& settings, Polygons& supportLayer_
         {
             if (poly.size() > 0)
             {
-                towerRoofs.push_back(poly);
+                tower_roofs.push_back(poly);
             }
         }
     }
@@ -1353,9 +1353,8 @@ void AreaSupport::handleTowers(const Settings& settings, Polygons& supportLayer_
     const double tan_tower_roof_angle = tan(tower_roof_angle);
     const coord_t tower_roof_expansion_distance = layer_thickness / tan_tower_roof_angle;
     const coord_t tower_diameter = settings.get<coord_t>("support_tower_diameter");
-    for (size_t roof_idx = 0; roof_idx < towerRoofs.size(); roof_idx++)
+    for (Polygons& tower_roof: tower_roofs)
     {
-        Polygons& tower_roof = towerRoofs[roof_idx];
         if (tower_roof.size() > 0)
         {
             supportLayer_this = supportLayer_this.unionPolygons(tower_roof);

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1354,18 +1354,20 @@ void AreaSupport::handleTowers(const Settings& settings, Polygons& supportLayer_
     const coord_t tower_diameter = settings.get<coord_t>("support_tower_diameter");
     for (Polygons& tower_roof: tower_roofs)
     {
-        if (tower_roof.size() > 0)
+        if (tower_roof.size() == 0)
         {
-            supportLayer_this = supportLayer_this.unionPolygons(tower_roof);
+            continue;
+        }
 
-            if (tower_roof[0].area() < tower_diameter * tower_diameter)
-            {
-                tower_roof = tower_roof.offset(tower_roof_expansion_distance);
-            }
-            else
-            {
-                tower_roof.clear();
-            }
+        supportLayer_this = supportLayer_this.unionPolygons(tower_roof);
+
+        if (tower_roof[0].area() < tower_diameter * tower_diameter)
+        {
+            tower_roof = tower_roof.offset(tower_roof_expansion_distance);
+        }
+        else
+        {
+            tower_roof.clear();
         }
     }
 }

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1019,12 +1019,11 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
                     constexpr size_t tower_top_layer_count = 6; // number of layers after which to conclude that a tiny support area needs a tower
                     if (layer_idx < layer_count - tower_top_layer_count && layer_idx >= tower_top_layer_count + bottom_empty_layer_count)
                     {
+                        const Polygons& layer_below = xy_disallowed_per_layer[layer_idx - tower_top_layer_count - bottom_empty_layer_count];
                         const Polygons& layer_above = support_areas[layer_idx + tower_top_layer_count];
                         const Point middle = AABB(poly).getMiddle();
                         const bool has_support_above = layer_above.inside(middle);
-                        constexpr bool no_support = false;
-                        constexpr bool no_prime_tower = false;
-                        const bool has_model_below = storage.getLayerOutlines(layer_idx - tower_top_layer_count - bottom_empty_layer_count, no_support, no_prime_tower).inside(middle);
+                        const bool has_model_below = layer_below.inside(middle);
                         if (has_support_above && ! has_model_below)
                         {
                             Polygons tiny_tower_here;


### PR DESCRIPTION
Fix is fairly simple.

Tower support is removed if there is a model below the tower support. However, if the model check was done on the model boundary itself. However as any support that is going beyond the xy_disallowed area is removed from the layer this check is a bit too strict. By replacing this boundary by the xy_disallowed area the code seems to work.