### PR TITLE
Cura 9486 hide seam is printed more randomly 

### DIFF
--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -481,10 +481,25 @@ protected:
                 }
             }
 
-            if(score < best_score)
+            constexpr float EPSILON = 25.0;
+            if(fabs(best_score - score) <= EPSILON)
             {
-                best_score = score;
+                // add breaker for two candidate starting location with similar score
+                // if we don't do this then we (can) get an un-even seam
+                // ties are broken by favouring points with lower x-coord
+                // if x-coord for both points are equal then break ties by
+                // favouring points with lower y-coord
+                const Point& best_point = (*path.converted)[best_i];
+                if(fabs(here.Y - best_point.Y) <= EPSILON ? best_point.X < here.X : best_point.Y < here.Y)
+                {
+                    best_score = std::min(best_score, score);
+                    best_i = i;
+                }
+            }
+            else if(score < best_score)
+            {
                 best_i = i;
+                best_score = score;
             }
         }
 

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -491,8 +491,7 @@ protected:
                 }
             }
 
-            constexpr float EPSILON = 25.0;
-            if(score + EPSILON < best_score)
+            if(score < best_score)
             {
                 best_score = score;
                 best_i = i;

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -15,6 +15,7 @@
 #include "settings/ZSeamConfig.h" //To read the seam configuration.
 #include "utils/linearAlg2D.h" //To find the angle of corners to hide seams.
 #include "utils/polygonUtils.h"
+#include <range/v3/view/enumerate.hpp>
 
 namespace cura
 {
@@ -416,21 +417,10 @@ protected:
             return vert;
         }
 
-        const Point focus_fixed_point = (seam_config.type == EZSeamType::USER_SPECIFIED)
-                                          ? seam_config.pos
-                                          : Point(0, std::sqrt(std::numeric_limits<coord_t>::max())); //Use sqrt, so the squared size can be used when comparing distances.
-        const size_t start_from_pos = std::min_element(path.converted->begin(), path.converted->end(), [focus_fixed_point](const Point& a, const Point& b) {
-                                                           return vSize2(a - focus_fixed_point) < vSize2(b - focus_fixed_point);
-                                                       }) - path.converted->begin();
-        const size_t end_before_pos = path.converted->size() + start_from_pos;
-
-        // Find a seam position in the simple polygon:
         size_t best_i;
         float best_score = std::numeric_limits<float>::infinity();
-        for(size_t i = start_from_pos; i < end_before_pos; ++i)
+        for(const auto& [i, here]: **path.converted | ranges::views::enumerate)
         {
-            const Point& here = (*path.converted)[i % path.converted->size()];
-
             //For most seam types, the shortest distance matters. Not for SHARPEST_CORNER though.
             //For SHARPEST_CORNER, use a fixed starting score of 0.
             const coord_t distance = (combing_boundary == nullptr)
@@ -463,7 +453,7 @@ protected:
             {
             default:
             case EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_INNER:
-                if(corner_angle < 0) //Indeed a concave corner? Give it some advantage over other corners. More advantage for sharper corners.
+                if(corner_angle < 0) // Indeed a concave corner? Give it some advantage over other corners. More advantage for sharper corners.
                 {
                     score -= (-corner_angle + 1.0) * corner_shift;
                 }
@@ -498,7 +488,7 @@ protected:
             }
         }
 
-        return best_i % path.converted->size();
+        return best_i;
     }
 
     /*!


### PR DESCRIPTION
@Vandresc found some issues that should be fixed by re-introducing the tie breaker. Had to disable the point-offsetting as this wouldn't play nicely with the tiebreaker.


![pirmaide](https://user-images.githubusercontent.com/6638028/200016823-d9307bcc-faf7-454c-bdff-da1a42b43123.PNG)
![linear (1)](https://user-images.githubusercontent.com/6638028/200016834-eb719d2f-cec2-42f0-9b0e-546b6b2cd65c.PNG)

Cura-9486