### PR TITLE
[CURA-9548] Move minimum support area operation to before offsets.

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -656,13 +656,8 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage)
         mesh_support_areas_per_layer.resize(storage.print_layer_count, Polygons());
 
         generateSupportAreasForMesh(storage, *infill_settings, *roof_settings, *bottom_settings, mesh_idx, storage.print_layer_count, mesh_support_areas_per_layer);
-        const double minimum_support_area = mesh.settings.get<double>("minimum_support_area");
         for (size_t layer_idx = 0; layer_idx < storage.print_layer_count; layer_idx++)
         {
-            if (minimum_support_area > 0.0)
-            {
-                mesh_support_areas_per_layer[layer_idx].removeSmallAreas(minimum_support_area);
-            }
             global_support_areas_per_layer[layer_idx].add(mesh_support_areas_per_layer[layer_idx]);
         }
     }
@@ -1283,6 +1278,16 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
 
     Polygons overhang_extented = basic_overhang.offset(max_dist_from_lower_layer + MM2INT(0.1)); // +0.1mm for easier joining with support from layer above
     Polygons full_overhang = overhang_extented.intersection(supportLayer_supportee);
+
+    // Apply 'minimum support overhang area', which is applied before the actual support.
+    // Not to be confused with 'minimum support area', which is applied _after_ everything has been generated.
+    const auto minimum_support_area = mesh.settings.get<double>("minimum_support_area");
+    if (minimum_support_area > 0)
+    {
+        full_overhang.removeSmallAreas(minimum_support_area);
+    }
+    basic_overhang = basic_overhang.intersection(full_overhang);
+
     return std::make_pair(basic_overhang, full_overhang);
 }
 


### PR DESCRIPTION
Otherwise support expansion or x/y offset will get applied before areas below the minimum support area are removed. This is reasonable in case you _don't_ want the minimum support area to be dependent on either of those things. Our thinking about this has changed. Applying the formula in the settings brings some problems with it, since, at that point, there is no information about on how many sides the support is surrounded by model, and thus no way of knowing how much _actually_ needs to be added to the minimum support area -- thus, move it to _before_ any of that happens, and _skip_ the formula altogether.

See also front-end: https://github.com/Ultimaker/Cura/pull/13762

