### PR TITLE
CURA-9901-introduce-small-layer-temperature

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -164,6 +164,8 @@ protected:
 
     double fan_speed; //!< The fan speed to be used during this extruder plan
 
+    double temperatureFactor; //!< Temperature reduction factor for small layers
+
     /*!
      * Set the fan speed to be used while printing this extruder plan
      * 

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -50,6 +50,7 @@ ExtruderPlan::ExtruderPlan
     fan_speed_layer_time_settings(fan_speed_layer_time_settings),
     retraction_config(retraction_config),
     extraTime(0.0),
+    temperatureFactor(0.0),
     slowest_path_speed(0.0)
 {
 }
@@ -1522,6 +1523,7 @@ void ExtruderPlan::forceMinimalLayerTime(double minTime, double minimalSpeed, do
         {
             // Even at cool min speed extrusion is not taken enough time. So speed is set to cool min speed.
             target_speed = minimalSpeed;
+            temperatureFactor = 1.0;
 
             // Update stored naive time estimates
             estimates.extrude_time = total_extrude_time_at_minimum_speed;
@@ -1536,6 +1538,7 @@ void ExtruderPlan::forceMinimalLayerTime(double minTime, double minimalSpeed, do
             // Linear interpolate between total_extrude_time_at_slowest_speed and total_extrude_time_at_minimum_speed
             const double factor = (total_extrude_time_at_minimum_speed - minExtrudeTime) / (total_extrude_time_at_minimum_speed - total_extrude_time_at_slowest_speed);
             target_speed = minimalSpeed * (1.0-factor) + slowest_path_speed * factor;
+            temperatureFactor = 1.0 - factor;
 
             // Update stored naive time estimates
             estimates.extrude_time = minExtrudeTime;

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -514,8 +514,15 @@ void LayerPlanBuffer::insertTempCommands()
             avg_flow = 0.0;
         }
 
-        const Temperature print_temp = preheat_config.getTemp(extruder, avg_flow, extruder_plan.is_initial_layer);
-        const Temperature initial_print_temp = extruder_settings.get<Temperature>("material_initial_print_temperature");
+        Temperature print_temp = preheat_config.getTemp(extruder, avg_flow, extruder_plan.is_initial_layer);
+        Temperature initial_print_temp = extruder_settings.get<Temperature>("material_initial_print_temperature");
+
+        if (extruder_plan.temperatureFactor > 0) // force lower printing temperatures due to minimum layer time
+        {
+            print_temp = print_temp * (1 - extruder_plan.temperatureFactor) + extruder_plan.temperatureFactor * extruder_settings.get<Temperature>("cool_min_temperature");
+            initial_print_temp = std::min(initial_print_temp, print_temp);
+        }
+
         if (initial_print_temp == 0.0 // user doesn't want to use initial print temp feature
             || extruder_settings.get<bool>("machine_extruders_share_heater") // ignore initial print temps when extruders share a heater
             || ! extruder_used_in_meshgroup[extruder] // prime blob uses print temp rather than initial print temp


### PR DESCRIPTION
The print temperature is decreased together with the print speed, so the behavior is more gradual. In the front end it is forced that the small_layer_temperature is larger then the final_printing_temperature, but small_layer_temperatures smaller then the initial_printing_temperature are allowed.

frontend PR: https://github.com/Ultimaker/Cura/pull/13830

CURA-9901

[CURA-9901]: https://ultimaker.atlassian.net/browse/CURA-9901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ