### PR TITLE
[CURA-9921] Correct bottom-layer(s) behaviour for exclusive tolerance.

### DIFF
--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -833,9 +833,9 @@ void Slicer::buildSegments(const Mesh& mesh, const std::vector<std::pair<int32_t
                                // Compensate for points exactly on the slice-boundary, except for 'inclusive', which already handles this correctly.
                                if (slicing_tolerance != SlicingTolerance::INCLUSIVE)
                                {
-                                   p0.z += static_cast<int>(p0.z == z);
-                                   p1.z += static_cast<int>(p1.z == z);
-                                   p2.z += static_cast<int>(p2.z == z);
+                                   p0.z += static_cast<int>(p0.z == z) * -static_cast<int>(p0.z < 1);
+                                   p1.z += static_cast<int>(p1.z == z) * -static_cast<int>(p1.z < 1);
+                                   p2.z += static_cast<int>(p2.z == z) * -static_cast<int>(p2.z < 1);
                                }
 
                                SlicerSegment s;


### PR DESCRIPTION
Since all points where increased by one, this lead the exclusive tolerance, in cases where the intial layer height is smaller or equal to the 'normal' layer height, to be missing a layer, since the model would be on z=0. Since the initial layer is not on the build-plate, this causes the number of bottom layers to not apply anymore.

should fix #1606