### PR TITLE
[CURA-9907] Fix different seams on different OS's.

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -196,7 +196,7 @@ void WallToolPaths::simplifyToolPaths(std::vector<VariableWidthLines>& toolpaths
     {
         for(ExtrusionLine& line : toolpaths[toolpaths_idx])
         {
-            line = simplifier.polyline(line);
+            line = line.is_closed ? simplifier.polygon(line) : simplifier.polyline(line);
         }
     }
 }

--- a/tests/utils/IntPointTest.cpp
+++ b/tests/utils/IntPointTest.cpp
@@ -22,5 +22,12 @@ TEST(IntPointTest, TestRotationMatrix)
 
     ASSERT_EQ(rotated_in_place, rotated_in_place_2) << "Matrix composition with translate and rotate failed.";
 }
+
+TEST(IntPointTest, TestSize)
+{
+    ASSERT_EQ(sizeof(Point::X), sizeof(coord_t));
+    ASSERT_LE(sizeof(coord_t), sizeof(int64_t));
+}
+
 } // namespace cura
 // NOLINTEND(*-magic-numbers)


### PR DESCRIPTION
(Probably) due to the different ways rounding happens in cases where intersecting lines are parallel... Which were caused by always simplifying extrusion-lines as polylines, even when closed (in which case they should be simplified as polygons).