### PR TITLE
[CURA-9975] brim ignored when extruder set

### DIFF
--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -133,12 +133,6 @@ void SkirtBrim::generate()
     std::vector<Polygons> starting_outlines(extruder_count);
     std::vector<Offset> all_brim_offsets = generateBrimOffsetPlan(starting_outlines);
     
-    coord_t max_offset = 0;
-    for (const Offset& offset : all_brim_offsets)
-    {
-        max_offset = std::max(max_offset, offset.offset_value);
-    }
-    
     constexpr LayerIndex layer_nr = 0;
     const bool include_support = true;
     Polygons covered_area = storage.getLayerOutlines(layer_nr, include_support, /*include_prime_tower*/ true, /*external_polys_only*/ false);

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -366,6 +366,11 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed() const
                 ret[extruder_nr] = true;
             }
         }
+        int skirt_brim_extruder_nr = mesh_group_settings.get<int>("skirt_brim_extruder_nr");
+        if (skirt_brim_extruder_nr >= 0)
+        {
+            ret[skirt_brim_extruder_nr] = true;
+        }
     }
     else if (adhesion_type == EPlatformAdhesion::RAFT)
     {


### PR DESCRIPTION
No skirt/brim was being printed when the skirt\_brim\_extruder was not used for any other part of the print besides the skirt/brim. This is because we were checking if the extruder was in use by looking for skirt/brim ploygons before we generate them. 

The solution is to assume the extruder is in use if it is selected as the skirt/brim extruder and build plate adhesion is enabled.