### PR TITLE
[CURA-9795] Fix floating models having a floating brim and no support with adaptive layers

### DIFF
--- a/src/settings/AdaptiveLayerHeights.cpp
+++ b/src/settings/AdaptiveLayerHeights.cpp
@@ -172,7 +172,12 @@ void AdaptiveLayerHeights::calculateLayers()
         // in this case, we use the layer height with the lowest
         if (! has_added_layer)
         {
-            z_level += allowed_layer_heights.back();
+            int min_layer_height = allowed_layer_heights.back();
+            AdaptiveLayer minimum_adaptive_layer(min_layer_height);
+            z_level += min_layer_height;
+            minimum_adaptive_layer.z_position = z_level;
+            previous_layer_height = min_layer_height;
+            layers.push_back(minimum_adaptive_layer);
         }
     }
 }

--- a/src/settings/AdaptiveLayerHeights.cpp
+++ b/src/settings/AdaptiveLayerHeights.cpp
@@ -172,7 +172,7 @@ void AdaptiveLayerHeights::calculateLayers()
         // in this case, we use the layer height with the lowest
         if (! has_added_layer)
         {
-            int min_layer_height = allowed_layer_heights.back();
+            const auto& min_layer_height = allowed_layer_heights.back();
             AdaptiveLayer minimum_adaptive_layer(min_layer_height);
             z_level += min_layer_height;
             minimum_adaptive_layer.z_position = z_level;


### PR DESCRIPTION
The problem was that there were no layers being generated when there was empty space between z0 and the model.

This fix adds a layer of the minimum height in these cases.

CURA-9795