### PR TITLE
[CURA-9536]  Bottom interface missing on step inclines

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1519,7 +1519,7 @@ void AreaSupport::generateSupportRoof(SliceDataStorage& storage, const SliceMesh
 void AreaSupport::generateSupportInterfaceLayer(Polygons& support_areas, const Polygons colliding_mesh_outlines, const coord_t safety_offset, const coord_t outline_offset, const double minimum_interface_area, Polygons& interface_polygons)
 {
     Polygons model = colliding_mesh_outlines.unionPolygons();
-    interface_polygons = support_areas.intersection(model);
+    interface_polygons = support_areas.offset(safety_offset / 2).intersection(model);
     interface_polygons = interface_polygons.offset(safety_offset).intersection(support_areas); // Make sure we don't generate any models that are not printable.
     if (outline_offset != 0)
     {

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1508,7 +1508,7 @@ void AreaSupport::generateSupportRoof(SliceDataStorage& storage, const SliceMesh
         }
 
         int lower = static_cast<int>(layer_idx);
-        int upper = static_cast<int>(layer_idx + roof_layer_count + z_distance_top + 5);
+        int upper = std::min(static_cast<int>(layer_idx + roof_layer_count + z_distance_top + 5), static_cast<int>(global_support_areas_per_layer.size()) - 1);
         for (Polygons& global_support : global_support_areas_per_layer | ranges::views::slice(lower, upper))
         {
             global_support = global_support.difference(roof);


### PR DESCRIPTION
Very steep inclines and declines both were missing interface in locations where the support was very close to the model. This PR resolves the issue by correctly projecting the lower layers up on tho the support layer. 

The diagram shows a side view of some interface next to a model. The block box represents the locations in the model we are searching for areas that need interface. This applies to roofing and flooring. 

![](https://user-images.githubusercontent.com/23387864/208469966-67a7a30b-56e0-4da5-95c1-77d944aeeb52.jpeg)