### PR TITLE
[CURA-9928] Fix: Skirt was 'filling in' non-convex part of model.

### DIFF
--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -136,6 +136,10 @@ void SkirtBrim::generate()
     constexpr LayerIndex layer_nr = 0;
     const bool include_support = true;
     Polygons covered_area = storage.getLayerOutlines(layer_nr, include_support, /*include_prime_tower*/ true, /*external_polys_only*/ false);
+    if (adhesion_type == EPlatformAdhesion::SKIRT)
+    {
+        covered_area = covered_area.approxConvexHull();
+    }
 
     std::vector<Polygons> allowed_areas_per_extruder(extruder_count);
     for (int extruder_nr = 0; extruder_nr < extruder_count; extruder_nr++)


### PR DESCRIPTION
The model (or rather, the 'dissalowed areas') gets subsstracted from the skirt/brim each offset. This caused an error since, for skirt, the offsets are calculated around the aproximate convex hull, but the part that was substracted from the area which should be included in each next pass was only the model itself. So, for a skirt with > 1 line-count, a skirt-distance low enough (approx. half a line width or less) to the model, and a model that was non-convex (concave), the skirt started filling in the non-conex 'gaps' left by the model and the convex skirt outline. This now no longer happens, since the covered and allowed areas are also 'aware' of the skirts 'convexity'.

