### PR TITLE
[CURA-9800] Remove limit support retraction

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -455,21 +455,6 @@ GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
                         }
                     }
                 }
-                if (combPaths.size() == 1)
-                {
-                    CombPath comb_path = combPaths[0];
-                    if
-                    (
-                        mesh_or_extruder_settings.get<bool>("limit_support_retractions") &&
-                        combPaths.throughAir &&
-                        ! comb_path.cross_boundary &&
-                        comb_path.size() == 2 &&
-                        comb_path[0] == *last_planned_position && comb_path[1] == p
-                    )
-                    { // limit the retractions from support to support, which didn't cross anything
-                        retract = false;
-                    }
-                }
             }
 
             const coord_t maximum_travel_resolution = mesh_or_extruder_settings.get<coord_t>("meshfix_maximum_travel_resolution");

--- a/tests/LayerPlanTest.cpp
+++ b/tests/LayerPlanTest.cpp
@@ -110,7 +110,6 @@ public:
         settings->add("layer_height", "0.1");
         settings->add("layer_start_x", "0");
         settings->add("layer_start_y", "0");
-        settings->add("limit_support_retractions", "false");
         settings->add("machine_center_is_zero", "false");
         settings->add("machine_depth", "1000");
         settings->add("machine_extruders_share_nozzle", "false");


### PR DESCRIPTION
This setting limits support retractions everywhere and does not limit them much in support.

CURA-9800