### PR TITLE
[CURA-9957] Change Ordering Constraints

### DIFF
--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -18,7 +18,7 @@ class LayerPlan;
 class InsetOrderOptimizer
 {
 public:
-    using value_type = std::unordered_set<std::pair<const ExtrusionLine*, const ExtrusionLine*>>;
+    using value_type = std::unordered_multimap<const ExtrusionLine*, const ExtrusionLine*>;
 
     /*!
      * Constructor for inset ordering optimizer.

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -603,7 +603,7 @@ public:
      * \param reverse_print_direction Whether to reverse the optimized order and their printing direction.
      * \param order_requirements Pairs where first needs to be printed before second. Pointers are pointing to elements of \p polygons
      */
-    void addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, const SpaceFillType space_fill_type, const bool enable_travel_optimization = false, const coord_t wipe_dist = 0, const Ratio flow_ratio = 1.0, const std::optional<Point> near_start_location = std::optional<Point>(), const double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT, const bool reverse_print_direction = false, const std::unordered_set<std::pair<ConstPolygonPointer, ConstPolygonPointer>>& order_requirements = PathOrderOptimizer<ConstPolygonPointer>::no_order_requirements);
+    void addLinesByOptimizer(const Polygons& polygons, const GCodePathConfig& config, const SpaceFillType space_fill_type, const bool enable_travel_optimization = false, const coord_t wipe_dist = 0, const Ratio flow_ratio = 1.0, const std::optional<Point> near_start_location = std::optional<Point>(), const double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT, const bool reverse_print_direction = false, const std::unordered_multimap<ConstPolygonPointer, ConstPolygonPointer>& order_requirements = PathOrderOptimizer<ConstPolygonPointer>::no_order_requirements);
 
     /*!
      * Add polygons to the g-code with monotonic order.

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -651,7 +651,7 @@ protected:
      * \param fan_speed optional fan speed override for this path
      */
     void addLinesInGivenOrder(
-        const std::vector<PathOrderPath<ConstPolygonPointer>>& paths, 
+        const std::vector<PathOrdering<ConstPolygonPointer>>& paths,
         const GCodePathConfig& config,
         const SpaceFillType space_fill_type,
         const coord_t wipe_dist,

--- a/include/PathOrder.h
+++ b/include/PathOrder.h
@@ -4,9 +4,9 @@
 #ifndef PATHORDER_H
 #define PATHORDER_H
 
+#include "PathOrdering.h"
 #include "settings/ZSeamConfig.h" //To get the seam settings.
 #include "utils/polygonUtils.h"
-#include "PathOrderPath.h"
 
 namespace cura
 {
@@ -37,7 +37,7 @@ public:
      * pointer to the vertex data, whether to close the loop or not, the
      * direction in which to print the path and where to start the path.
      */
-    std::vector<PathOrderPath<PathType>> paths;
+    std::vector<PathOrdering<PathType>> paths;
 
     /*!
      * The location where the nozzle is assumed to start from before printing
@@ -108,7 +108,7 @@ protected:
      */
     void detectLoops()
     {
-        for(PathOrderPath<PathType>& path : paths)
+        for(PathOrdering<PathType>& path : paths)
         {
             if(path.is_closed) //Already a polygon. No need to detect loops.
             {

--- a/include/PathOrderMonotonic.h
+++ b/include/PathOrderMonotonic.h
@@ -9,7 +9,7 @@
 #include <unordered_map> //To track monotonic sequences.
 
 #include "PathOrder.h"
-#include "PathOrderPath.h"
+#include "PathOrdering.h"
 
 namespace cura
 {
@@ -41,7 +41,7 @@ template<typename PathType>
 class PathOrderMonotonic : public PathOrder<PathType>
 {
 public:
-    using Path = PathOrderPath<PathType>;
+    using Path = PathOrdering<PathType>;
     using PathOrder<PathType>::coincident_point_distance;
 
     PathOrderMonotonic(const AngleRadians monotonic_direction, const coord_t max_adjacent_distance, const Point start_point)

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -20,8 +20,6 @@
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/reverse.hpp>
 
-namespace rv = ranges::views;
-
 namespace cura
 {
 
@@ -164,7 +162,7 @@ public:
         //Add all vertices to a bucket grid so that we can find nearby endpoints quickly.
         const coord_t snap_radius = 10_mu; // 0.01mm grid cells. Chaining only needs to consider polylines which are next to each other.
         SparsePointGridInclusive<size_t> line_bucket_grid(snap_radius);
-        for(const auto& [i, path]: paths | rv::enumerate)
+        for(const auto& [i, path]: paths | ranges::views::enumerate)
         {
             if (path.converted->empty())
             {
@@ -285,14 +283,14 @@ protected:
 
             std::vector<OrderablePath> available_candidates;
             available_candidates.reserve(nearby_candidates.size());
-            for(auto& candidate : nearby_candidates | rv::filter(isPicked))
+            for(auto& candidate : nearby_candidates | ranges::views::filter(isPicked))
             {
                 available_candidates.push_back(candidate);
             }
 
             if(available_candidates.empty()) // We need to broaden our search through all candidates
             {
-                for(auto& path : paths | rv::filter(notPicked))
+                for(auto& path : paths | ranges::views::filter(notPicked))
                 {
                     available_candidates.push_back(path);
                 }
@@ -432,7 +430,7 @@ protected:
         std::vector<OrderablePath> reversed;
         //Don't replace with swap, assign or insert. They require functions that we can't implement for all template arguments for Path.
         reversed.reserve(pathsOrderPaths.size());
-        for(auto& path: pathsOrderPaths | rv::reverse)
+        for(auto& path: pathsOrderPaths | ranges::views::reverse)
         {
             reversed.push_back(path);
             reversed.back().backwards = !reversed.back().backwards;
@@ -553,7 +551,7 @@ protected:
 
         size_t best_i;
         float best_score = std::numeric_limits<float>::infinity();
-        for(const auto& [i, here]: **path.converted | rv::enumerate)
+        for(const auto& [i, here]: **path.converted | ranges::views::enumerate)
         {
             //For most seam types, the shortest distance matters. Not for SHARPEST_CORNER though.
             //For SHARPEST_CORNER, use a fixed starting score of 0.

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -387,36 +387,41 @@ protected:
             return order;
         };
 
-        std::function<void(const Path)> handle_node = [&current_position, &optimized_order, this, &visited](const Path current_node)
-        {
-            // We should make map from node <-> path for this stuff
-            for (auto& path : paths)
+        const std::function<std::nullptr_t(const Path, const std::nullptr_t)> handle_node =
+            [&current_position, &optimized_order, this, &visited]
+            (const Path current_node, const std::nullptr_t _state)
             {
-                if (path.vertices == current_node)
+                // We should make map from node <-> path for this stuff
+                for (auto& path : paths)
                 {
-                    if(path.is_closed)
+                    if (path.vertices == current_node)
                     {
-                        current_position = (*path.converted)[path.start_vertex]; //We end where we started.
-                    }
-                    else
-                    {
-                        //Pick the other end from where we started.
-                        current_position = path.start_vertex == 0 ? path.converted->back() : path.converted->front();
-                    }
+                        if(path.is_closed)
+                        {
+                            current_position = (*path.converted)[path.start_vertex]; //We end where we started.
+                        }
+                        else
+                        {
+                            //Pick the other end from where we started.
+                            current_position = path.start_vertex == 0 ? path.converted->back() : path.converted->front();
+                        }
 
-                    // Add to optimized order
-                    optimized_order.push_back(path);
+                        // Add to optimized order
+                        optimized_order.push_back(path);
 
-                    break;
+                        break;
+                    }
                 }
-            }
-        };
+
+                return nullptr;
+            };
 
         while (roots.size() != 0)
         {
             Path root = findClosestPathVertices(current_position, roots);
             roots.erase(root);
-            actions::dfs_conditional_neighbour_view(root, order_requirements, handle_node, visited, get_neighbours);
+
+            actions::dfs(root, order_requirements, handle_node, nullptr, visited, get_neighbours);
         }
 
         return optimized_order;

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -73,8 +73,6 @@ public:
      */
     std::unordered_map<Path, OrderablePath> vertices_to_paths;
 
-    std::unordered_map<int, OrderablePath> bucket_index_to_path;
-
     /*!
      * The location where the nozzle is assumed to start from before printing
      * these parts.
@@ -304,7 +302,7 @@ protected:
                 }
             }
 
-            OrderablePath best_candidate = findClosestPath_(current_position, available_candidates);
+            OrderablePath best_candidate = findClosestPath(current_position, available_candidates);
 
             OrderablePath best_path = best_candidate;
             optimized_order.push_back(best_path);
@@ -366,7 +364,7 @@ protected:
             auto local_current_position = current_position;
             while (candidates.size() != 0)
             {
-                Path best_candidate = findClosestPath(local_current_position, candidates);
+                Path best_candidate = findClosestPathVertices(local_current_position, candidates);
 
                 candidates.erase(best_candidate);
                 order.push_back(best_candidate);
@@ -421,7 +419,7 @@ protected:
 
         while (roots.size() != 0)
         {
-            Path root = findClosestPath(current_position, roots);
+            Path root = findClosestPathVertices(current_position, roots);
             roots.erase(root);
             actions::dfs_conditional_neighbour_view(root, order_requirements, handle_node, visited, get_neighbours);
         }
@@ -447,7 +445,7 @@ protected:
         return reversed;
     }
 
-    Path findClosestPath(Point start_position, std::unordered_set<Path> candidate_paths)
+    Path findClosestPathVertices(Point start_position, std::unordered_set<Path> candidate_paths)
     {
         std::vector<OrderablePath> candidate_orderable_paths;
 
@@ -456,11 +454,11 @@ protected:
             candidate_orderable_paths.push_back(vertices_to_paths.at(path));
         }
 
-        OrderablePath best_candidate = findClosestPath_(start_position, candidate_orderable_paths);
+        OrderablePath best_candidate = findClosestPath(start_position, candidate_orderable_paths);
         return best_candidate.vertices;
     }
 
-    OrderablePath findClosestPath_(Point start_position, std::vector<OrderablePath> candidate_paths)
+    OrderablePath findClosestPath(Point start_position, std::vector<OrderablePath> candidate_paths)
     // TODO: Pass in paths and make static
     {
         coord_t best_distance2 = std::numeric_limits<coord_t>::max();

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -203,7 +203,8 @@ public:
         if (order_requirements.empty())
         {
             optimized_order = getOptimizedOrder(line_bucket_grid, snap_radius);
-        } else
+        }
+        else
         {
             optimized_order = getOptimizerOrderWithConstraints(line_bucket_grid, snap_radius, order_requirements);
         }
@@ -401,12 +402,13 @@ protected:
                         //Pick the other end from where we started.
                         current_position = path.start_vertex == 0 ? path.converted->back() : path.converted->front();
                     }
+
+                    // Add to optimized order
+                    optimized_order.push_back(path);
+
                     break;
                 }
             }
-
-            // Add to optimized order
-            optimized_order.push_back(current_node);
         };
 
         while (roots.size() != 0)

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -269,8 +269,8 @@ protected:
     /*
      * Whether to print all outer walls in a group, one after another.
      *
-     * If this is enabled outer walls will be printer first and then all other
-     * walls will be printer. If reversed they will be printer last.
+     * If this is enabled outer walls will be printed first and then all other
+     * walls will be printed. If reversed they will be printed last.
      */
     bool group_outer_walls;
 
@@ -483,7 +483,7 @@ protected:
         }
         else
         {
-            while (roots.size() != 0)
+            while (!roots.empty)
             {
                 Path root = findClosestPathVertices(current_position, roots);
                 roots.erase(root);

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef PATHORDEROPTIMIZER_H

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -135,7 +135,6 @@ public:
      */
     void optimize()
     {
-        spdlog::info("getOptimizedOrder");
         if(paths.empty())
         {
             return;

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -380,21 +380,16 @@ protected:
                 order.push_back(best_candidate);
 
                 // update local_current_position
-                for (auto& path : paths)
+                auto path = vertices_to_paths[best_candidate];
+
+                if(path->is_closed)
                 {
-                    if (path.vertices == best_candidate)
-                    {
-                        if(path.is_closed)
-                        {
-                            local_current_position = (*path.converted)[path.start_vertex]; //We end where we started.
-                        }
-                        else
-                        {
-                            //Pick the other end from where we started.
-                            local_current_position = path.start_vertex == 0 ? path.converted->back() : path.converted->front();
-                        }
-                        break;
-                    }
+                    local_current_position = (*path->converted)[path->start_vertex]; //We end where we started.
+                }
+                else
+                {
+                    //Pick the other end from where we started.
+                    local_current_position = path->start_vertex == 0 ? path->converted->back() : path->converted->front();
                 }
             }
 
@@ -432,11 +427,12 @@ protected:
 
         if (group_outer_walls)
         {
-            // We want all outer walls to be printed first (For outside in ordering) or last (for inside out ordering)
-            std::unordered_set<Path> outer_walls = reverse_direction ? leaves : roots;
-
             if (reverse_direction)
             {
+                // When the order is reverse the leaves of the order requirement are the outer walls
+                std::unordered_set<Path> outer_walls = leaves;
+
+                // We don't want to add the outerwalls until after we finish all inner walls. Adding them to visited stops dfs from visiting these nodes.
                 visited.insert(outer_walls.begin(), outer_walls.end());
 
                 // Add all inner walls
@@ -457,6 +453,9 @@ protected:
             }
             else
             {
+                // The roots are the outer walls when reverse is false.
+                std::unordered_set<Path> outer_walls = roots;
+
                 // Add all outer walls
                 std::unordered_set<Path> root_neighbours;
                 while (! outer_walls.empty())
@@ -483,7 +482,7 @@ protected:
         }
         else
         {
-            while (!roots.empty)
+            while (!roots.empty())
             {
                 Path root = findClosestPathVertices(current_position, roots);
                 roots.erase(root);

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -282,14 +282,11 @@ protected:
 
         while(optimized_order.size() < paths.size())
         {
-            //First see if we already know about some nearby paths due to the line bucket grid.
-            std::vector<size_t> nearby_candidates_indexes = line_bucket_grid.getNearbyVals(current_position, snap_radius);
-
-            //Shit Code delete later?
+            //Use bucket grid to find paths within snap_radius
             std::vector<OrderablePath> nearby_candidates;
-            for (auto i : nearby_candidates_indexes)
+            for (auto i : line_bucket_grid.getNearbyVals(current_position, snap_radius))
             {
-                nearby_candidates.push_back(paths[i]);
+                nearby_candidates.push_back(paths[i]); // Convert bucket indexes to corresponding paths
             }
 
             std::vector<OrderablePath> available_candidates;

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -68,9 +68,8 @@ public:
      */
     std::vector<OrderablePath> paths;
 
-
     /*!
-     * Maps the path implementation to it's container
+     * Maps the path implementation to it's orderable path container
      */
     std::unordered_map<Path, OrderablePath> vertices_to_paths;
 

--- a/include/PathOrdering.h
+++ b/include/PathOrdering.h
@@ -24,7 +24,7 @@ namespace cura
  * with optimized paths.
  */
 template<typename PathType>
-struct PathOrderPath
+struct PathOrdering
 {
     /*!
      * Construct a new planned path.
@@ -33,7 +33,7 @@ struct PathOrderPath
      * done after all of the input paths have been added, to prevent
      * invalidating the pointers.
      */
-    PathOrderPath(const PathType& vertices, const bool is_closed = false, const size_t start_vertex = 0, const bool backwards = false)
+    PathOrdering(const PathType& vertices, const bool is_closed = false, const size_t start_vertex = 0, const bool backwards = false)
         : vertices(vertices)
         , start_vertex(start_vertex)
         , is_closed(is_closed)

--- a/include/utils/concepts/generic.h
+++ b/include/utils/concepts/generic.h
@@ -12,7 +12,7 @@ namespace cura
 template<typename T>
 concept hashable = requires(T value)
 {
-    { std::hash<T>{}(value) } -> std::convertible_to<std::size_t>;
+    { std::hash<T>{}(value) } -> concepts::convertible_to<std::size_t>;
 };
 } // namespace cura
 

--- a/include/utils/concepts/generic.h
+++ b/include/utils/concepts/generic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef CURAENGINE_GENERIC_H

--- a/include/utils/concepts/graph.h
+++ b/include/utils/concepts/graph.h
@@ -18,12 +18,6 @@ namespace cura
 template<class T>
 concept nodeable = hashable<T>;
 
-/* # stateable
- * Describing the basic requirement for a state in a graph.
- */
-template<class T>
-concept stateable = true;  // TODO: describe a proper concept for this
-
 /* # graphable
  * Describing the basic requirement for a directed graph, namely that it is a map, where the `key_type` and the `mapped_type`
  * exist and are of the same type.

--- a/include/utils/concepts/graph.h
+++ b/include/utils/concepts/graph.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef UTILS_CONCEPTS_GRAPH_H

--- a/include/utils/views/dfs.h
+++ b/include/utils/views/dfs.h
@@ -26,10 +26,9 @@ template <typename Node, typename State>
 constexpr void dfs(
     const Node& current_node,
     const isGraph auto& dag,
-    const State& state,
-    std::function<State(const Node, const Node, const State)> handle_node,
+    std::function<State(const Node, const State)> handle_node,
     isSet auto& visited,
-    const Node& parent_node = nullptr)
+    const State& state = nullptr)
 {
     if (visited.contains(current_node))
     {
@@ -37,7 +36,7 @@ constexpr void dfs(
     }
     visited.emplace(current_node);
 
-    auto current_state = handle_node(current_node, parent_node, state);
+    auto current_state = handle_node(current_node, state);
 
     const auto& [children_begin, children_end] = dag.equal_range(current_node);
     auto children = ranges::make_subrange(children_begin, children_end);
@@ -46,12 +45,28 @@ constexpr void dfs(
         dfs(
             child_node,
             dag,
-            current_state,
             handle_node,
             visited,
-            current_node
+            current_state
         );
     }
+}
+
+template <typename Node>
+constexpr void dfs_parent_view(
+    const Node& current_node,
+    const isGraph auto& dag,
+    std::function<void(const Node, const Node)> handle_node,
+    isSet auto& visited)
+{
+    const std::function<Node(const Node, const Node)> parent_view =
+        [handle_node](auto current_node, auto parent_node)
+    {
+        handle_node(current_node, parent_node);
+        return current_node;
+    };
+
+    dfs(current_node, dag, parent_view, visited);
 }
 } // namespace cura::actions
 

--- a/include/utils/views/dfs.h
+++ b/include/utils/views/dfs.h
@@ -99,15 +99,17 @@ constexpr void dfs_conditional_neighbour_view(
     const Node& current_node,
     const Graph graph,
     std::function<void(const Node)> handle_node,
+    std::unordered_set<Node> visited,
     std::function<std::vector<Node>(const Node, const Graph&)> get_neighbours)
 {
-    const std::function<void(const Node, const std::nullptr_t)> wrapped_handle_node =
-        [handle_node](auto current_node, auto depth)
+    const std::function<std::nullptr_t(const Node, const std::nullptr_t)> wrapped_handle_node =
+        [handle_node](auto current_node, auto)
     {
-        handle_node(current_node, depth);
+        handle_node(current_node);
+        return nullptr;
     };
 
-    dfs(current_node, graph, wrapped_handle_node, nullptr, std::unordered_set<Node>(), get_neighbours);
+    dfs(current_node, graph, wrapped_handle_node, nullptr, visited, get_neighbours);
 }
 } // namespace cura::actions
 

--- a/include/utils/views/dfs.h
+++ b/include/utils/views/dfs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef CURAENGINE_DFS_SORT_H

--- a/include/utils/views/dfs.h
+++ b/include/utils/views/dfs.h
@@ -19,6 +19,7 @@ namespace cura::actions
  * \param state a state that propagate
  * \param handle_node Custom call back function called at each visited node. Arguments for the functions are the current node, and the state resulted from the parent node
  * \param visited nodes as defined by concept \isSet; _note: visited will not be ordered if it is of type `unordered_###`
+ * \param parent_node the node in the dag that triggered the call to dfs on current_node.
  */
 
 template <typename Node, typename State>
@@ -26,8 +27,9 @@ constexpr void dfs(
     const Node& current_node,
     const isGraph auto& dag,
     const State& state,
-    std::function<State(const Node, const State)> handle_node,
-    isSet auto& visited)
+    std::function<State(const Node, const Node, const State)> handle_node,
+    isSet auto& visited,
+    const Node& parent_node = nullptr)
 {
     if (visited.contains(current_node))
     {
@@ -35,7 +37,7 @@ constexpr void dfs(
     }
     visited.emplace(current_node);
 
-    auto current_state = handle_node(current_node, state);
+    auto current_state = handle_node(current_node, parent_node, state);
 
     const auto& [children_begin, children_end] = dag.equal_range(current_node);
     auto children = ranges::make_subrange(children_begin, children_end);
@@ -46,7 +48,8 @@ constexpr void dfs(
             dag,
             current_state,
             handle_node,
-            visited
+            visited,
+            current_node
         );
     }
 }

--- a/include/utils/views/dfs.h
+++ b/include/utils/views/dfs.h
@@ -43,8 +43,8 @@ constexpr void dfs(
     const Node& current_node,
     const Graph& graph,
     std::function<State(const Node, const State)> handle_node,
+    std::unordered_set<Node>& visited,
     const State& state = nullptr,
-    std::unordered_set<Node> visited = std::unordered_set<Node>(),
     std::function<std::vector<Node>(const Node, const Graph&)> get_neighbours = details::get_neighbours<Node, Graph>
 ) {
     if (visited.contains(current_node))
@@ -57,7 +57,7 @@ constexpr void dfs(
 
     for (const auto& neighbour : get_neighbours(current_node, graph))
     {
-        dfs(neighbour, graph, handle_node, current_state, visited, get_neighbours);
+        dfs(neighbour, graph, handle_node, visited, current_state, get_neighbours);
     }
 }
 
@@ -70,7 +70,8 @@ constexpr void dfs_parent_state(const Node& current_node, const Graph& graph, st
         return current_node;
     };
 
-    dfs(current_node, graph, parent_view);
+    auto visited = std::unordered_set<Node>();
+    dfs(current_node, graph, parent_view, visited);
 }
 
 template<nodeable Node, graphable Graph>
@@ -81,8 +82,8 @@ constexpr void dfs_depth_state(const Node& current_node, const Graph& graph, std
         handle_node(current_node, depth);
         return depth + 1;
     };
-
-    dfs(current_node, graph, depth_view, 0u);
+    auto visited = std::unordered_set<Node>();
+    dfs(current_node, graph, depth_view, visited, 0u);
 }
 
 } // namespace cura::actions

--- a/include/utils/views/dfs.h
+++ b/include/utils/views/dfs.h
@@ -22,26 +22,31 @@ namespace cura::actions
  * \param parent_node the node in the graph that triggered the call to dfs on current_node.
  */
 
-template<nodeable Node, stateable State, graphable Graph>
+namespace details
+{
+template<nodeable Node, graphable Graph>
+std::function<std::vector<Node>(const Node, const Graph&)> get_neighbours = [](const Node current_node, const Graph& graph)
+{
+    const auto& [neighbour_begin, neighbour_end] = graph.equal_range(current_node);
+    auto neighbours_iterator = ranges::make_subrange(neighbour_begin, neighbour_end);
+    std::vector<Node> neighbours;
+    for (const auto& [_, neighbour] : neighbours_iterator)
+    {
+        neighbours.push_back(neighbour);
+    }
+    return neighbours;
+};
+};
+
+template<nodeable Node, typename State, graphable Graph>
 constexpr void dfs(
     const Node& current_node,
     const Graph& graph,
     std::function<State(const Node, const State)> handle_node,
     const State& state = nullptr,
     std::unordered_set<Node> visited = std::unordered_set<Node>(),
-    std::function<std::vector<Node>(const Node, const Graph&)> get_neighbours =
-        [](const Node current_node, const Graph& graph)
-    {
-        const auto& [neighbour_begin, neighbour_end] = graph.equal_range(current_node);
-        auto neighbours_iterator = ranges::make_subrange(neighbour_begin, neighbour_end);
-        std::vector<Node> neighbours;
-        for (const auto& [_, neighbour] : neighbours_iterator)
-        {
-            neighbours.push_back(neighbour);
-        }
-        return neighbours;
-    })
-{
+    std::function<std::vector<Node>(const Node, const Graph&)> get_neighbours = details::get_neighbours<Node, Graph>
+) {
     if (visited.contains(current_node))
     {
         return;
@@ -57,7 +62,7 @@ constexpr void dfs(
 }
 
 template<nodeable Node, graphable Graph>
-constexpr void dfs_parent_view(const Node& current_node, const Graph& graph, std::function<void(const Node, const Node)> handle_node)
+constexpr void dfs_parent_state(const Node& current_node, const Graph& graph, std::function<void(const Node, const Node)> handle_node)
 {
     const std::function<Node(const Node, const Node)> parent_view = [handle_node](auto current_node, auto parent_node)
     {
@@ -69,7 +74,7 @@ constexpr void dfs_parent_view(const Node& current_node, const Graph& graph, std
 }
 
 template<nodeable Node, graphable Graph>
-constexpr void dfs_depth_view(const Node& current_node, const Graph& graph, std::function<void(const Node, const unsigned int)> handle_node)
+constexpr void dfs_depth_state(const Node& current_node, const Graph& graph, std::function<void(const Node, const unsigned int)> handle_node)
 {
     const std::function<unsigned int(const Node, const unsigned int)> depth_view = [handle_node](auto current_node, auto depth)
     {
@@ -80,18 +85,6 @@ constexpr void dfs_depth_view(const Node& current_node, const Graph& graph, std:
     dfs(current_node, graph, depth_view, 0u);
 }
 
-template<nodeable Node, graphable Graph>
-constexpr void
-    dfs_conditional_neighbour_view(const Node& current_node, const Graph graph, std::function<void(const Node)> handle_node, std::unordered_set<Node> visited, std::function<std::vector<Node>(const Node, const Graph&)> get_neighbours)
-{
-    const std::function<std::nullptr_t(const Node, const std::nullptr_t)> wrapped_handle_node = [handle_node](auto current_node, auto)
-    {
-        handle_node(current_node);
-        return nullptr;
-    };
-
-    dfs(current_node, graph, wrapped_handle_node, nullptr, visited, get_neighbours);
-}
 } // namespace cura::actions
 
 #endif // CURAENGINE_DFS_SORT_H

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1525,7 +1525,7 @@ void FffGcodeWriter::addMeshLayerToGCode(const SliceDataStorage& storage, const 
         part_order_optimizer.addPolygon(&part);
     }
     part_order_optimizer.optimize();
-    for (const PathOrderPath<const SliceLayerPart*>& path : part_order_optimizer.paths)
+    for (const PathOrdering<const SliceLayerPart*>& path : part_order_optimizer.paths)
     {
         addMeshPartToGCode(storage, mesh, extruder_nr, mesh_config, *path.vertices, gcode_layer);
     }
@@ -2389,7 +2389,7 @@ bool FffGcodeWriter::processSkin(const SliceDataStorage& storage, LayerPlan& gco
     }
     part_order_optimizer.optimize();
 
-    for (const PathOrderPath<const SkinPart*>& path : part_order_optimizer.paths)
+    for (const PathOrdering<const SkinPart*>& path : part_order_optimizer.paths)
     {
         const SkinPart& skin_part = *path.vertices;
 
@@ -2887,7 +2887,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
     bool need_travel_to_end_of_last_spiral = true;
 
     // Print the thicker infill lines first. (double or more layer thickness, infill combined with previous layers)
-    for (const PathOrderPath<const SupportInfillPart*>& path : island_order_optimizer.paths)
+    for (const PathOrdering<const SupportInfillPart*>& path : island_order_optimizer.paths)
     {
         const SupportInfillPart& part = *path.vertices;
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1250,7 +1250,7 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
     const Settings& global_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     bool inner_to_outer = global_settings.get<EPlatformAdhesion>("adhesion_type") == EPlatformAdhesion::BRIM && // for skirt outer to inner is faster
                             train.settings.get<coord_t>("brim_gap") < line_w; // for a large brim gap it's not so bad for the overextrudate to propagate inward.
-    std::unordered_set<std::pair<ConstPolygonPointer, ConstPolygonPointer>> order_requirements;
+    std::unordered_multimap<ConstPolygonPointer, ConstPolygonPointer> order_requirements;
     for (const std::pair<SquareGrid::GridPoint, SparsePointGridInclusiveImpl::SparsePointGridInclusiveElem<BrimLineReference>>& p : grid)
     {
         const BrimLineReference& here = p.second.val;
@@ -1268,11 +1268,11 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
             }
             if ((nearby.inset_idx < here.inset_idx) == inner_to_outer)
             {
-                order_requirements.emplace(std::make_pair(nearby.poly, here.poly));
+                order_requirements.insert(std::make_pair(nearby.poly, here.poly));
             }
             else
             {
-                order_requirements.emplace(std::make_pair(here.poly, nearby.poly));
+                order_requirements.insert(std::make_pair(here.poly, nearby.poly));
             }
         }
     }

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1268,11 +1268,11 @@ void FffGcodeWriter::processSkirtBrim(const SliceDataStorage& storage, LayerPlan
             }
             if ((nearby.inset_idx < here.inset_idx) == inner_to_outer)
             {
-                order_requirements.insert(std::make_pair(nearby.poly, here.poly));
+                order_requirements.insert({nearby.poly, here.poly });
             }
             else
             {
-                order_requirements.insert(std::make_pair(here.poly, nearby.poly));
+                order_requirements.insert({ here.poly, nearby.poly });
             }
         }
     }

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -260,12 +260,19 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const auto& 
         {
             const LineLoc* root_ = root;
             const std::function<void(const LineLoc*, const LineLoc*)> set_order_constraints =
-                [&order, &min_node, &root_, graph]
+                [&order, &min_node, &root_, graph, outer_to_inner]
                 (const auto& current_node, const auto& parent_node)
                 {
                    if (min_node[current_node] == root_ && parent_node != nullptr)
                    {
-                       order.emplace(parent_node->line, current_node->line);
+                       if (outer_to_inner)
+                       {
+                           order.insert(std::make_pair(parent_node->line, current_node->line));
+                       }
+                       else
+                       {
+                           order.insert(std::make_pair(current_node->line, parent_node->line));
+                       }
                    }
                 };
 
@@ -280,7 +287,7 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const auto& 
     }
 
     // flip the key values if we want to print from inner to outer walls
-    return outer_to_inner ? order : rv::zip(order | rv::values, order | rv::keys) | rg::to<value_type>;
+    return order;
 }
 
 InsetOrderOptimizer::value_type InsetOrderOptimizer::getInsetOrder(const auto& input, const bool outer_to_inner)

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -263,12 +263,9 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const auto& 
                 [&order, &min_node, &root_, graph]
                 (const auto& current_node, const auto& parent_node)
                 {
-                   if (min_node[current_node] == root_)
+                   if (min_node[current_node] == root_ && parent_node != nullptr)
                    {
-                       if (parent_node != nullptr)
-                       {
-                           order.emplace(parent_node->line, current_node->line);
-                       }
+                       order.emplace(parent_node->line, current_node->line);
                    }
                 };
 

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -112,7 +112,7 @@ bool InsetOrderOptimizer::addToLayer()
     order_optimizer.optimize();
 
     cura::Point p_end{ 0, 0 };
-    for (const PathOrderPath<const ExtrusionLine*>& path : order_optimizer.paths)
+    for (const PathOrdering<const ExtrusionLine*>& path : order_optimizer.paths)
     {
         if (path.vertices->empty())
             continue;

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -21,7 +21,6 @@
 #include <range/v3/view/drop.hpp>
 #include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/join.hpp>
-#include <range/v3/view/map.hpp>
 #include <range/v3/view/remove_if.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/take_exactly.hpp>
@@ -94,8 +93,7 @@ bool InsetOrderOptimizer::addToLayer()
     constexpr Polygons* combing_boundary = nullptr;
     // When we alternate walls, also alternate the direction at which the first wall starts in.
     // On even layers we start with normal direction, on odd layers with inverted direction.
-    constexpr bool reverse_all_paths = false;
-    PathOrderOptimizer<const ExtrusionLine*> order_optimizer(gcode_layer.getLastPlannedPositionOrStartingPosition(), z_seam_config, detect_loops, combing_boundary, reverse_all_paths, order);
+    PathOrderOptimizer<const ExtrusionLine*> order_optimizer(gcode_layer.getLastPlannedPositionOrStartingPosition(), z_seam_config, detect_loops, combing_boundary, reverse, order);
 
     for (const auto& line : walls_to_be_added)
     {

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -109,7 +109,6 @@ bool InsetOrderOptimizer::addToLayer()
         }
     }
 
-
     order_optimizer.optimize();
 
     cura::Point p_end{ 0, 0 };
@@ -203,7 +202,7 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const auto& 
         roots.emplace(locator);
     }
 
-    std::unordered_set<std::pair<const ExtrusionLine*, const ExtrusionLine*>> order; // A linked list of the output order
+    std::unordered_multimap<const ExtrusionLine*, const ExtrusionLine*> order;
 
     for (const LineLoc* root : roots)
     {

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -91,9 +91,10 @@ bool InsetOrderOptimizer::addToLayer()
 
     constexpr bool detect_loops = false;
     constexpr Polygons* combing_boundary = nullptr;
+    constexpr bool group_outer_walls = true;
     // When we alternate walls, also alternate the direction at which the first wall starts in.
     // On even layers we start with normal direction, on odd layers with inverted direction.
-    PathOrderOptimizer<const ExtrusionLine*> order_optimizer(gcode_layer.getLastPlannedPositionOrStartingPosition(), z_seam_config, detect_loops, combing_boundary, reverse, order);
+    PathOrderOptimizer<const ExtrusionLine*> order_optimizer(gcode_layer.getLastPlannedPositionOrStartingPosition(), z_seam_config, detect_loops, combing_boundary, reverse, order, group_outer_walls);
 
     for (const auto& line : walls_to_be_added)
     {

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -230,7 +230,7 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const auto& 
                     }
                 };
 
-            actions::dfs_depth_view(root, graph, initialize_nodes);
+            actions::dfs_depth_state(root, graph, initialize_nodes);
         };
 
         // For each hole root perform a dfs, and keep track of depth from hole root
@@ -250,7 +250,7 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const auto& 
                         }
                     };
 
-                actions::dfs_depth_view(hole_root, graph, update_nodes);
+                actions::dfs_depth_state(hole_root, graph, update_nodes);
             }
         };
 
@@ -275,12 +275,12 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const auto& 
                    }
                 };
 
-            actions::dfs_parent_view(root, graph, set_order_constraints);
+            actions::dfs_parent_state(root, graph, set_order_constraints);
 
             for (auto& hole_root : hole_roots)
             {
                 root_ = hole_root;
-                actions::dfs_parent_view(hole_root, graph, set_order_constraints);
+                actions::dfs_parent_state(hole_root, graph, set_order_constraints);
             }
         }
     }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1971,7 +1971,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 {
                     gcode.writeTravel(path.points[point_idx], speed);
                 }
-                if (path.unretract_before_last_travel_move)
+                if (path.unretract_before_last_travel_move && final_travel_z == z)
                 {
                     // We need to unretract before the last travel move of the path if the next path is an outer wall.
                     gcode.writeUnretractionAndPrime();

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -647,7 +647,7 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons,
 
     if (! reverse_order)
     {
-        for (const PathOrderPath<ConstPolygonPointer>& path : orderOptimizer.paths)
+        for (const PathOrdering<ConstPolygonPointer>& path : orderOptimizer.paths)
         {
             addPolygon(*path.vertices, path.start_vertex, path.backwards, config, wall_0_wipe_dist, spiralize, flow_ratio, always_retract);
         }
@@ -656,7 +656,7 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons,
     {
         for (int index = orderOptimizer.paths.size() - 1; index >= 0; --index)
         {
-            const PathOrderPath<ConstPolygonPointer>& path = orderOptimizer.paths[index];
+            const PathOrdering<ConstPolygonPointer>& path = orderOptimizer.paths[index];
             addPolygon(**path.vertices, path.start_vertex, path.backwards, config, wall_0_wipe_dist, spiralize, flow_ratio, always_retract);
         }
     }
@@ -1147,7 +1147,7 @@ void LayerPlan::addWalls(const Polygons& walls,
         orderOptimizer.addPolygon(walls[poly_idx]);
     }
     orderOptimizer.optimize();
-    for (const PathOrderPath<ConstPolygonPointer>& path : orderOptimizer.paths)
+    for (const PathOrdering<ConstPolygonPointer>& path : orderOptimizer.paths)
     {
         addWall(**path.vertices, path.start_vertex, settings, non_bridge_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract);
     }
@@ -1199,13 +1199,13 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons,
 }
 
 
-void LayerPlan::addLinesInGivenOrder(const std::vector<PathOrderPath<ConstPolygonPointer>>& paths, const GCodePathConfig& config, const SpaceFillType space_fill_type, const coord_t wipe_dist, const Ratio flow_ratio, const double fan_speed)
+void LayerPlan::addLinesInGivenOrder(const std::vector<PathOrdering<ConstPolygonPointer>>& paths, const GCodePathConfig& config, const SpaceFillType space_fill_type, const coord_t wipe_dist, const Ratio flow_ratio, const double fan_speed)
 {
     coord_t half_line_width = config.getLineWidth() / 2;
     coord_t line_width_2 = half_line_width * half_line_width;
     for (size_t order_idx = 0; order_idx < paths.size(); order_idx++)
     {
-        const PathOrderPath<ConstPolygonPointer>& path = paths[order_idx];
+        const PathOrdering<ConstPolygonPointer>& path = paths[order_idx];
         ConstPolygonRef polyline = *path.vertices;
         const size_t start_idx = path.start_vertex;
         assert(start_idx == 0 || start_idx == polyline.size() - 1 || path.is_closed);
@@ -1274,7 +1274,7 @@ void LayerPlan::addLinesInGivenOrder(const std::vector<PathOrderPath<ConstPolygo
             // Don't wipe if next starting point is very near
             if (wipe && (order_idx < paths.size() - 1))
             {
-                const PathOrderPath<ConstPolygonPointer>& next_path = paths[order_idx + 1];
+                const PathOrdering<ConstPolygonPointer>& next_path = paths[order_idx + 1];
                 ConstPolygonRef next_polygon = *next_path.vertices;
                 const size_t next_start = next_path.start_vertex;
                 const Point& next_p0 = next_polygon[next_start];

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1163,7 +1163,7 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons,
                                     const std::optional<Point> near_start_location,
                                     const double fan_speed,
                                     const bool reverse_print_direction,
-                                    const std::unordered_set<std::pair<ConstPolygonPointer, ConstPolygonPointer>>& order_requirements)
+                                    const std::unordered_multimap<ConstPolygonPointer, ConstPolygonPointer>& order_requirements)
 {
     Polygons boundary;
     if (enable_travel_optimization && ! comb_boundary_minimum.empty())

--- a/src/PathOrderPath.cpp
+++ b/src/PathOrderPath.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2022 Ultimaker B.V.
+//Copyright (c) 2023 UltiMaker
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "PathOrdering.h" //The definitions we're implementing here.

--- a/src/PathOrderPath.cpp
+++ b/src/PathOrderPath.cpp
@@ -1,44 +1,44 @@
 //Copyright (c) 2022 Ultimaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
-#include "PathOrderPath.h" //The definitions we're implementing here.
-#include "sliceDataStorage.h" //For SliceLayerPart.
+#include "PathOrdering.h" //The definitions we're implementing here.
 #include "WallToolPaths.h"
+#include "sliceDataStorage.h" //For SliceLayerPart.
 
 namespace cura
 {
 
     template<>
-    ConstPolygonRef PathOrderPath<ConstPolygonPointer>::getVertexData()
+    ConstPolygonRef PathOrdering<ConstPolygonPointer>::getVertexData()
     {
         return *vertices;
     }
 
     template<>
-    ConstPolygonRef PathOrderPath<PolygonPointer>::getVertexData()
+    ConstPolygonRef PathOrdering<PolygonPointer>::getVertexData()
     {
         return *vertices;
     }
 
     template<>
-    ConstPolygonRef PathOrderPath<const SkinPart*>::getVertexData()
+    ConstPolygonRef PathOrdering<const SkinPart*>::getVertexData()
     {
         return vertices->outline.outerPolygon();
     }
 
     template<>
-    ConstPolygonRef PathOrderPath<const SliceLayerPart*>::getVertexData()
+    ConstPolygonRef PathOrdering<const SliceLayerPart*>::getVertexData()
     {
         return vertices->outline.outerPolygon();
     }
 
     template<>
-    ConstPolygonRef PathOrderPath<const SupportInfillPart*>::getVertexData()
+    ConstPolygonRef PathOrdering<const SupportInfillPart*>::getVertexData()
     {
         return vertices->outline.outerPolygon();
     }
     template<>
-    ConstPolygonRef PathOrderPath<const ExtrusionLine*>::getVertexData()
+    ConstPolygonRef PathOrdering<const ExtrusionLine*>::getVertexData()
     {
         if ( ! cached_vertices)
         {

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1405,7 +1405,7 @@ void SkeletalTrapezoidation::generateSegments()
               [this](edge_t* a, edge_t* b)
               {
                   if (a->to->data.distance_to_boundary == b->to->data.distance_to_boundary)
-                  { // Ordering between two 'upward' edges of the same distance is important when one of the edges is flat and connected to the other
+                  { // PathOrdering between two 'upward' edges of the same distance is important when one of the edges is flat and connected to the other
                       if (a->from->data.distance_to_boundary == a->to->data.distance_to_boundary && b->from->data.distance_to_boundary == b->to->data.distance_to_boundary)
                       {
                           coord_t max = std::numeric_limits<coord_t>::max();
@@ -1423,7 +1423,7 @@ void SkeletalTrapezoidation::generateSegments()
                       }
                       else
                       {
-                          // Ordering is not important
+                          // PathOrdering is not important
                       }
                   }
                   return a->to->data.distance_to_boundary > b->to->data.distance_to_boundary;

--- a/src/Wireframe2gcode.cpp
+++ b/src/Wireframe2gcode.cpp
@@ -641,7 +641,7 @@ void Wireframe2gcode::processSkirt()
     order.optimize();
 
     const Settings& scene_settings = Application::getInstance().current_slice->scene.settings;
-    for (const PathOrderPath<PolygonPointer>& path : order.paths)
+    for (const PathOrdering<PolygonPointer>& path : order.paths)
     {
         gcode.writeTravel((*path.vertices)[path.start_vertex], scene_settings.get<Velocity>("speed_travel"));
         for (size_t vertex_index = 0; vertex_index < path.vertices->size(); ++vertex_index)

--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -166,7 +166,7 @@ std::vector<Point> VoronoiUtils::discretizeParabola(const Point& p, const Segmen
     // are more than 10 microns away from the projected apex
     bool add_apex = (sx - px) * dir < -10 && (ex - px) * dir > 10;
 
-    assert(! (add_marking_start && add_marking_end) || add_apex);
+//    assert(! (add_marking_start && add_marking_end) || add_apex);
     if (add_marking_start && add_marking_end && ! add_apex)
     {
         spdlog::warn("Failing to discretize parabola! Must add an apex or one of the endpoints.");

--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -166,7 +166,7 @@ std::vector<Point> VoronoiUtils::discretizeParabola(const Point& p, const Segmen
     // are more than 10 microns away from the projected apex
     bool add_apex = (sx - px) * dir < -10 && (ex - px) * dir > 10;
 
-//    assert(! (add_marking_start && add_marking_end) || add_apex);
+    assert(! (add_marking_start && add_marking_end) || add_apex);
     if (add_marking_start && add_marking_end && ! add_apex)
     {
         spdlog::warn("Failing to discretize parabola! Must add an apex or one of the endpoints.");

--- a/tests/PathOrderMonotonicTest.cpp
+++ b/tests/PathOrderMonotonicTest.cpp
@@ -27,22 +27,22 @@ class PathOrderMonotonicTest : public testing::TestWithParam<std::tuple<std::str
 {
 };
 
-inline Point startVertex(const PathOrderPath<ConstPolygonPointer>& path)
+inline Point startVertex(const PathOrdering<ConstPolygonPointer>& path)
 {
     return (*path.vertices)[path.start_vertex];
 }
 
-inline Point endVertex(const PathOrderPath<ConstPolygonPointer>& path)
+inline Point endVertex(const PathOrdering<ConstPolygonPointer>& path)
 {
     return (*path.vertices)[path.vertices->size() - (1 + path.start_vertex)];
 }
 
-coord_t projectPathAlongAxis(const PathOrderPath<ConstPolygonPointer>& path, const Point& vector)
+coord_t projectPathAlongAxis(const PathOrdering<ConstPolygonPointer>& path, const Point& vector)
 {
     return dot(startVertex(path), vector);
 }
 
-coord_t projectEndAlongAxis(const PathOrderPath<ConstPolygonPointer>& path, const Point& vector)
+coord_t projectEndAlongAxis(const PathOrdering<ConstPolygonPointer>& path, const Point& vector)
 {
     return dot(endVertex(path), vector);
 }
@@ -88,7 +88,7 @@ bool getInfillLines(const std::string& filename, const AngleRadians& angle, Poly
 }
 
 #ifdef TEST_PATHS_SVG_OUTPUT
-void writeDebugSVG(const std::string& original_filename, const AngleRadians& angle, const Point& monotonic_vec, const std::vector<std::vector<PathOrderPath<ConstPolygonPointer>>>& sections)
+void writeDebugSVG(const std::string& original_filename, const AngleRadians& angle, const Point& monotonic_vec, const std::vector<std::vector<PathOrdering<ConstPolygonPointer>>>& sections)
 {
     constexpr int buff_size = 1024;
     char buff[buff_size];
@@ -149,7 +149,7 @@ TEST_P(PathOrderMonotonicTest, SectionsTest)
     object_under_test.optimize();
 
     // Collect sections:
-    std::vector<std::vector<PathOrderPath<ConstPolygonPointer>>> sections;
+    std::vector<std::vector<PathOrdering<ConstPolygonPointer>>> sections;
     sections.emplace_back();
     coord_t last_path_mono_projection = projectPathAlongAxis(object_under_test.paths.front(), monotonic_axis);
     for (const auto& path : object_under_test.paths)

--- a/tests/WallsComputationTest.cpp
+++ b/tests/WallsComputationTest.cpp
@@ -49,23 +49,19 @@ public:
     {
         square_shape.emplace_back();
         square_shape.back().emplace_back(0, 0);
-        square_shape.back().emplace_back(MM2INT(10), 0);
-        square_shape.back().emplace_back(MM2INT(10), MM2INT(10));
-        square_shape.back().emplace_back(0, MM2INT(10));
+        square_shape.back().emplace_back(MM2INT(20), 0);
+        square_shape.back().emplace_back(MM2INT(20), MM2INT(20));
+        square_shape.back().emplace_back(0, MM2INT(20));
 
         ff_holes.emplace_back();
         ff_holes.back().emplace_back(0, 0);
-        ff_holes.back().emplace_back(10000, 0);
-        ff_holes.back().emplace_back(10000, 5000);
+        ff_holes.back().emplace_back(5000, 0);
+        ff_holes.back().emplace_back(5000, 5000);
         ff_holes.back().emplace_back(0, 5000);
         ff_holes.emplace_back();
-        ff_holes.back().emplace_back(1000, 1000);
-        ff_holes.back().emplace_back(1000, 4000);
-        ff_holes.back().emplace_back(4000, 2500);
-        ff_holes.emplace_back();
-        ff_holes.back().emplace_back(6000, 1000);
-        ff_holes.back().emplace_back(6000, 4000);
-        ff_holes.back().emplace_back(9000, 2500);
+        ff_holes.back().emplace_back(6000, 9000);
+        ff_holes.back().emplace_back(9000, 7500);
+        ff_holes.back().emplace_back(6000, 6000);
 
         // Settings for a simple 2 walls, about as basic as possible.
         settings.add("alternate_extra_perimeter", "false");

--- a/tests/WallsComputationTest.cpp
+++ b/tests/WallsComputationTest.cpp
@@ -151,7 +151,7 @@ TEST_F(WallsComputationTest, WallToolPathsGetWeakOrder)
     {
         all_paths.emplace_back(line);
     }
-    std::unordered_set<std::pair<const ExtrusionLine*, const ExtrusionLine*>> order = InsetOrderOptimizer::getRegionOrder(all_paths, outer_to_inner);
+    auto order = InsetOrderOptimizer::getRegionOrder(all_paths, outer_to_inner);
 
     // Verify that something was generated.
     EXPECT_FALSE(part.wall_toolpaths.empty()) << "There must be some walls.";


### PR DESCRIPTION
Added parent to dfs handle\_node function. I chose this over passing parent as the state variable because it makes it clearer what we are doing. Also, I think this can be useful in the future when using dfs.

Added comments in InsetOrderOptimizer.cpp

Removed sibling constraint in ordering and added parent->child constraint instead.

CURA-9957