### PR TITLE
Fix gaps between skin and wall

### DIFF
--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -264,12 +264,12 @@ void SkinInfillAreaComputation::applySkinExpansion(const Polygons& original_outl
     // Remove thin pieces of support for Skin Removal Width.
     if(bottom_skin_preshrink > 0 || (min_width == 0 && bottom_skin_expand_distance != 0))
     {
-        downskin = downskin.offset(-bottom_skin_preshrink / 2, ClipperLib::jtRound).offset(bottom_skin_preshrink / 2, ClipperLib::jtRound);
+        downskin = downskin.offset(-bottom_skin_preshrink / 2, ClipperLib::jtMiter).offset(bottom_skin_preshrink / 2, ClipperLib::jtMiter).intersection(downskin);
         should_bottom_be_clipped = true;  // Rounding errors can lead to propagation of errors. This could mean that skin goes beyond the original outline
     }
     if(top_skin_preshrink > 0 || (min_width == 0 && top_skin_expand_distance != 0))
     {
-        upskin = upskin.offset(-top_skin_preshrink / 2, ClipperLib::jtRound).offset(top_skin_preshrink / 2, ClipperLib::jtRound);
+        upskin = upskin.offset(-top_skin_preshrink / 2, ClipperLib::jtMiter).offset(top_skin_preshrink / 2, ClipperLib::jtMiter);
         should_top_be_clipped = true;  // Rounding errors can lead to propagation of errors. This could mean that skin goes beyond the original outline
     }
 


### PR DESCRIPTION
Use join type miter for morphological open operation. I think the reason this is needed is best shown through an example:

### When using join type round
![Untitled Diagram drawio](https://user-images.githubusercontent.com/6638028/211870463-39621424-c7cb-4ff8-be0c-6f060ceb12c5.png)

### When using join type miter
![Untitled Diagram drawio](https://user-images.githubusercontent.com/6638028/211870845-16ee845c-6109-4597-81f9-d371f2313603.png)

Before we used round, which cases the skin to no longer be attached to walls in corners.
![211524708-6c0680d9-d7dd-4a03-8f02-f2494de08aa0-1](https://user-images.githubusercontent.com/6638028/211871073-736e95c3-2174-4a8d-9e51-7b9aba5c1a26.jpg)

Any artifacts caused by the positive offsetting using joint type miter will be mitigated because the final shapes are limited to the area of the original skin: https://github.com/Ultimaker/CuraEngine/blob/dbe17822ab036e5ccb490214ef07abe8e46139d4/src/skin.cpp#L276-L283

Fixes [11881](https://github.com/Ultimaker/Cura/issues/11881)
contributes to CURA-9204