### PR TITLE
Request meshgroup Settings `ExtruderTrain` after check for `auto`

### DIFF
--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <spdlog/spdlog.h>

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <spdlog/spdlog.h>
@@ -282,8 +282,7 @@ Polygons SliceDataStorage::getLayerOutlines(const LayerIndex layer_nr, const boo
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     if (layer_nr < 0 && layer_nr < -static_cast<LayerIndex>(Raft::getFillerLayerCount()))
     { // when processing raft
-        ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr");
-        if (include_support && (extruder_nr == -1 || extruder_nr == int(train.extruder_nr)))
+        if (include_support && (extruder_nr == -1 || extruder_nr == int(mesh_group_settings.get<ExtruderTrain&>("adhesion_extruder_nr").extruder_nr)))
         {
             if (external_polys_only)
             {


### PR DESCRIPTION
Fixes to CURA-10154 Engine crash when (adhession/support) extruder set to auto

Also fixes one of the crashes in CURA-10025

# Description

First check for the value `-1` before requesting the mesh group settings extruder train. Since the parent of that value doesn't set the `extruder_nr`

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Locally

**Test Configuration**:
* Operating System: Linux Ubuntu KDE

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change