### PR TITLE
CURA-9658 Clean up support generation

### DIFF
--- a/include/utils/polygon.h
+++ b/include/utils/polygon.h
@@ -1259,6 +1259,13 @@ public:
     void removeSmallAreas(const double min_area_size, const bool remove_holes = false);
 
     /*!
+     * Removes polygons with circumference smaller than \p min_circumference_size (in micron).
+     * Unless \p remove_holes is true, holes are not removed even if their circumference is below \p min_circumference_size.
+     * However, holes that are contained within outlines whose circumference is below the threshold are removed though.
+     */
+    void removeSmallCircumference(const coord_t min_circumference_size, const bool remove_holes = false);
+
+    /*!
      * Removes overlapping consecutive line segments which don't delimit a
      * positive area.
      *

--- a/include/utils/polygon.h
+++ b/include/utils/polygon.h
@@ -1263,7 +1263,7 @@ public:
      * Unless \p remove_holes is true, holes are not removed even if their circumference is below \p min_circumference_size.
      * However, holes that are contained within outlines whose circumference is below the threshold are removed though.
      */
-    void removeSmallCircumference(const coord_t min_circumference_size, const bool remove_holes = false);
+    [[maybe_unused]] void removeSmallCircumference(const coord_t min_circumference_size, const bool remove_holes = false);
 
     /*!
      * Removes polygons with circumference smaller than \p min_circumference_size (in micron) _and_

--- a/include/utils/polygon.h
+++ b/include/utils/polygon.h
@@ -1266,6 +1266,15 @@ public:
     void removeSmallCircumference(const coord_t min_circumference_size, const bool remove_holes = false);
 
     /*!
+     * Removes polygons with circumference smaller than \p min_circumference_size (in micron) _and_
+     * an area smaller then \p min_area_size (note that min_area_size is in mm^2, not in micron^2).
+     * Unless \p remove_holes is true, holes are not removed even if their circumference is
+     * below \p min_circumference_size and their area smaller then \p min_area_size.
+     * However, holes that are contained within outlines whose circumference is below the threshold are removed though.
+     */
+    void removeSmallAreaCircumference(const double min_area_size, const coord_t min_circumference_size, const bool remove_holes = false);
+
+    /*!
      * Removes overlapping consecutive line segments which don't delimit a
      * positive area.
      *

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -926,7 +926,7 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
                                                    // "specs" has a small area).
                                                    const auto nozzle_diameter = mesh_group_settings.get<coord_t>("machine_nozzle_size");
                                                    const coord_t min_circumference = nozzle_diameter * M_PI;
-                                                   const double min_area = INT2MM2(10 * (nozzle_diameter * nozzle_diameter) / (4 * M_PI));
+                                                   const double min_area = INT2MM2((nozzle_diameter * nozzle_diameter) / 4 * M_PI);
                                                    constexpr bool remove_holes = true;
                                                    larger_area_below.removeSmallAreaCircumference(min_area, min_circumference, remove_holes);
                                                }
@@ -1303,7 +1303,7 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
     {
         const auto nozzle_diameter = mesh.settings.get<coord_t>("machine_nozzle_size");
         const coord_t min_circumference = nozzle_diameter * M_PI;
-        const double min_area = INT2MM2(10 * (nozzle_diameter * nozzle_diameter) / (4 * M_PI));
+        const double min_area = INT2MM2((nozzle_diameter * nozzle_diameter) / 4 * M_PI);
         constexpr bool remove_holes = true;
         basic_overhang.removeSmallAreaCircumference(min_area, min_circumference, remove_holes);
     }

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -674,12 +674,6 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage)
     {
         Polygons& support_areas = global_support_areas_per_layer[layer_idx];
         support_areas = support_areas.unionPolygons();
-
-//        AABB aabb(support_areas);
-//        aabb.expand(1000);
-//        std::string name = std::string("tmp/global_support_area") + std::to_string(layer_idx) + std::string(".svg");
-//        SVG svg(name, aabb);
-//        svg.writePolygons(support_areas, SVG::Color::ORANGE, 3.0);
     }
 
     // handle support interface

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -891,7 +891,6 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
                                            Polygons larger_area_below; // the areas in the layer below that protrude beyond the area of the current layer
                                            if (layer_idx > 1)
                                            {
-                                               // shrink a little so that areas that only protrude very slightly are ignored
                                                larger_area_below = mesh.layers[layer_idx - 1].getOutlines().difference(mesh.layers[layer_idx].getOutlines());
 
                                                if (!larger_area_below.empty())

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -674,6 +674,12 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage)
     {
         Polygons& support_areas = global_support_areas_per_layer[layer_idx];
         support_areas = support_areas.unionPolygons();
+
+//        AABB aabb(support_areas);
+//        aabb.expand(1000);
+//        std::string name = std::string("tmp/global_support_area") + std::to_string(layer_idx) + std::string(".svg");
+//        SVG svg(name, aabb);
+//        svg.writePolygons(support_areas, SVG::Color::ORANGE, 3.0);
     }
 
     // handle support interface
@@ -892,9 +898,9 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
                                            if (layer_idx > 1)
                                            {
                                                // shrink a little so that areas that only protrude very slightly are ignored
-                                               larger_area_below = mesh.layers[layer_idx - 1].getOutlines().difference(mesh.layers[layer_idx].getOutlines()).offset(-layer_thickness / 10);
+                                               larger_area_below = mesh.layers[layer_idx - 1].getOutlines().difference(mesh.layers[layer_idx].getOutlines());
 
-                                               if (larger_area_below.size())
+                                               if (!larger_area_below.empty())
                                                {
                                                    // if the layer below protrudes sufficiently such that a normal support at xy_distance could be placed there,
                                                    // we don't want to use the min XY distance in that area and so we remove the wide area from larger_area_below
@@ -906,13 +912,29 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
                                                    // area_beyond_limit is the portion of the layer below's outline that lies further away from the current layer's outline than limit_distance
                                                    Polygons area_beyond_limit = mesh.layers[layer_idx - 1].getOutlines().difference(mesh.layers[layer_idx].getOutlines().offset(limit_distance));
 
-                                                   if (area_beyond_limit.size())
+                                                   if (!area_beyond_limit.empty())
                                                    {
                                                        // expand area_beyond_limit so that the inner hole fills in all the way back to the current layer's outline
                                                        // and use that to remove the regions in larger_area_below that should not use min XY because the regions are
                                                        // wide enough for a normal support to be placed there
                                                        larger_area_below = larger_area_below.difference(area_beyond_limit.offset(limit_distance + 10));
                                                    }
+                                               }
+
+                                               {
+                                                   // Remove tiny "specs" in the `larger_area_below` polygon. As the polygon is a difference between the outline of
+                                                   // the current layer and the layer below this area is _usually_ a very narrow right surrounding the model (these
+                                                   // areas are desired). However, sometimes these areas become so narrow that only tiny dots are present. As the area
+                                                   // of both the rings and the specs are very small we cannot use the `removeSmallAreas` utility function. Instead, we
+                                                   // use the `removeSmallAreaCircumference` which removes polygons if both the area and circumference exceed a certain
+                                                   // threshold; we want a small circumference to differentiate between "rings" and "specs" (both have small area but
+                                                   // specs also have small circumference) and we want a small area to differentiate between larger blobs and "specs" in
+                                                   // polygon (both have a circumference but only "specs" have a "larger blobs" both have a small circumference but only
+                                                   // "specs" has a small area).
+                                                   constexpr size_t min_circumference = 500;
+                                                   constexpr double min_area = 0.1;
+                                                   constexpr bool remove_holes = true;
+                                                   larger_area_below.removeSmallAreaCircumference(min_area, min_circumference, remove_holes);
                                                }
                                            }
 
@@ -1268,7 +1290,7 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
     Polygons basic_overhang = supportLayer_supportee.difference(supportLayer_supported);
 
     const SupportLayer& support_layer = storage.support.supportLayers[layer_idx];
-    if (support_layer.anti_overhang.size())
+    if (!support_layer.anti_overhang.empty())
     {
         // Merge anti overhang into one polygon, otherwise overlapping polygons
         // will create opposite effect.
@@ -1284,8 +1306,16 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
     //     Polygons overhang =  basic_overhang.unionPolygons(support_extension);
     //         presumably the computation above is slower than the one below
 
-    Polygons overhang_extented = basic_overhang.offset(max_dist_from_lower_layer + MM2INT(0.1)); // +0.1mm for easier joining with support from layer above
-    Polygons full_overhang = overhang_extented.intersection(supportLayer_supportee);
+    {
+        constexpr size_t min_circumference = 500;
+        constexpr double min_area_size = 0.1;
+        constexpr bool remove_holes = true;
+        basic_overhang.removeSmallAreaCircumference(min_area_size, min_circumference, remove_holes);
+    }
+
+    Polygons overhang_extended = basic_overhang.offset(max_dist_from_lower_layer + MM2INT(0.1)); // +0.1mm for easier joining with support from layer above
+    Polygons full_overhang = overhang_extended.intersection(supportLayer_supportee);
+
     return std::make_pair(basic_overhang, full_overhang);
 }
 

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -924,8 +924,9 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
                                                    // specs also have small circumference) and we want a small area to differentiate between larger blobs and "specs" in
                                                    // polygon (both have a circumference but only "specs" have a "larger blobs" both have a small circumference but only
                                                    // "specs" has a small area).
-                                                   constexpr size_t min_circumference = 500;
-                                                   constexpr double min_area = 0.1;
+                                                   const auto nozzle_diameter = mesh_group_settings.get<coord_t>("machine_nozzle_size");
+                                                   const coord_t min_circumference = nozzle_diameter * M_PI;
+                                                   const double min_area = INT2MM2(10 * (nozzle_diameter * nozzle_diameter) / (4 * M_PI));
                                                    constexpr bool remove_holes = true;
                                                    larger_area_below.removeSmallAreaCircumference(min_area, min_circumference, remove_holes);
                                                }
@@ -1300,10 +1301,11 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
     //         presumably the computation above is slower than the one below
 
     {
-        constexpr size_t min_circumference = 500;
-        constexpr double min_area_size = 0.1;
+        const auto nozzle_diameter = mesh.settings.get<coord_t>("machine_nozzle_size");
+        const coord_t min_circumference = nozzle_diameter * M_PI;
+        const double min_area = INT2MM2(10 * (nozzle_diameter * nozzle_diameter) / (4 * M_PI));
         constexpr bool remove_holes = true;
-        basic_overhang.removeSmallAreaCircumference(min_area_size, min_circumference, remove_holes);
+        basic_overhang.removeSmallAreaCircumference(min_area, min_circumference, remove_holes);
     }
 
     Polygons overhang_extended = basic_overhang.offset(max_dist_from_lower_layer + MM2INT(0.1)); // +0.1mm for easier joining with support from layer above

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -599,39 +599,7 @@ void Polygons::removeSmallAreas(const double min_area_size, const bool remove_ho
 
 void Polygons::removeSmallCircumference(const coord_t min_circumference_size, const bool remove_holes)
 {
-    Polygons new_polygon;
-
-    bool outline_is_removed = false;
-    for (ConstPolygonRef poly : paths)
-    {
-        bool is_outline = poly.area() >= 0;
-        auto circumference = poly.polygonLength();
-
-        if (is_outline)
-        {
-            if (circumference >= min_circumference_size)
-            {
-                new_polygon.add(poly);
-                outline_is_removed = false;
-            }
-            else
-            {
-                outline_is_removed = true;
-            }
-        }
-        else if (outline_is_removed)
-        {
-            // containing parent outline is removed; hole should be removed as well
-        }
-        else if (!remove_holes || circumference >= min_circumference_size)
-        {
-            // keep hole-polygon if we do not remove holes, or if its
-            // circumference is bigger then the minimum circumference size
-            new_polygon.add(poly);
-        }
-    }
-
-    *this = new_polygon;
+    removeSmallAreaCircumference(0.0, min_circumference_size, remove_holes);
 }
 
 void Polygons::removeSmallAreaCircumference(const double min_area_size, const coord_t min_circumference_size, const bool remove_holes)
@@ -647,7 +615,7 @@ void Polygons::removeSmallAreaCircumference(const double min_area_size, const co
 
         if (is_outline)
         {
-            if (circumference >= min_circumference_size && area >= min_area_size)
+            if (circumference >= min_circumference_size && std::abs(area) >= min_area_size)
             {
                 new_polygon.add(poly);
                 outline_is_removed = false;
@@ -661,7 +629,7 @@ void Polygons::removeSmallAreaCircumference(const double min_area_size, const co
         {
             // containing parent outline is removed; hole should be removed as well
         }
-        else if (!remove_holes || (circumference >= min_circumference_size && area >= min_area_size))
+        else if (!remove_holes || (circumference >= min_circumference_size && std::abs(area) >= min_area_size))
         {
             // keep hole-polygon if we do not remove holes, or if its
             // circumference is bigger then the minimum circumference size

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -634,6 +634,44 @@ void Polygons::removeSmallCircumference(const coord_t min_circumference_size, co
     *this = new_polygon;
 }
 
+void Polygons::removeSmallAreaCircumference(const double min_area_size, const coord_t min_circumference_size, const bool remove_holes)
+{
+    Polygons new_polygon;
+
+    bool outline_is_removed = false;
+    for (ConstPolygonRef poly : paths)
+    {
+        double area = poly.area();
+        auto circumference = poly.polygonLength();
+        bool is_outline = area >= 0;
+
+        if (is_outline)
+        {
+            if (circumference >= min_circumference_size && area >= min_area_size)
+            {
+                new_polygon.add(poly);
+                outline_is_removed = false;
+            }
+            else
+            {
+                outline_is_removed = true;
+            }
+        }
+        else if (outline_is_removed)
+        {
+            // containing parent outline is removed; hole should be removed as well
+        }
+        else if (!remove_holes || (circumference >= min_circumference_size && area >= min_area_size))
+        {
+            // keep hole-polygon if we do not remove holes, or if its
+            // circumference is bigger then the minimum circumference size
+            new_polygon.add(poly);
+        }
+    }
+
+    *this = new_polygon;
+}
+
 void Polygons::removeDegenerateVerts()
 {
     _removeDegenerateVerts(false);

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -597,6 +597,43 @@ void Polygons::removeSmallAreas(const double min_area_size, const bool remove_ho
     paths.resize(new_end - paths.begin());
 }
 
+void Polygons::removeSmallCircumference(const coord_t min_circumference_size, const bool remove_holes)
+{
+    Polygons new_polygon;
+
+    bool outline_is_removed = false;
+    for (ConstPolygonRef poly : paths)
+    {
+        bool is_outline = poly.area() >= 0;
+        auto circumference = poly.polygonLength();
+
+        if (is_outline)
+        {
+            if (circumference >= min_circumference_size)
+            {
+                new_polygon.add(poly);
+                outline_is_removed = false;
+            }
+            else
+            {
+                outline_is_removed = true;
+            }
+        }
+        else if (outline_is_removed)
+        {
+            // containing parent outline is removed; hole should be removed as well
+        }
+        else if (!remove_holes || circumference >= min_circumference_size)
+        {
+            // keep hole-polygon if we do not remove holes, or if its
+            // circumference is bigger then the minimum circumference size
+            new_polygon.add(poly);
+        }
+    }
+
+    *this = new_polygon;
+}
+
 void Polygons::removeDegenerateVerts()
 {
     _removeDegenerateVerts(false);


### PR DESCRIPTION
When generating support normally a layer would look something like.
<img src="https://user-images.githubusercontent.com/6638028/212685640-db7b7848-8a2c-4218-82e5-a6a7f9034c5b.png" width=400/>
In this image the colors have the following meaning:
- the **orange** polygon represents the area where overhang is not allowed to be places,
- the **bue** polygon represents the area where non-overhang is allowed to be placed and
- the **green* polygon represents the outline of the model.
The area describing the disallowed overhang support areas would sometimes have very small "specs"
<img src="https://user-images.githubusercontent.com/6638028/212687436-bbb137b8-9a90-4b0f-84bf-190a8bb09c7d.png" width=400/>

With this PR all these tiny specs are removed from the layers. These specs cause a lot of issues such floating support and as well as these "hairs" on the inside of the support.

![Screenshot 2023-01-16 at 14 22 41](https://user-images.githubusercontent.com/6638028/212688480-a01fbc59-500f-4d19-afe6-c18e153a2f45.png)

Previously we tried to remove these small specs by offsetting the polygon.
https://github.com/Ultimaker/CuraEngine/blob/2f2e068574f691ad30e91668aef8050c7310572e/src/support.cpp#L895

However this was only mitigating the problem; there is are still polygon differences for where even after offsetting the areas would roughly over lap causing these tiny specs artifacts. Instead, I propose a solution where these specs are removed by removing _all_ polygons with a small circumference.
https://github.com/Ultimaker/CuraEngine/blob/75af1ab7e5301af71d841630178da1091bc2bc5b/src/support.cpp#L1310-L1313

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2023-01-16 at 15 13 39](https://user-images.githubusercontent.com/6638028/212698593-0d7e954b-ef1b-474b-9c99-1285bc6f6a44.png) | ![Screenshot 2023-01-16 at 14 59 42](https://user-images.githubusercontent.com/6638028/212698565-5f486ac3-4390-4dcc-8ec1-b73a979ad033.png) |
| ![Screenshot 2023-01-16 at 15 57 54](https://user-images.githubusercontent.com/6638028/212708052-75fb2bae-1d3d-4f63-97bc-8024489c0533.png) | ![Screenshot 2023-01-16 at 15 56 49](https://user-images.githubusercontent.com/6638028/212708039-500beb9e-78c4-4767-850a-faa262ddd055.png) |
| ![Screenshot 2023-01-16 at 16 04 16](https://user-images.githubusercontent.com/6638028/212709487-cfebf167-8ca0-4707-a6d4-363edb7cffb7.png) | ![Screenshot 2023-01-16 at 16 05 39](https://user-images.githubusercontent.com/6638028/212709502-68261874-7197-4917-8371-1a82f609c1c6.png) |


Contributes to CURA-9658