### PR TITLE
Fix out of bound indexing error

### DIFF
--- a/src/InterlockingGenerator.cpp
+++ b/src/InterlockingGenerator.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2022 Ultimaker B.V.
+//Copyright (c) 2023 UltiMaker
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <spdlog/spdlog.h>

--- a/src/InterlockingGenerator.cpp
+++ b/src/InterlockingGenerator.cpp
@@ -194,9 +194,9 @@ void InterlockingGenerator::applyMicrostructureToOutlines(const std::unordered_s
     // Every `beam_layer_count` number of layers are combined to an interlocking beam layer
     // to store these we need ceil(max_layer_count / beam_layer_count) of these layers
     // the formula is rewritten as (max_layer_count + beam_layer_count - 1) / beam_layer_count, so it works for integer division
-    size_t num_interlocking_beams = (max_layer_count + beam_layer_count - 1) / beam_layer_count;
-    structure_per_layer[0].resize(num_interlocking_beams);
-    structure_per_layer[1].resize(num_interlocking_beams);
+    size_t num_interlocking_layers = (max_layer_count + beam_layer_count - 1) / beam_layer_count;
+    structure_per_layer[0].resize(num_interlocking_layers);
+    structure_per_layer[1].resize(num_interlocking_layers);
 
     // Only compute cell structure for half the layers, because since our beams are two layers high, every odd layer of the structure will be the same as the layer below.
     for (const GridPoint3& grid_loc : cells)

--- a/src/InterlockingGenerator.cpp
+++ b/src/InterlockingGenerator.cpp
@@ -1,8 +1,6 @@
 //Copyright (c) 2023 UltiMaker
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
-#include <spdlog/spdlog.h>
-
 #include "InterlockingGenerator.h"
 
 #include <algorithm> // max


### PR DESCRIPTION
contributes to CURA-10025

# Description
Fix crash of cura when slicing the attached interlocking model.
[EngineCrash_interlocking.3mf.zip](https://github.com/Ultimaker/CuraEngine/files/10466676/EngineCrash_interlocking.3mf.zip)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] Locally

**Test Configuration**:
* Operating System: MacOS 12.3.1

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change