### PR TITLE
[CURA-10047] Disable fuzzy skin when using interlocking.

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -704,8 +704,8 @@ void FffPolygonGenerator::processDerivedWallsSkinInfill(SliceMeshStorage& mesh)
     // combine infill
     SkinInfillAreaComputation::combineInfillLayers(mesh);
 
-    // fuzzy skin
-    if (mesh.settings.get<bool>("magic_fuzzy_skin_enabled"))
+    // Fuzzy skin. Disabled when using interlocking structures, the internal interlocking walls become fuzzy.
+    if (mesh.settings.get<bool>("magic_fuzzy_skin_enabled") && !mesh.settings.get<bool>("interlocking_enable"))
     {
         processFuzzyWalls(mesh);
     }


### PR DESCRIPTION
Disable fuzzy skin when using interlocking. Using these settings together causes the interlocking structure walls to be fuzzy (These are inside model)

merge with https://github.com/Ultimaker/Cura/pull/14341

Type of change
 Bug fix (non-breaking change which fixes an issue)
How Has This Been Tested?
 Slicing with and without fuzzy/interlocking enabled
Test Configuration:

Operating System: MacOS
Checklist:
 My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
 I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
 I have commented my code, particularly in hard-to-understand areas
 I have uploaded any files required to test this change