### PR TITLE
[CURA-10173] Move 'hole horizontal expansion' code.

### DIFF
--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2022 Ultimaker B.V.
+//Copyright (c) 2023 UltiMaker B.V.
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "layerPart.h"
@@ -58,32 +58,11 @@ void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, Sl
     {
         result = layer->polygons.splitIntoParts(union_layers || union_all_remove_holes);
     }
-    const coord_t hole_offset = settings.get<coord_t>("hole_xy_offset");
+
     for(auto & part : result)
     {
         storageLayer.parts.emplace_back();
-        if (hole_offset != 0)
-        {
-            // holes are to be expanded or shrunk
-            Polygons outline;
-            Polygons holes;
-            for (const PolygonRef poly : part)
-            {
-                if (poly.orientation())
-                {
-                    outline.add(poly);
-                }
-                else
-                {
-                    holes.add(poly.offset(hole_offset));
-                }
-            }
-            storageLayer.parts.back().outline.add(outline.difference(holes.unionPolygons()));
-        }
-        else
-        {
-            storageLayer.parts.back().outline = part;
-        }
+        storageLayer.parts.back().outline = part;
         storageLayer.parts.back().boundaryBox.calculate(storageLayer.parts.back().outline);
         if (storageLayer.parts.back().outline.empty())
         {
@@ -91,6 +70,7 @@ void createLayerWithParts(const Settings& settings, SliceLayer& storageLayer, Sl
         }
     }
 }
+
 void createLayerParts(SliceMeshStorage& mesh, Slicer* slicer)
 {
     const auto total_layers = slicer->layers.size();

--- a/src/layerPart.cpp
+++ b/src/layerPart.cpp
@@ -1,4 +1,4 @@
-//Copyright (c) 2023 UltiMaker B.V.
+//Copyright (c) 2023 UltiMaker
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "layerPart.h"

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <algorithm> // remove_if
@@ -1004,17 +1004,43 @@ void Slicer::makePolygons(Mesh& mesh, SlicingTolerance slicing_tolerance, std::v
 
     const coord_t xy_offset = mesh.settings.get<coord_t>("xy_offset");
     const coord_t xy_offset_0 = mesh.settings.get<coord_t>("xy_offset_layer_0");
+    const coord_t xy_offset_hole = mesh.settings.get<coord_t>("hole_xy_offset");
+    cura::parallel_for<size_t>
+    (
+        0,
+        layers.size(),
+        [&layers, layer_apply_initial_xy_offset, xy_offset, xy_offset_0, xy_offset_hole](size_t layer_nr)
+        {
+            const coord_t xy_offset_local = (layer_nr <= layer_apply_initial_xy_offset) ? xy_offset_0 : xy_offset;
+            if (xy_offset_local != 0)
+            {
+                layers[layer_nr].polygons = layers[layer_nr].polygons.offset(xy_offset_local, ClipperLib::JoinType::jtRound);
+            }
+            if (xy_offset_hole != 0)
+            {
+                auto parts = layers[layer_nr].polygons.splitIntoParts();
+                layers[layer_nr].polygons.clear();
 
-    cura::parallel_for<size_t>(0,
-                               layers.size(),
-                               [&layers, layer_apply_initial_xy_offset, xy_offset, xy_offset_0](size_t layer_nr)
-                               {
-                                   const coord_t xy_offset_local = (layer_nr <= layer_apply_initial_xy_offset) ? xy_offset_0 : xy_offset;
-                                   if (xy_offset_local != 0)
-                                   {
-                                       layers[layer_nr].polygons = layers[layer_nr].polygons.offset(xy_offset_local, ClipperLib::JoinType::jtRound);
-                                   }
-                               });
+                Polygons holes;
+                for (auto& part : parts)
+                {
+                    for (const PolygonRef poly : part)
+                    {
+                        if (poly.orientation())
+                        {
+                            layers[layer_nr].polygons.add(poly);
+                        }
+                        else
+                        {
+                            holes.add(poly.offset(xy_offset_hole));
+                        }
+                    }
+                }
+
+                layers[layer_nr].polygons = layers[layer_nr].polygons.difference(holes.unionPolygons());
+            }
+        }
+    );
 
     mesh.expandXY(xy_offset);
 }

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 UltiMaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <algorithm> // remove_if

--- a/tests/integration/SlicePhaseTest.cpp
+++ b/tests/integration/SlicePhaseTest.cpp
@@ -43,6 +43,7 @@ class SlicePhaseTest : public testing::Test
         scene.settings.add("meshfix_maximum_extrusion_area_deviation", "2000");
         scene.settings.add("xy_offset", "0");
         scene.settings.add("xy_offset_layer_0", "0");
+        scene.settings.add("hole_xy_offset", "0");
         scene.settings.add("support_mesh", "false");
         scene.settings.add("anti_overhang_mesh", "false");
         scene.settings.add("cutting_mesh", "false");


### PR DESCRIPTION
# Description

Hole expanding/shrinking happened after interlocking structure generation. This messed with the interlocks. The holes generated there should not be affected by expansion, holes or no.

This fixes it, by placing hole horizontal expansion with the rest of the horizontal expansion code, which happens _before_ interlocking structure generation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Hole horizontal expansion 0.0 still slices properly.
- [x] Hole horizontal expansion < 0.0 shrinks the holes that where in the model itself but not the holes generated for interlocking structures.
- [x] Hole horizontal expansion > 0.0 enlarges the holes that where in the model itself but not the holes generated for interlocking structures.

**Test Configuration**:
* Operating System: Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change