### PR TITLE
[CURA-10148] Move prime-tower-brim code when otherwise using skirt adhesion.

### DIFF
--- a/include/SkirtBrim.h
+++ b/include/SkirtBrim.h
@@ -1,4 +1,4 @@
-//Copyright (c) 2018 Ultimaker B.V.
+//Copyright (c) 2023 UltiMaker
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef SKIRT_BRIM_H
@@ -117,6 +117,15 @@ private:
      * \return An ordered list of offsets to perform in the order in which they are to be performed.
      */
     std::vector<Offset> generateBrimOffsetPlan(std::vector<Polygons>& starting_outlines);
+
+    /*!
+     * In case that the models have skirt 'adhesion', but the prime tower has a brim, the covered areas are different.
+     *
+     * Since the output of this function will need to be handled differently than the rest of the adhesion lines, have a separate function.
+     * Specifically, for skirt an additional 'approximate convex hull' is applied to the initial 'covered area', which is detrimental to brim.
+     * \return An ordered list of offsets of the prime-tower to perform in the order in which they are to be performed.
+     */
+    std::vector<Offset> generatePrimeTowerBrimForSkirtAdhesionOffsetPlan();
 
     /*!
      * Generate the primary skirt/brim of the one skirt_brim_extruder or of all extruders simultaneously.

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <spdlog/spdlog.h>
@@ -64,7 +64,6 @@ SkirtBrim::SkirtBrim(SliceDataStorage& storage) :
     }
 }
 
-
 std::vector<SkirtBrim::Offset> SkirtBrim::generateBrimOffsetPlan(std::vector<Polygons>& starting_outlines)
 {
     std::vector<Offset> all_brim_offsets;
@@ -107,6 +106,14 @@ std::vector<SkirtBrim::Offset> SkirtBrim::generateBrimOffsetPlan(std::vector<Pol
         }
     }
 
+    std::sort(all_brim_offsets.begin(), all_brim_offsets.end(), OffsetSorter);
+    return all_brim_offsets;
+}
+
+std::vector<SkirtBrim::Offset> SkirtBrim::generatePrimeTowerBrimForSkirtAdhesionOffsetPlan()
+{
+    std::vector<Offset> prime_brim_offsets;
+
     const Settings& global_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     const bool prime_tower_brim_enable = global_settings.get<bool>("prime_tower_brim_enable");
     if (adhesion_type == EPlatformAdhesion::SKIRT && prime_tower_brim_enable && storage.primeTower.enabled)
@@ -119,27 +126,23 @@ std::vector<SkirtBrim::Offset> SkirtBrim::generateBrimOffsetPlan(std::vector<Pol
         {
             const bool is_last = line_idx == line_count - 1;
             coord_t offset = gap + line_widths[extruder_nr] / 2 + line_widths[extruder_nr] * line_idx;
-            all_brim_offsets.emplace_back(&storage.primeTower.outer_poly, external_polys_only[extruder_nr], offset, offset, line_idx, extruder_nr, is_last);
+            prime_brim_offsets.emplace_back(&storage.primeTower.outer_poly, external_polys_only[extruder_nr], offset, offset, line_idx, extruder_nr, is_last);
         }
     }
 
-    std::sort(all_brim_offsets.begin(), all_brim_offsets.end(), OffsetSorter);
-
-    return all_brim_offsets;
+    std::sort(prime_brim_offsets.begin(), prime_brim_offsets.end(), OffsetSorter);
+    return prime_brim_offsets;
 }
 
 void SkirtBrim::generate()
 {
     std::vector<Polygons> starting_outlines(extruder_count);
     std::vector<Offset> all_brim_offsets = generateBrimOffsetPlan(starting_outlines);
+    std::vector<Offset> prime_brim_offsets_for_skirt = generatePrimeTowerBrimForSkirtAdhesionOffsetPlan();
     
     constexpr LayerIndex layer_nr = 0;
     const bool include_support = true;
     Polygons covered_area = storage.getLayerOutlines(layer_nr, include_support, /*include_prime_tower*/ true, /*external_polys_only*/ false);
-    if (adhesion_type == EPlatformAdhesion::SKIRT)
-    {
-        covered_area = covered_area.approxConvexHull();
-    }
 
     std::vector<Polygons> allowed_areas_per_extruder(extruder_count);
     for (int extruder_nr = 0; extruder_nr < extruder_count; extruder_nr++)
@@ -156,6 +159,22 @@ void SkirtBrim::generate()
             // so that the brim lines don't overlap with the holes by half the line width
             allowed_areas_per_extruder[extruder_nr] = allowed_areas_per_extruder[extruder_nr].difference(getInternalHoleExclusionArea(covered_area, extruder_nr));
         }
+    }
+
+    // Note that the brim generated here for the prime-tower is _only_ when the rest if the model uses skirt.
+    // If everything uses brim to begin with, _including_ the prime-tower, it's not generated here, but along the rest.
+    if (! prime_brim_offsets_for_skirt.empty())
+    {
+        // Note that his ignores the returned lengths: Less 'correct' in a sense, will be predictable for the user.
+        generatePrimaryBrim(prime_brim_offsets_for_skirt, covered_area, allowed_areas_per_extruder);
+    }
+
+    // Apply 'approximate convex hull' if the adhesion is skirt _after_ any skirt but also prime-tower-brim adhesion.
+    // Otherwise, the now expanded convex hull covered areas will mess with that brim. Fortunately this does not mess
+    // with the other area calculation above, since they are either itself a simple/convex shape or relevant for brim.
+    if (adhesion_type == EPlatformAdhesion::SKIRT)
+    {
+        covered_area = covered_area.approxConvexHull();
     }
 
     std::vector<coord_t> total_length = generatePrimaryBrim(all_brim_offsets, covered_area, allowed_areas_per_extruder);


### PR DESCRIPTION
Brim and skirt use a mutually exclusive 'covered areas'. For the skirt, it's important to do a convex hull(-ish) operation on the initial covered areas. This shouldn't be done for brim. This caused trouble in the case that brim and skirt where used together, namely, when the prime tower brim is enabled, but the adhesion is otherwise skirt. This caused the brim of the prime-tower to adhere to the convex hull like covered areas for the skirt of the rest of the models, causing a gap in the prime-tower brim. The solution is mostly just being very careful when to add what, made easy by the fact that the machine and disallowed-per-extruder areas don't need to be recalculated when (just) a convex hull operation is done afterwards.