### PR TITLE
Prevent interlocking structure being printed in midair

### DIFF
--- a/src/InterlockingGenerator.cpp
+++ b/src/InterlockingGenerator.cpp
@@ -11,11 +11,11 @@
 #include "utils/polygonUtils.h"
 #include "utils/VoxelUtils.h"
 
-namespace cura 
+namespace cura
 {
-    
+
 // TODO: optimization: only go up to the min layer count + a couple of layers instead of max_layer_count
-  
+
 void InterlockingGenerator::generateInterlockingStructure(std::vector<Slicer*>& volumes)
 {
     Settings& global_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
@@ -55,7 +55,7 @@ void InterlockingGenerator::generateInterlockingStructure(std::vector<Slicer*>& 
 
             gen.generateInterlockingStructure();
         }
-        
+
     }
 }
 
@@ -104,7 +104,7 @@ std::vector<std::unordered_set<GridPoint3>> InterlockingGenerator::getShellVoxel
         
         addBoundaryCells(rotated_polygons_per_layer, kernel, mesh_voxels);
     }
-    
+
     return voxels_per_mesh;
 }
 
@@ -232,25 +232,16 @@ void InterlockingGenerator::applyMicrostructureToOutlines(const std::unordered_s
             {
                 break;
             }
-            const Polygons* areas_here = &structure_per_layer[mesh_idx][layer_nr / beam_layer_count];
-            Polygons area_here_limited_to_outline;
-            if ( ! air_filtering
-                || air_dilation.kernel_size.x < interface_dilation.kernel_size.x // prevent voxels floating in mid air
-                || air_dilation.kernel_size.y < interface_dilation.kernel_size.y
-                || air_dilation.kernel_size.z < interface_dilation.kernel_size.z
-            )
-            {
-                area_here_limited_to_outline = *areas_here;
-                Polygons layer_outlines = layer_regions[layer_nr];
-                layer_outlines.applyMatrix(unapply_rotation);
-                area_here_limited_to_outline = area_here_limited_to_outline.intersection(layer_outlines); // Prevent structure from protruding out of the models
-                areas_here = &area_here_limited_to_outline;
-            }
+
+            Polygons layer_outlines = layer_regions[layer_nr];
+            layer_outlines.applyMatrix(unapply_rotation);
+
+            const Polygons areas_here = structure_per_layer[mesh_idx][layer_nr / beam_layer_count].intersection(layer_outlines);
             const Polygons& areas_other = structure_per_layer[ ! mesh_idx][layer_nr / beam_layer_count];
 
             SlicerLayer& layer = mesh->layers[layer_nr];
             layer.polygons = layer.polygons.difference(areas_other) // reduce layer areas inward with beams from other mesh
-                                            .unionPolygons(*areas_here); // extend layer areas outward with newly added beams
+                                            .unionPolygons(areas_here); // extend layer areas outward with newly added beams
         }
     }
 }


### PR DESCRIPTION
### Description
This PR prevents the following interlocking from happening in midair.
<img width="1680" alt="Screenshot 2023-01-24 at 17 39 04" src="https://user-images.githubusercontent.com/6638028/214637553-4c3dbd33-5820-406e-94e2-b7e786374498.png">

When inspecting the generated voxels destined for this interlocking structure we can clearly see the wrongly generated voxels.
![Screenshot 2023-01-24 at 17 38 47](https://user-images.githubusercontent.com/6638028/214644310-ee7e012e-0086-4059-b565-c9d0985b4cf8.png)
I went into a bit of a rabbit hole to what could have caused this behavior. Allow me to briefly explain what is going on.
### Analysis

Explain through the following example; here we want to create an interlocking structure between the blue and red meshes.
<img width="300" alt="Untitled Diagram-Page-3 drawio" src="https://user-images.githubusercontent.com/6638028/214644196-6bbce4c0-fdc8-485d-8a3d-939c86c6d984.png">
First we find those voxels that are located on the boundary of the combined shape (marked as green) and those that are located on the boundary of the individual. The boundary is dilated with a certain amount of voxels. The voxels where the interlocking structure is are those voxels on the boundary of the individual meshes but not on the boundary of the combined mesh (yellow voxels - green voxels).

| <img width="300" alt="Untitled Diagram-Page-1 drawio" src="https://user-images.githubusercontent.com/6638028/214644685-2c1d42d2-f3ca-4fea-9512-62fde9775f5a.png"> | <img width="300" alt="Untitled Diagram-Page-2 drawio" src="https://user-images.githubusercontent.com/6638028/214645291-d26e71ce-817b-476f-bb99-3e3411c7e5be.png"> | <img width="300" alt="Untitled Diagram-Page-4 drawio" src="https://user-images.githubusercontent.com/6638028/214643550-056cd239-842f-4ba9-9351-53e1d0fab0e4.png"> |
|--------|--------|---------|
|Voxels on the boundary of the combined mesh | Voxels on the boundary of the individual meshes  |  Voxels marking where the interlocking structure is located |

This works great in theory, however the shapes of combined mesh and the individual meshes do not completely align. That is due to this line (when removing the line the bug is resolved):

https://github.com/Ultimaker/CuraEngine/blob/c18a934fa54b7445a693de38faec4e103bbb9af4/src/InterlockingGenerator.cpp#L146

A morphological close operation is executed in order to merge both meshes together and remove any gaps in between. Removing the gaps between both meshes is indeed desired behavior. A negative side effect of this operation is that this operation may also slightly change the boundary of the polygon. As the boundary is now changed the voxels it intersects is also changed. Applying the same morphological close operation to the individual meshes caused similar but different issues, so another approach was taken.

### Solution

The solution is fairly simple;  contain the interlocking structure to always be within the boundary of the combined polygon when adding it to the individual mesh layer polygons. This step was already needed when the dilation of the individual meshes is larger then the dilation of the combined mesh, but now this limiting of the interlocking structure is _always_ limited to the combined polygon.

Applying this intersection comes with a penalty cost. However, due to the finicky nature of slightly miss-aligned voxels intersections I think this step would always be needed for those edge cases.