### PR TITLE
CURA-10201_fill-narrow-skin-with-walls

### DIFF
--- a/include/infill.h
+++ b/include/infill.h
@@ -39,6 +39,7 @@ class Infill
     coord_t max_resolution; //!< Min feature size of the output
     coord_t max_deviation; //!< Max deviation fro the original poly when enforcing max_resolution
     size_t wall_line_count; //!< Number of walls to generate at the boundary of the infill region, spaced \ref infill_line_width apart
+    coord_t small_area_width; //!< Maximum width of a small infill region to be filled with walls
     const Point infill_origin; //!< origin of the infill pattern
     bool skip_line_stitching; //!< Whether to bypass the line stitching normally performed for polyline type infills
     bool fill_gaps; //!< Whether to fill gaps in strips of infill that would be too thin to fit the infill lines. If disabled, those areas are left empty.
@@ -65,6 +66,7 @@ public:
         , coord_t max_resolution
         , coord_t max_deviation
         , size_t wall_line_count = 0
+        , coord_t small_area_width = 0
         , const Point& infill_origin = Point()
         , bool skip_line_stitching = false
         , bool fill_gaps = true
@@ -88,6 +90,7 @@ public:
     , max_resolution(max_resolution)
     , max_deviation(max_deviation)
     , wall_line_count(wall_line_count)
+    , small_area_width(small_area_width)
     , infill_origin(infill_origin)
     , skip_line_stitching(skip_line_stitching)
     , fill_gaps(fill_gaps)

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -742,6 +742,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr coord_t wipe_dist = 0;
 
         const size_t wall_line_count = base_settings.get<size_t>("raft_base_wall_count");
+        const coord_t small_area_width = 0; // A raft never has a small region due to the large horizontal expansion.
         const coord_t line_spacing = base_settings.get<coord_t>("raft_base_line_spacing");
         const Point& infill_origin = Point();
         constexpr bool skip_stitching = false;
@@ -776,6 +777,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                                max_resolution,
                                max_deviation,
                                wall_line_count,
+                               small_area_width,
                                infill_origin,
                                skip_stitching,
                                fill_gaps,
@@ -859,6 +861,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr bool connect_polygons = true; // why not?
 
         constexpr int wall_line_count = 0;
+        const coord_t small_area_width = 0; // A raft never has a small region due to the large horizontal expansion.
         const Point infill_origin = Point();
         constexpr bool skip_stitching = false;
         constexpr bool connected_zigzags = false;
@@ -883,6 +886,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                                interface_max_resolution,
                                interface_max_deviation,
                                wall_line_count,
+                               small_area_width,
                                infill_origin,
                                skip_stitching,
                                fill_gaps,
@@ -949,6 +953,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         constexpr bool zig_zaggify_infill = true;
 
         constexpr size_t wall_line_count = 0;
+        const coord_t small_area_width = 0; // A raft never has a small region due to the large horizontal expansion.
         const Point& infill_origin = Point();
         constexpr bool skip_stitching = false;
         constexpr bool connected_zigzags = false;
@@ -974,6 +979,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                                surface_max_resolution,
                                surface_max_deviation,
                                wall_line_count,
+                               small_area_width,
                                infill_origin,
                                skip_stitching,
                                fill_gaps,
@@ -1634,6 +1640,7 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
             }
 
             constexpr size_t wall_line_count = 0; // wall toolpaths are when gradual infill areas are determined
+            const coord_t small_area_width = mesh.settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
             constexpr coord_t infill_overlap = 0; // Overlap is handled when the wall toolpaths are generated
             constexpr bool skip_stitching = false;
             constexpr bool connected_zigzags = false;
@@ -1661,6 +1668,7 @@ bool FffGcodeWriter::processMultiLayerInfill(const SliceDataStorage& storage, La
                                max_resolution,
                                max_deviation,
                                wall_line_count,
+                               small_area_width,
                                infill_origin,
                                skip_stitching,
                                fill_gaps,
@@ -1837,6 +1845,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage,
             // infill region with skin above has to have at least one infill wall line
             const size_t min_skin_below_wall_count = wall_line_count > 0 ? wall_line_count : 1;
             const size_t skin_below_wall_count = density_idx == last_idx ? min_skin_below_wall_count : 0;
+            const coord_t small_area_width = mesh.settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
             wall_tool_paths.emplace_back(std::vector<VariableWidthLines>());
             const coord_t overlap = infill_overlap - (density_idx == last_idx ? 0 : wall_line_count * infill_line_width);
             Infill infill_comp(pattern,
@@ -1853,6 +1862,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage,
                                max_resolution,
                                max_deviation,
                                skin_below_wall_count,
+                               small_area_width,
                                infill_origin,
                                skip_stitching,
                                fill_gaps,
@@ -1889,6 +1899,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage,
         in_outline.removeSmallAreas(minimum_small_area);
 
         constexpr size_t wall_line_count_here = 0; // Wall toolpaths were generated in generateGradualInfill for the sparsest density, denser parts don't have walls by default
+        const coord_t small_area_width = mesh.settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
         constexpr coord_t overlap = 0; // overlap is already applied for the sparsest density in the generateGradualInfill
 
         wall_tool_paths.emplace_back();
@@ -1906,6 +1917,7 @@ bool FffGcodeWriter::processSingleLayerInfill(const SliceDataStorage& storage,
                            max_resolution,
                            max_deviation,
                            wall_line_count_here,
+                           small_area_width,
                            infill_origin,
                            skip_stitching,
                            fill_gaps,
@@ -2628,6 +2640,7 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage,
     constexpr int infill_multiplier = 1;
     constexpr int extra_infill_shift = 0;
     const size_t wall_line_count = mesh.settings.get<size_t>("skin_outline_count");
+    const coord_t small_area_width = mesh.settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
     const bool zig_zaggify_infill = pattern == EFillMethod::ZIG_ZAG;
     const bool connect_polygons = mesh.settings.get<bool>("connect_skin_polygons");
     coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");
@@ -2655,6 +2668,7 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage,
                        max_resolution,
                        max_deviation,
                        wall_line_count,
+                       small_area_width,
                        infill_origin,
                        skip_line_stitching,
                        fill_gaps,
@@ -2939,6 +2953,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                 const Polygons& area = part.infill_area_per_combine_per_density[density_idx][combine_idx];
 
                 constexpr size_t wall_count = 0; // Walls are generated somewhere else, so their layers aren't vertically combined.
+                const coord_t small_area_width = mesh_group_settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
                 constexpr bool skip_stitching = false;
                 const bool fill_gaps = density_idx == 0; // Only fill gaps for one of the densities.
                 Infill infill_comp(support_pattern,
@@ -2955,6 +2970,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                                    max_resolution,
                                    max_deviation,
                                    wall_count,
+                                   small_area_width,
                                    infill_origin,
                                    skip_stitching,
                                    fill_gaps,
@@ -3078,6 +3094,7 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, Lay
     constexpr size_t infill_multiplier = 1;
     constexpr coord_t extra_infill_shift = 0;
     const auto wall_line_count = roof_extruder.settings.get<size_t>("support_roof_wall_count");
+    const coord_t small_area_width = roof_extruder.settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
     const Point infill_origin;
     constexpr bool skip_stitching = false;
     constexpr bool fill_gaps = true;
@@ -3119,6 +3136,7 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, Lay
                             max_resolution,
                             max_deviation,
                             wall_line_count,
+                            small_area_width,
                             infill_origin,
                             skip_stitching,
                             fill_gaps,
@@ -3189,6 +3207,7 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
     constexpr size_t infill_multiplier = 1;
     constexpr coord_t extra_infill_shift = 0;
     const auto wall_line_count = bottom_extruder.settings.get<size_t>("support_bottom_wall_count");
+    const coord_t small_area_width = bottom_extruder.settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
 
     const Point infill_origin;
     constexpr bool skip_stitching = false;
@@ -3216,6 +3235,7 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
                               max_resolution,
                               max_deviation,
                               wall_line_count,
+                              small_area_width,
                               infill_origin,
                               skip_stitching,
                               fill_gaps,

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2640,7 +2640,7 @@ void FffGcodeWriter::processSkinPrintFeature(const SliceDataStorage& storage,
     constexpr int infill_multiplier = 1;
     constexpr int extra_infill_shift = 0;
     const size_t wall_line_count = mesh.settings.get<size_t>("skin_outline_count");
-    const coord_t small_area_width = mesh.settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
+    const coord_t small_area_width = mesh.settings.get<coord_t>("small_skin_width");
     const bool zig_zaggify_infill = pattern == EFillMethod::ZIG_ZAG;
     const bool connect_polygons = mesh.settings.get<bool>("connect_skin_polygons");
     coord_t max_resolution = mesh.settings.get<coord_t>("meshfix_maximum_resolution");

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -64,6 +64,7 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
     const Ratio ironing_flow = mesh.settings.get<Ratio>("ironing_flow");
     const bool enforce_monotonic_order = mesh.settings.get<bool>("ironing_monotonic");
     constexpr size_t wall_line_count = 0;
+    const coord_t small_area_width = mesh.settings.get<coord_t>("min_even_wall_line_width") * 2; // Maximum width of a region that can still be filled with one wall.
     const Point infill_origin = Point();
     const bool skip_line_stitching = enforce_monotonic_order;
 
@@ -85,7 +86,7 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
     }
     Polygons ironed_areas = areas.offset(ironing_inset);
 
-    Infill infill_generator(pattern, zig_zaggify_infill, connect_polygons, ironed_areas, line_width, line_spacing, infill_overlap, infill_multiplier, direction, layer.z - 10, shift, max_resolution, max_deviation, wall_line_count, infill_origin, skip_line_stitching);
+    Infill infill_generator(pattern, zig_zaggify_infill, connect_polygons, ironed_areas, line_width, line_spacing, infill_overlap, infill_multiplier, direction, layer.z - 10, shift, max_resolution, max_deviation, wall_line_count, small_area_width, infill_origin, skip_line_stitching);
     std::vector<VariableWidthLines> ironing_paths;
     Polygons ironing_polygons;
     Polygons ironing_lines;

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -82,9 +82,45 @@ void Infill::generate(std::vector<VariableWidthLines>& toolpaths,
 
     inner_contour = generateWallToolPaths(toolpaths, outer_contour, wall_line_count, infill_line_width, infill_overlap, settings);
 
-    // Apply a half-line-width offset if the pattern prints partly alongside the walls, to get an area that we can simply print the centreline alongside the edge.
-    // The lines along the edge must lie next to the border, not on it.
-    // This makes those algorithms a lot simpler.
+    // It does not make sense to print a pattern in a narrow region. So the infill region
+    // is split into a narrow region that will be filled with walls and the normal region
+    // that will be filled with the pattern. This split of regions is not needed if the
+    // infill pattern is concentric.
+    if (pattern != EFillMethod::CONCENTRIC)
+    {
+        // Split the infill region in a narrow region and the normal region.
+        Polygons narrow_infill = inner_contour;
+        inner_contour = inner_contour.offset(-small_area_width / 2).offset(small_area_width / 2);
+        narrow_infill = narrow_infill.intersection(narrow_infill.difference(inner_contour));
+        narrow_infill = Simplify(max_resolution, max_deviation, 0).polygon(narrow_infill);
+
+        // Small corners of a bigger area should not be considered narrow and are therefore added to the bigger area again.
+        for (PolygonsPart& narrow_infill_part : narrow_infill.splitIntoParts())
+        {
+            if (narrow_infill_part.offset(-infill_line_width / 2).offset(infill_line_width / 2).area() < infill_line_width * infill_line_width * 10)
+            {
+                if (! inner_contour.intersection(narrow_infill_part.offset(infill_line_width / 4)).empty())
+                {
+                    narrow_infill = narrow_infill.difference(narrow_infill_part);
+                    inner_contour = inner_contour.unionPolygons(narrow_infill_part);
+                }
+            }
+        }
+
+        // Fill narrow area with walls.
+        const size_t narrow_wall_count = std::round(small_area_width / infill_line_width) + 1;
+        WallToolPaths wall_toolpaths(narrow_infill, infill_line_width, narrow_wall_count, 0, settings);
+        std::vector<VariableWidthLines> narrow_infill_paths = wall_toolpaths.getToolPaths();
+        if (! narrow_infill_paths.empty())
+        {
+            for (const auto& narrow_infill_path : narrow_infill_paths)
+            {
+                toolpaths.push_back(narrow_infill_path);
+            }
+        }
+    }
+
+    // apply an extra offset in case the pattern prints along the sides of the area.
     if (pattern == EFillMethod::ZIG_ZAG // Zig-zag prints the zags along the walls.
         || (zig_zaggify
             && (pattern == EFillMethod::LINES // Zig-zaggified infill patterns print their zags along the walls.
@@ -92,49 +128,9 @@ void Infill::generate(std::vector<VariableWidthLines>& toolpaths,
                 || pattern == EFillMethod::GYROID || pattern == EFillMethod::CROSS || pattern == EFillMethod::CROSS_3D))
         || infill_multiplier % 2 == 0) // Multiplied infill prints loops of infill, partly along the walls, if even. For odd multipliers >1 it gets offset by the multiply algorithm itself.
     {
-        // Get gaps beforehand (that are caused when the 1/2 line width inset is done after this):
-        // (Note that we give it a _full_ line width here, because unlike the old situation this can produce walls that are actually smaller than that.)
-        constexpr coord_t gap_wall_count = 1; // Only need one wall here, less even, in a sense.
-        constexpr coord_t wall_0_inset = 0; // Don't apply any outer wall inset for these. That's just for the outer wall.
-        WallToolPaths wall_toolpaths(inner_contour, infill_line_width, gap_wall_count, wall_0_inset, settings);
-        std::vector<VariableWidthLines> gap_fill_paths = wall_toolpaths.getToolPaths();
-
-        // Add the gap filling to the toolpaths and make the new inner contour 'aware' of the gap infill:
-        // (Can't use getContours here, because only _some_ of the lines Arachne has generated are needed.)
-        Polygons gap_filled_areas;
-        for (const auto& var_width_line : gap_fill_paths)
-        {
-            VariableWidthLines thin_walls_only;
-            for (const auto& extrusion : var_width_line)
-            {
-                if (extrusion.is_odd && extrusion.inset_idx == 0)
-                {
-                    Polygon path;
-                    for (const auto& junction : extrusion.junctions)
-                    {
-                        path.add(junction.p);
-                    }
-                    if (path.polygonLength() >= infill_line_width * 4) // Don't fill gaps that are very small (with paths less than 2 line widths long, 4 back and forth).
-                    {
-                        gap_filled_areas.add(path);
-                        if (fill_gaps)
-                        {
-                            thin_walls_only.push_back(extrusion);
-                        }
-                    }
-                }
-            }
-            if (! thin_walls_only.empty())
-            {
-                toolpaths.push_back(thin_walls_only);
-            }
-        }
-        gap_filled_areas = gap_filled_areas.offsetPolyLine(infill_line_width / 2).unionPolygons();
-
-        // Now do the actual inset, to make place for the extra 'zig-zagify' lines:
-        inner_contour = inner_contour.difference(gap_filled_areas).offset(-infill_line_width / 2);
+        inner_contour = inner_contour.offset(-infill_line_width / 2);
+        inner_contour = Simplify(max_resolution, max_deviation, 0).polygon(inner_contour);
     }
-    inner_contour = Simplify(max_resolution, max_deviation, 0).polygon(inner_contour);
 
     if (infill_multiplier > 1)
     {

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -86,7 +86,7 @@ void Infill::generate(std::vector<VariableWidthLines>& toolpaths,
     // is split into a narrow region that will be filled with walls and the normal region
     // that will be filled with the pattern. This split of regions is not needed if the
     // infill pattern is concentric.
-    if (pattern != EFillMethod::CONCENTRIC)
+    if (pattern != EFillMethod::CONCENTRIC && small_area_width > 0)
     {
         // Split the infill region in a narrow region and the normal region.
         Polygons narrow_infill = inner_contour;


### PR DESCRIPTION
So far only skin with a width of one line was printed with a wall instead the normal pattern. But with this contribution the width of the skin regions that need to be filled with walls is exposed to the user interface.

Small skin region cause jerky motions for a normal lines pattern. Especially when printing at higher speeds you get more vibrations in the printer and the visual quality of the top layer is reduced. Since the printer needs to slow down for every turn also productivity is impacted.

frontend: https://github.com/Ultimaker/Cura/pull/14386