### PR TITLE
CURA-9976 - Fixes engine crash in skeletal trapezoidation 

### DIFF
--- a/benchmark/wall_benchmark.h
+++ b/benchmark/wall_benchmark.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef CURAENGINE_WALL_BENCHMARK_H
@@ -58,6 +58,7 @@ public:
         settings.add("meshfix_maximum_deviation", "0.1");
         settings.add("meshfix_maximum_extrusion_area_deviation", "0.01");
         settings.add("meshfix_maximum_resolution", "0.01");
+        settings.add("min_wall_line_width", "0.3");
         settings.add("min_bead_width", "0");
         settings.add("min_feature_size", "0");
         settings.add("wall_0_extruder_nr", "0");

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -51,6 +51,10 @@ WallToolPaths::WallToolPaths(const Polygons& outline, const coord_t bead_width_0
 const std::vector<VariableWidthLines>& WallToolPaths::generate()
 {
     const coord_t allowed_distance = settings.get<coord_t>("meshfix_maximum_deviation");
+
+    // Sometimes small slivers of polygons mess up the prepared_outline. By performing an open-close operation
+    // 1/4 of the min_wall_line_width these slivers are removed, while still keeping enough information to not
+    // degrade the print quality; These features can't be printed anyhow. See PR CuraEngine#1811 for some screenshots
     const coord_t open_close_distance = settings.get<coord_t>("min_wall_line_width") / 4;
     const coord_t epsilon_offset = (allowed_distance / 2) - 1;
     const AngleRadians transitioning_angle = settings.get<AngleRadians>("wall_transition_angle");

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -51,13 +51,14 @@ WallToolPaths::WallToolPaths(const Polygons& outline, const coord_t bead_width_0
 const std::vector<VariableWidthLines>& WallToolPaths::generate()
 {
     const coord_t allowed_distance = settings.get<coord_t>("meshfix_maximum_deviation");
+    const coord_t open_close_distance = settings.get<coord_t>("min_wall_line_width") / 4;
     const coord_t epsilon_offset = (allowed_distance / 2) - 1;
     const AngleRadians transitioning_angle = settings.get<AngleRadians>("wall_transition_angle");
     constexpr coord_t discretization_step_size = MM2INT(0.8);
 
     // Simplify outline for boost::voronoi consumption. Absolutely no self intersections or near-self intersections allowed:
     // TODO: Open question: Does this indeed fix all (or all-but-one-in-a-million) cases for manifold but otherwise possibly complex polygons?
-    Polygons prepared_outline = outline.offset(-allowed_distance).offset(allowed_distance * 2).offset(-allowed_distance);
+    Polygons prepared_outline = outline.offset(-open_close_distance).offset(open_close_distance * 2).offset(-open_close_distance);
     prepared_outline = Simplify(settings).polygon(prepared_outline);
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <algorithm> //For std::partition_copy and std::min_element.
 #include <unordered_set>
@@ -57,7 +57,7 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
 
     // Simplify outline for boost::voronoi consumption. Absolutely no self intersections or near-self intersections allowed:
     // TODO: Open question: Does this indeed fix all (or all-but-one-in-a-million) cases for manifold but otherwise possibly complex polygons?
-    Polygons prepared_outline = outline.offset(-epsilon_offset).offset(epsilon_offset * 2).offset(-epsilon_offset);
+    Polygons prepared_outline = outline.offset(-allowed_distance).offset(allowed_distance * 2).offset(-allowed_distance);
     prepared_outline = Simplify(settings).polygon(prepared_outline);
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();

--- a/tests/WallsComputationTest.cpp
+++ b/tests/WallsComputationTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 UltiMaker
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <range/v3/view/join.hpp>
@@ -75,6 +75,7 @@ public:
         settings.add("meshfix_maximum_deviation", "0.1");
         settings.add("meshfix_maximum_extrusion_area_deviation", "0.01");
         settings.add("meshfix_maximum_resolution", "0.01");
+        settings.add("min_wall_line_width", "0.3");
         settings.add("min_bead_width", "0");
         settings.add("min_feature_size", "0");
         settings.add("wall_0_extruder_nr", "0");


### PR DESCRIPTION
# Description

Investigating the crashes with the Visual Debugger (See https://github.com/Ultimaker/CuraEngine/pull/1806 ) showed that the polygons, fed into the Skeletaltrapezodaition class sometimes showed a small sliver of a sharp sliver of a shape. This would (in all likelihood) trip up the generation of the ST_graph.

![Screenshot 2023-01-27 at 11 42 52](https://user-images.githubusercontent.com/8535734/215094354-e3644c9f-a243-415e-83de-82c31a598274.png)
zoomed in
![Screenshot 2023-01-27 at 11 42 43](https://user-images.githubusercontent.com/8535734/215094397-d162dcc0-c38e-4311-87cf-43c285ca6e63.png)
zoomed in some more
![Screenshot 2023-01-27 at 11 42 28](https://user-images.githubusercontent.com/8535734/215094578-6857b78c-fe0f-4d19-80a1-46013d765767.png)
zoomed in even further
![Screenshot 2023-01-27 at 11 42 32](https://user-images.githubusercontent.com/8535734/215094638-c6347070-28d4-4f5c-a018-2baa883242cf.png)

Further sanitize the input for the ST graph and remove remaining polygon slivers proofed to be sufficient. By increasing the open-close distance with the `min_wall_line_width / 4` fixes all reported crashes linked in the PR. The simplification that this open-close operation performs should well be within the limits of the printable features. No degradation
of quality should occur.

Fixes CURA-9976

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Locally (all linked models managed to slice)
- [X] With the visual debugger
- [X] With the GCodeAnalyzer (no significant changes in GCode observed)

**Test Configuration**:
* Operating System: Linux Ubuntu (KDE)

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change

# Fixes the following GH issues:
- fixes Ultimaker/Cura#13643
- fixes Ultimaker/Cura#13662
- fixes Ultimaker/Cura#13663
- fixes Ultimaker/Cura#13673
- fixes Ultimaker/Cura#13894
- fixes Ultimaker/Cura#13911
- fixes Ultimaker/Cura#13948
- fixes Ultimaker/Cura#13949
- fixes Ultimaker/Cura#13954
- fixes Ultimaker/Cura#14023
- fixes Ultimaker/Cura#14024
- fixes Ultimaker/Cura#14251
- fixes Ultimaker/Cura#14303
- fixes Ultimaker/Cura#14042
- fixes Ultimaker/Cura#14040
- fixes Ultimaker/Cura#13889
- fixes Ultimaker/Cura#13960
- fixes Ultimaker/Cura#13962
- fixes Ultimaker/Cura#14163

