### PR TITLE
[CURA-10050] interlocking boundary issue fix

### DIFF
--- a/include/InterlockingGenerator.h
+++ b/include/InterlockingGenerator.h
@@ -58,7 +58,7 @@ protected:
     /*!
      * Generate an interlocking structure between two meshes
      */
-    void generateInterlockingStructure();
+    void generateInterlockingStructure() const;
 
     /*!
      * Private class for storing some variables used in the computation of the interlocking structure between two meshes.
@@ -86,6 +86,12 @@ protected:
     , air_dilation(air_dilation)
     , air_filtering(air_filtering)
     {}
+
+    /*! Special handling for thin strips of material.
+     *
+     * Expand the meshes into each other where they need it, namely when a thin strip of material needs to be attached.
+     */
+    void handleThinAreas() const;
 
     /*!
      * Compute the voxels overlapping with the shell of both models.

--- a/src/InterlockingGenerator.cpp
+++ b/src/InterlockingGenerator.cpp
@@ -63,13 +63,14 @@ void InterlockingGenerator::generateInterlockingStructure(std::vector<Slicer*>& 
 
 void InterlockingGenerator::handleThinAreas() const
 {
-    constexpr coord_t number_of_beams_detect = 4;
-    constexpr coord_t number_of_beams_expand = 2;
+    constexpr coord_t number_of_beams_detect = 2;
+    constexpr coord_t number_of_beams_expand = 1;
     constexpr coord_t rounding_errors = 5;
 
     const coord_t max_beam_width = std::max(beam_width_a, beam_width_b);
     const coord_t detect = (max_beam_width * number_of_beams_detect) + rounding_errors;
     const coord_t expand = (max_beam_width * number_of_beams_expand) + rounding_errors;
+    const coord_t close_gaps = std::min(mesh_a.mesh->settings.get<coord_t>("line_width"), mesh_b.mesh->settings.get<coord_t>("line_width")) / 4;
 
     // Only alter layers when they are present in both mesh, zip should take care if that.
     for (auto layer : ranges::views::zip(mesh_a.layers, mesh_b.layers))
@@ -87,8 +88,8 @@ void InterlockingGenerator::handleThinAreas() const
 
         // Expanded thin areas of the opposing polygon should 'eat into' the larger areas of the polygon,
         // and conversely, add the expansions to their own thin areas.
-        polys_a = polys_a.difference(thin_expansion_b).unionPolygons(thin_expansion_a);
-        polys_b = polys_b.difference(thin_expansion_a).unionPolygons(thin_expansion_b);
+        polys_a = polys_a.difference(thin_expansion_b).unionPolygons(thin_expansion_a).offset(close_gaps).offset(-close_gaps);
+        polys_b = polys_b.difference(thin_expansion_a).unionPolygons(thin_expansion_b).offset(close_gaps).offset(-close_gaps);
     }
 }
 


### PR DESCRIPTION
When an air-gap is specified, some cells are removed from the boundary of the object.

When that object consist of a thin strip of material, removed cells on the edge could cause the interlocking structure to be completely disconnected from the rest of the same material, defeating the purpose of interlocking. (Note that there can absolutely be disconnected islands when only looking at one layer -- this issue however affected the whole, zo also in the z direction.)

The applied fix is to expand the thin parts of a model into the parts of the other model. (See pictures provided by a colleague below.)

![Screenshot 2023-01-24 at 17 02 41](https://user-images.githubusercontent.com/41987080/215139552-49b5c9ea-b855-4e77-a53d-2e96b45e7f10.png)
![Screenshot 2023-01-24 at 17 02 56](https://user-images.githubusercontent.com/41987080/215139579-7313e9da-ca34-41ad-8b90-79edefab4bcb.png)
