### PR TITLE
Early out if paths are empty

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "ExtruderTrain.h"
@@ -357,6 +357,10 @@ constexpr bool InsetOrderOptimizer::shouldReversePath(const bool use_one_extrude
 
 std::vector<ExtrusionLine> InsetOrderOptimizer::getWallsToBeAdded(const bool reverse, const bool use_one_extruder)
 {
+    if (paths.empty())
+    {
+        return { };
+    }
     rg::any_view<VariableWidthLines> view;
     if (reverse)
     {


### PR DESCRIPTION
This fixes a crash when trying to reverse an empty path.

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change