### PR TITLE
Use the `extruder_switch_retraction_config` when switching extruders.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <algorithm>
@@ -1764,11 +1764,11 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
             if (prev_retraction_config.retraction_hop_after_extruder_switch)
             {
                 z_hop_height = prev_retraction_config.extruder_switch_retraction_config.zHop;
-                gcode.switchExtruder(extruder_nr, prev_retraction_config.retraction_config, z_hop_height);
+                gcode.switchExtruder(extruder_nr, prev_retraction_config.extruder_switch_retraction_config, z_hop_height);
             }
             else
             {
-                gcode.switchExtruder(extruder_nr, prev_retraction_config.retraction_config);
+                gcode.switchExtruder(extruder_nr, prev_retraction_config.extruder_switch_retraction_config);
             }
 
             { // require printing temperature to be met


### PR DESCRIPTION
When CURA-9876 implemented per-object retraction settings we accidentally used the general `retraction_config` and not the specific extruder switch config. This led to over extrusion with each nozzle switch.

Fixes to CURA-10241

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Multiple tests on UM5 printers
- [X] Checking the retraction amount in the GCode during a nozzle switch in text editor
- [X] Checked retract and un-retracts with GCodeAnalyzer

**Test Configuration**:
* Operating System: Linux

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change