### PR TITLE
CURA-10050 Interlocking Workaround II

### DIFF
--- a/include/InterlockingGenerator.h
+++ b/include/InterlockingGenerator.h
@@ -87,6 +87,12 @@ protected:
     , air_filtering(air_filtering)
     {}
 
+    /*! Aaa
+     *
+     * a
+     */
+    std::pair<Polygons, Polygons> growBorderAreasPerpendicular(const Polygons& a, const Polygons& b, const coord_t& detect) const;
+
     /*! Special handling for thin strips of material.
      *
      * Expand the meshes into each other where they need it, namely when a thin strip of material needs to be attached.

--- a/include/InterlockingGenerator.h
+++ b/include/InterlockingGenerator.h
@@ -87,9 +87,12 @@ protected:
     , air_filtering(air_filtering)
     {}
 
-    /*! Aaa
+    /*! Given two polygons, return the parts that border on air, and grow 'perpendicular' up to 'detect' distance.
      *
-     * a
+     * \param a The first polygon.
+     * \param b The second polygon.
+     * \param detec The expand distance. (Not equal to offset, but a series of small offsets and differences).
+     * \return A pair of polygons that repressent the 'borders' of a and b, but expanded 'perpendicularly'.
      */
     std::pair<Polygons, Polygons> growBorderAreasPerpendicular(const Polygons& a, const Polygons& b, const coord_t& detect) const;
 

--- a/src/InterlockingGenerator.cpp
+++ b/src/InterlockingGenerator.cpp
@@ -127,8 +127,6 @@ void InterlockingGenerator::handleThinAreas(const std::unordered_set<GridPoint3>
         const Polygons thin_expansion_a{ large_b.intersection(polys_a.difference(large_a).offset(expand)).intersection(near_interlock_per_layer[layer_nr]).intersection(from_border_a).offset(rounding_errors) };
         const Polygons thin_expansion_b{ large_a.intersection(polys_b.difference(large_b).offset(expand)).intersection(near_interlock_per_layer[layer_nr]).intersection(from_border_b).offset(rounding_errors) };
 
-        // TODO??: when 'grow' solution is finished, possibly replace the first 'large' over there with the entire model?
-
         // Expanded thin areas of the opposing polygon should 'eat into' the larger areas of the polygon,
         // and conversely, add the expansions to their own thin areas.
         polys_a = polys_a.unionPolygons(thin_expansion_a).difference(thin_expansion_b).offset(close_gaps).offset(-close_gaps);


### PR DESCRIPTION
Previously, as a workaround for interlocking structures not adhering to thin strips of material, an extra blob of material was added wherever interlocking microstructure was disconnected from the border-material. It turns out that this blob can intersect the border, completely negating (the purpose of) the air-boundary (the air-boundary is why these unexpected gaps can be there in the first place).

Now, we detect which parts of the border we can actually blob the connecting material on to. Because it does morphological operations in a loop, it might be slow. This will however be limited to whenever interlocking is on, and this workaround is expected to become a real fix before the final is out.