### PR TITLE
Cura 10232 fix crash computesegmentcellrange

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -53,9 +53,10 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     const coord_t allowed_distance = settings.get<coord_t>("meshfix_maximum_deviation");
 
     // Sometimes small slivers of polygons mess up the prepared_outline. By performing an open-close operation
-    // 1/4 of the min_wall_line_width these slivers are removed, while still keeping enough information to not
-    // degrade the print quality; These features can't be printed anyhow. See PR CuraEngine#1811 for some screenshots
-    const coord_t open_close_distance = settings.get<coord_t>("min_wall_line_width") / 4;
+    // with half the minimum printable feature size or minimum line width, these slivers are removed, while still
+    // keeping enough information to not degrade the print quality;
+    // These features can't be printed anyhow. See PR CuraEngine#1811 for some screenshots
+    const coord_t open_close_distance = settings.get<bool>("fill_outline_gaps") ? settings.get<coord_t>("min_feature_size") / 2 - 5 : settings.get<coord_t>("min_wall_line_width") / 2 - 5;
     const coord_t epsilon_offset = (allowed_distance / 2) - 1;
     const AngleRadians transitioning_angle = settings.get<AngleRadians>("wall_transition_angle");
     constexpr coord_t discretization_step_size = MM2INT(0.8);
@@ -63,6 +64,7 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     // Simplify outline for boost::voronoi consumption. Absolutely no self intersections or near-self intersections allowed:
     // TODO: Open question: Does this indeed fix all (or all-but-one-in-a-million) cases for manifold but otherwise possibly complex polygons?
     Polygons prepared_outline = outline.offset(-open_close_distance).offset(open_close_distance * 2).offset(-open_close_distance);
+    prepared_outline.removeSmallAreas(small_area_length * small_area_length, false);
     prepared_outline = Simplify(settings).polygon(prepared_outline);
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();
@@ -70,7 +72,6 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     // Removing collinear edges may introduce self intersections, so we need to fix them again
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();
-    prepared_outline.removeSmallAreas(small_area_length * small_area_length, false);
     prepared_outline = prepared_outline.unionPolygons();
 
     if (prepared_outline.area() <= 0)

--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -166,7 +166,7 @@ std::vector<Point> VoronoiUtils::discretizeParabola(const Point& p, const Segmen
     // are more than 10 microns away from the projected apex
     bool add_apex = (sx - px) * dir < -10 && (ex - px) * dir > 10;
 
-    //assert(! (add_marking_start && add_marking_end) || add_apex);
+    assert(! (add_marking_start && add_marking_end) || add_apex);
     if (add_marking_start && add_marking_end && ! add_apex)
     {
         spdlog::warn("Failing to discretize parabola! Must add an apex or one of the endpoints.");

--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <optional>
@@ -166,7 +166,7 @@ std::vector<Point> VoronoiUtils::discretizeParabola(const Point& p, const Segmen
     // are more than 10 microns away from the projected apex
     bool add_apex = (sx - px) * dir < -10 && (ex - px) * dir > 10;
 
-    assert(! (add_marking_start && add_marking_end) || add_apex);
+    //assert(! (add_marking_start && add_marking_end) || add_apex);
     if (add_marking_start && add_marking_end && ! add_apex)
     {
         spdlog::warn("Failing to discretize parabola! Must add an apex or one of the endpoints.");


### PR DESCRIPTION
# Description
More fine-grained polygon simplifications. This seems to take care of all other crashes as well. Except for the torso model, provided in Ultimaker/Cura#13663

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Sliced all models with previous crashes

**Test Configuration**:
* Operating System: Linux Manajaro

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change