### PR TITLE
Maximum volumetric flow rate, with fixes

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1821,6 +1821,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         const ExtruderTrain& extruder = Application::getInstance().current_slice->scene.extruders[extruder_nr];
 
         bool update_extrusion_offset = true;
+        const double max_mm3_per_sec = extruder.settings.get<double>("material_max_mm3_per_sec");
 
         for (unsigned int path_idx = 0; path_idx < paths.size(); path_idx++)
         {
@@ -1935,6 +1936,13 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
             // for some movements such as prime tower purge, the speed may get changed by this factor
             speed *= path.speed_factor;
+
+            //Extrusion flow rate limiting
+            const double mm3_per_sec = path.getExtrusionMM3perMM() * speed;
+            if (max_mm3_per_sec > 0 && mm3_per_sec > max_mm3_per_sec)
+            {
+                speed *= max_mm3_per_sec / mm3_per_sec;
+            }
 
             //This seems to be the best location to place this, but still not ideal.
             if (path.mesh != current_mesh)
@@ -2113,6 +2121,13 @@ bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, const size_t extruder_
     coord_t coasting_min_dist_considered = MM2INT(0.1); // hardcoded setting for when to not perform coasting
 
     const double extrude_speed = path.config->getSpeed() * path.speed_factor * path.speed_back_pressure_factor;
+
+    const double max_mm3_per_sec = extruder.settings.get<double>("material_max_mm3_per_sec"); //flow rate limiting
+    const double mm3_per_sec = path.getExtrusionMM3perMM() * extrude_speed;
+    if (max_mm3_per_sec > 0 && mm3_per_sec > max_mm3_per_sec)
+    {
+        extrude_speed *= max_mm3_per_sec / mm3_per_sec;
+    }
 
     const coord_t coasting_dist = MM2INT(MM2_2INT(coasting_volume) / layer_thickness) / path.config->getLineWidth(); // closing brackets of MM2INT at weird places for precision issues
     const double coasting_min_volume = extruder.settings.get<double>("coasting_min_volume");

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1993,7 +1993,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 { // normal path to gcode algorithm
                     for (unsigned int point_idx = 0; point_idx < path.points.size(); point_idx++)
                     {
-                        const double extrude_speed = speed * path.speed_back_pressure_factor;
+                        double extrude_speed = speed * path.speed_back_pressure_factor;
                         communication->sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView(), path.config->getLayerThickness(), extrude_speed);
                         gcode.writeExtrusion(path.points[point_idx], extrude_speed, path.getExtrusionMM3perMM(), path.config->type, update_extrusion_offset);
                     }
@@ -2028,7 +2028,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         p0 = p1;
                         gcode.setZ(std::round(z + layer_thickness * length / totalLength));
 
-                        const double extrude_speed = speed * path.speed_back_pressure_factor;
+                        double extrude_speed = speed * path.speed_back_pressure_factor;
                         communication->sendLineTo(path.config->type, path.points[point_idx], path.getLineWidthForLayerView(), path.config->getLayerThickness(), extrude_speed);
                         gcode.writeExtrusion(path.points[point_idx], extrude_speed, path.getExtrusionMM3perMM(), path.config->type, update_extrusion_offset);
                     }
@@ -2120,7 +2120,7 @@ bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, const size_t extruder_
 
     coord_t coasting_min_dist_considered = MM2INT(0.1); // hardcoded setting for when to not perform coasting
 
-    const double extrude_speed = path.config->getSpeed() * path.speed_factor * path.speed_back_pressure_factor;
+    double extrude_speed = path.config->getSpeed() * path.speed_factor * path.speed_back_pressure_factor;
 
     const double max_mm3_per_sec = extruder.settings.get<double>("material_max_mm3_per_sec"); //flow rate limiting
     const double mm3_per_sec = path.getExtrusionMM3perMM() * extrude_speed;


### PR DESCRIPTION
# Description

This PR adds functionality for setting a maximum volumetric flow rate, which prevents hitting the limit at which a certain hotend can melt material. 

This PR attempts to fix the compilation errors in #1814 
```
/home/runner/work/CuraEngine/CuraEngine/src/LayerPlan.cpp:2129:23: error: assignment of read-only variable ‘extrude_speed’
 2129 |         extrude_speed *= max_mm3_per_sec / mm3_per_sec;
```
It contains the commit from #1814 and therefore all necessary changes to CuraEngine. 

It goes with [#14452 on Cura](https://github.com/Ultimaker/Cura/pull/14452), which adds the required settings to the frontend. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Compiled flawless. 

The preview clearly shows that the flow and speed get limited if the maximum flow rate is reached:

With maximum set to 0.0mm³/s (disabled):

![Screenshot_20230212_154216](https://user-images.githubusercontent.com/54219098/218317789-95b4b68c-6231-4b14-9bd8-b31929259c49.png)

With maximum set to 5mm³/s:

![Screenshot_20230212_154244](https://user-images.githubusercontent.com/54219098/218317786-6915ef69-a4a9-4c25-9d08-21c88fdc3ba3.png)



**Test Configuration**:
* Operating System:
Arch 6.1.10 Wayland/KDE
# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change