### PR TITLE
[CURA-10028] Interlocking connecting with non printable meshes

### DIFF
--- a/src/InterlockingGenerator.cpp
+++ b/src/InterlockingGenerator.cpp
@@ -38,6 +38,11 @@ void InterlockingGenerator::generateInterlockingStructure(std::vector<Slicer*>& 
             Slicer& mesh_b = *volumes[mesh_b_idx];
             size_t extruder_nr_b = mesh_b.mesh->settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr;
 
+            if (!mesh_a.mesh->isPrinted() || !mesh_b.mesh->isPrinted())
+            {
+                continue;
+            }
+
             if (extruder_nr_a == extruder_nr_b || !mesh_a.mesh->getAABB().expand(ignored_gap).hit(mesh_b.mesh->getAABB()))
             {
                 // early out for when meshes don't share any overlap in their bounding box


### PR DESCRIPTION
# Description

Interlocking structures were being generated between modifier/support blockers and printable meshes. This pr filters out non printable meshes when generating interlocking structures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Slice model with an intersecting support blocker and interlocking structures enabled

**Test Configuration**:
* Operating System: MacOS

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change