### PR TITLE
[CURA-9860] fix extra support layer when raft is enabled

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -22,12 +22,9 @@ public:
 
     /*!
      * \brief Get the height difference between the raft and the bottom of
-     * layer 1.
-     * 
-     * This is used for the filler layers because they don't use the
-     * layer_0_z_overlap.
+     * layer 0.
      */
-    static coord_t getZdiffBetweenRaftAndLayer1();
+    static coord_t getZdiffBetweenRaftAndLayer0();
 
     /*!
      * \brief Get the amount of layers to fill the airgap and initial layer with

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1027,12 +1027,9 @@ LayerPlan& FffGcodeWriter::processLayer(const SliceDataStorage& storage, LayerIn
             break;
         }
 
-        if (layer_nr == 0)
+        if (layer_nr < 0 && mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") == EPlatformAdhesion::RAFT)
         {
-            if (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") == EPlatformAdhesion::RAFT)
-            {
-                include_helper_parts = false;
-            }
+            include_helper_parts = false;
         }
     }
 

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -379,24 +379,6 @@ void FffPolygonGenerator::slices2polygons(SliceDataStorage& storage, TimeKeeper&
     }
 
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-    if (isEmptyLayer(storage, 0) && ! isEmptyLayer(storage, 1))
-    {
-        // the first layer is empty, the second is not empty, so remove the empty first layer as support isn't going to be generated under it.
-        // Do this irrespective of the value of remove_empty_first_layers as that setting is hidden when support is enabled and so cannot be relied upon
-
-        removeEmptyFirstLayers(storage, storage.print_layer_count); // changes storage.print_layer_count!
-    }
-
-    spdlog::info("Layer count: {}", storage.print_layer_count);
-
-    // layerparts2HTML(storage, "output/output.html");
-
-    Progress::messageProgressStage(Progress::Stage::SUPPORT, &time_keeper);
-
-    AreaSupport::generateOverhangAreas(storage);
-    AreaSupport::generateSupportAreas(storage);
-    TreeSupport tree_support_generator(storage);
-    tree_support_generator.generateSupportAreas(storage);
 
     // we need to remove empty layers after we have processed the insets
     // processInsets might throw away parts if they have no wall at all (cause it doesn't fit)
@@ -412,6 +394,13 @@ void FffPolygonGenerator::slices2polygons(SliceDataStorage& storage, TimeKeeper&
         spdlog::warn("Stopping process because there are no non-empty layers.");
         return;
     }
+
+    Progress::messageProgressStage(Progress::Stage::SUPPORT, &time_keeper);
+
+    AreaSupport::generateOverhangAreas(storage);
+    AreaSupport::generateSupportAreas(storage);
+    TreeSupport tree_support_generator(storage);
+    tree_support_generator.generateSupportAreas(storage);
 
     computePrintHeightStatistics(storage);
 

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -92,11 +92,7 @@ coord_t Raft::getZdiffBetweenRaftAndLayer1()
         return 0;
     }
     const coord_t airgap = std::max(coord_t(0), train.settings.get<coord_t>("raft_airgap"));
-    const coord_t layer_0_overlap = mesh_group_settings.get<coord_t>("layer_0_z_overlap");
-
-    const coord_t layer_height_0 = mesh_group_settings.get<coord_t>("layer_height_0");
-
-    const coord_t z_diff_raft_to_bottom_of_layer_1 = std::max(coord_t(0), airgap + layer_height_0 - layer_0_overlap);
+    const coord_t z_diff_raft_to_bottom_of_layer_1 = std::max(coord_t(0), airgap);
     return z_diff_raft_to_bottom_of_layer_1;
 }
 

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -83,7 +83,7 @@ coord_t Raft::getTotalThickness()
         + surface_train.settings.get<size_t>("raft_surface_layers") * surface_train.settings.get<coord_t>("raft_surface_thickness");
 }
 
-coord_t Raft::getZdiffBetweenRaftAndLayer1()
+coord_t Raft::getZdiffBetweenRaftAndLayer0()
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     const ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr");
@@ -92,14 +92,13 @@ coord_t Raft::getZdiffBetweenRaftAndLayer1()
         return 0;
     }
     const coord_t airgap = std::max(coord_t(0), train.settings.get<coord_t>("raft_airgap"));
-    const coord_t z_diff_raft_to_bottom_of_layer_1 = std::max(coord_t(0), airgap);
-    return z_diff_raft_to_bottom_of_layer_1;
+    return airgap;
 }
 
 size_t Raft::getFillerLayerCount()
 {
     const coord_t normal_layer_height = Application::getInstance().current_slice->scene.current_mesh_group->settings.get<coord_t>("layer_height");
-    return round_divide(getZdiffBetweenRaftAndLayer1(), normal_layer_height);
+    return round_divide(getZdiffBetweenRaftAndLayer0(), normal_layer_height);
 }
 
 coord_t Raft::getFillerLayerHeight()
@@ -110,7 +109,7 @@ coord_t Raft::getFillerLayerHeight()
         const coord_t normal_layer_height = mesh_group_settings.get<coord_t>("layer_height");
         return normal_layer_height;
     }
-    return round_divide(getZdiffBetweenRaftAndLayer1(), getFillerLayerCount());
+    return round_divide(getZdiffBetweenRaftAndLayer0(), getFillerLayerCount());
 }
 
 


### PR DESCRIPTION
There was an extra layer of support between the raft and the model, even if the air-gap was set to 0.