### PR TITLE
[CURA-10310] support fixes Friday

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1065,9 +1065,6 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
         // Move up from model, handle stair-stepping.
         moveUpFromModel(storage, stair_removal, sloped_areas_per_layer[layer_idx], layer_this, layer_idx, bottom_empty_layer_count, bottom_stair_step_layer_count, bottom_stair_step_width);
 
-        // Perform close operation to remove areas from support area that are unprintable
-        layer_this = layer_this.offset(-half_min_feature_width).offset(half_min_feature_width);
-
         // remove areas smaller than the minimum support area
         layer_this.removeSmallAreas(minimum_support_area);
 
@@ -1136,6 +1133,17 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
                                        support_areas[layer_idx] = support_areas[layer_idx].difference(storage.getLayerOutlines(layer_idx + layer_z_distance_top - 1, no_support, no_prime_tower));
                                    });
     }
+
+    // Perform close operation to remove areas from support area that are unprintable
+    cura::parallel_for<size_t>
+    (
+        0,
+        layer_count - layer_z_distance_top,
+        [&](const size_t layer_idx)
+        {
+            support_areas[layer_idx] = support_areas[layer_idx].offset(-half_min_feature_width).offset(half_min_feature_width);
+        }
+    );
 
     // Procedure to remove floating support
     for (size_t layer_idx = 1; layer_idx < layer_count - 1; layer_idx ++)

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1059,7 +1059,10 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
             layer_this = layer_this.unionPolygons(storage.support.supportLayers[layer_idx].support_mesh_drop_down);
         }
 
-        layer_this = layer_this.difference(xy_disallowed_per_layer[layer_idx]);
+        if (layer_idx >= 1)
+        {
+            layer_this = layer_this.difference(xy_disallowed_per_layer[layer_idx - 1]);
+        }
 
         // Move up from model, handle stair-stepping.
         moveUpFromModel(storage, stair_removal, sloped_areas_per_layer[layer_idx], layer_this, layer_idx, bottom_empty_layer_count, bottom_stair_step_layer_count, bottom_stair_step_width);

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -918,6 +918,7 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
                                    {
                                        xy_disallowed_per_layer[layer_idx] = outlines.offset(xy_distance);
                                    }
+                                   xy_disallowed_per_layer[layer_idx] = xy_disallowed_per_layer[layer_idx].smooth(min_even_wall_line_width);
                                });
 
     std::vector<Polygons> tower_roofs;
@@ -1057,6 +1058,8 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
         { // handle support mesh which should be supported by more support
             layer_this = layer_this.unionPolygons(storage.support.supportLayers[layer_idx].support_mesh_drop_down);
         }
+
+        layer_this = layer_this.difference(xy_disallowed_per_layer[layer_idx]);
 
         // Move up from model, handle stair-stepping.
         moveUpFromModel(storage, stair_removal, sloped_areas_per_layer[layer_idx], layer_this, layer_idx, bottom_empty_layer_count, bottom_stair_step_layer_count, bottom_stair_step_width);


### PR DESCRIPTION
Prevent jitters by:
- Thin strips (unlike small areas) should first be propagated first before any unprintable spots are removed.
- Stop propagation of material that will be cut off by the 'minimum x/y distance' (as opposed to normal x/y distance).
- _(In front-end, see [the frontend PR here](https://github.com/Ultimaker/Cura/pull/14591): Infill patterns don't stay the same from layer to layer. This could cause jitters, but also wholly missing or floating support. -- You can easily see this when brim is enabled, and brim is generated for an area of support that just ... _stops_ somewhere at layer whatever.)_

---

_EDIT: Converted to draft for safety w.r.t. multiple possible solutions, but otherwise 'finished'._