### PR TITLE
Varying x/y distance

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -294,7 +294,15 @@ private:
     static void cleanup(SliceDataStorage& storage);
 
 
-    static Polygons generateXYDisallowedArea(const SliceMeshStorage& storage, const Settings& infill_settings, const LayerIndex layer_idx);
+    /*!
+     * generates varying xy disallowed areas for \param layer_idx where the offset distance is dependent on the wall angle
+     *
+     * \param storage Data storage containing the input layer data and
+     * \param settings The settings to use to calculate the offsets
+     * \param layer_idx The layer for which the disallowed areas are to be calcualted
+     *
+     */
+    static Polygons generateVaryingXYDisallowedArea(const SliceMeshStorage& storage, const Settings& infill_settings, const LayerIndex layer_idx);
 };
 
 

--- a/include/support.h
+++ b/include/support.h
@@ -292,6 +292,9 @@ private:
      * 
      */
     static void cleanup(SliceDataStorage& storage);
+
+
+    static Polygons generateXYDisallowedArea(const SliceMeshStorage& storage, const Settings& infill_settings, const LayerIndex layer_idx);
 };
 
 

--- a/include/utils/polygon.h
+++ b/include/utils/polygon.h
@@ -1444,6 +1444,8 @@ public:
             }
         }
     }
+
+    Polygons offset(const std::vector<int>& offset_dists) const;
 };
 
 /*!

--- a/include/utils/views/get.h
+++ b/include/utils/views/get.h
@@ -39,7 +39,7 @@ namespace cura::views
  */
 constexpr auto get(auto&& proj)
 {
-    return ranges::make_view_closure(ranges::views::transform([proj](auto&& item) { return decltype(std::invoke(proj, item)) { std::invoke(proj, std::forward<decltype(item)>(item)) }; }));
+    return ranges::make_view_closure(ranges::views::transform([proj](auto&& item) { return std::invoke(proj, std::forward<decltype(item)>(item)); }));
 }
 } // namespace cura::views
 

--- a/include/utils/views/get.h
+++ b/include/utils/views/get.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef UTILS_VIEWS_GET_H
@@ -39,7 +39,7 @@ namespace cura::views
  */
 constexpr auto get(auto&& proj)
 {
-    return ranges::make_view_closure(ranges::views::transform([proj](auto item) { return decltype(std::invoke(proj, item)) { std::invoke(proj, item) }; }));
+    return ranges::make_view_closure(ranges::views::transform([proj](auto&& item) { return decltype(std::invoke(proj, item)) { std::invoke(proj, std::forward<decltype(item)>(item)) }; }));
 }
 } // namespace cura::views
 

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -927,8 +927,8 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
             auto slope = dist_to_boundary / delta_z;
 
             auto nearby_vals = slope_at_point.getNearbyVals(p0, search_radius);
-            auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0.L);
-            auto cumulative_slope = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.L);
+            auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0);
+            auto cumulative_slope = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.);
 
             n += 1;
             cumulative_slope += slope;
@@ -942,14 +942,14 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
             for (const auto& point: poly)
             {
                 auto nearby_vals = slope_at_point.getNearbyVals(point, search_radius);
-                auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0.L);
-                auto cumulative_slope = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.L);
+                auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0);
+                auto cumulative_slope = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.);
 
                 if (n != 0)
                 {
-                    auto slope = cumulative_slope / n;
+                    auto slope = cumulative_slope / static_cast<double>(n);
                     auto wall_angle = std::atan(slope);
-                    auto ratio = std::min(wall_angle / overhang_angle, 1.L);
+                    auto ratio = std::min(wall_angle / overhang_angle, 1.);
 
                     auto xy_distance_varying = std::lerp(xy_distance, xy_distance_natural, ratio);
 
@@ -957,8 +957,8 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
 
                     // update and insert cumulative varying xy distance in one go
                     offset_dist_at_point.insert(point, {
-                                                       ranges::accumulate(nearby_vals_offset_dist | views::get( &point_pair_t::first ), 0.L) + 1.L,
-                                                       ranges::accumulate(nearby_vals_offset_dist | views::get( &point_pair_t::second ), 0.L) + xy_distance_varying
+                                                       ranges::accumulate(nearby_vals_offset_dist | views::get( &point_pair_t::first ), 0) + 1,
+                                                       ranges::accumulate(nearby_vals_offset_dist | views::get( &point_pair_t::second ), 0.) + xy_distance_varying
                                                    });
                 }
             }
@@ -972,8 +972,8 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
         {
             auto nearby_vals = offset_dist_at_point.getNearbyVals(point, search_radius);
 
-            auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0.L);
-            auto cumulative_offset_dist = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.L);
+            auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0);
+            auto cumulative_offset_dist = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.);
 
             double offset_dist {};
             if (n == 0)

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -822,9 +822,9 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
     //    here either the slope or overhang area is stored
     std::vector<std::tuple<double, double, Polygons>> z_distances_layer_deltas;
 
-    constexpr LayerIndex layer_index_offset = 1;
+    constexpr LayerIndex layer_index_offset { 1 };
 
-    const LayerIndex layer_idx_below = std::max(layer_idx - layer_index_offset, static_cast<LayerIndex>(0));
+    const LayerIndex layer_idx_below { std::max(layer_idx - layer_index_offset, LayerIndex { 0 } };
     if (layer_idx_below != layer_idx)
     {
         auto layer_below = storage.layers[layer_idx_below].getOutlines()

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -793,8 +793,8 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
 {
     const auto& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
     const auto layer_thickness = mesh_group_settings.get<coord_t>("layer_height");
-    const auto support_distance_top = mesh_group_settings.get<coord_t>("support_top_distance");
-    const auto support_distance_bot = mesh_group_settings.get<coord_t>("support_bottom_distance");
+    const auto support_distance_top = static_cast<double>(mesh_group_settings.get<coord_t>("support_top_distance"));
+        const auto support_distance_bot = static_cast<double>(mesh_group_settings.get<coord_t>("support_bottom_distance"));
     const auto overhang_angle = mesh_group_settings.get<AngleRadians>("support_angle");
     const auto xy_distance = static_cast<double>(mesh_group_settings.get<coord_t>("support_xy_distance"));
 
@@ -833,13 +833,13 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
                                .smooth(close_dist);
 
         z_distances_layer_deltas.emplace_back(
-            static_cast<double>(support_distance_top),
+            support_distance_top,
             static_cast<double>(layer_index_offset * layer_thickness),
             layer_current.difference(layer_below)
         );
 
         z_distances_layer_deltas.emplace_back(
-            static_cast<double>(support_distance_bot),
+            support_distance_bot,
             static_cast<double>(layer_index_offset * layer_thickness),
             layer_below.difference(layer_current)
         );
@@ -854,7 +854,7 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
                                .smooth(close_dist);
 
         z_distances_layer_deltas.emplace_back(
-            static_cast<double>(support_distance_bot),
+            support_distance_bot,
             static_cast<double>(layer_index_offset * layer_thickness),
             layer_current.difference(layer_above)
         );

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -799,7 +799,7 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
     const auto xy_distance = static_cast<double>(mesh_group_settings.get<coord_t>("support_xy_distance"));
 
     constexpr coord_t snap_radius = 10;
-    constexpr coord_t close_dist = 15; // needs to be larger than the snap radius!
+    constexpr coord_t close_dist = snap_radius + 5; // needs to be larger than the snap radius!
     constexpr coord_t search_radius = 0;
 
     auto layer_current = storage.layers[layer_idx].getOutlines().offset(-close_dist).offset(close_dist).smooth(close_dist);

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -6,6 +6,10 @@
 #include <numeric>
 #include <unordered_set>
 
+#include <range/v3/view/join.hpp>
+#include <range/v3/view/zip.hpp>
+#include <range/v3/range/primitives.hpp>
+
 #include "utils/linearAlg2D.h" // pointLiesOnTheRightOfLine
 #include "utils/Simplify.h"
 
@@ -41,7 +45,7 @@ bool ConstPolygonRef::_inside(Point p, bool border_result) const
 
     int crossings = 0;
     Point p0 = back();
-    for(unsigned int n=0; n<size(); n++)
+    for (unsigned int n = 0; n < size(); n++)
     {
         Point p1 = thiss[n];
         // no tests unless the segment p0-p1 is at least partly at, or to right of, p.X
@@ -77,12 +81,12 @@ bool Polygons::empty() const
 
 Polygons Polygons::approxConvexHull(int extra_outset)
 {
-    constexpr int overshoot = MM2INT(100); //10cm (hard-coded value).
+    constexpr int overshoot = MM2INT(100); // 10cm (hard-coded value).
 
     Polygons convex_hull;
-    //Perform the offset for each polygon one at a time.
-    //This is necessary because the polygons may overlap, in which case the offset could end up in an infinite loop.
-    //See http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Classes/ClipperOffset/_Body.htm
+    // Perform the offset for each polygon one at a time.
+    // This is necessary because the polygons may overlap, in which case the offset could end up in an infinite loop.
+    // See http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Classes/ClipperOffset/_Body.htm
     for (const ClipperLib::Path& path : paths)
     {
         Polygons offset_result;
@@ -96,36 +100,36 @@ Polygons Polygons::approxConvexHull(int extra_outset)
 
 void Polygons::makeConvex()
 {
-    for(PolygonRef poly : *this)
+    for (PolygonRef poly : *this)
     {
-        if(poly.size() <= 3)
+        if (poly.size() <= 3)
         {
-            continue; //Already convex.
+            continue; // Already convex.
         }
 
         Polygon convexified;
 
-        //Start from a vertex that is known to be on the convex hull: The one with the lowest X.
+        // Start from a vertex that is known to be on the convex hull: The one with the lowest X.
         const size_t start_index = std::min_element(poly.begin(), poly.end(), [](Point a, Point b) { return a.X == b.X ? a.Y < b.Y : a.X < b.X; }) - poly.begin();
         convexified.path->push_back(poly[start_index]);
 
-        for(size_t i = 1; i <= poly.size(); ++ i)
+        for (size_t i = 1; i <= poly.size(); ++i)
         {
             const Point& current = poly[(start_index + i) % poly.size()];
 
-            //Track backwards to make sure we haven't been in a concave pocket for multiple vertices already.
-            while(convexified.size() >= 2
-                && (LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], current) >= 0
-                ||  LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], convexified.path->front()) > 0))
+            // Track backwards to make sure we haven't been in a concave pocket for multiple vertices already.
+            while (convexified.size() >= 2
+                   && (LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], current) >= 0
+                       || LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], convexified.path->front()) > 0))
             {
                 convexified.path->pop_back();
             }
             convexified.path->push_back(current);
         }
-        //remove last vertex as the starting vertex is added in the last iteration of the loop
+        // remove last vertex as the starting vertex is added in the last iteration of the loop
         convexified.path->pop_back();
 
-        poly.path->swap(*convexified.path); //Due to vector's implementation, this is constant time.
+        poly.path->swap(*convexified.path); // Due to vector's implementation, this is constant time.
     }
 }
 
@@ -160,11 +164,11 @@ bool PolygonsPart::inside(Point p, bool border_result) const
     {
         return false;
     }
-    if (!(*this)[0].inside(p, border_result))
+    if (! (*this)[0].inside(p, border_result))
     {
         return false;
     }
-    for(unsigned int n = 1; n < paths.size(); n++)
+    for (unsigned int n = 1; n < paths.size(); n++)
     {
         if ((*this)[n].inside(p, border_result))
         {
@@ -219,7 +223,7 @@ unsigned int Polygons::findInside(Point p, bool border_result)
     {
         PolygonRef poly = thiss[poly_idx];
         Point p0 = poly.back();
-        for(Point& p1 : poly)
+        for (Point& p1 : poly)
         {
             short comp = LinearAlg2D::pointLiesOnTheRightOfLine(p, p0, p1);
             if (comp == 1)
@@ -232,7 +236,7 @@ unsigned int Polygons::findInside(Point p, bool border_result)
                 }
                 else
                 {
-                    x = p0.X + (p1.X-p0.X) * (p.Y-p0.Y) / (p1.Y-p0.Y);
+                    x = p0.X + (p1.X - p0.X) * (p.Y - p0.Y) / (p1.Y - p0.Y);
                 }
                 if (x < min_x[poly_idx])
                 {
@@ -262,14 +266,17 @@ unsigned int Polygons::findInside(Point p, bool border_result)
             }
         }
     }
-    if (n_unevens % 2 == 0) { ret = NO_INDEX; }
+    if (n_unevens % 2 == 0)
+    {
+        ret = NO_INDEX;
+    }
     return ret;
 }
 
 Polygons Polygons::intersectionPolyLines(const Polygons& polylines, bool restitch, const coord_t max_stitch_distance) const
 {
     Polygons split_polylines = polylines.splitPolylinesIntoSegments();
-    
+
     ClipperLib::PolyTree result;
     ClipperLib::Clipper clipper(clipper_init);
     clipper.AddPaths(split_polylines.paths, ClipperLib::ptSubject, false);
@@ -277,7 +284,7 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines, bool restitc
     clipper.Execute(ClipperLib::ctIntersection, result);
     Polygons ret;
     ClipperLib::OpenPathsFromPolyTree(result, ret.paths);
-    
+
     if (restitch)
     {
         Polygons result_lines, result_polygons;
@@ -287,7 +294,8 @@ Polygons Polygons::intersectionPolyLines(const Polygons& polylines, bool restitc
         // if polylines got stitched into polygons, split them back up into a polyline again, because the result only admits polylines
         for (PolygonRef poly : result_polygons)
         {
-            if (poly.empty()) continue;
+            if (poly.empty())
+                continue;
             if (poly.size() > 2)
             {
                 poly.emplace_back(poly[0]);
@@ -303,7 +311,8 @@ void Polygons::toPolylines()
 {
     for (PolygonRef poly : *this)
     {
-        if (poly.empty()) continue;
+        if (poly.empty())
+            continue;
         poly.emplace_back(poly.front());
     }
 }
@@ -357,6 +366,43 @@ Polygons Polygons::offset(int distance, ClipperLib::JoinType join_type, double m
     clipper.AddPaths(unionPolygons().paths, join_type, ClipperLib::etClosedPolygon);
     clipper.MiterLimit = miter_limit;
     clipper.Execute(ret.paths, distance);
+    return ret;
+}
+
+Polygons Polygons::offset(const std::vector<int>& offset_dists) const
+{
+    assert(this->pointCount() == offset_dists.size());
+
+    Polygons ret;
+    int i = 0;
+    for (auto& poly_line : this->paths)
+    {
+        std::vector<ClipperLib::IntPoint> ret_poly_line;
+
+        auto prev_p = poly_line.back();
+        auto prev_dist = offset_dists[i + poly_line.size() - 1];
+
+        for (auto& p: poly_line)
+        {
+            auto offset_dist = offset_dists[i];
+
+            auto vec_dir = prev_p - p;
+            auto offset_p1 = turn90CCW(normal(vec_dir, prev_dist));
+            auto offset_p2 = turn90CCW(normal(vec_dir, offset_dist));
+
+            ret_poly_line.push_back(prev_p + offset_p1);
+            ret_poly_line.push_back(p + offset_p2);
+
+            prev_p = p;
+            prev_dist = offset_dist;
+            i ++;
+        }
+
+        ret.add(ret_poly_line);
+    }
+
+    ClipperLib::SimplifyPolygons(ret.paths, ClipperLib::PolyFillType::pftNonZero);
+
     return ret;
 }
 
@@ -799,8 +845,8 @@ bool ConstPolygonRef::smooth_corner_complex(const Point p1, ListPolyIt& p0_it, L
     // p2_it = end point of line
     if (std::abs(v02_size2 - shortcut_length2) < shortcut_length * 10) // i.e. if (size2 < l * (l+10) && size2 > l * (l-10))
     { // v02 is approximately shortcut length
-        // handle this separately to avoid rounding problems below in the getPointOnLineWithDist function
-        // p0_it and p2_it are already correct
+      // handle this separately to avoid rounding problems below in the getPointOnLineWithDist function
+      // p0_it and p2_it are already correct
     }
     else if (!backward_is_blocked && !forward_is_blocked)
     { // introduce two new points
@@ -1054,21 +1100,21 @@ void ConstPolygonRef::smooth_corner_simple(const Point p0, const Point p1, const
 
 void ConstPolygonRef::smooth_outward(const AngleDegrees min_angle, int shortcut_length, PolygonRef result) const
 {
-// example of smoothed out corner:
-//
-//               6
-//               ^
-//               |
-// inside        |     outside
-//         2>3>4>5
-//         ^    /                   .
-//         |   /                    .
-//         1  /                     .
-//         ^ /                      .
-//         |/                       .
-//         |
-//         |
-//         0
+    // example of smoothed out corner:
+    //
+    //               6
+    //               ^
+    //               |
+    // inside        |     outside
+    //         2>3>4>5
+    //         ^    /                   .
+    //         |   /                    .
+    //         1  /                     .
+    //         ^ /                      .
+    //         |/                       .
+    //         |
+    //         |
+    //         0
 
     int shortcut_length2 = shortcut_length * shortcut_length;
     float cos_min_angle = cos(min_angle / 180 * M_PI);
@@ -1158,7 +1204,7 @@ Polygons Polygons::smooth_outward(const AngleDegrees max_angle, int shortcut_len
 
 
 
-void ConstPolygonRef::splitPolylineIntoSegments(Polygons& result) const 
+void ConstPolygonRef::splitPolylineIntoSegments(Polygons& result) const
 {
     Point last = front();
     for (size_t idx = 1; idx < size(); idx++)
@@ -1169,7 +1215,7 @@ void ConstPolygonRef::splitPolylineIntoSegments(Polygons& result) const
     }
 }
 
-Polygons ConstPolygonRef::splitPolylineIntoSegments() const 
+Polygons ConstPolygonRef::splitPolylineIntoSegments() const
 {
     Polygons ret;
     splitPolylineIntoSegments(ret);
@@ -1182,7 +1228,7 @@ void ConstPolygonRef::splitPolygonIntoSegments(Polygons& result) const
     result.addLine(back(), front());
 }
 
-Polygons ConstPolygonRef::splitPolygonIntoSegments() const 
+Polygons ConstPolygonRef::splitPolygonIntoSegments() const
 {
     Polygons ret;
     splitPolygonIntoSegments(ret);
@@ -1191,19 +1237,19 @@ Polygons ConstPolygonRef::splitPolygonIntoSegments() const
 
 void ConstPolygonRef::smooth(int remove_length, PolygonRef result) const
 {
-// a typical zigzag with the middle part to be removed by removing (1) :
-//
-//               3
-//               ^
-//               |
-//               |
-// inside        |     outside
-//          1--->2
-//          ^
-//          |
-//          |
-//          |
-//          0
+    // a typical zigzag with the middle part to be removed by removing (1) :
+    //
+    //               3
+    //               ^
+    //               |
+    //               |
+    // inside        |     outside
+    //          1--->2
+    //          ^
+    //          |
+    //          |
+    //          |
+    //          0
     const ConstPolygonRef& thiss = *path;
     ClipperLib::Path* poly = result.path;
     if (size() > 0)

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -387,11 +387,16 @@ Polygons Polygons::offset(const std::vector<int>& offset_dists) const
             auto offset_dist = offset_dists[i];
 
             auto vec_dir = prev_p - p;
-            auto offset_p1 = turn90CCW(normal(vec_dir, prev_dist));
-            auto offset_p2 = turn90CCW(normal(vec_dir, offset_dist));
 
-            ret_poly_line.push_back(prev_p + offset_p1);
-            ret_poly_line.push_back(p + offset_p2);
+            constexpr coord_t min_vec_len = 10;
+            if (vSize2(vec_dir) > min_vec_len * min_vec_len)
+            {
+                auto offset_p1 = turn90CCW(normal(vec_dir, prev_dist));
+                auto offset_p2 = turn90CCW(normal(vec_dir, offset_dist));
+
+                ret_poly_line.push_back(prev_p + offset_p1);
+                ret_poly_line.push_back(p + offset_p2);
+            }
 
             prev_p = p;
             prev_dist = offset_dist;

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -371,6 +371,7 @@ Polygons Polygons::offset(int distance, ClipperLib::JoinType join_type, double m
 
 Polygons Polygons::offset(const std::vector<int>& offset_dists) const
 {
+    // we need as many offset-dists as points
     assert(this->pointCount() == offset_dists.size());
 
     Polygons ret;

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -406,7 +406,7 @@ Polygons Polygons::offset(const std::vector<int>& offset_dists) const
         ret.add(ret_poly_line);
     }
 
-    ClipperLib::SimplifyPolygons(ret.paths, ClipperLib::PolyFillType::pftNonZero);
+    ClipperLib::SimplifyPolygons(ret.paths, ClipperLib::PolyFillType::pftPositive);
 
     return ret;
 }


### PR DESCRIPTION
### Problem description
When x/y-distance priority is set to z overrides x/y we have 3 different support distance values that compete, namely
- z-distance, a vertical distance from the model
- x/y-distance, a horizontal distance from the model
- minimum x/y-distance, a horizontal distance, usually smaller then the x/y-distance from the model

These different distances are visualized in the figure below.

![xx](https://user-images.githubusercontent.com/6638028/220095728-d577e7e5-103b-4fd2-abd6-f9a1946890ec.png)

As the priority is set to z distance the z-distance takes priority over the x/y-distance. However, by blindly following this z-distance the support will at some point attach to the model. Here the minimum x/y-distance comes into play to at least leave small gap between the support and the model. Once the boundary of the model is perfectly vertical only the x/y-distance is used.

The problem we are experiencing is when some of the walls are approximately vertical, we cannot reliably detect this, causing the disallowed distance to jitter between the x/y-distance and the minimum x/y-distance. This is exceptionally noticeable in organic models.

![xxxasdf](https://user-images.githubusercontent.com/6638028/220096030-148ef492-77d0-41ad-9902-72637ca087a3.png)

### Solution
This PR aims to solve this issue by introducing a smooth transition from the minimum x/y-distance to the x/y-distance. Support placed due to overhangs have an implicit x/y-distance, this distance can be derived from the overhang angle and the z-distance (we call this distance the natural x/y-distance).

<img width="1680" alt="Screenshot 2023-02-20 at 11 28 00" src="https://user-images.githubusercontent.com/6638028/220095276-2effabd4-dddc-47b8-bb54-b8309411f321.png">

### Known issues

There is still an issue with discontinuous between adjacent triangles. This can seen in the support example above. As there is a sudden change in wall angle there is also a hard jump in x/y distance; solving a 

For smoothing in the z-direction this can easily be solved by increasing the `layer_index_offset` here
https://github.com/Ultimaker/CuraEngine/blob/2fa64d3e67559b65232c4615aa4e3efd11cbcf8a/src/support.cpp#L822

However there is also an issue for the x/y distances. If two adjacent triangles have different overhang angles their offset can differ per offset. This can result in some very ugly looking disallowed areas. See image below. Note that this is done with an extreme x/distance of 3.0mm; default value is 0.7mm for ultimaker printers (the issue is virtually non-existent when using this default value).

A solution to the issue would be to smooth the x/y offset distance with the surrounding x/y offset distances. This would mimic the `layer_index_offset` for the z-direction in the x/y direction.

![filename_114](https://user-images.githubusercontent.com/6638028/220097259-7e91c545-7978-4c6a-bf93-de956a669746.svg)

CURA-10297