### PR TITLE
CURA-10224 Fix brim generation

### DIFF
--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -86,7 +86,7 @@ std::vector<SkirtBrim::Offset> SkirtBrim::generateBrimOffsetPlan(std::vector<Pol
 
     for (int extruder_nr = 0; extruder_nr < extruder_count; extruder_nr++)
     {
-        if (!extruder_is_used[extruder_nr] || (skirt_brim_extruder_nr >= 0 && extruder_nr != skirt_brim_extruder_nr))
+        if (!extruder_is_used[extruder_nr] || (skirt_brim_extruder_nr >= 0 && extruder_nr != skirt_brim_extruder_nr) || starting_outlines[extruder_nr].empty())
         {
             continue; // only include offsets for brim extruder
         }
@@ -141,7 +141,7 @@ void SkirtBrim::generate()
     std::vector<Offset> prime_brim_offsets_for_skirt = generatePrimeTowerBrimForSkirtAdhesionOffsetPlan();
     
     constexpr LayerIndex layer_nr = 0;
-    const bool include_support = true;
+    constexpr bool include_support = true;
     Polygons covered_area = storage.getLayerOutlines(layer_nr, include_support, /*include_prime_tower*/ true, /*external_polys_only*/ false);
 
     std::vector<Polygons> allowed_areas_per_extruder(extruder_count);
@@ -468,7 +468,7 @@ Polygons SkirtBrim::getFirstLayerOutline(const int extruder_nr /* = -1 */)
     constexpr coord_t smallest_line_length = 200;
     constexpr coord_t largest_error_of_removed_point = 50;
     first_layer_outline = Simplify(smallest_line_length, largest_error_of_removed_point, 0).polygon(first_layer_outline);
-    if (first_layer_outline.size() == 0)
+    if (first_layer_outline.empty())
     {
         spdlog::error("Couldn't generate skirt / brim! No polygons on first layer.");
     }

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -519,7 +519,7 @@ Polygons AreaSupport::join(const SliceDataStorage& storage, const Polygons& supp
                 adhesion_size = std::max(adhesion_size, coord_t(
                     skirt_brim_extruder.settings.get<coord_t>(adhesion_width_str)
                     + skirt_brim_extruder.settings.get<coord_t>("skirt_brim_line_width")
-                    * (skirt_brim_extruder.settings.get<coord_t>(adhesion_line_count_str) - 1) // - 1 because the line is also included in extra_skirt_line_width
+                    * (skirt_brim_extruder.settings.get<size_t>(adhesion_line_count_str) - 1) // - 1 because the line is also included in extra_skirt_line_width
                     * skirt_brim_extruder.settings.get<Ratio>("initial_layer_line_width_factor")
                     + extra_skirt_line_width));
                 }


### PR DESCRIPTION
When the model-part for any particular extruder did not have any area on the brim width requirement was not properly fulfilled. This setting was completely ignored and only the lines printed in order to fill the "minimum brim/skrit length" requirement.

| Without fix | With fix |
| ----------| --------|
| <img width="1680" alt="Screenshot 2023-02-28 at 11 26 16" src="https://user-images.githubusercontent.com/6638028/221827048-f4e81dd6-6539-4dd0-be84-54db5f8c205e.png"> | <img width="1680" alt="Screenshot 2023-02-28 at 11 25 49" src="https://user-images.githubusercontent.com/6638028/221827021-ed3d4e54-1050-47c9-8770-525f4a78f64e.png"> |

