### PR TITLE
Fix support generation for models with narrow walls

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1492,16 +1492,19 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
     // To avoids generating support for textures on vertical surfaces, a moving average
     // is taken over smooth_height. The smooth_height is currently an educated guess
     // that we might want to expose to the frontend in the future.
-    Polygons outlines_below = storage.getLayerOutlines(layer_idx - 1, no_support, no_prime_tower)
-                                                         .offset(max_dist_from_lower_layer);
+    Polygons outlines_below =
+        storage.getLayerOutlines(layer_idx - 1, no_support, no_prime_tower)
+        .offset(max_dist_from_lower_layer);
     for (int layer_idx_offset = 2; layer_idx - layer_idx_offset >= 0 && layer_idx_offset <= layers_below; layer_idx_offset ++)
     {
-        auto outlines_below_ = storage.getLayerOutlines(layer_idx - layer_idx_offset, no_support, no_prime_tower)
-                                   .offset(max_dist_from_lower_layer * layer_idx_offset);
+        auto outlines_below_ =
+            storage.getLayerOutlines(layer_idx - layer_idx_offset, no_support, no_prime_tower)
+            .offset(max_dist_from_lower_layer * layer_idx_offset);
         outlines_below = outlines_below.unionPolygons(outlines_below_);
     }
 
-    Polygons basic_overhang = outlines
+    Polygons basic_overhang =
+        outlines
         .difference(outlines_below);
 
     const SupportLayer& support_layer = storage.support.supportLayers[layer_idx];
@@ -1514,7 +1517,10 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
         basic_overhang = basic_overhang.difference(merged_polygons);
     }
 
-    Polygons overhang_extended = basic_overhang.offset(max_dist_from_lower_layer * layers_below + MM2INT(0.1)); // +0.1mm for easier joining with support from layer above
+    Polygons overhang_extended =
+        basic_overhang
+        // +0.1mm for easier joining with support from layer above
+        .offset(max_dist_from_lower_layer * layers_below + MM2INT(0.1));
     Polygons full_overhang = overhang_extended.intersection(outlines);
 
     return std::make_pair(basic_overhang, full_overhang);


### PR DESCRIPTION
This was basically a side effect from [CURA-10314](https://ultimaker.atlassian.net/browse/CURA-10314). For this feature we were looking at the layer(s) above. The idea is that the overhang needs to exist for multiple layers before support is generated. When looking above the overhang angle is limited by the area of the above layer shrunken by `tan(overhang_angle) * delta_z`. As this shrinking behavior is achieved using a negative offset narrow walls would completely be removed.

In order to keep in line with the spirit of the contributions from [CURA-10314](https://ultimaker.atlassian.net/browse/CURA-10314) we instead look to the layer(s) below rather then above. When looking below a positive offset need to be taken in order to achieve a similar result. With a positive offset these narrow features can never be removed.

| Without Fix | With Fix |
|----------|---------|
| ![Screenshot 2023-02-28 at 14 09 32](https://user-images.githubusercontent.com/6638028/221863660-93f78b0e-c6c5-425d-b3fd-0b41c707eb4c.png) | ![Screenshot 2023-02-28 at 14 08 25](https://user-images.githubusercontent.com/6638028/221863481-83e3f53d-10a6-414d-bcf3-f6772e80d760.png) |


@rijkvanmanen FYI

CURA-10336

[CURA-10314]: https://ultimaker.atlassian.net/browse/CURA-10314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CURA-10314]: https://ultimaker.atlassian.net/browse/CURA-10314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ