### PR TITLE
[CURA-10268] Fix wipe for walls.

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -110,7 +110,6 @@ bool InsetOrderOptimizer::addToLayer()
 
     order_optimizer.optimize();
 
-    cura::Point p_end{ 0, 0 };
     for (const PathOrdering<const ExtrusionLine*>& path : order_optimizer.paths)
     {
         if (path.vertices->empty())
@@ -127,9 +126,6 @@ bool InsetOrderOptimizer::addToLayer()
         const bool revert_layer = alternate_walls && (layer_nr % 2);
         const bool backwards = path.backwards != (revert_inset != revert_layer);
         const size_t start_index = (backwards != path.backwards) ? path.vertices->size() - (path.start_vertex + 1) : path.start_vertex;
-
-        p_end = path.backwards ? path.vertices->back().p : path.vertices->front().p;
-        const cura::Point p_start = path.backwards ? path.vertices->front().p : path.vertices->back().p;
         const bool linked_path = ! path.is_closed;
 
         gcode_writer.setExtruder_addPrime(storage, gcode_layer, extruder_nr);

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -130,7 +130,7 @@ bool InsetOrderOptimizer::addToLayer()
 
         p_end = path.backwards ? path.vertices->back().p : path.vertices->front().p;
         const cura::Point p_start = path.backwards ? path.vertices->front().p : path.vertices->back().p;
-        const bool linked_path = p_start != p_end;
+        const bool linked_path = ! path.is_closed;
 
         gcode_writer.setExtruder_addPrime(storage, gcode_layer, extruder_nr);
         gcode_layer.setIsInside(true); // Going to print walls, which are always inside.


### PR DESCRIPTION
For wiping in the walls (as opposed to infill) there was an extra requirement for the path not to be a linked path, that is to say, we don't wipe for open paths where there could be another of its exact type right after. -- In order to detect whether something is a 'linked path', we need to determine if a path is closed or not. Previously, a path was closed if and only if the end-vertex was the same as the start-vertex. That equivalence has been dropped. Fortunately, `is_closed` was added way before that, so it can now be used to determine the `is_linked` status of the path.