### PR TITLE
Revert boost fix

### DIFF
--- a/benchmark/wall_benchmark.h
+++ b/benchmark/wall_benchmark.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 UltiMaker
+// Copyright (c) 2022 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef CURAENGINE_WALL_BENCHMARK_H
@@ -58,7 +58,6 @@ public:
         settings.add("meshfix_maximum_deviation", "0.1");
         settings.add("meshfix_maximum_extrusion_area_deviation", "0.01");
         settings.add("meshfix_maximum_resolution", "0.01");
-        settings.add("min_wall_line_width", "0.3");
         settings.add("min_bead_width", "0");
         settings.add("min_feature_size", "0");
         settings.add("wall_0_extruder_nr", "0");

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -53,10 +53,9 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     const coord_t allowed_distance = settings.get<coord_t>("meshfix_maximum_deviation");
 
     // Sometimes small slivers of polygons mess up the prepared_outline. By performing an open-close operation
-    // with half the minimum printable feature size or minimum line width, these slivers are removed, while still
-    // keeping enough information to not degrade the print quality;
-    // These features can't be printed anyhow. See PR CuraEngine#1811 for some screenshots
-    const coord_t open_close_distance = settings.get<bool>("fill_outline_gaps") ? settings.get<coord_t>("min_feature_size") / 2 - 5 : settings.get<coord_t>("min_wall_line_width") / 2 - 5;
+    // 1/4 of the min_wall_line_width these slivers are removed, while still keeping enough information to not
+    // degrade the print quality; These features can't be printed anyhow. See PR CuraEngine#1811 for some screenshots
+    const coord_t open_close_distance = settings.get<coord_t>("min_wall_line_width") / 4;
     const coord_t epsilon_offset = (allowed_distance / 2) - 1;
     const AngleRadians transitioning_angle = settings.get<AngleRadians>("wall_transition_angle");
     constexpr coord_t discretization_step_size = MM2INT(0.8);
@@ -64,7 +63,6 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     // Simplify outline for boost::voronoi consumption. Absolutely no self intersections or near-self intersections allowed:
     // TODO: Open question: Does this indeed fix all (or all-but-one-in-a-million) cases for manifold but otherwise possibly complex polygons?
     Polygons prepared_outline = outline.offset(-open_close_distance).offset(open_close_distance * 2).offset(-open_close_distance);
-    prepared_outline.removeSmallAreas(small_area_length * small_area_length, false);
     prepared_outline = Simplify(settings).polygon(prepared_outline);
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();
@@ -72,6 +70,7 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
     // Removing collinear edges may introduce self intersections, so we need to fix them again
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();
+    prepared_outline.removeSmallAreas(small_area_length * small_area_length, false);
     prepared_outline = prepared_outline.unionPolygons();
 
     if (prepared_outline.area() <= 0)

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2023 UltiMaker
-// CuraEngine is released under the terms of the AGPLv3 or higher
+// Copyright (c) 2022 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include <algorithm> //For std::partition_copy and std::min_element.
 #include <unordered_set>
@@ -51,18 +51,13 @@ WallToolPaths::WallToolPaths(const Polygons& outline, const coord_t bead_width_0
 const std::vector<VariableWidthLines>& WallToolPaths::generate()
 {
     const coord_t allowed_distance = settings.get<coord_t>("meshfix_maximum_deviation");
-
-    // Sometimes small slivers of polygons mess up the prepared_outline. By performing an open-close operation
-    // 1/4 of the min_wall_line_width these slivers are removed, while still keeping enough information to not
-    // degrade the print quality; These features can't be printed anyhow. See PR CuraEngine#1811 for some screenshots
-    const coord_t open_close_distance = settings.get<coord_t>("min_wall_line_width") / 4;
     const coord_t epsilon_offset = (allowed_distance / 2) - 1;
     const AngleRadians transitioning_angle = settings.get<AngleRadians>("wall_transition_angle");
     constexpr coord_t discretization_step_size = MM2INT(0.8);
 
     // Simplify outline for boost::voronoi consumption. Absolutely no self intersections or near-self intersections allowed:
     // TODO: Open question: Does this indeed fix all (or all-but-one-in-a-million) cases for manifold but otherwise possibly complex polygons?
-    Polygons prepared_outline = outline.offset(-open_close_distance).offset(open_close_distance * 2).offset(-open_close_distance);
+    Polygons prepared_outline = outline.offset(-epsilon_offset).offset(epsilon_offset * 2).offset(-epsilon_offset);
     prepared_outline = Simplify(settings).polygon(prepared_outline);
     PolygonUtils::fixSelfIntersections(epsilon_offset, prepared_outline);
     prepared_outline.removeDegenerateVerts();

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1190,7 +1190,7 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
             const coord_t offset_per_step = support_line_width / 2;
 
             // perform a small offset we don't enlarge small features of the support
-            Polygons horizontal_expansion = layer_this.offset(-half_min_feature_width).offset(half_min_feature_width);
+            Polygons horizontal_expansion = layer_this;
             for (coord_t offset_cumulative = 0; offset_cumulative <= extension_offset; offset_cumulative += offset_per_step)
             {
                 horizontal_expansion = horizontal_expansion.offset(offset_per_step);

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1618,7 +1618,7 @@ void AreaSupport::handleTowers(const Settings& settings, const Polygons& xy_disa
     {
         supportLayer_this = supportLayer_this.unionPolygons(tower_roof);
 
-        if (tower_roof[0].area() < tower_diameter * tower_diameter)
+        if (tower_roof.area() < tower_diameter * tower_diameter)
         {
             constexpr bool no_support = false;
             constexpr bool no_prime_tower = false;
@@ -1641,7 +1641,7 @@ void AreaSupport::handleTowers(const Settings& settings, const Polygons& xy_disa
                     // could indefinitely stay within the towers list
                     break;
                 }
-                if (tower_roof[0].area() >= tower_diameter * tower_diameter)
+                if (tower_roof.area() >= tower_diameter * tower_diameter)
                 {
                     // the desired size of the roof tower is reached, add the support tower to the
                     // current layer and clear the support tower itself

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1190,7 +1190,7 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
             const coord_t offset_per_step = support_line_width / 2;
 
             // perform a small offset we don't enlarge small features of the support
-            Polygons horizontal_expansion = layer_this;
+            Polygons horizontal_expansion = layer_this.offset(-half_min_feature_width).offset(half_min_feature_width);
             for (coord_t offset_cumulative = 0; offset_cumulative <= extension_offset; offset_cumulative += offset_per_step)
             {
                 horizontal_expansion = horizontal_expansion.offset(offset_per_step);

--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 UltiMaker
+// Copyright (c) 2022 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <optional>

--- a/tests/WallsComputationTest.cpp
+++ b/tests/WallsComputationTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 UltiMaker
+// Copyright (c) 2022 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <range/v3/view/join.hpp>
@@ -71,7 +71,6 @@ public:
         settings.add("meshfix_maximum_deviation", "0.1");
         settings.add("meshfix_maximum_extrusion_area_deviation", "0.01");
         settings.add("meshfix_maximum_resolution", "0.01");
-        settings.add("min_wall_line_width", "0.3");
         settings.add("min_bead_width", "0");
         settings.add("min_feature_size", "0");
         settings.add("wall_0_extruder_nr", "0");


### PR DESCRIPTION
### DO NOT MERGE THIS PR
This branch is made to determine if all boost fixes are a regression, or actually improve crashes

Reverts https://github.com/Ultimaker/CuraEngine/pull/1811 and https://github.com/Ultimaker/CuraEngine/pull/1822

CURA-10348