### PR TITLE
CURA-9933_insert-M104-mid-polygon

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -1,5 +1,5 @@
-//Copyright (c) 2022 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef LAYER_PLAN_H
 #define LAYER_PLAN_H
@@ -91,17 +91,10 @@ public:
      */
     ExtruderPlan(const size_t extruder, const LayerIndex layer_nr, const bool is_initial_layer, const bool is_raft_layer, const coord_t layer_thickness, const FanSpeedLayerTimeSettings& fan_speed_layer_time_settings, const RetractionConfig& retraction_config);
 
-    /*!
-     * Add a new Insert, constructed with the given arguments
-     * 
-     * \see NozzleTempInsert
-     * 
-     * \param contructor_args The arguments for the constructor of an insert 
-     */
-    template<typename... Args>
-    void insertCommand(Args&&... contructor_args)
+
+    void insertCommand(auto&& insert)
     {
-        inserts.emplace_back(contructor_args...);
+        inserts.emplace_back(std::forward<decltype(insert)>(insert));
     }
 
     /*!
@@ -111,7 +104,7 @@ public:
      * \param gcode The gcode exporter to which to write the temperature command.
      * \param cumulative_path_time The time spend on this path up to this point.
      */
-    void handleInserts(const int64_t& path_idx, GCodeExport& gcode, const double& cumulative_path_time = std::numeric_limits<double>::infinity());
+    void handleInserts(const size_t path_idx, GCodeExport& gcode, const double& cumulative_path_time = std::numeric_limits<double>::infinity());
 
     /*!
      * Insert all remaining temp inserts into gcode, to be called at the end of an extruder plan

--- a/include/pathPlanning/NozzleTempInsert.h
+++ b/include/pathPlanning/NozzleTempInsert.h
@@ -17,7 +17,7 @@ class GCodeExport;
 struct NozzleTempInsert
 {
     const unsigned int path_idx; //!< The path before which to insert this command
-    double time_after_path_start; //!< The time after the start of the path, before which to insert the command // TODO: use this to insert command in between moves in a path!
+    double time_after_path_start; //!< The time after the start of the path, before which to insert the command
     int extruder; //!< The extruder for which to set the temp
     double temperature; //!< The temperature of the temperature command to insert
     bool wait; //!< Whether to wait for the temperature to be reached

--- a/include/pathPlanning/NozzleTempInsert.h
+++ b/include/pathPlanning/NozzleTempInsert.h
@@ -1,8 +1,10 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef PATH_PLANNING_NOZZLE_TEMP_INSERT_H
 #define PATH_PLANNING_NOZZLE_TEMP_INSERT_H
+
+#include <cstddef>
 
 namespace cura
 {
@@ -11,24 +13,34 @@ class GCodeExport;
 
 /*!
  * A gcode command to insert before a specific path.
- * 
+ *
  * Currently only used for preheat commands
  */
 struct NozzleTempInsert
 {
-    const unsigned int path_idx; //!< The path before which to insert this command
-    double time_after_path_start; //!< The time after the start of the path, before which to insert the command
-    int extruder; //!< The extruder for which to set the temp
-    double temperature; //!< The temperature of the temperature command to insert
-    bool wait; //!< Whether to wait for the temperature to be reached
-    NozzleTempInsert(unsigned int path_idx, int extruder, double temperature, bool wait, double time_after_path_start = 0.0);
+    size_t path_idx{}; //!< The path before which to insert this command
+    size_t extruder{}; //!< The extruder for which to set the temp
+    double temperature{}; //!< The temperature of the temperature command to insert
+    bool wait{}; //!< Whether to wait for the temperature to be reached
+    double time_after_path_start{ 0.0 }; //!< The time after the start of the path, before which to insert the command
+
+    constexpr std::partial_ordering operator<=>(const NozzleTempInsert& other) const
+    {
+        if (path_idx == other.path_idx)
+        {
+            return time_after_path_start <=> other.time_after_path_start;
+        }
+        return path_idx <=> other.path_idx;
+    }
 
     /*!
      * Write the temperature command at the current position in the gcode.
      * \param gcode The actual gcode writer
      */
     void write(GCodeExport& gcode);
-};
-}//namespace cura
 
-#endif//PATH_PLANNING_NOZZLE_TEMP_INSERT_H
+};
+
+} // namespace cura
+
+#endif // PATH_PLANNING_NOZZLE_TEMP_INSERT_H

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1827,7 +1827,13 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         gcode.writeFanCommand(extruder_plan.getFanSpeed());
         std::vector<GCodePath>& paths = extruder_plan.paths;
 
-        extruder_plan.inserts.sort([](const NozzleTempInsert& a, const NozzleTempInsert& b) -> bool { return a.path_idx < b.path_idx; });
+        extruder_plan.inserts.sort([](const NozzleTempInsert& a, const NozzleTempInsert& b) -> bool {
+                                       if (a.path_idx == b.path_idx) {
+                                           return a.time_after_path_start < b.time_after_path_start;
+                                       } else {
+                                           return a.path_idx < b.path_idx;
+                                       }
+                                   });
 
         const ExtruderTrain& extruder = Application::getInstance().current_slice->scene.extruders[extruder_nr];
 

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -55,7 +55,7 @@ ExtruderPlan::ExtruderPlan
 {
 }
 
-void ExtruderPlan::handleInserts(const int64_t& path_idx, GCodeExport& gcode, const double& cumulative_path_time)
+void ExtruderPlan::handleInserts(const size_t path_idx, GCodeExport& gcode, const double& cumulative_path_time)
 {
     while (! inserts.empty() && path_idx >= inserts.front().path_idx && inserts.front().time_after_path_start < cumulative_path_time)
     { // handle the Insert to be inserted before this path_idx (and all inserts not handled yet)
@@ -1827,13 +1827,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         gcode.writeFanCommand(extruder_plan.getFanSpeed());
         std::vector<GCodePath>& paths = extruder_plan.paths;
 
-        extruder_plan.inserts.sort([](const NozzleTempInsert& a, const NozzleTempInsert& b) -> bool {
-                                       if (a.path_idx == b.path_idx) {
-                                           return a.time_after_path_start < b.time_after_path_start;
-                                       } else {
-                                           return a.path_idx < b.path_idx;
-                                       }
-                                   });
+        extruder_plan.inserts.sort();
 
         const ExtruderTrain& extruder = Application::getInstance().current_slice->scene.extruders[extruder_nr];
 
@@ -1849,7 +1843,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
         for (int64_t path_idx = 0; path_idx < paths.size(); path_idx++)
         {
-            extruder_plan.handleInserts(path_idx - 1, gcode);
+            extruder_plan.handleInserts(path_idx, gcode);
             cumulative_path_time = 0.; // reset to 0 for current path.
 
             GCodePath& path = paths[path_idx];

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -69,7 +69,6 @@ void ExtruderPlan::handleAllRemainingInserts(GCodeExport& gcode)
     while (! inserts.empty())
     { // handle the Insert to be inserted before this path_idx (and all inserts not handled yet)
         NozzleTempInsert& insert = inserts.front();
-        assert(insert.path_idx == paths.size());
         insert.write(gcode);
         inserts.pop_front();
     }

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <spdlog/spdlog.h>
@@ -144,14 +144,21 @@ void LayerPlanBuffer::insertPreheatCommand(ExtruderPlan& extruder_plan_before, c
         acc_time += path.estimates.getTotalTime();
         if (acc_time >= time_before_extruder_plan_end)
         {
-            bool wait = false;
-            extruder_plan_before.insertCommand(path_idx, extruder_nr, temp, wait, acc_time - time_before_extruder_plan_end);
+            constexpr bool wait = false;
+            extruder_plan_before.insertCommand(NozzleTempInsert{ .path_idx = path_idx,
+                                                                 .extruder = extruder_nr,
+                                                                 .temperature = temp,
+                                                                 .wait = wait,
+                                                                 .time_after_path_start = acc_time - time_before_extruder_plan_end });
             return;
         }
     }
-    bool wait = false;
+    constexpr bool wait = false;
     constexpr size_t path_idx = 0;
-    extruder_plan_before.insertCommand(path_idx, extruder_nr, temp, wait); // insert at start of extruder plan if time_after_extruder_plan_start > extruder_plan.time
+    extruder_plan_before.insertCommand(NozzleTempInsert{ .path_idx = path_idx,
+                                                         .extruder = extruder_nr,
+                                                         .temperature = temp,
+                                                         .wait = wait }); // insert at start of extruder plan if time_after_extruder_plan_start > extruder_plan.time
 }
 
 Preheat::WarmUpResult LayerPlanBuffer::computeStandbyTempPlan(std::vector<ExtruderPlan*>& extruder_plans, unsigned int extruder_plan_idx)
@@ -226,7 +233,10 @@ void LayerPlanBuffer::handleStandbyTemp(std::vector<ExtruderPlan*>& extruder_pla
     spdlog::warn("Couldn't find previous extruder plan so as to set the standby temperature. Inserting temp command in earliest available layer.");
     ExtruderPlan& earliest_extruder_plan = *extruder_plans[0];
     constexpr bool wait = false;
-    earliest_extruder_plan.insertCommand(0, extruder, standby_temp, wait);
+    earliest_extruder_plan.insertCommand(NozzleTempInsert{ .path_idx = 0,
+                                                           .extruder = extruder,
+                                                           .temperature = standby_temp,
+                                                           .wait = wait });
 }
 
 void LayerPlanBuffer::insertPreheatCommand_multiExtrusion(std::vector<ExtruderPlan*>& extruder_plans, unsigned int extruder_plan_idx)
@@ -271,7 +281,10 @@ void LayerPlanBuffer::insertPreheatCommand_multiExtrusion(std::vector<ExtruderPl
     // time_before_extruder_plan_to_insert falls before all plans in the buffer
     bool wait = false;
     unsigned int path_idx = 0;
-    extruder_plans[0]->insertCommand(path_idx, extruder, initial_print_temp, wait); // insert preheat command at verfy beginning of buffer
+    extruder_plans[0]->insertCommand(NozzleTempInsert { .path_idx = path_idx,
+                                                       .extruder = extruder,
+                                                       .temperature = initial_print_temp,
+                                                       .wait = wait }); // insert preheat command at verfy beginning of buffer
 }
 
 void LayerPlanBuffer::insertTempCommands(std::vector<ExtruderPlan*>& extruder_plans, unsigned int extruder_plan_idx)
@@ -337,7 +350,10 @@ void LayerPlanBuffer::insertPrintTempCommand(ExtruderPlan& extruder_plan)
             }
         }
         bool wait = false;
-        extruder_plan.insertCommand(path_idx, extruder, print_temp, wait);
+        extruder_plan.insertCommand(NozzleTempInsert{ .path_idx = path_idx,
+                                                      .extruder = extruder,
+                                                      .temperature = print_temp,
+                                                      .wait = wait });
     }
     extruder_plan.heated_pre_travel_time = heated_pre_travel_time;
 }
@@ -465,7 +481,11 @@ void LayerPlanBuffer::insertFinalPrintTempCommand(std::vector<ExtruderPlan*>& ex
         }
         bool wait = false;
         double time_after_path_start = extrusion_time_seen - cool_down_time;
-        precool_extruder_plan->insertCommand(path_idx, extruder, final_print_temp, wait, time_after_path_start);
+        precool_extruder_plan->insertCommand(NozzleTempInsert { .path_idx = path_idx,
+                                                                .extruder = extruder,
+                                                                .temperature = final_print_temp,
+                                                                .wait = wait,
+                                                                .time_after_path_start = time_after_path_start });
     }
 }
 

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -135,19 +135,17 @@ void LayerPlanBuffer::processFanSpeedLayerTime()
 }
 
 
-void LayerPlanBuffer::insertPreheatCommand(ExtruderPlan& extruder_plan_before, const Duration time_after_extruder_plan_start, const size_t extruder_nr, const Temperature temp)
+void LayerPlanBuffer::insertPreheatCommand(ExtruderPlan& extruder_plan_before, const Duration time_before_extruder_plan_end, const size_t extruder_nr, const Temperature temp)
 {
     Duration acc_time = 0.0;
     for (unsigned int path_idx = extruder_plan_before.paths.size() - 1; int(path_idx) != -1; path_idx--)
     {
         GCodePath& path = extruder_plan_before.paths[path_idx];
-        const Duration time_this_path = path.estimates.getTotalTime();
-        acc_time += time_this_path;
-        if (acc_time > time_after_extruder_plan_start)
+        acc_time += path.estimates.getTotalTime();
+        if (acc_time >= time_before_extruder_plan_end)
         {
-            const Duration time_before_path_end = acc_time - time_after_extruder_plan_start;
             bool wait = false;
-            extruder_plan_before.insertCommand(path_idx, extruder_nr, temp, wait, time_this_path - time_before_path_end);
+            extruder_plan_before.insertCommand(path_idx, extruder_nr, temp, wait, acc_time - time_before_extruder_plan_end);
             return;
         }
     }

--- a/src/pathPlanning/NozzleTempInsert.cpp
+++ b/src/pathPlanning/NozzleTempInsert.cpp
@@ -1,26 +1,15 @@
-//Copyright (c) 2022 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
-#include <assert.h>
 #include "gcodeExport.h"
 #include "pathPlanning/NozzleTempInsert.h"
 
 namespace cura
 {
 
-NozzleTempInsert::NozzleTempInsert(unsigned int path_idx, int extruder, double temperature, bool wait, double time_after_path_start)
-: path_idx(path_idx)
-, time_after_path_start(time_after_path_start)
-, extruder(extruder)
-, temperature(temperature)
-, wait(wait)
-{
-    assert(temperature != 0 && temperature != -1 && "Temperature command must be set!");
-}
-
 void NozzleTempInsert::write(GCodeExport& gcode)
 {
     gcode.writeTemperatureCommand(extruder, temperature, wait);
 }
 
-}
+} // namespace cura


### PR DESCRIPTION
The preheat and precool commands are now inserted mid polygon/polyline, making the timing much more accurate. Not yet mid segment, but that is also not too important. The timing is still not perfect, and I am not sure why. But this is already a big step in the right direction.

This branch is cleaned version of the [CURA-9540 spike branch](https://github.com/Ultimaker/CuraEngine/tree/CURA-9540_insert_temp_mid_polygon).