### PR TITLE
Fix fuzzy skin

### DIFF
--- a/include/utils/Simplify.h
+++ b/include/utils/Simplify.h
@@ -199,12 +199,6 @@ protected:
             }
         }
 
-        // make sure for closed polygons that the polygon ends at the start point
-        if (is_closed && filtered.front() != filtered.back())
-        {
-            appendVertex(filtered, filtered.front());
-        }
-
         return filtered;
     }
 

--- a/include/utils/Simplify.h
+++ b/include/utils/Simplify.h
@@ -199,6 +199,12 @@ protected:
             }
         }
 
+        // make sure for closed polygons that the polygon ends at the start point
+        if (is_closed && filtered.front() != filtered.back())
+        {
+            appendVertex(filtered, filtered.front());
+        }
+
         return filtered;
     }
 

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -199,11 +199,16 @@ void WallToolPaths::removeSmallLines(std::vector<VariableWidthLines>& toolpaths)
 void WallToolPaths::simplifyToolPaths(std::vector<VariableWidthLines>& toolpaths, const Settings& settings)
 {
     const Simplify simplifier(settings);
-    for(size_t toolpaths_idx = 0; toolpaths_idx < toolpaths.size(); ++toolpaths_idx)
+    for (auto& toolpath : toolpaths)
     {
-        for(ExtrusionLine& line : toolpaths[toolpaths_idx])
+        for (auto& line : toolpath)
         {
             line = line.is_closed ? simplifier.polygon(line) : simplifier.polyline(line);
+
+            if (line.is_closed && line.front() != line.back())
+            {
+                line.emplace_back(line.front());
+            }
         }
     }
 }

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -205,7 +205,7 @@ void WallToolPaths::simplifyToolPaths(std::vector<VariableWidthLines>& toolpaths
         {
             line = line.is_closed ? simplifier.polygon(line) : simplifier.polyline(line);
 
-            if (line.is_closed && line.front() != line.back())
+            if (line.is_closed && line.size() >= 2 && line.front() != line.back())
             {
                 line.emplace_back(line.front());
             }


### PR DESCRIPTION
Previously we had semantics that for all closed paths the last point was equal to the first point; `path.front() != path.back()`. With commit d31d61518b1659f6a5181573918b0141e726b3f2 the semantics changed.

Fixes https://github.com/Ultimaker/Cura/issues/14750, CURA-10368
