### PR TITLE
Fix integer underflow on 32 bit systems

### DIFF
--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1606,7 +1606,7 @@ SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beadin
     // TODO: don't use toolpath locations past the middle!
     // TODO: stretch bead widths and locations of the higher bead count beading to fit in the left over space
     coord_t next_inset_idx;
-    for (next_inset_idx = left.toolpath_locations.size() - 1; next_inset_idx >= 0; next_inset_idx--)
+    for (next_inset_idx = coord_t(left.toolpath_locations.size()) - 1; next_inset_idx >= 0; next_inset_idx--)
     {
         if (switching_radius > left.toolpath_locations[next_inset_idx])
         {


### PR DESCRIPTION
# Description

Fixes a possible integer underflow which causes an out of bounds array access when `size_t` and `coord_t` are different sizes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

We build CuraEngine to WebAssembly. Repro steps are a bit more involved than I can easily include here, but I am able to consistently crash the program, and have observed it no longer crashes after this fix.

<details>

<summary>Test Results (wasm)</summary>

```

12:12:22:~/Workspace/CuraEngine/build/Release % ctest
Test project /Users/cody/Workspace/CuraEngine/build/Release
      Start  1: ClipperTest
 1/23 Test  #1: ClipperTest ......................   Passed    0.06 sec
      Start  2: ExtruderPlanTest
 2/23 Test  #2: ExtruderPlanTest .................   Passed    0.05 sec
      Start  3: GCodeExportTest
 3/23 Test  #3: GCodeExportTest ..................   Passed    0.05 sec
      Start  4: InfillTest
 4/23 Test  #4: InfillTest .......................   Passed    0.05 sec
      Start  5: LayerPlanTest
 5/23 Test  #5: LayerPlanTest ....................   Passed    0.05 sec
      Start  6: PathOrderOptimizerTest
 6/23 Test  #6: PathOrderOptimizerTest ...........   Passed    0.05 sec
      Start  7: PathOrderMonotonicTest
 7/23 Test  #7: PathOrderMonotonicTest ...........   Passed    0.05 sec
      Start  8: TimeEstimateCalculatorTest
 8/23 Test  #8: TimeEstimateCalculatorTest .......   Passed    0.05 sec
      Start  9: WallsComputationTest
 9/23 Test  #9: WallsComputationTest .............   Passed    0.05 sec
      Start 10: SlicePhaseTest
10/23 Test #10: SlicePhaseTest ...................   Passed    0.05 sec
      Start 11: SettingsTest
11/23 Test #11: SettingsTest .....................   Passed    0.05 sec
      Start 12: AABBTest
12/23 Test #12: AABBTest .........................   Passed    0.05 sec
      Start 13: AABB3DTest
13/23 Test #13: AABB3DTest .......................   Passed    0.05 sec
      Start 14: IntPointTest
14/23 Test #14: IntPointTest .....................   Passed    0.05 sec
      Start 15: LinearAlg2DTest
15/23 Test #15: LinearAlg2DTest ..................   Passed    0.05 sec
      Start 16: MinimumSpanningTreeTest
16/23 Test #16: MinimumSpanningTreeTest ..........   Passed    0.05 sec
      Start 17: PolygonConnectorTest
17/23 Test #17: PolygonConnectorTest .............   Passed    0.05 sec
      Start 18: PolygonTest
18/23 Test #18: PolygonTest ......................   Passed    0.05 sec
      Start 19: PolygonUtilsTest
19/23 Test #19: PolygonUtilsTest .................   Passed    0.05 sec
      Start 20: SimplifyTest
20/23 Test #20: SimplifyTest .....................   Passed    0.05 sec
      Start 21: SparseGridTest
21/23 Test #21: SparseGridTest ...................   Passed    0.14 sec
      Start 22: StringTest
22/23 Test #22: StringTest .......................   Passed    0.11 sec
      Start 23: UnionFindTest
23/23 Test #23: UnionFindTest ....................   Passed    0.05 sec

100% tests passed, 0 tests failed out of 23

Total Test time (real) =   1.34 sec

```

</details>

**Test Configuration**:
* Operating System: WebAssembly

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
  - Will provide at request