### PR TITLE
Add TARGET_MACHINE.NAME header comments

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -226,6 +226,7 @@ std::string GCodeExport::getFileHeader(const std::vector<bool>& extruder_is_used
         break;
     default:
         prefix << ";FLAVOR:" << flavorToString(flavor) << new_line;
+        prefix << ";TARGET_MACHINE.NAME:" << transliterate(machine_name) << new_line;
         prefix << ";TIME:" << ((print_time) ? static_cast<int>(*print_time) : 6666) << new_line;
         if (flavor == EGCodeFlavor::ULTIGCODE)
         {

--- a/tests/GCodeExportTest.cpp
+++ b/tests/GCodeExportTest.cpp
@@ -330,7 +330,7 @@ TEST_F(GCodeExportTest, HeaderUltiGCode)
     std::string result = gcode.getFileHeader(extruder_is_used, &print_time, filament_used);
 
     EXPECT_EQ(result,
-              ";FLAVOR:UltiGCode\n;TIME:1337\n;MATERIAL:100\n;MATERIAL2:200\n;NOZZLE_DIAMETER:0.4\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;"
+              ";FLAVOR:UltiGCode\n;TARGET_MACHINE.NAME:Your favourite 3D printer\n;TIME:1337\n;MATERIAL:100\n;MATERIAL2:200\n;NOZZLE_DIAMETER:0.4\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;"
               "MAXY:1\n;MAXZ:1\n");
 }
 
@@ -349,7 +349,7 @@ TEST_F(GCodeExportTest, HeaderRepRap)
     std::string result = gcode.getFileHeader(extruder_is_used, &print_time, filament_used);
 
     EXPECT_EQ(result,
-              ";FLAVOR:RepRap\n;TIME:1337\n;Filament used: 0.02m, 0.05m\n;Layer height: "
+              ";FLAVOR:RepRap\n;TARGET_MACHINE.NAME:Your favourite 3D printer\n;TIME:1337\n;Filament used: 0.02m, 0.05m\n;Layer height: "
               "0.123\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;MAXY:1\n;MAXZ:1\n");
 }
 
@@ -368,7 +368,7 @@ TEST_F(GCodeExportTest, HeaderMarlin)
     std::string result = gcode.getFileHeader(extruder_is_used, &print_time, filament_used);
 
     EXPECT_EQ(result,
-              ";FLAVOR:Marlin\n;TIME:1337\n;Filament used: 0.02m, 0.05m\n;Layer height: "
+              ";FLAVOR:Marlin\n;TARGET_MACHINE.NAME:Your favourite 3D printer\n;TIME:1337\n;Filament used: 0.02m, 0.05m\n;Layer height: "
               "0.123\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;MAXY:1\n;MAXZ:1\n");
 }
 
@@ -385,7 +385,7 @@ TEST_F(GCodeExportTest, HeaderMarlinVolumetric)
     std::string result = gcode.getFileHeader(extruder_is_used, &print_time, filament_used);
 
     EXPECT_EQ(result,
-              ";FLAVOR:Marlin(Volumetric)\n;TIME:1337\n;Filament used: 100mm3, 200mm3\n;Layer height: "
+              ";FLAVOR:Marlin(Volumetric)\n;TARGET_MACHINE.NAME:Your favourite 3D printer\n;TIME:1337\n;Filament used: 100mm3, 200mm3\n;Layer height: "
               "0.123\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;MAXY:1\n;MAXZ:1\n");
 }
 


### PR DESCRIPTION

# Description

This improves the ability to run gcode on heterogeneous print farms by indicating the machine the code is intended to run on. See #14283 for the related bug.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Edited tests in `tests/GCodeExportTest.cpp` to also confirm the presence of the new header line.  

**Test Configuration**:

* Operating System: Ubuntu 20.04, in a docker container (see bug link for details).

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x]  I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas *(N/A really)*
- [x] I have uploaded any files required to test this change