### PR TITLE
[CURA-10500] simplify fixes

### DIFF
--- a/include/infill.h
+++ b/include/infill.h
@@ -91,7 +91,7 @@ public:
     , max_resolution(max_resolution)
     , max_deviation(max_deviation)
     , wall_line_count(wall_line_count)
-    , small_area_width(small_area_width)
+    , small_area_width(0) // FIXME!: Disable small_area_width for the 5.4.x releases. Current plan is to figure out why this feature causes small line segments & fix that before 5.5.x
     , infill_origin(infill_origin)
     , skip_line_stitching(skip_line_stitching)
     , fill_gaps(fill_gaps)

--- a/include/utils/Simplify.h
+++ b/include/utils/Simplify.h
@@ -221,18 +221,16 @@ protected:
         }
 
         //Now remove the marked vertices in one sweep.
-        AABB aabb;
         Polygonal filtered = createEmpty(polygon);
         for(size_t i = 0; i < result.size(); ++i)
         {
             if(!to_delete[i])
             {
                 appendVertex(filtered, result[i]);
-                aabb.include(getPosition(result[i]));
             }
         }
 
-        if (detectSmall(filtered, min_size) || aabb.area() < min_resolution * min_resolution)
+        if (detectSmall(filtered, min_size))
         {
             return createEmpty(filtered);
         }

--- a/include/utils/Simplify.h
+++ b/include/utils/Simplify.h
@@ -294,6 +294,7 @@ protected:
      * \param vertex The index of the vertex to remove.
      * \param deviation2 The previously found deviation for this vertex.
      * \param is_closed Whether we're working on a closed polygon or an open
+     \return Whether something is actually removed
      * polyline.
      */
     template<typename Polygonal>

--- a/include/utils/Simplify.h
+++ b/include/utils/Simplify.h
@@ -199,7 +199,7 @@ protected:
 
             //Iteratively remove the least important point until a threshold.
             coord_t vertex_importance = 0;
-            while ((polygon.size() - current_removed) > min_size && ! by_importance.empty())
+            while (! by_importance.empty() && (polygon.size() - current_removed) > min_size)
             {
                 std::pair<size_t, coord_t> vertex = by_importance.top();
                 by_importance.pop();

--- a/include/utils/Simplify.h
+++ b/include/utils/Simplify.h
@@ -4,7 +4,6 @@
 #ifndef UTILS_SIMPLIFY_H
 #define UTILS_SIMPLIFY_H
 
-#include "AABB.h"
 #include "polygon.h"
 #include "ExtrusionLine.h"
 #include "linearAlg2D.h" //To calculate line deviations and intersecting lines.

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -661,7 +661,7 @@ void LayerPlan::addWallLine(const Point& p0,
                             Ratio speed_factor,
                             double distance_to_bridge_start)
 {
-    const coord_t min_line_len = 5; // we ignore lines less than 5um long
+    const coord_t min_line_len = settings.get<coord_t>("meshfix_maximum_resolution") / 2; // Shouldn't cut up stuff (too much) below the required simplify resolution.
     const double acceleration_segment_len = MM2INT(1); // accelerate using segments of this length
     const double acceleration_factor = 0.75; // must be < 1, the larger the value, the slower the acceleration
     const bool spiralize = false;

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -72,7 +72,8 @@ void WallsComputation::generateWalls(SliceLayerPart* part, SectionType section_t
         part->wall_toolpaths = wall_tool_paths.getToolPaths();
         part->inner_area = wall_tool_paths.getInnerContour();
     }
-    part->print_outline = Simplify(settings).polygon(part->outline);
+    part->outline = PolygonsPart(Simplify(settings).polygon(part->outline));
+    part->print_outline = part->outline;
 }
 
 /*

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -72,7 +72,7 @@ void WallsComputation::generateWalls(SliceLayerPart* part, SectionType section_t
         part->wall_toolpaths = wall_tool_paths.getToolPaths();
         part->inner_area = wall_tool_paths.getInnerContour();
     }
-    part->outline = PolygonsPart(Simplify(settings).polygon(part->outline));
+    part->outline = PolygonsPart { Simplify(settings).polygon(part->outline) };
     part->print_outline = part->outline;
 }
 

--- a/src/WallsComputation.cpp
+++ b/src/WallsComputation.cpp
@@ -72,7 +72,7 @@ void WallsComputation::generateWalls(SliceLayerPart* part, SectionType section_t
         part->wall_toolpaths = wall_tool_paths.getToolPaths();
         part->inner_area = wall_tool_paths.getInnerContour();
     }
-    part->print_outline = part->outline;
+    part->print_outline = Simplify(settings).polygon(part->outline);
 }
 
 /*

--- a/src/utils/LinearAlg2D.cpp
+++ b/src/utils/LinearAlg2D.cpp
@@ -191,43 +191,10 @@ bool LinearAlg2D::lineSegmentsCollide(const Point& a_from_transformed, const Poi
 
 coord_t LinearAlg2D::getDist2FromLine(const Point& p, const Point& a, const Point& b)
 {
-    constexpr coord_t SQRT_LLONG_MAX_FLOOR = 3037000499;
-
-    //  x.......a------------b
-    //  :
-    //  :
-    //  p
-    // return px_size^2 (if there is no overflow)
-    const Point vab = b - a;
-    const Point vap = p - a;
-    const coord_t ab_size2 = vSize2(vab);
-    const coord_t ap_size2 = vSize2(vap);
-    coord_t px_size2;
-    if(ab_size2 == 0) //Line of 0 length. Assume it's a line perpendicular to the direction to p.
-    {
-        return ap_size2;
-    }
-    const coord_t dott = dot(vab, vap);
-    if (dott != 0 && std::abs(dott) > SQRT_LLONG_MAX_FLOOR)
-    { // dott * dott will overflow so calculate px_size2 via its square root
-        coord_t px_size = LinearAlg2D::getDistFromLine(p, a, b);
-        if (px_size <= SQRT_LLONG_MAX_FLOOR)
-        {
-            // Due to rounding and conversion errors, this multiplication may not be the exact value that would be
-            // produced via the dott product, but it should still be close enough
-            px_size2 = px_size * px_size;
-        }
-        else
-        {
-            px_size2 = std::numeric_limits<long long>::max();
-        }
-    }
-    else
-    {
-        const coord_t ax_size2 = dott * dott / ab_size2;
-        px_size2 = std::max(coord_t(0), ap_size2 - ax_size2);
-    }
-    return px_size2;
+    // NOTE: The version that tried to do a faster calulation wasn't actually that much faster, and introduced errors.
+    //       Use this for now, should we need this, we can reimplement later.
+    const auto dist = getDistFromLine(p, a, b);
+    return dist * dist;
 }
 
 bool LinearAlg2D::isInsideCorner(const Point a, const Point b, const Point c, const Point query_point)

--- a/tests/utils/LinearAlg2DTest.cpp
+++ b/tests/utils/LinearAlg2DTest.cpp
@@ -5,6 +5,9 @@
 #include <cstdint>
 #include <gtest/gtest.h>
 
+#include "utils/SVG.h"
+#include "utils/Simplify.h"
+
 // NOLINTBEGIN(*-magic-numbers)
 namespace cura
 {
@@ -296,6 +299,36 @@ INSTANTIATE_TEST_SUITE_P(RotateAroundInstantiation,
                                          RotateAroundParameters(Point(-67, 14), Point(50, 50), 0, Point(-67, 14)), // No rotation at all.
                                          RotateAroundParameters(Point(-67, 14), Point(50, 50), 12, Point(-57, -9)) // 12 degrees rotation. Actually ends up at [-57, -9.5]!
                                          ));
+
+class Temp {};
+
+TEST(Temp, LineDistTests)
+{
+    std::srand(987);
+    for (int z = 0; z < 100; ++z)
+    {
+        const Point p{ 500000 + (std::rand() % 4000) - 2000, 500000 + (std::rand() % 4000) - 2000 };
+
+        RAND_MAX;
+
+        const coord_t d = (std::rand() % 2000) - 1000 /2;
+        const double rang = std::rand() / (static_cast<double>(RAND_MAX) / 6.29);
+        const Point x{ p.X + static_cast<coord_t>(d * std::cos(rang)), p.Y - static_cast<coord_t>(d * std::sin(rang)) };
+
+        // Use positive lengths here, so line and line-segment should give the same answers.
+        coord_t len = std::rand() % 1000;
+        const Point a{ x.X + static_cast<coord_t>(len * std::sin(rang)), x.Y + static_cast<coord_t>(len * std::cos(rang)) };
+        len = std::rand() % 1000;
+        const Point b{ x.X - static_cast<coord_t>(len * std::sin(rang)), x.Y - static_cast<coord_t>(len * std::cos(rang)) };
+
+        const coord_t abs_d = std::abs(d);
+        EXPECT_NEAR(LinearAlg2D::getDistFromLine(p, a, b), abs_d, 5);
+        EXPECT_NEAR(vSize(LinearAlg2D::getClosestOnLine(p, a, b) - x), 0, 5);
+        EXPECT_NEAR(vSize(LinearAlg2D::getClosestOnLineSegment(p, a, b) - x), 0, 5);
+        EXPECT_NEAR(LinearAlg2D::getDist2FromLine(p, a, b), abs_d * abs_d, 25);
+        EXPECT_NEAR(LinearAlg2D::getDist2FromLineSegment(a, p, b), abs_d * abs_d, 25);
+    }
+}
 
 } // namespace cura
 // NOLINTEND(*-magic-numbers)

--- a/tests/utils/LinearAlg2DTest.cpp
+++ b/tests/utils/LinearAlg2DTest.cpp
@@ -5,9 +5,6 @@
 #include <cstdint>
 #include <gtest/gtest.h>
 
-#include "utils/SVG.h"
-#include "utils/Simplify.h"
-
 // NOLINTBEGIN(*-magic-numbers)
 namespace cura
 {

--- a/tests/utils/LinearAlg2DTest.cpp
+++ b/tests/utils/LinearAlg2DTest.cpp
@@ -326,7 +326,7 @@ TEST(Temp, LineDistTests)
         EXPECT_NEAR(vSize(LinearAlg2D::getClosestOnLine(p, a, b) - x), 0, 5);
         EXPECT_NEAR(vSize(LinearAlg2D::getClosestOnLineSegment(p, a, b) - x), 0, 5);
         EXPECT_NEAR(LinearAlg2D::getDist2FromLine(p, a, b), abs_d * abs_d, 25);
-        EXPECT_NEAR(LinearAlg2D::getDist2FromLineSegment(a, p, b), abs_d * abs_d, 25);
+        //EXPECT_NEAR(LinearAlg2D::getDist2FromLineSegment(a, p, b), abs_d * abs_d, 25);
     }
 }
 

--- a/tests/utils/LinearAlg2DTest.cpp
+++ b/tests/utils/LinearAlg2DTest.cpp
@@ -309,8 +309,6 @@ TEST(Temp, LineDistTests)
     {
         const Point p{ 500000 + (std::rand() % 4000) - 2000, 500000 + (std::rand() % 4000) - 2000 };
 
-        RAND_MAX;
-
         const coord_t d = (std::rand() % 2000) - 1000 /2;
         const double rang = std::rand() / (static_cast<double>(RAND_MAX) / 6.29);
         const Point x{ p.X + static_cast<coord_t>(d * std::cos(rang)), p.Y - static_cast<coord_t>(d * std::sin(rang)) };
@@ -322,11 +320,13 @@ TEST(Temp, LineDistTests)
         const Point b{ x.X - static_cast<coord_t>(len * std::sin(rang)), x.Y - static_cast<coord_t>(len * std::cos(rang)) };
 
         const coord_t abs_d = std::abs(d);
-        EXPECT_NEAR(LinearAlg2D::getDistFromLine(p, a, b), abs_d, 5);
-        EXPECT_NEAR(vSize(LinearAlg2D::getClosestOnLine(p, a, b) - x), 0, 5);
-        EXPECT_NEAR(vSize(LinearAlg2D::getClosestOnLineSegment(p, a, b) - x), 0, 5);
-        EXPECT_NEAR(LinearAlg2D::getDist2FromLine(p, a, b), abs_d * abs_d, 25);
-        //EXPECT_NEAR(LinearAlg2D::getDist2FromLineSegment(a, p, b), abs_d * abs_d, 25);
+        ASSERT_NEAR(LinearAlg2D::getDistFromLine(p, a, b), abs_d, 5);
+        ASSERT_NEAR(vSize(LinearAlg2D::getClosestOnLine(p, a, b) - x), 0, 5);
+        ASSERT_NEAR(vSize(LinearAlg2D::getClosestOnLineSegment(p, a, b) - x), 0, 5);
+        ASSERT_NEAR(std::sqrt(LinearAlg2D::getDist2FromLine(p, a, b)), abs_d, 5);
+        ASSERT_NEAR(std::sqrt(LinearAlg2D::getDist2FromLineSegment(a, p, b)), abs_d, 5);
+
+        ASSERT_NEAR(std::round(std::sqrt(LinearAlg2D::getDist2FromLine(p, a, b))), LinearAlg2D::getDistFromLine(p, a, b), 5);
     }
 }
 

--- a/tests/utils/SimplifyTest.cpp
+++ b/tests/utils/SimplifyTest.cpp
@@ -231,7 +231,7 @@ TEST_F(SimplifyTest, LimitedError)
         increasing_zigzag.add(Point(0, increasing_zigzag.size() * y_step));
     }
 
-    size_t limit_vertex = 2 * simplifier.max_deviation / amplitude_step + 2; // 2 vertices per zag. Deviation/step zags. Add 2 since deviation equal to max is allowed.
+    size_t limit_vertex = 2 * simplifier.max_deviation / amplitude_step + 3; // 2 vertices per zag. Deviation/step zags. Add 3 since deviation equal to max +- epsilon is allowed.
 
     Polygon simplified = simplifier.polyline(increasing_zigzag);
 
@@ -397,7 +397,7 @@ TEST_F(SimplifyTest, ToDegenerate)
     segment.add(Point(4, 0)); // Less than 5 micron long, so vertices would always be removed.
 
     segment = simplifier.polyline(segment);
-    EXPECT_EQ(segment.size(), 2) << "The segment did not get simplified because that would reduce its vertices to less than 2, making it degenerate.";
+    EXPECT_EQ(segment.size(), 0) << "The segment got removed entirely, because simplification would reduce its vertices to less than 2, making it degenerate.";
 }
 
 } // namespace cura


### PR DESCRIPTION
Things that where probably causing jagged edges:
- Bridging (which is on for first-party printers) could chop up line segments almost to the 5 micron level.
- The iteration when simplifying wasn't exhaustive. Especially, there was a check to see if we where still below 2 or 3 for polylines and polygons respective, but the corresponding remove didn't always. You'll note that we _also_ _completely_ iterate a number of times. If it's determined that this diminishes the deviation checks too much, we can probably just leave it at the > 0 check (instead of > #min_nr_of_vertices) for `by_importance`.
- We where also not sure about the squared version of the line-distance, since those give different answers when a square-root was taken compared to the non-squared version.

At the moment I think this is enough to not introduce jaggies into polygons or polylines _that are not themselves fine details_. There are still some small lines that ping the checker, bit those seem a bunch of small polylines (which have fixed endpoints) that you'd need to have one or more special cases for, since you either _do_ need to remove the end-points then, or accept that in those cases some deviation is accepted (like throwing away paths that are not by much, but still, above the minimum length).