### PR TITLE
Replace size_t format string in InfillTest.cpp

### DIFF
--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -57,7 +57,7 @@ public:
         , connect_polygons(connect_polygons)
         , line_distance(line_distance)
     {
-        name = fmt::format("InfillParameters_{d}_{d}_{d}_{d}", static_cast<int>(pattern), zig_zagify, connect_polygons, line_distance);
+        name = fmt::format("InfillParameters_{:d}_{:d}_{:d}_{:d}", static_cast<int>(pattern), zig_zagify, connect_polygons, line_distance);
     }
 };
 
@@ -89,7 +89,7 @@ public:
         , result_lines(std::move(result_lines))
         , result_polygons(std::move(result_polygons))
     {
-        name = fmt::format("InfillTestParameters_P{d}_Z{d}_C{d}_L{d}__{d}", static_cast<int>(params.pattern), params.zig_zagify, params.connect_polygons, params.line_distance, test_polygon_id);
+        name = fmt::format("InfillTestParameters_P{:d}_Z{:d}_C{:d}_L{:d}__{:d}", static_cast<int>(params.pattern), params.zig_zagify, params.connect_polygons, params.line_distance, test_polygon_id);
     }
 
     friend std::ostream& operator<<(std::ostream& os, const InfillTestParameters& params)

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include <filesystem>
 #include <utility>
+#include <fmt/format.h>
 
 #include <scripta/logger.h>
 
@@ -20,16 +21,6 @@
 // NOLINTBEGIN(*-magic-numbers)
 namespace cura
 {
-template<typename... Ts>
-std::string makeName(const std::string& format_string, Ts... args)
-{
-    // FIXME: once we use spdlog, we can use fmt::format instead, see CURA-8258
-    constexpr int buff_size = 1024;
-    char buff[buff_size];
-    std::snprintf(buff, buff_size, format_string.c_str(), args...);
-    return std::string(buff);
-}
-
 coord_t getPatternMultiplier(const EFillMethod& pattern)
 {
     switch (pattern)
@@ -66,8 +57,7 @@ public:
         , connect_polygons(connect_polygons)
         , line_distance(line_distance)
     {
-        // FIXME: Once we are using spdlog as logger, we'll also use fmt::format() here, see CURA-8258.
-        name = makeName("InfillParameters_%d_%d_%d_%lld", static_cast<int>(pattern), static_cast<int>(zig_zagify), static_cast<int>(connect_polygons), line_distance);
+        name = fmt::format("InfillParameters_{d}_{d}_{d}_{d}", static_cast<int>(pattern), zig_zagify, connect_polygons, line_distance);
     }
 };
 
@@ -99,8 +89,7 @@ public:
         , result_lines(std::move(result_lines))
         , result_polygons(std::move(result_polygons))
     {
-        // FIXME: Once we are using spdlog as logger, we'll also use fmt::format() here, see CURA-8258.
-        name = makeName("InfillTestParameters_P%d_Z%d_C%d_L%lld__%zu", static_cast<int>(params.pattern), static_cast<int>(params.zig_zagify), static_cast<int>(params.connect_polygons), params.line_distance, test_polygon_id);
+        name = fmt::format("InfillTestParameters_P{d}_Z{d}_C{d}_L{d}__{d}", static_cast<int>(params.pattern), params.zig_zagify, params.connect_polygons, params.line_distance, test_polygon_id);
     }
 
     friend std::ostream& operator<<(std::ostream& os, const InfillTestParameters& params)

--- a/tests/InfillTest.cpp
+++ b/tests/InfillTest.cpp
@@ -100,7 +100,7 @@ public:
         , result_polygons(std::move(result_polygons))
     {
         // FIXME: Once we are using spdlog as logger, we'll also use fmt::format() here, see CURA-8258.
-        name = makeName("InfillTestParameters_P%d_Z%d_C%d_L%lld__%lld", static_cast<int>(params.pattern), static_cast<int>(params.zig_zagify), static_cast<int>(params.connect_polygons), params.line_distance, test_polygon_id);
+        name = makeName("InfillTestParameters_P%d_Z%d_C%d_L%lld__%zu", static_cast<int>(params.pattern), static_cast<int>(params.zig_zagify), static_cast<int>(params.connect_polygons), params.line_distance, test_polygon_id);
     }
 
     friend std::ostream& operator<<(std::ostream& os, const InfillTestParameters& params)


### PR DESCRIPTION
# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->
The format string in tests/InfillTest.cpp is not correct for the (last) `size_t` argument, causing test failure on 32-bit architectures.
This PR replaces the `%lld` with the correct C99 format string for `size_t`: `%zu`.

It's expected that this will work with every current C standard library used for CuraEngine.
If this is not the case and C90 C library compatibility is desired, a more conservative format string can be used, such as `%llu`. This was tested successfully on i686 with gcc 12/glibc 2.37, even though it's not 100% correct for a 32-bit `size_t`.

Fixes: #1897 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Build on amd64 and i686 Linux
- [ ] Run unit test InfillTest

**Test Configuration**:
* Operating System: Debian trixie/sid
* amd64 (native) AND i686 (chroot)

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change