### PR TITLE
[CURA-10805] unify plugin slot calls

### DIFF
--- a/benchmark/simplify_benchmark.h
+++ b/benchmark/simplify_benchmark.h
@@ -64,7 +64,7 @@ BENCHMARK_DEFINE_F(SimplifyTestFixture, simplify_slot_noplugin)(benchmark::State
         Polygons simplified;
 		for (const auto& polys : shapes)
 		{
-			benchmark::DoNotOptimize(simplified = slots::instance().invoke<plugins::slot_simplify>(polys, MM2INT(0.25), MM2INT(0.025), 50000));
+			benchmark::DoNotOptimize(simplified = slots::instance().invoke<plugins::v0::SlotID::SIMPLIFY_MODIFY>(polys, MM2INT(0.25), MM2INT(0.025), 50000));
 		}
 	}
 }
@@ -78,7 +78,7 @@ BENCHMARK_DEFINE_F(SimplifyTestFixture, simplify_slot_localplugin)(benchmark::St
 
     try
     {
-        slots::instance().connect<plugins::slot_simplify>(utils::createChannel({host, port}));
+        slots::instance().connect<plugins::v0::SlotID::SIMPLIFY_MODIFY>(utils::createChannel({host, port}));
     }
     catch (std::runtime_error e)
     {
@@ -89,7 +89,7 @@ BENCHMARK_DEFINE_F(SimplifyTestFixture, simplify_slot_localplugin)(benchmark::St
         Polygons simplified;
         for (const auto& polys : shapes)
         {
-            benchmark::DoNotOptimize(simplified = slots::instance().invoke<plugins::slot_simplify>(polys, MM2INT(0.25), MM2INT(0.025), 50000));
+            benchmark::DoNotOptimize(simplified = slots::instance().invoke<plugins::v0::SlotID::SIMPLIFY_MODIFY>(polys, MM2INT(0.25), MM2INT(0.025), 50000));
         }
     }
 }

--- a/include/plugins/broadcasts.h
+++ b/include/plugins/broadcasts.h
@@ -11,15 +11,31 @@
 namespace cura::plugins::details
 {
 
-template<utils::CharRangeLiteral BroadcastChannel>
-requires utils::is_broadcast_channel_v<BroadcastChannel, "BroadcastSettings"> constexpr auto broadcast_message_factory(auto&&... args)
+template<v0::SlotID T1, v0::SlotID T2>
+class is_broadcast_channel
+{
+    inline static constexpr bool value_() noexcept
+    {
+        return T1 == T2;
+    }
+
+public:
+    inline static constexpr bool value = value_();
+};
+
+template<v0::SlotID T1, v0::SlotID T2>
+inline constexpr bool is_broadcast_channel_v = is_broadcast_channel<T1, T2>::value;
+
+
+template<v0::SlotID BroadcastSlot>
+requires is_broadcast_channel_v<BroadcastSlot, v0::SlotID::BROADCAST_SETTINGS> constexpr auto broadcast_message_factory(auto&&... args)
 {
     return broadcast_settings_request{}(std::forward<decltype(args)>(args)...);
 };
 
 
-template<class Stub, utils::CharRangeLiteral BroadcastChannel>
-requires utils::is_broadcast_channel_v<BroadcastChannel, "BroadcastSettings"> constexpr auto broadcast_factory()
+template<class Stub, v0::SlotID BroadcastSlot>
+requires is_broadcast_channel_v<BroadcastSlot, v0::SlotID::BROADCAST_SETTINGS> constexpr auto broadcast_factory()
 {
     return agrpc::RPC<&Stub::PrepareAsyncBroadcastSettings>{};
 }

--- a/include/plugins/broadcasts.h
+++ b/include/plugins/broadcasts.h
@@ -30,14 +30,16 @@ inline constexpr bool is_broadcast_channel_v = is_broadcast_channel<T1, T2>::val
 
 
 template<v0::SlotID BroadcastSlot>
-requires is_broadcast_channel_v<BroadcastSlot, v0::SlotID::BROADCAST_SETTINGS> constexpr auto broadcast_message_factory(auto&&... args)
+requires is_broadcast_channel_v<BroadcastSlot, v0::SlotID::BROADCAST_SETTINGS>
+constexpr auto broadcast_message_factory(auto&&... args)
 {
     return broadcast_settings_request{}(std::forward<decltype(args)>(args)...);
 };
 
 
 template<class Stub, v0::SlotID BroadcastSlot>
-requires is_broadcast_channel_v<BroadcastSlot, v0::SlotID::BROADCAST_SETTINGS> constexpr auto broadcast_factory()
+requires is_broadcast_channel_v<BroadcastSlot, v0::SlotID::BROADCAST_SETTINGS>
+constexpr auto broadcast_factory()
 {
     return agrpc::RPC<&Stub::PrepareAsyncBroadcastSettings>{};
 }

--- a/include/plugins/pluginproxy.h
+++ b/include/plugins/pluginproxy.h
@@ -188,10 +188,10 @@ public:
         return ret_value;
     }
 
-    template<utils::CharRangeLiteral BroadcastChannel>
+    template<v0::SlotID S>
     void broadcast(auto&&... args)
     {
-        if (! plugin_info_->broadcast_subscriptions.contains(BroadcastChannel.value))
+        if (! plugin_info_->broadcast_subscriptions.contains(SlotName<S>().value))
         {
             return;
         }
@@ -199,7 +199,7 @@ public:
         grpc::Status status;
 
         boost::asio::co_spawn(
-            grpc_context, [this, &grpc_context, &status, &args...]() { return this->broadcastCall<BroadcastChannel>(grpc_context, status, std::forward<decltype(args)>(args)...); }, boost::asio::detached);
+            grpc_context, [this, &grpc_context, &status, &args...]() { return this->broadcastCall<S>(grpc_context, status, std::forward<decltype(args)>(args)...); }, boost::asio::detached);
         grpc_context.run();
 
         if (! status.ok()) // TODO: handle different kind of status codes
@@ -250,14 +250,14 @@ private:
         co_return;
     }
 
-    template<utils::CharRangeLiteral BroadcastChannel>
+    template<v0::SlotID S>
     boost::asio::awaitable<void> broadcastCall(agrpc::GrpcContext& grpc_context, grpc::Status& status, auto&&... args)
     {
         grpc::ClientContext client_context{};
         prep_client_context(client_context);
 
-        auto broadcaster{ details::broadcast_factory<broadcast_stub_t, BroadcastChannel>() };
-        auto request = details::broadcast_message_factory<BroadcastChannel>(std::forward<decltype(args)>(args)...);
+        auto broadcaster{ details::broadcast_factory<broadcast_stub_t, S>() };
+        auto request = details::broadcast_message_factory<S>(std::forward<decltype(args)>(args)...);
         auto response = google::protobuf::Empty{};
         status = co_await broadcaster.request(grpc_context, broadcast_stub_, client_context, request, response, boost::asio::use_awaitable);
         co_return;

--- a/include/plugins/pluginproxy.h
+++ b/include/plugins/pluginproxy.h
@@ -23,6 +23,7 @@
 #include "plugins/broadcasts.h"
 #include "plugins/exception.h"
 #include "plugins/metadata.h"
+#include "plugins/types.h"
 #include "utils/format/thread_id.h"
 #include "utils/types/char_range_literal.h"
 #include "utils/types/generic.h"

--- a/include/plugins/slotproxy.h
+++ b/include/plugins/slotproxy.h
@@ -80,12 +80,12 @@ public:
         return std::invoke(default_process, std::forward<decltype(args)>(args)...);
     }
 
-    template<utils::CharRangeLiteral BroadcastChannel>
+    template<v0::SlotID S>
     void broadcast(auto&&...args)
     {
         if (plugin_.has_value())
         {
-            plugin_.value().template broadcast<BroadcastChannel>(std::forward<decltype(args)>(args)...);
+            plugin_.value().template broadcast<S>(std::forward<decltype(args)>(args)...);
         }
     }
 };

--- a/include/plugins/slots.h
+++ b/include/plugins/slots.h
@@ -168,13 +168,6 @@ using slot_postprocess = decltype(details::SlotType<v0::SlotID::POSTPROCESS_MODI
 
 using SlotTypes = details::Typelist<slot_simplify, slot_postprocess>;
 
-template<v0::SlotID> constexpr auto SlotName() noexcept;
-template<> constexpr auto SlotName<v0::SlotID::BROADCAST_SETTINGS>() noexcept { return utils::CharRangeLiteral("BroadcastSettings"); };
-template<> constexpr auto SlotName<v0::SlotID::SIMPLIFY_MODIFY>() noexcept { return utils::CharRangeLiteral("SimplifyModify"); };
-template<> constexpr auto SlotName<v0::SlotID::POSTPROCESS_MODIFY>() noexcept { return utils::CharRangeLiteral("PostprocessModify"); };
-template<> constexpr auto SlotName<v0::SlotID::INFILL_MODIFY>() noexcept { return utils::CharRangeLiteral("InfillModify"); };
-template<> constexpr auto SlotName<v0::SlotID::INFILL_GENERATE>() noexcept { return utils::CharRangeLiteral("InfillGenerate"); };
-
 } // namespace plugins
 
 using slots = plugins::details::SingletonRegistry<plugins::SlotTypes, plugins::details::Holder>;

--- a/include/plugins/slots.h
+++ b/include/plugins/slots.h
@@ -111,11 +111,11 @@ public:
         get_type<Tp>().proxy = Tp{ std::forward<Tp>(std::move(plugin)) };
     }
 
-    template<utils::CharRangeLiteral BroadcastChannel>
+    template<v0::SlotID S>
     void broadcast(auto&&... args)
     {
-        value_.proxy.template broadcast<BroadcastChannel>(std::forward<decltype(args)>(args)...);
-        Base::value_.proxy.template broadcast<BroadcastChannel>(std::forward<decltype(args)>(args)...);
+        value_.proxy.template broadcast<S>(std::forward<decltype(args)>(args)...);
+        Base::value_.proxy.template broadcast<S>(std::forward<decltype(args)>(args)...);
     }
 
 protected:
@@ -167,6 +167,14 @@ using slot_simplify = decltype(details::SlotType<v0::SlotID::SIMPLIFY_MODIFY>::s
 using slot_postprocess = decltype(details::SlotType<v0::SlotID::POSTPROCESS_MODIFY>::slot_definition());
 
 using SlotTypes = details::Typelist<slot_simplify, slot_postprocess>;
+
+template<v0::SlotID> constexpr auto SlotName() noexcept;
+template<> constexpr auto SlotName<v0::SlotID::BROADCAST_SETTINGS>() noexcept { return utils::CharRangeLiteral("BroadcastSettings"); };
+template<> constexpr auto SlotName<v0::SlotID::SIMPLIFY_MODIFY>() noexcept { return utils::CharRangeLiteral("SimplifyModify"); };
+template<> constexpr auto SlotName<v0::SlotID::POSTPROCESS_MODIFY>() noexcept { return utils::CharRangeLiteral("PostprocessModify"); };
+template<> constexpr auto SlotName<v0::SlotID::INFILL_MODIFY>() noexcept { return utils::CharRangeLiteral("InfillModify"); };
+template<> constexpr auto SlotName<v0::SlotID::INFILL_GENERATE>() noexcept { return utils::CharRangeLiteral("InfillGenerate"); };
+
 } // namespace plugins
 
 using slots = plugins::details::SingletonRegistry<plugins::SlotTypes, plugins::details::Holder>;

--- a/include/plugins/slots.h
+++ b/include/plugins/slots.h
@@ -62,12 +62,15 @@ using slot_simplify_ = SlotProxy<v0::SlotID::SIMPLIFY_MODIFY, "<=1.0.0", slots::
 template<class Default = default_process>
 using slot_postprocess_ = SlotProxy<v0::SlotID::POSTPROCESS_MODIFY, "<=1.0.0", slots::postprocess::v0::PostprocessModifyService::Stub, Validator, postprocess_request, postprocess_response, Default>;
 
+using SLOT_NOT_IMPLEMENTED = std::void_t<>;
+
+// Only declared, not defined, on purpose, we only need the type: mapping from SlotID to slot-proxy.
 template<v0::SlotID> class SlotType { public: static auto slot_definition(); };
-//template<> class SlotType<v0::SlotID::BROADCAST_SETTINGS> { public: static ____ slot_definition(); };
+template<> class SlotType<v0::SlotID::BROADCAST_SETTINGS> { public: static SLOT_NOT_IMPLEMENTED slot_definition(); };
 template<> class SlotType<v0::SlotID::SIMPLIFY_MODIFY> { public: static slot_simplify_<simplify_default> slot_definition(); };
 template<> class SlotType<v0::SlotID::POSTPROCESS_MODIFY> { public: static slot_postprocess_<> slot_definition(); };
-//template<> class SlotType<v0::SlotID::INFILL_MODIFY> { public: static ____ slot_definition(); };
-//template<> class SlotType<v0::SlotID::INFILL_GENERATE> { public: static ____ slot_definition(); };
+template<> class SlotType<v0::SlotID::INFILL_MODIFY> { public: static SLOT_NOT_IMPLEMENTED slot_definition(); };
+template<> class SlotType<v0::SlotID::INFILL_GENERATE> { public: static SLOT_NOT_IMPLEMENTED slot_definition(); };
 
 template<typename... Types>
 struct Typelist

--- a/include/plugins/slots.h
+++ b/include/plugins/slots.h
@@ -65,12 +65,42 @@ using slot_postprocess_
 using SLOT_NOT_IMPLEMENTED = std::void_t<>;
 
 // Only declared, not defined, on purpose, we only need the type: mapping from SlotID to slot-proxy.
-template<v0::SlotID> class SlotType { public: static auto slot_definition(); };
-template<> class SlotType<v0::SlotID::BROADCAST_SETTINGS> { public: static SLOT_NOT_IMPLEMENTED slot_definition(); };
-template<> class SlotType<v0::SlotID::SIMPLIFY_MODIFY> { public: static slot_simplify_<simplify_default> slot_definition(); };
-template<> class SlotType<v0::SlotID::POSTPROCESS_MODIFY> { public: static slot_postprocess_<> slot_definition(); };
-template<> class SlotType<v0::SlotID::INFILL_MODIFY> { public: static SLOT_NOT_IMPLEMENTED slot_definition(); };
-template<> class SlotType<v0::SlotID::INFILL_GENERATE> { public: static SLOT_NOT_IMPLEMENTED slot_definition(); };
+template<v0::SlotID>
+class SlotType
+{
+public:
+    static auto slot_definition();
+};
+template<>
+class SlotType<v0::SlotID::BROADCAST_SETTINGS>
+{
+public:
+    static SLOT_NOT_IMPLEMENTED slot_definition();
+};
+template<>
+class SlotType<v0::SlotID::SIMPLIFY_MODIFY>
+{
+public:
+    static slot_simplify_<simplify_default> slot_definition();
+};
+template<>
+class SlotType<v0::SlotID::POSTPROCESS_MODIFY>
+{
+public:
+    static slot_postprocess_<> slot_definition();
+};
+template<>
+class SlotType<v0::SlotID::INFILL_MODIFY>
+{
+public:
+    static SLOT_NOT_IMPLEMENTED slot_definition();
+};
+template<>
+class SlotType<v0::SlotID::INFILL_GENERATE>
+{
+public:
+    static SLOT_NOT_IMPLEMENTED slot_definition();
+};
 
 template<typename... Types>
 struct Typelist
@@ -161,7 +191,7 @@ template<typename T>
 struct Holder
 {
     T proxy;
-    //FIXME?: Consider saving SlotID here and checking for equality on that, instead of the proxy.
+    // FIXME?: Consider saving SlotID here and checking for equality on that, instead of the proxy.
 };
 
 } // namespace details

--- a/include/plugins/types.h
+++ b/include/plugins/types.h
@@ -69,12 +69,33 @@ struct formatter<grpc::string_ref>
 namespace cura::plugins
 {
 
-template<v0::SlotID> constexpr auto SlotName() noexcept;
-template<> constexpr auto SlotName<v0::SlotID::BROADCAST_SETTINGS>() noexcept { return utils::CharRangeLiteral("BroadcastSettings"); };
-template<> constexpr auto SlotName<v0::SlotID::SIMPLIFY_MODIFY>() noexcept { return utils::CharRangeLiteral("SimplifyModify"); };
-template<> constexpr auto SlotName<v0::SlotID::POSTPROCESS_MODIFY>() noexcept { return utils::CharRangeLiteral("PostprocessModify"); };
-template<> constexpr auto SlotName<v0::SlotID::INFILL_MODIFY>() noexcept { return utils::CharRangeLiteral("InfillModify"); };
-template<> constexpr auto SlotName<v0::SlotID::INFILL_GENERATE>() noexcept { return utils::CharRangeLiteral("InfillGenerate"); };
+template<v0::SlotID>
+constexpr auto SlotName() noexcept;
+template<>
+constexpr auto SlotName<v0::SlotID::BROADCAST_SETTINGS>() noexcept
+{
+    return utils::CharRangeLiteral("BroadcastSettings");
+};
+template<>
+constexpr auto SlotName<v0::SlotID::SIMPLIFY_MODIFY>() noexcept
+{
+    return utils::CharRangeLiteral("SimplifyModify");
+};
+template<>
+constexpr auto SlotName<v0::SlotID::POSTPROCESS_MODIFY>() noexcept
+{
+    return utils::CharRangeLiteral("PostprocessModify");
+};
+template<>
+constexpr auto SlotName<v0::SlotID::INFILL_MODIFY>() noexcept
+{
+    return utils::CharRangeLiteral("InfillModify");
+};
+template<>
+constexpr auto SlotName<v0::SlotID::INFILL_GENERATE>() noexcept
+{
+    return utils::CharRangeLiteral("InfillGenerate");
+};
 
 } // namespace cura::plugins
 

--- a/include/plugins/types.h
+++ b/include/plugins/types.h
@@ -12,6 +12,7 @@
 
 #include "utils/IntPoint.h"
 #include "utils/polygon.h"
+#include "utils/types/char_range_literal.h"
 
 #include "cura/plugins/v0/slot_id.pb.h"
 
@@ -65,4 +66,17 @@ struct formatter<grpc::string_ref>
 };
 
 } // namespace fmt
+
+namespace cura::plugins
+{
+
+template<v0::SlotID> constexpr auto SlotName() noexcept;
+template<> constexpr auto SlotName<v0::SlotID::BROADCAST_SETTINGS>() noexcept { return utils::CharRangeLiteral("BroadcastSettings"); };
+template<> constexpr auto SlotName<v0::SlotID::SIMPLIFY_MODIFY>() noexcept { return utils::CharRangeLiteral("SimplifyModify"); };
+template<> constexpr auto SlotName<v0::SlotID::POSTPROCESS_MODIFY>() noexcept { return utils::CharRangeLiteral("PostprocessModify"); };
+template<> constexpr auto SlotName<v0::SlotID::INFILL_MODIFY>() noexcept { return utils::CharRangeLiteral("InfillModify"); };
+template<> constexpr auto SlotName<v0::SlotID::INFILL_GENERATE>() noexcept { return utils::CharRangeLiteral("InfillGenerate"); };
+
+} // namespace cura::plugins
+
 #endif // PLUGINS_TYPES_H

--- a/include/utils/types/generic.h
+++ b/include/utils/types/generic.h
@@ -29,23 +29,6 @@ concept grpc_convertable = requires(T value)
     requires ranges::semiregular<typename T::native_value_type>;
 };
 
-template<utils::CharRangeLiteral T1, utils::CharRangeLiteral T2>
-class is_broadcast_channel
-{
-    inline static constexpr bool value_() noexcept
-    {
-        constexpr std::string_view t1{ T1.value };
-        constexpr std::string_view t2{ T2.value };
-        return t1.compare(t2) == 0;
-    }
-
-public:
-    inline static constexpr bool value = value_();
-};
-
-template<utils::CharRangeLiteral T1, utils::CharRangeLiteral T2>
-inline constexpr bool is_broadcast_channel_v = is_broadcast_channel<T1, T2>::value;
-
 #ifdef OLDER_APPLE_CLANG
 
 // std::integral and std::floating_point are not implemented in older Apple Clang versions < 13

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -339,7 +339,7 @@ void ArcusCommunication::beginGCode()
 
 void ArcusCommunication::flushGCode()
 {
-    const std::string& message_str = slots::instance().invoke<plugins::slot_postprocess >(private_data->gcode_output_stream.str());
+    const std::string& message_str = slots::instance().invoke<plugins::v0::SlotID::POSTPROCESS_MODIFY>(private_data->gcode_output_stream.str());
     if (message_str.size() == 0)
     {
         return;
@@ -372,7 +372,7 @@ void ArcusCommunication::sendCurrentPosition(const Point& position)
 void ArcusCommunication::sendGCodePrefix(const std::string& prefix) const
 {
     std::shared_ptr<proto::GCodePrefix> message = std::make_shared<proto::GCodePrefix>();
-    message->set_data(slots::instance().invoke<plugins::slot_postprocess >(prefix));
+    message->set_data(slots::instance().invoke<plugins::v0::SlotID::POSTPROCESS_MODIFY>(prefix));
     private_data->socket->sendMessage(message);
 }
 
@@ -516,10 +516,10 @@ void ArcusCommunication::sliceNext()
             switch (plugin.id())
             {
             case cura::proto::SlotID::SIMPLIFY_MODIFY:
-                slots::instance().connect<plugins::slot_simplify>(utils::createChannel({ plugin.address(), plugin.port() }));
+                slots::instance().connect<plugins::v0::SlotID::SIMPLIFY_MODIFY>(utils::createChannel({ plugin.address(), plugin.port() }));
                 break;
             case cura::proto::SlotID::POSTPROCESS_MODIFY:
-                slots::instance().connect<plugins::slot_postprocess>(utils::createChannel({ plugin.address(), plugin.port() }));
+                slots::instance().connect<plugins::v0::SlotID::POSTPROCESS_MODIFY>(utils::createChannel({ plugin.address(), plugin.port() }));
                 break;
             default:
                 spdlog::error("Not yet implemented: {}", plugin.id());

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -536,7 +536,7 @@ void ArcusCommunication::sliceNext()
     private_data->readExtruderSettingsMessage(slice_message->extruders());
 
     // Broadcast the settings to the plugins
-    slots::instance().broadcast<"BroadcastSettings">(*slice_message);
+    slots::instance().broadcast<plugins::v0::SlotID::BROADCAST_SETTINGS>(*slice_message);
     const size_t extruder_count = slice.scene.extruders.size();
 
     // For each setting, register what extruder it should be obtained from (if this is limited to an extruder).

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -788,10 +788,11 @@ void SlicerLayer::makePolygons(const Mesh* mesh)
 
     // Finally optimize all the polygons. Every point removed saves time in the long run.
     // polygons = Simplify(mesh->settings).polygon(polygons);
-    polygons = slots::instance().invoke<plugins::v0::SlotID::SIMPLIFY_MODIFY>(polygons,
-                                                                              mesh->settings.get<coord_t>("meshfix_maximum_resolution"),
-                                                                              mesh->settings.get<coord_t>("meshfix_maximum_deviation"),
-                                                                              static_cast<coord_t>(mesh->settings.get<size_t>("meshfix_maximum_extrusion_area_deviation")));
+    polygons = slots::instance().invoke<plugins::v0::SlotID::SIMPLIFY_MODIFY>(
+        polygons,
+        mesh->settings.get<coord_t>("meshfix_maximum_resolution"),
+        mesh->settings.get<coord_t>("meshfix_maximum_deviation"),
+        static_cast<coord_t>(mesh->settings.get<size_t>("meshfix_maximum_extrusion_area_deviation")));
     polygons.removeDegenerateVerts(); // remove verts connected to overlapping line segments
 
     // Clean up polylines for Surface Mode printing

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -774,7 +774,7 @@ void SlicerLayer::makePolygons(const Mesh* mesh)
 
     // Finally optimize all the polygons. Every point removed saves time in the long run.
 //    polygons = Simplify(mesh->settings).polygon(polygons);
-    polygons = slots::instance().invoke<plugins::slot_simplify>(polygons, mesh->settings.get<coord_t>("meshfix_maximum_resolution"), mesh->settings.get<coord_t>("meshfix_maximum_deviation"), static_cast<coord_t>(mesh->settings.get<size_t>("meshfix_maximum_extrusion_area_deviation")));
+    polygons = slots::instance().invoke<plugins::v0::SlotID::SIMPLIFY_MODIFY>(polygons, mesh->settings.get<coord_t>("meshfix_maximum_resolution"), mesh->settings.get<coord_t>("meshfix_maximum_deviation"), static_cast<coord_t>(mesh->settings.get<size_t>("meshfix_maximum_extrusion_area_deviation")));
     polygons.removeDegenerateVerts(); // remove verts connected to overlapping line segments
 
     // Clean up polylines for Surface Mode printing


### PR DESCRIPTION
Clean up the different ways which basically all come down to just 'slot identification' by unifying all (at least to the 'outside world' -- the non-plugin parts) by always using SlotID as an identifier. 