### PR TITLE
skirt_brim remains empty when generating the brimlines around support

### DIFF
--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -403,6 +403,7 @@ Polygons SkirtBrim::getFirstLayerOutline(const int extruder_nr /* = -1 */)
             }
         }
 
+
         if (skirt_around_prime_tower_brim)
         {
             const int prime_tower_brim_extruder_nr = storage.primeTower.extruder_order[0];
@@ -626,6 +627,12 @@ void SkirtBrim::generateSupportBrim()
 
     const coord_t brim_width = brim_line_width * line_count;
     coord_t skirt_brim_length = 0;
+
+    if (storage.skirt_brim[support_infill_extruder.extruder_nr].empty())
+    {
+        storage.skirt_brim[support_infill_extruder.extruder_nr].emplace_back();
+    }
+
     for (const SkirtBrimLine& brim_line : storage.skirt_brim[support_infill_extruder.extruder_nr])
     {
         skirt_brim_length += brim_line.closed_polygons.polygonLength();


### PR DESCRIPTION
CURA-10502

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change