### PR TITLE
Add string-switch type and integrate into settings retrieval

### DIFF
--- a/include/settings/EnumSettings.h
+++ b/include/settings/EnumSettings.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2021 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef ENUMSETTINGS_H
 #define ENUMSETTINGS_H
@@ -27,7 +27,7 @@ enum class EFillMethod
     CROSS_3D,
     GYROID,
     LIGHTNING,
-    NONE, // NOTE: Should remain last! (May be used in testing to enumarate the enum.)
+    NONE, // NOTE: Should remain second last! Before PLUGIN (Might be used in testing to enumerate the enum.)
     PLUGIN, // Place plugin after none to prevent it from being tested in the gtest suite.
 };
 
@@ -39,7 +39,8 @@ enum class EPlatformAdhesion
     SKIRT,
     BRIM,
     RAFT,
-    NONE
+    NONE,
+    PLUGIN,
 };
 
 /*!
@@ -49,7 +50,8 @@ enum class ESupportType
 {
     NONE,
     PLATFORM_ONLY,
-    EVERYWHERE
+    EVERYWHERE,
+    PLUGIN,
 };
 
 /*!
@@ -58,7 +60,8 @@ enum class ESupportType
 enum class ESupportStructure
 {
     NORMAL,
-    TREE
+    TREE,
+    PLUGIN,
 };
 
 enum class EZSeamType
@@ -71,7 +74,8 @@ enum class EZSeamType
     /* The 'Skirt/brim' type behaves like shortest, except it doesn't try to do tie-breaking for similar locations to
      * the last attempt, as that gives a different result when the seams are next to each other instead of on top.
      */
-    SKIRT_BRIM
+    SKIRT_BRIM,
+    PLUGIN,
 };
 
 enum class EZSeamCornerPrefType
@@ -80,26 +84,30 @@ enum class EZSeamCornerPrefType
     Z_SEAM_CORNER_PREF_INNER,
     Z_SEAM_CORNER_PREF_OUTER,
     Z_SEAM_CORNER_PREF_ANY,
-    Z_SEAM_CORNER_PREF_WEIGHTED
+    Z_SEAM_CORNER_PREF_WEIGHTED,
+    PLUGIN,
 };
 
 enum class ESurfaceMode
 {
     NORMAL,
     SURFACE,
-    BOTH
+    BOTH,
+    PLUGIN,
 };
 
 enum class FillPerimeterGapMode
 {
     NOWHERE,
-    EVERYWHERE
+    EVERYWHERE,
+    PLUGIN,
 };
 
 enum class BuildPlateShape
 {
     RECTANGULAR,
-    ELLIPTIC
+    ELLIPTIC,
+    PLUGIN,
 };
 
 enum class CombingMode
@@ -108,7 +116,8 @@ enum class CombingMode
     ALL,
     NO_SKIN,
     NO_OUTER_SURFACES,
-    INFILL
+    INFILL,
+    PLUGIN,
 };
 
 /*!
@@ -117,20 +126,23 @@ enum class CombingMode
 enum class DraftShieldHeightLimitation
 {
     FULL, // Draft shield takes full height of the print.
-    LIMITED // Draft shield is limited by draft_shield_height setting.
+    LIMITED, // Draft shield is limited by draft_shield_height setting.
+    PLUGIN,
 };
 
 enum class SupportDistPriority
 {
     XY_OVERRIDES_Z,
-    Z_OVERRIDES_XY
+    Z_OVERRIDES_XY,
+    PLUGIN,
 };
 
 enum class SlicingTolerance
 {
     MIDDLE,
     INCLUSIVE,
-    EXCLUSIVE
+    EXCLUSIVE,
+    PLUGIN,
 };
 /*!
  * Different flavors of GCode. Some machines require different types of GCode.
@@ -207,6 +219,7 @@ enum class EGCodeFlavor
      * Real RepRap GCode suitable for printers using RepRap firmware (e.g. Duet controllers)
      **/
     REPRAP = 8,
+    PLUGIN = 9,
 };
 
 /*!
@@ -228,7 +241,8 @@ enum class InsetDirection
      * If the innermost wall is a central wall, it is printed last. Otherwise
      * prints the same as inside out.
      */
-    CENTER_LAST
+    CENTER_LAST,
+    PLUGIN,
 };
 
 } // namespace cura

--- a/include/utils/types/string_switch.h
+++ b/include/utils/types/string_switch.h
@@ -10,7 +10,7 @@ namespace cura::utils
 {
 
 // Source: https://learnmoderncpp.com/2020/06/01/strings-as-switch-case-labels/
-inline constexpr uint64_t hash_djb2a(const std::string_view value)
+constexpr inline uint64_t hash_djb2a(const std::string_view value)
 {
     uint64_t hash{ 5381 };
     for (unsigned char c : value)
@@ -20,7 +20,7 @@ inline constexpr uint64_t hash_djb2a(const std::string_view value)
     return hash;
 }
 
-inline constexpr uint64_t hash_enum(const std::string_view value)
+constexpr inline uint64_t hash_enum(const std::string_view value)
 {
     constexpr uint64_t plugin_namespace_sep_location{ 6 };
     if (value.size() > plugin_namespace_sep_location && value.at(plugin_namespace_sep_location) == ':')

--- a/include/utils/types/string_switch.h
+++ b/include/utils/types/string_switch.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
+
+#ifndef UTILS_TYPES_STRING_SWITCH_H
+#define UTILS_TYPES_STRING_SWITCH_H
+
+#include <string_view>
+
+namespace cura::utils
+{
+
+// Source: https://learnmoderncpp.com/2020/06/01/strings-as-switch-case-labels/
+inline constexpr uint64_t hash_djb2a(const std::string_view value)
+{
+    uint64_t hash{ 5381 };
+    for (unsigned char c : value)
+    {
+        hash = ((hash << 5) + hash) ^ c;
+    }
+    return hash;
+}
+
+inline constexpr uint64_t hash_enum(const std::string_view value)
+{
+    constexpr uint64_t plugin_namespace_sep_location{ 6 };
+    if (value.size() > plugin_namespace_sep_location && value.at(plugin_namespace_sep_location) == ':')
+    {
+        return hash_djb2a("plugin");
+    }
+    return hash_djb2a(value);
+}
+
+constexpr inline auto operator""_sw(const char* str, size_t len)
+{
+    return hash_enum(std::string_view{ str, len });
+}
+
+
+} // namespace cura::utils
+
+#endif // UTILS_TYPES_STRING_SWITCH_H

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "settings/Settings.h"
@@ -18,6 +18,7 @@
 #include "utils/FMatrix4x3.h"
 #include "utils/polygon.h"
 #include "utils/string.h" //For Escaped.
+#include "utils/types/string_switch.h" //For string switch.
 
 #include <spdlog/spdlog.h>
 
@@ -135,8 +136,8 @@ std::vector<ExtruderTrain*> Settings::get<std::vector<ExtruderTrain*>>(const std
 template<>
 LayerIndex Settings::get<LayerIndex>(const std::string& key) const
 {
-    return std::atoi(get<std::string>(key).c_str())
-         - 1; // For the user we display layer numbers starting from 1, but we start counting from 0. Still it may be negative for Raft layers.
+    // For the user we display layer numbers starting from 1, but we start counting from 0. Still it may be negative for Raft layers.
+    return std::atoi(get<std::string>(key).c_str()) - 1;
 }
 
 template<>
@@ -185,12 +186,16 @@ template<>
 DraftShieldHeightLimitation Settings::get<DraftShieldHeightLimitation>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "limited")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "full"_sw:
+        return DraftShieldHeightLimitation::FULL;
+    case "limited"_sw:
         return DraftShieldHeightLimitation::LIMITED;
-    }
-    else // if (value == "full") or default.
-    {
+    case "plugin"_sw:
+        return DraftShieldHeightLimitation::PLUGIN;
+    default:
         return DraftShieldHeightLimitation::FULL;
     }
 }
@@ -350,109 +355,74 @@ template<>
 EGCodeFlavor Settings::get<EGCodeFlavor>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    // I wish that switch statements worked for std::string...
-    if (value == "Griffin")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "Marlin"_sw:
+        return EGCodeFlavor::MARLIN;
+    case "Griffin"_sw:
         return EGCodeFlavor::GRIFFIN;
-    }
-    else if (value == "UltiGCode")
-    {
+    case "UltiGCode"_sw:
         return EGCodeFlavor::ULTIGCODE;
-    }
-    else if (value == "Makerbot")
-    {
+    case "Makerbot"_sw:
         return EGCodeFlavor::MAKERBOT;
-    }
-    else if (value == "BFB")
-    {
+    case "BFB"_sw:
         return EGCodeFlavor::BFB;
-    }
-    else if (value == "MACH3")
-    {
+    case "MACH3"_sw:
         return EGCodeFlavor::MACH3;
-    }
-    else if (value == "RepRap (Volumetric)")
-    {
+    case "RepRap (Volumetric)"_sw:
         return EGCodeFlavor::MARLIN_VOLUMATRIC;
-    }
-    else if (value == "Repetier")
-    {
+    case "Repetier"_sw:
         return EGCodeFlavor::REPETIER;
-    }
-    else if (value == "RepRap (RepRap)")
-    {
+    case "RepRap (RepRap)"_sw:
         return EGCodeFlavor::REPRAP;
+    case "plugin"_sw:
+        return EGCodeFlavor::PLUGIN;
+    default:
+        return EGCodeFlavor::MARLIN;
     }
-    // Default:
-    return EGCodeFlavor::MARLIN;
 }
 
 template<>
 EFillMethod Settings::get<EFillMethod>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "lines")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "none"_sw:
+        return EFillMethod::NONE;
+    case "lines"_sw:
         return EFillMethod::LINES;
-    }
-    else if (value == "grid")
-    {
+    case "grid"_sw:
         return EFillMethod::GRID;
-    }
-    else if (value == "cubic")
-    {
+    case "cubic"_sw:
         return EFillMethod::CUBIC;
-    }
-    else if (value == "cubicsubdiv")
-    {
+    case "cubicsubdiv"_sw:
         return EFillMethod::CUBICSUBDIV;
-    }
-    else if (value == "tetrahedral")
-    {
+    case "tetrahedral"_sw:
         return EFillMethod::TETRAHEDRAL;
-    }
-    else if (value == "quarter_cubic")
-    {
+    case "quarter_cubic"_sw:
         return EFillMethod::QUARTER_CUBIC;
-    }
-    else if (value == "triangles")
-    {
+    case "triangles"_sw:
         return EFillMethod::TRIANGLES;
-    }
-    else if (value == "trihexagon")
-    {
+    case "trihexagon"_sw:
         return EFillMethod::TRIHEXAGON;
-    }
-    else if (value == "concentric")
-    {
+    case "concentric"_sw:
         return EFillMethod::CONCENTRIC;
-    }
-    else if (value == "zigzag")
-    {
+    case "zigzag"_sw:
         return EFillMethod::ZIG_ZAG;
-    }
-    else if (value == "cross")
-    {
+    case "cross"_sw:
         return EFillMethod::CROSS;
-    }
-    else if (value == "cross_3d")
-    {
+    case "cross_3d"_sw:
         return EFillMethod::CROSS_3D;
-    }
-    else if (value == "gyroid")
-    {
+    case "gyroid"_sw:
         return EFillMethod::GYROID;
-    }
-    else if (value == "lightning")
-    {
+    case "lightning"_sw:
         return EFillMethod::LIGHTNING;
-    }
-    else if (value.rfind("PLUGIN", 0) == 0)
-    {
+    case "plugin"_sw:
         return EFillMethod::PLUGIN;
-    }
-    else // Default.
-    {
+    default:
         return EFillMethod::NONE;
     }
 }
@@ -461,20 +431,20 @@ template<>
 EPlatformAdhesion Settings::get<EPlatformAdhesion>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "brim")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "skirt"_sw:
+        return EPlatformAdhesion::SKIRT;
+    case "brim"_sw:
         return EPlatformAdhesion::BRIM;
-    }
-    else if (value == "raft")
-    {
+    case "raft"_sw:
         return EPlatformAdhesion::RAFT;
-    }
-    else if (value == "none")
-    {
+    case "none"_sw:
         return EPlatformAdhesion::NONE;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return EPlatformAdhesion::PLUGIN;
+    default:
         return EPlatformAdhesion::SKIRT;
     }
 }
@@ -483,16 +453,18 @@ template<>
 ESupportType Settings::get<ESupportType>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "everywhere")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "none"_sw:
+        return ESupportType::NONE;
+    case "everywhere"_sw:
         return ESupportType::EVERYWHERE;
-    }
-    else if (value == "buildplate")
-    {
+    case "buildplate"_sw:
         return ESupportType::PLATFORM_ONLY;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return ESupportType::PLUGIN;
+    default:
         return ESupportType::NONE;
     }
 }
@@ -501,16 +473,16 @@ template<>
 ESupportStructure Settings::get<ESupportStructure>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "normal")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "normal"_sw:
         return ESupportStructure::NORMAL;
-    }
-    else if (value == "tree")
-    {
+    case "tree"_sw:
         return ESupportStructure::TREE;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return ESupportStructure::PLUGIN;
+    default:
         return ESupportStructure::NORMAL;
     }
 }
@@ -520,21 +492,20 @@ template<>
 EZSeamType Settings::get<EZSeamType>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "random")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "shortest"_sw:
+        return EZSeamType::SHORTEST;
+    case "random"_sw:
         return EZSeamType::RANDOM;
-    }
-    else if (value == "back") // It's called 'back' internally because originally this was intended to allow the user to put the seam in the back of the object where it's less
-                              // visible.
-    {
+    case "back"_sw:
         return EZSeamType::USER_SPECIFIED;
-    }
-    else if (value == "sharpest_corner")
-    {
+    case "sharpest_corner"_sw:
         return EZSeamType::SHARPEST_CORNER;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return EZSeamType::PLUGIN;
+    default:
         return EZSeamType::SHORTEST;
     }
 }
@@ -543,24 +514,22 @@ template<>
 EZSeamCornerPrefType Settings::get<EZSeamCornerPrefType>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "z_seam_corner_inner")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "z_seam_corner_none"_sw:
+        return EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE;
+    case "z_seam_corner_inner"_sw:
         return EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_INNER;
-    }
-    else if (value == "z_seam_corner_outer")
-    {
+    case "z_seam_corner_outer"_sw:
         return EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_OUTER;
-    }
-    else if (value == "z_seam_corner_any")
-    {
+    case "z_seam_corner_any"_sw:
         return EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_ANY;
-    }
-    else if (value == "z_seam_corner_weighted")
-    {
+    case "z_seam_corner_weighted"_sw:
         return EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_WEIGHTED;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return EZSeamCornerPrefType::PLUGIN;
+    default:
         return EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE;
     }
 }
@@ -569,16 +538,18 @@ template<>
 ESurfaceMode Settings::get<ESurfaceMode>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "surface")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "normal"_sw:
+        return ESurfaceMode::NORMAL;
+    case "surface"_sw:
         return ESurfaceMode::SURFACE;
-    }
-    else if (value == "both")
-    {
+    case "both"_sw:
         return ESurfaceMode::BOTH;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return ESurfaceMode::PLUGIN;
+    default:
         return ESurfaceMode::NORMAL;
     }
 }
@@ -586,12 +557,17 @@ ESurfaceMode Settings::get<ESurfaceMode>(const std::string& key) const
 template<>
 FillPerimeterGapMode Settings::get<FillPerimeterGapMode>(const std::string& key) const
 {
-    if (get<std::string>(key) == "everywhere")
+    const std::string& value = get<std::string>(key);
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "nowhere"_sw:
+        return FillPerimeterGapMode::NOWHERE;
+    case "everywhere"_sw:
         return FillPerimeterGapMode::EVERYWHERE;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return FillPerimeterGapMode::PLUGIN;
+    default:
         return FillPerimeterGapMode::NOWHERE;
     }
 }
@@ -599,12 +575,17 @@ FillPerimeterGapMode Settings::get<FillPerimeterGapMode>(const std::string& key)
 template<>
 BuildPlateShape Settings::get<BuildPlateShape>(const std::string& key) const
 {
-    if (get<std::string>(key) == "elliptic")
+    const std::string& value = get<std::string>(key);
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "rectangular"_sw:
+        return BuildPlateShape::RECTANGULAR;
+    case "elliptic"_sw:
         return BuildPlateShape::ELLIPTIC;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return BuildPlateShape::PLUGIN;
+    default:
         return BuildPlateShape::RECTANGULAR;
     }
 }
@@ -613,24 +594,22 @@ template<>
 CombingMode Settings::get<CombingMode>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "off")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "all"_sw:
+        return CombingMode::ALL;
+    case "off"_sw:
         return CombingMode::OFF;
-    }
-    else if (value == "noskin")
-    {
+    case "noskin"_sw:
         return CombingMode::NO_SKIN;
-    }
-    else if (value == "no_outer_surfaces")
-    {
+    case "no_outer_surfaces"_sw:
         return CombingMode::NO_OUTER_SURFACES;
-    }
-    else if (value == "infill")
-    {
+    case "infill"_sw:
         return CombingMode::INFILL;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return CombingMode::PLUGIN;
+    default:
         return CombingMode::ALL;
     }
 }
@@ -638,12 +617,17 @@ CombingMode Settings::get<CombingMode>(const std::string& key) const
 template<>
 SupportDistPriority Settings::get<SupportDistPriority>(const std::string& key) const
 {
-    if (get<std::string>(key) == "z_overrides_xy")
+    const std::string& value = get<std::string>(key);
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "xy_overrides_z"_sw:
+        return SupportDistPriority::XY_OVERRIDES_Z;
+    case "z_overrides_xy"_sw:
         return SupportDistPriority::Z_OVERRIDES_XY;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return SupportDistPriority::PLUGIN;
+    default:
         return SupportDistPriority::XY_OVERRIDES_Z;
     }
 }
@@ -652,16 +636,18 @@ template<>
 SlicingTolerance Settings::get<SlicingTolerance>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "inclusive")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "middle"_sw:
+        return SlicingTolerance::MIDDLE;
+    case "inclusive"_sw:
         return SlicingTolerance::INCLUSIVE;
-    }
-    else if (value == "exclusive")
-    {
+    case "exclusive"_sw:
         return SlicingTolerance::EXCLUSIVE;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return SlicingTolerance::PLUGIN;
+    default:
         return SlicingTolerance::MIDDLE;
     }
 }
@@ -670,12 +656,16 @@ template<>
 InsetDirection Settings::get<InsetDirection>(const std::string& key) const
 {
     const std::string& value = get<std::string>(key);
-    if (value == "outside_in")
+    using namespace cura::utils;
+    switch (hash_enum(value))
     {
+    case "inside_out"_sw:
+        return InsetDirection::INSIDE_OUT;
+    case "outside_in"_sw:
         return InsetDirection::OUTSIDE_IN;
-    }
-    else // Default.
-    {
+    case "plugin"_sw:
+        return InsetDirection::PLUGIN;
+    default:
         return InsetDirection::INSIDE_OUT;
     }
 }

--- a/tests/settings/SettingsTest.cpp
+++ b/tests/settings/SettingsTest.cpp
@@ -1,10 +1,12 @@
-// Copyright (c) 2022 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "settings/Settings.h" //The class under test.
+
 #include "Application.h" //To test extruder train settings.
 #include "ExtruderTrain.h"
 #include "Slice.h"
+#include "settings/EnumSettings.h"
 #include "settings/FlowTempGraph.h"
 #include "settings/types/Angle.h"
 #include "settings/types/Duration.h"
@@ -14,6 +16,7 @@
 #include "settings/types/Velocity.h"
 #include "utils/Coord_t.h"
 #include "utils/FMatrix4x3.h" //Testing matrix transformation settings.
+
 #include <cmath> //For M_PI.
 #include <gtest/gtest.h>
 #include <memory> //For shared_ptr.
@@ -248,6 +251,18 @@ TEST_F(SettingsTest, LimitToExtruder)
     current_slice->scene.settings.add("test_setting", "Sting has been kidnapped. The Police have no lead.");
 
     EXPECT_EQ(limit_extruder_value, settings.get<std::string>("test_setting"));
+}
+
+TEST_F(SettingsTest, PluginExtendedEnum)
+{
+    settings.add("infill_type", "PLUGIN::plugin_1::MOZAIC");
+    EXPECT_EQ(settings.get<EFillMethod>("infill_type"), EFillMethod::PLUGIN);
+}
+
+TEST_F(SettingsTest, EnumStringSwitch)
+{
+    settings.add("infill_type", "lightning");
+    EXPECT_EQ(settings.get<EFillMethod>("infill_type"), EFillMethod::LIGHTNING);
 }
 
 } // namespace cura


### PR DESCRIPTION
This commit introduces a new type 'string-switch' to handle string comparisons in a switch-case format. This is achieved by employing a DJB2a-based hash function to convert each string to a unique, corresponding enum value. The primary motivation behind this was to refactor the existing settings retrieval process, which was heavily reliant on long if-else constructs. By replacing these with more manageable switch statements, the code readability and maintainability is significantly improved. This change also facilitates the addition of new settings by simply extending existing enums and the related switch statements.

Contributes to CURA-10702