### PR TITLE
Refactor numeric types for better type safety and reduced code repeti…

### DIFF
--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2022 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef GCODEEXPORT_H
 #define GCODEEXPORT_H
@@ -462,14 +462,14 @@ public:
      * \param hop_height The height to move above the current layer.
      * \param speed The speed used for moving. 
      */
-    void writeZhopStart(const coord_t hop_height, Velocity speed = 0);
+    void writeZhopStart(const coord_t hop_height, Velocity speed = 0.0);
 
     /*!
      * End a z hop: go back to the layer height
      *
      * \param speed The speed used for moving.
      */
-    void writeZhopEnd(Velocity speed = 0);
+    void writeZhopEnd(Velocity speed = 0.0);
 
     /*!
      * Start the new_extruder: 

--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -6,20 +6,20 @@
 
 #include <deque> // for extrusionAmountAtPreviousRetractions
 #ifdef BUILD_TESTS
-    #include <gtest/gtest_prod.h> //To allow tests to use protected members.
+#include <gtest/gtest_prod.h> //To allow tests to use protected members.
 #endif
-#include <sstream> // for stream.str()
-#include <stdio.h>
-
-#include "utils/AABB3D.h" //To track the used build volume for the Griffin header.
-#include "timeEstimate.h"
 #include "settings/EnumSettings.h"
 #include "settings/Settings.h" //For MAX_EXTRUDERS.
 #include "settings/types/Temperature.h" //Bed temperature.
 #include "settings/types/Velocity.h"
+#include "sliceDataStorage.h"
+#include "timeEstimate.h"
+#include "utils/AABB3D.h" //To track the used build volume for the Griffin header.
 #include "utils/IntPoint.h"
 #include "utils/NoCopy.h"
-#include "sliceDataStorage.h"
+
+#include <sstream> // for stream.str()
+#include <stdio.h>
 
 namespace cura
 {
@@ -28,8 +28,8 @@ struct LayerIndex;
 class RetractionConfig;
 struct WipeScriptConfig;
 
-//The GCodeExport class writes the actual GCode. This is the only class that knows how GCode looks and feels.
-//  Any customizations on GCodes flavors are done in this class.
+// The GCodeExport class writes the actual GCode. This is the only class that knows how GCode looks and feels.
+//   Any customizations on GCodes flavors are done in this class.
 class GCodeExport : public NoCopy
 {
 #ifdef BUILD_TESTS
@@ -79,8 +79,10 @@ private:
         bool waited_for_temperature; //!< Whether the most recent temperature command has been a heat-and-wait command (M109) or not (M104).
         Temperature initial_temp; //!< Temperature this nozzle needs to be at the start of the print.
 
-        double retraction_e_amount_current; //!< The current retracted amount (in mm or mm^3), or zero(i.e. false) if it is not currently retracted (positive values mean retracted amount, so negative impact on E values)
-        double retraction_e_amount_at_e_start; //!< The ExtruderTrainAttributes::retraction_amount_current value at E0, i.e. the offset (in mm or mm^3) from E0 to the situation where the filament is at the tip of the nozzle.
+        double retraction_e_amount_current; //!< The current retracted amount (in mm or mm^3), or zero(i.e. false) if it is not currently retracted (positive values mean retracted
+                                            //!< amount, so negative impact on E values)
+        double retraction_e_amount_at_e_start; //!< The ExtruderTrainAttributes::retraction_amount_current value at E0, i.e. the offset (in mm or mm^3) from E0 to the situation
+                                               //!< where the filament is at the tip of the nozzle.
 
         double prime_volume; //!< Amount of material (in mm^3) to be primed after an unretration (due to oozing and/or coasting)
         Velocity last_retraction_prime_speed; //!< The last prime speed (in mm/s) of the to-be-primed amount
@@ -92,16 +94,19 @@ private:
         std::deque<double> extruded_volume_at_previous_n_retractions; // in mm^3
 
         ExtruderTrainAttributes()
-        : is_primed(false)
-        , is_used(false)
-        , extruderCharacter(0)
-        , filament_area(0)
-        , totalFilament(0)
-        , currentTemperature(0)
-        , waited_for_temperature(false)
-        , initial_temp(0)
-        , retraction_e_amount_current(0.0), retraction_e_amount_at_e_start(0.0),
-            prime_volume(0.0), last_retraction_prime_speed(0.0), fan_number(0)
+            : is_primed(false)
+            , is_used(false)
+            , extruderCharacter(0)
+            , filament_area(0)
+            , totalFilament(0)
+            , currentTemperature(0)
+            , waited_for_temperature(false)
+            , initial_temp(0)
+            , retraction_e_amount_current(0.0)
+            , retraction_e_amount_at_e_start(0.0)
+            , prime_volume(0.0)
+            , last_retraction_prime_speed(0.0)
+            , fan_number(0)
         {
         }
     };
@@ -120,23 +125,27 @@ private:
     double max_extrusion_offset; //!< 0 to turn it off, normally 4
     double extrusion_offset_factor; //!< default 1
 
-    Point3 currentPosition; //!< The last build plate coordinates written to gcode (which might be different from actually written gcode coordinates when the extruder offset is encoded in the gcode)
+    Point3 currentPosition; //!< The last build plate coordinates written to gcode (which might be different from actually written gcode coordinates when the extruder offset is
+                            //!< encoded in the gcode)
     Velocity currentSpeed; //!< The current speed (F values / 60) in mm/s
-    Acceleration current_print_acceleration; //!< The current acceleration (in mm/s^2) used for print moves (and also for travel moves if the gcode flavor doesn't have separate travel acceleration)
-    Acceleration current_travel_acceleration; //!< The current acceleration (in mm/s^2) used for travel moves for those gcode flavors that have separate print and travel accelerations
+    Acceleration current_print_acceleration; //!< The current acceleration (in mm/s^2) used for print moves (and also for travel moves if the gcode flavor doesn't have separate
+                                             //!< travel acceleration)
+    Acceleration
+        current_travel_acceleration; //!< The current acceleration (in mm/s^2) used for travel moves for those gcode flavors that have separate print and travel accelerations
     Velocity current_jerk; //!< The current jerk in the XY direction (in mm/s^3)
 
     AABB3D total_bounding_box; //!< The bounding box of all g-code.
 
     /*!
      * The z position to be used on the next xy move, if the head wasn't in the correct z position yet.
-     * 
+     *
      * \see GCodeExport::writeExtrusion(Point, double, double)
-     * 
+     *
      * \note After GCodeExport::writeExtrusion(Point, double, double) has been called currentPosition.z coincides with this value
      */
     coord_t current_layer_z;
-    coord_t is_z_hopped; //!< The amount by which the print head is currently z hopped, or zero if it is not z hopped. (A z hop is used during travel moves to avoid collision with other layer parts)
+    coord_t is_z_hopped; //!< The amount by which the print head is currently z hopped, or zero if it is not z hopped. (A z hop is used during travel moves to avoid collision with
+                         //!< other layer parts)
 
     size_t current_extruder;
     double current_fan_speed;
@@ -154,15 +163,15 @@ private:
 
     Temperature initial_bed_temp; //!< bed temperature at the beginning of the print.
     Temperature bed_temperature; //!< Current build plate temperature.
-    Temperature build_volume_temperature;  //!< build volume temperature
-    bool machine_heated_build_volume;  //!< does the machine have the ability to control/stabilize build-volume-temperature
+    Temperature build_volume_temperature; //!< build volume temperature
+    bool machine_heated_build_volume; //!< does the machine have the ability to control/stabilize build-volume-temperature
 protected:
     /*!
      * Convert an E value to a value in mm (if it wasn't already in mm) for the current extruder.
-     * 
+     *
      * E values are either in mm or in mm^3
      * The current extruder is used to determine the filament area to make the conversion.
-     * 
+     *
      * \param e the value to convert
      * \return the value converted to mm
      */
@@ -170,10 +179,10 @@ protected:
 
     /*!
      * Convert a volume value to an E value (which might be volumetric as well) for the current extruder.
-     * 
+     *
      * E values are either in mm or in mm^3
      * The current extruder is used to determine the filament area to make the conversion.
-     * 
+     *
      * \param mm3 the value to convert
      * \return the value converted to mm or mm3 depending on whether the E axis is volumetric
      */
@@ -181,10 +190,10 @@ protected:
 
     /*!
      * Convert a distance value to an E value (which might be linear/distance based as well) for the current extruder.
-     * 
+     *
      * E values are either in mm or in mm^3
      * The current extruder is used to determine the filament area to make the conversion.
-     * 
+     *
      * \param mm the value to convert
      * \return the value converted to mm or mm3 depending on whether the E axis is volumetric
      */
@@ -203,7 +212,6 @@ protected:
     double eToMm3(double e, size_t extruder);
 
 public:
-    
     GCodeExport();
     ~GCodeExport();
 
@@ -224,10 +232,11 @@ public:
      * \param mat_ids The material GUIDs for each material.
      * \return The string representing the file header
      */
-    std::string getFileHeader(const std::vector<bool>& extruder_is_used,
-                              const Duration* print_time = nullptr,
-                              const std::vector<double>& filament_used = std::vector<double>(),
-                              const std::vector<std::string>& mat_ids = std::vector<std::string>());
+    std::string getFileHeader(
+        const std::vector<bool>& extruder_is_used,
+        const Duration* print_time = nullptr,
+        const std::vector<double>& filament_used = std::vector<double>(),
+        const std::vector<std::string>& mat_ids = std::vector<std::string>());
 
     void setSliceUUID(const std::string& slice_uuid);
 
@@ -241,7 +250,7 @@ public:
 
     void setFlavor(EGCodeFlavor flavor);
     EGCodeFlavor getFlavor() const;
-    
+
     void setZ(int z);
 
     void setFlowRateExtrusionSettings(double max_extrusion_offset, double extrusion_offset_factor);
@@ -252,24 +261,24 @@ public:
      * \param extra_prime_distance Amount of material in mm.
      */
     void addExtraPrimeAmount(double extra_prime_volume);
-    
+
     Point3 getPosition() const;
-    
+
     Point getPositionXY() const;
 
     int getPositionZ() const;
 
     int getExtruderNr() const;
-    
+
     void setFilamentDiameter(size_t extruder, const coord_t diameter);
-    
+
     double getCurrentExtrudedVolume() const;
 
     /*!
      * Get the total extruded volume for a specific extruder in mm^3
-     * 
+     *
      * Retractions and unretractions don't contribute to this.
-     * 
+     *
      * \param extruder_nr The extruder number for which to get the total netto extruded volume
      * \return total filament printed in mm^3
      */
@@ -277,19 +286,19 @@ public:
 
     /*!
      * Get the total estimated print time in seconds for each feature
-     * 
+     *
      * \return total print time in seconds for each feature
      */
     std::vector<Duration> getTotalPrintTimePerFeature();
     /*!
      * Get the total print time in seconds for the complete print
-     * 
+     *
      * \return total print time in seconds for the complete print
      */
     double getSumTotalPrintTimes();
     void updateTotalPrintTime();
     void resetTotalPrintTimeAndFilament();
-    
+
     void writeComment(const std::string& comment);
     void writeTypeComment(const PrintFeatureType& type);
 
@@ -304,7 +313,7 @@ public:
 
     /*!
      * Write a comment saying what (estimated) time has passed up to this point
-     * 
+     *
      * \param time The time passed up till this point
      */
     void writeTimeComment(const Duration time);
@@ -318,21 +327,21 @@ public:
      * Write a comment saying that the print has a certain number of layers.
      */
     void writeLayerCountComment(const size_t layer_count);
-    
+
     void writeLine(const char* line);
-    
+
     /*!
      * Reset the current_e_value to prevent too high E values.
-     * 
+     *
      * The current extruded volume is added to the current extruder_attr.
      */
     void resetExtrusionValue();
-    
+
     void writeDelay(const Duration& time_amount);
 
     /*!
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
-     * 
+     *
      * \param p location to go to
      * \param speed movement speed
      */
@@ -340,7 +349,7 @@ public:
 
     /*!
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
-     * 
+     *
      * \param p location to go to
      * \param speed movement speed
      * \param feature the feature that's currently printing
@@ -351,7 +360,7 @@ public:
     /*!
      * Go to a X/Y location with the z-hopped Z value
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
-     * 
+     *
      * \param p location to go to
      * \param speed movement speed
      */
@@ -361,9 +370,9 @@ public:
      * Go to a X/Y location with the extrusion Z
      * Perform un-z-hop
      * Perform unretraction
-     * 
+     *
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
-     * 
+     *
      * \param p location to go to
      * \param speed movement speed
      * \param feature the feature that's currently printing
@@ -380,10 +389,10 @@ public:
     bool initializeExtruderTrains(const SliceDataStorage& storage, const size_t start_extruder_nr);
 
     /*!
-    * Set temperatures for the initial layer. Called by 'processStartingCode' and whenever a new object is started at layer 0.
-    *
-    * \param[in] storage where the slice data is stored.
-    * \param[in] start_extruder_nr The extruder with which to start the print.
+     * Set temperatures for the initial layer. Called by 'processStartingCode' and whenever a new object is started at layer 0.
+     *
+     * \param[in] storage where the slice data is stored.
+     * \param[in] start_extruder_nr The extruder with which to start the print.
      */
     void processInitialLayerTemperature(const SliceDataStorage& storage, const size_t start_extruder_nr);
 
@@ -398,7 +407,7 @@ public:
 private:
     /*!
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
-     * 
+     *
      * \param x build plate x
      * \param y build plate y
      * \param z build plate z
@@ -411,7 +420,7 @@ private:
      * Perform unretract
      * Write extrusion move
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
-     * 
+     *
      * \param x build plate x
      * \param y build plate y
      * \param z build plate z
@@ -420,13 +429,20 @@ private:
      * \param feature the print feature that's currently printing
      * \param update_extrusion_offset whether to update the extrusion offset to match the current flow rate
      */
-    void writeExtrusion(const coord_t x, const coord_t y, const coord_t z, const Velocity& speed, const double extrusion_mm3_per_mm, const PrintFeatureType& feature, const bool update_extrusion_offset = false);
+    void writeExtrusion(
+        const coord_t x,
+        const coord_t y,
+        const coord_t z,
+        const Velocity& speed,
+        const double extrusion_mm3_per_mm,
+        const PrintFeatureType& feature,
+        const bool update_extrusion_offset = false);
 
     /*!
      * Write the F, X, Y, Z and E value (if they are not different from the last)
-     * 
+     *
      * convenience function called from writeExtrusion and writeTravel
-     * 
+     *
      * This function also applies the gcode offset by calling \ref GCodeExport::getGcodePos
      * This function updates the \ref GCodeExport::total_bounding_box
      * It estimates the time in \ref GCodeExport::estimateCalculator for the correct feature
@@ -444,12 +460,13 @@ private:
      * \param feature print feature to track print time for
      */
     void writeMoveBFB(const int x, const int y, const int z, const Velocity& speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
+
 public:
     /*!
      * Get ready for extrusion moves:
      * - unretract (G11 or G1 E.)
      * - prime blob (G1 E)
-     * 
+     *
      * It estimates the time in \ref GCodeExport::estimateCalculator
      * It updates \ref GCodeExport::current_e_value and \ref GCodeExport::currentSpeed
      */
@@ -458,9 +475,9 @@ public:
 
     /*!
      * Start a z hop with the given \p hop_height.
-     * 
+     *
      * \param hop_height The height to move above the current layer.
-     * \param speed The speed used for moving. 
+     * \param speed The speed used for moving.
      */
     void writeZhopStart(const coord_t hop_height, Velocity speed = 0.0);
 
@@ -472,23 +489,23 @@ public:
     void writeZhopEnd(Velocity speed = 0.0);
 
     /*!
-     * Start the new_extruder: 
+     * Start the new_extruder:
      * - set new extruder
      * - zero E value
      * - write extruder start gcode
-     * 
+     *
      * \param new_extruder The extruder to start with
      */
     void startExtruder(const size_t new_extruder);
 
     /*!
-     * Switch to the new_extruder: 
+     * Switch to the new_extruder:
      * - perform neccessary retractions
      * - fiddle with E-values
      * - write extruder end gcode
      * - set new extruder
      * - write extruder start gcode
-     * 
+     *
      * \param new_extruder The extruder to switch to
      * \param retraction_config_old_extruder The extruder switch retraction config of the old extruder, to perform the extruder switch retraction with.
      * \param perform_z_hop The amount by which the print head should be z hopped during extruder switch, or zero if it should not z hop.
@@ -501,7 +518,7 @@ public:
 
     /*!
      * Write the gcode for priming the current extruder train so that it can be used.
-     * 
+     *
      * \param travel_speed The travel speed when priming involves a movement
      */
     void writePrimeTrain(const Velocity& travel_speed);
@@ -512,9 +529,9 @@ public:
      * \param extruder The current extruder
      */
     void setExtruderFanNumber(int extruder);
-    
+
     void writeFanCommand(double speed);
-    
+
     void writeTemperatureCommand(const size_t extruder, const Temperature& temperature, const bool wait = false);
     void writeBedTemperatureCommand(const Temperature& temperature, const bool wait = false);
     void writeBuildVolumeTemperatureCommand(const Temperature& temperature, const bool wait = false);
@@ -542,7 +559,7 @@ public:
     /*!
      * Handle the initial (bed/nozzle) temperatures before any gcode is processed.
      * These temperatures are set in the pre-print setup in the firmware.
-     * 
+     *
      * See FffGcodeWriter::processStartingCode
      * \param start_extruder_nr The extruder with which to start this print
      */
@@ -551,10 +568,10 @@ public:
     /*!
      * Override or set an initial nozzle temperature as written by GCodeExport::setInitialTemps
      * This is used primarily during better specification of temperatures in LayerPlanBuffer::insertPreheatCommand
-     * 
+     *
      * \warning This function must be called before any of the layers in the meshgroup are written to file!
      * That's because it sets the current temperature in the gcode!
-     * 
+     *
      * \param extruder_nr The extruder number for which to better specify the temp
      * \param temp The temp at which the nozzle should be at startup
      */
@@ -562,7 +579,7 @@ public:
 
     /*!
      * Finish the gcode: turn fans off, write end gcode and flush all gcode left in the buffer.
-     * 
+     *
      * \param endCode The end gcode to be appended at the very end.
      */
     void finalize(const char* endCode);
@@ -579,7 +596,7 @@ public:
      *
      * \param extruder Extruder number which last_e_value_after_wipe value to reset.
      */
-     void ResetLastEValueAfterWipe(size_t extruder);
+    void ResetLastEValueAfterWipe(size_t extruder);
 
     /*!
      *  Generate g-code for wiping current nozzle using provided config.
@@ -589,6 +606,6 @@ public:
     void insertWipeScript(const WipeScriptConfig& wipe_config);
 };
 
-}
+} // namespace cura
 
-#endif//GCODEEXPORT_H
+#endif // GCODEEXPORT_H

--- a/include/settings/types/LayerIndex.h
+++ b/include/settings/types/LayerIndex.h
@@ -1,8 +1,10 @@
-//Copyright (c) 2019 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef LAYERINDEX_H
 #define LAYERINDEX_H
+
+#include "utils/types/numeric_facade.h"
 
 #include <functional>
 
@@ -15,112 +17,27 @@ namespace cura
  * This is a facade. It behaves exactly like an integer but is used to indicate
  * that it is a layer number.
  */
-struct LayerIndex
+struct LayerIndex : public utils::NumericFacade<int64_t>
 {
-    /*
-     * \brief Default constructor setting the layer index to 0.
-     */
-    constexpr LayerIndex() : value(0) {};
+    using base_type = utils::NumericFacade<int64_t>;
+    using base_type::NumericFacade;
 
-    /*
-     * \brief Casts an integer to a LayerIndex instance.
-     */
-    constexpr LayerIndex(int value) : value(value) {};
-
-    /*
-     * \brief Casts the LayerIndex instance to an integer.
-     */
-    constexpr operator int() const
-    {
-        return value;
-    }
-
-    /*
-     * Some operators to add and subtract layer numbers.
-     */
-    LayerIndex operator +(const LayerIndex& other) const
-    {
-        return LayerIndex(value + other.value);
-    }
-    template<typename E> LayerIndex operator +(const E& other) const
-    {
-        return LayerIndex(value + other);
-    }
-
-    LayerIndex operator -(const LayerIndex& other) const
-    {
-        return LayerIndex(value - other.value);
-    }
-    template<typename E> LayerIndex operator -(const E& other) const
-    {
-        return LayerIndex(value - other);
-    }
-
-    LayerIndex& operator +=(const LayerIndex& other)
-    {
-        value += other.value;
-        return *this;
-    }
-    template<typename E> LayerIndex& operator +=(const E& other)
-    {
-        value += other;
-        return *this;
-    }
-
-    LayerIndex& operator -=(const LayerIndex& other)
-    {
-        value -= other.value;
-        return *this;
-    }
-    template<typename E> LayerIndex& operator -=(const E& other)
-    {
-        value -= other;
-        return *this;
-    }
-
-    LayerIndex& operator ++()
-    {
-        value++;
-        return *this;
-    }
-    LayerIndex operator ++(int) //Postfix.
-    {
-        LayerIndex original_value(value);
-        operator++(); //Increment myself.
-        return original_value;
-    }
-    LayerIndex& operator --()
-    {
-        value--;
-        return *this;
-    }
-    LayerIndex operator --(int) //Postfix.
-    {
-        LayerIndex original_value(value);
-        operator--(); //Decrement myself.
-        return original_value;
-    }
-
-    /*
-     * \brief The actual layer index.
-     *
-     * Note that this could be negative for raft layers.
-     */
-    int value = 0;
+    constexpr LayerIndex(const base_type& base) noexcept
+        : base_type{ base } {};
 };
 
-}
+} // namespace cura
 
 namespace std
 {
-    template<>
-    struct hash<cura::LayerIndex>
+template<>
+struct hash<cura::LayerIndex>
+{
+    auto operator()(const cura::LayerIndex& layer_index) const
     {
-        size_t operator()(const cura::LayerIndex& layer_index) const
-        {
-            return hash<int>()(layer_index.value);
-        }
-    };
-}
+        return hash<decltype(layer_index.value)>()(layer_index.value);
+    }
+};
+} // namespace std
 
-#endif //LAYERINDEX_H
+#endif // LAYERINDEX_H

--- a/include/settings/types/Ratio.h
+++ b/include/settings/types/Ratio.h
@@ -1,8 +1,11 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef RATIO_H
 #define RATIO_H
+
+#include "utils/types/numeric_facade.h"
+
 
 namespace cura
 {
@@ -12,104 +15,28 @@ namespace cura
  *
  * This is a facade. It behaves like a double.
  */
-class Ratio
+struct Ratio : public utils::NumericFacade<double>
 {
-public:
-    /*
-     * \brief Default constructor setting the ratio to 1.
-     */
-    constexpr Ratio() : value(1.0) {};
+    using base_type = utils::NumericFacade<double>;
+    using base_type::NumericFacade;
 
-    /*
-     * \brief Casts a double to a Ratio instance.
-     */
-    constexpr Ratio(double value) : value(value) {};
+    constexpr Ratio(const base_type& base) noexcept
+        : base_type{ base } {};
 
     /*!
      * Create the Ratio with a numerator and a divisor from arbitrary types
-     * \tparam E1 required to be castable to a double
-     * \tparam E2 required to be castable to a double
      * \param numerator the numerator of the ratio
      * \param divisor the divisor of the ratio
      */
-    template <typename E1, typename E2>
-    constexpr Ratio(const E1& numerator, const E2& divisor)
-        : value(static_cast<double>(numerator) / static_cast<double>(divisor)) {};
-
-    /*
-     * \brief Casts the Ratio instance to a double.
-     */
-    operator double() const
-    {
-        return value;
-    }
-
-    /*
-     * Some Relational operators
-     */
-    template <typename E>
-    constexpr bool operator==(const E& rhs) const
-    {
-        return value == static_cast<double>(rhs);
-    }
-
-    template <typename E>
-    constexpr bool operator!=(const E& rhs) const
-    {
-        return !(rhs == *this);
-    }
-
-    /*
-     * Some operators for arithmetic on ratios.
-     */
-    Ratio operator *(const Ratio& other) const
-    {
-        return Ratio(value * other.value);
-    }
-    template<typename E> Ratio operator *(const E& other) const
-    {
-        return Ratio(value * other);
-    }
-    Ratio operator /(const Ratio& other) const
-    {
-        return Ratio(value / other.value);
-    }
-    template<typename E> Ratio operator /(const E& other) const
-    {
-        return Ratio(value / other);
-    }
-    Ratio& operator *=(const Ratio& other)
-    {
-        value *= other.value;
-        return *this;
-    }
-    template<typename E> Ratio& operator *=(const E& other)
-    {
-        value *= other;
-        return *this;
-    }
-    Ratio& operator /=(const Ratio& other)
-    {
-        value /= other.value;
-        return *this;
-    }
-    template<typename E> Ratio& operator /=(const E& other)
-    {
-        value /= other;
-        return *this;
-    }
-
-    /*
-     * \brief The actual ratio, as a double.
-     */
-    double value = 0;
+    constexpr Ratio(const utils::numeric auto numerator, const utils::numeric auto divisor)
+        : base_type{ static_cast<value_type>(numerator) / static_cast<value_type>(divisor) } {};
 };
 
-constexpr Ratio operator "" _r(const long double ratio)
+constexpr Ratio operator"" _r(const long double ratio)
 {
-    return Ratio(ratio);
+    return { ratio };
 }
 
-}
+} // namespace cura
 
-#endif //RATIO_H
+#endif // RATIO_H

--- a/include/settings/types/Velocity.h
+++ b/include/settings/types/Velocity.h
@@ -1,8 +1,10 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef VELOCITY_H
 #define VELOCITY_H
+
+#include "utils/types/numeric_facade.h"
 
 namespace cura
 {
@@ -12,74 +14,24 @@ namespace cura
  *
  * This is a facade. It behaves like a double, only it can't be negative.
  */
-struct Velocity
+struct Velocity : public utils::NumericFacade<double>
 {
-    /*
-     * \brief Default constructor setting velocity to 0.
-     */
-    constexpr Velocity() : value(0.0) {};
+    using base_type = utils::NumericFacade<double>;
+    using base_type::NumericFacade;
 
-    /*
-     * \brief Casts a double to a Velocity instance.
-     */
-    constexpr Velocity(double value) : value(value) {};
-
-    /*
-     * \brief Casts the Temperature instance to a double.
-     */
-    constexpr operator double() const
-    {
-        return value;
-    }
-
-    /*
-     * Some operators for arithmetic on velocities.
-     */
-    Velocity operator *(const Velocity& other) const
-    {
-        return Velocity(value * other.value);
-    }
-    template<typename E> Velocity operator *(const E& other) const
-    {
-        return Velocity(value * other);
-    }
-    Velocity operator /(const Velocity& other) const
-    {
-        return Velocity(value / other.value);
-    }
-    template<typename E> Velocity operator /(const E& other) const
-    {
-        return Velocity(value / other);
-    }
-    Velocity& operator *=(const Velocity& other)
-    {
-        value *= other.value;
-        return *this;
-    }
-    template<typename E> Velocity& operator *=(const E& other)
-    {
-        value *= other;
-        return *this;
-    }
-    Velocity& operator /=(const Velocity& other)
-    {
-        value /= other.value;
-        return *this;
-    }
-    template<typename E> Velocity& operator /=(const E& other)
-    {
-        value /= other;
-        return *this;
-    }
-
-    /*
-     * \brief The actual temperature, as a double.
-     */
-    double value = 0;
+    constexpr Velocity(const base_type& base) noexcept
+        : base_type{ base } {};
 };
 
-using Acceleration = Velocity; //Use the same logic for acceleration variables.
+struct Acceleration : public utils::NumericFacade<double>
+{
+    using base_type = utils::NumericFacade<double>;
+    using base_type::NumericFacade;
 
-}
+    constexpr Acceleration(const base_type& base) noexcept
+        : base_type{ base } {};
+};
 
-#endif //VELOCITY_H
+} // namespace cura
+
+#endif // VELOCITY_H

--- a/include/support.h
+++ b/include/support.h
@@ -6,8 +6,8 @@
 
 #include "utils/polygon.h"
 
-#include <vector>
 #include <cstddef>
+#include <vector>
 
 namespace cura
 {
@@ -24,7 +24,7 @@ public:
     /*!
      * \brief Move support mesh outlines from slicer data into the support
      * storage.
-     * 
+     *
      * \param[out] storage Where to store the support areas.
      * \param mesh_settings Where to get the settings from what kind of support
      * mesh it is.
@@ -74,7 +74,8 @@ private:
      * \param global_support_areas_per_layer the global support areas per layer
      * \param total_layer_count total number of layers
      */
-    static void splitGlobalSupportAreasIntoSupportInfillParts(SliceDataStorage& storage, const std::vector<Polygons>& global_support_areas_per_layer, unsigned int total_layer_count);
+    static void
+        splitGlobalSupportAreasIntoSupportInfillParts(SliceDataStorage& storage, const std::vector<Polygons>& global_support_areas_per_layer, unsigned int total_layer_count);
 
     /*!
      * Generate gradual support on the already generated support areas. This must be called after generateSupportAreas().
@@ -105,11 +106,11 @@ private:
 
     /*!
      * \brief Combines the support infill of multiple layers.
-     * 
+     *
      * The support infill layers are combined while the thickness of each layer is
      * multiplied such that the infill should fill up again to the full height of
      * all combined layers.
-     * 
+     *
      * \param storage data storage containing the input layer outline data and containing the output support storage per layer
      */
     static void combineSupportInfillLayers(SliceDataStorage& storage);
@@ -138,7 +139,7 @@ private:
      * meshes with drop down and once for all support meshes without drop down.
      * The \p mesh_idx should then correspond to an empty \ref SliceMeshStorage
      * of one support mesh with the given value of support_mesh_drop_down.
-     * 
+     *
      * \param storage Data storage containing the input layer outline data.
      * \param infill_settings The settings which are based on the infill of the
      * support.
@@ -150,7 +151,14 @@ private:
      * areas.
      * \param layer_count Total number of layers.
      */
-    static void generateSupportAreasForMesh(SliceDataStorage& storage, const Settings& infill_settings, const Settings& roof_settings, const Settings& bottom_settings, const size_t mesh_idx, const size_t layer_count, std::vector<Polygons>& support_areas);
+    static void generateSupportAreasForMesh(
+        SliceDataStorage& storage,
+        const Settings& infill_settings,
+        const Settings& roof_settings,
+        const Settings& bottom_settings,
+        const size_t mesh_idx,
+        const size_t layer_count,
+        std::vector<Polygons>& support_areas);
 
     /*!
      * Generate support bottom areas for a given mesh.
@@ -197,7 +205,13 @@ private:
      * \param minimum_interface_area Minimum area size for resulting interface polygons.
      * \param[out] interface_polygons The resulting interface layer. Do not use `interface` in windows!
      */
-    static void generateSupportInterfaceLayer(Polygons& support_areas, const Polygons mesh_outlines, const coord_t safety_offset, const coord_t outline_offset, const double minimum_interface_area, Polygons& interface_polygons);
+    static void generateSupportInterfaceLayer(
+        Polygons& support_areas,
+        const Polygons mesh_outlines,
+        const coord_t safety_offset,
+        const coord_t outline_offset,
+        const double minimum_interface_area,
+        Polygons& interface_polygons);
 
     /*!
      * \brief Join current support layer with the support of the layer above,
@@ -214,20 +228,26 @@ private:
     /*!
      * Move the support up from model (cut away polygons to ensure bottom z distance)
      * and apply stair step transformation.
-     * 
+     *
      * If the bottom stairs defined only by the step height are too wide,
      * the top half of the step will be as wide as the stair step width
      * and the bottom half will follow the model.
-     * 
+     *
      * \param storage Where to get model outlines from
-     * \param[in,out] stair_removal The polygons to be removed for stair stepping on the current layer (input) and for the next layer (output). Only changed every [step_height] layers.
-     * \param[in,out] support_areas The support areas before and after this function
-     * \param layer_idx The layer number of the support layer we are processing
-     * \param bottom_empty_layer_count The number of empty layers between the bottom of support and the top of the model on which support rests
-     * \param bottom_stair_step_layer_count The max height (in nr of layers) of the support bottom stairs
-     * \param support_bottom_stair_step_width The max width of the support bottom stairs
+     * \param[in,out] stair_removal The polygons to be removed for stair stepping on the current layer (input) and for the next layer (output). Only changed every [step_height]
+     * layers. \param[in,out] support_areas The support areas before and after this function \param layer_idx The layer number of the support layer we are processing \param
+     * bottom_empty_layer_count The number of empty layers between the bottom of support and the top of the model on which support rests \param bottom_stair_step_layer_count The
+     * max height (in nr of layers) of the support bottom stairs \param support_bottom_stair_step_width The max width of the support bottom stairs
      */
-    static void moveUpFromModel(const SliceDataStorage& storage, Polygons& stair_removal, Polygons& sloped_areas, Polygons& support_areas, const size_t layer_idx, const size_t bottom_empty_layer_count, const size_t bottom_stair_step_layer_count, const coord_t support_bottom_stair_step_width);
+    static void moveUpFromModel(
+        const SliceDataStorage& storage,
+        Polygons& stair_removal,
+        Polygons& sloped_areas,
+        Polygons& support_areas,
+        const size_t layer_idx,
+        const size_t bottom_empty_layer_count,
+        const size_t bottom_stair_step_layer_count,
+        const coord_t support_bottom_stair_step_width);
 
     /*!
      * Joins the layer part outlines of all meshes and collects the overhang
@@ -236,26 +256,26 @@ private:
      * \param mesh Output mesh to store the resulting overhang points in.
      */
     static void detectOverhangPoints(const SliceDataStorage& storage, SliceMeshStorage& mesh);
-    
+
     /*!
      * \brief Compute the basic overhang and full overhang of a layer.
      *
      * The basic overhang consists of the parts of this layer which are too far
      * away from the layer below to be supported. The full overhang consists of
      * the basic overhang extended toward the border of the layer below.
-     * 
+     *
      *             layer 2
      * layer 1 ______________|
      * _______|         ^^^^^ basic overhang
      *         ^^^^^^^^^^^^^^ full overhang
-     * 
+     *
      * \param storage The slice data storage.
      * \param mesh The mesh for which to compute the basic overhangs.
      * \param layer_idx The layer for which to compute the overhang.
      * \return A pair of basic overhang and full overhang.
      */
     static std::pair<Polygons, Polygons> computeBasicAndFullOverhang(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const unsigned int layer_idx);
-    
+
     /*!
      * \brief Adds tower pieces to the current support layer.
      *
@@ -277,9 +297,8 @@ private:
         std::vector<Polygons>& tower_roofs,
         std::vector<std::vector<Polygons>>& overhang_points,
         LayerIndex layer_idx,
-        size_t layer_count
-    );
-    
+        size_t layer_count);
+
     /*!
      * \brief Adds struts (towers against a wall) to the current layer.
      * \param settings The settings to use to create the wall struts.
@@ -291,10 +310,10 @@ private:
     /*!
      * Clean up the SupportInfillParts.
      * Remove parts which have nothing to be printed.
-     * 
+     *
      * Remove parts which are too small for the first wall.
      * For parts without walls: remove if combined into upper layers.
-     * 
+     *
      */
     static void cleanup(SliceDataStorage& storage);
 
@@ -311,6 +330,6 @@ private:
 };
 
 
-}//namespace cura
+} // namespace cura
 
-#endif//SUPPORT_H
+#endif // SUPPORT_H

--- a/include/support.h
+++ b/include/support.h
@@ -1,8 +1,13 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef SUPPORT_H
 #define SUPPORT_H
+
+#include "utils/polygon.h"
+
+#include <vector>
+#include <cstddef>
 
 namespace cura
 {

--- a/include/timeEstimate.h
+++ b/include/timeEstimate.h
@@ -1,5 +1,5 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef TIME_ESTIMATE_H
 #define TIME_ESTIMATE_H
@@ -11,11 +11,11 @@
 #include "PrintFeature.h"
 #include "settings/types/Duration.h" //Print time estimates.
 #include "settings/types/Velocity.h" //Speeds and accelerations at which we print.
+#include "settings/types/Ratio.h"
 
 namespace cura
 {
 
-class Ratio;
 class Settings;
 
 /*!
@@ -68,10 +68,10 @@ public:
     };
 
 private:
-    Velocity max_feedrate[NUM_AXIS] = {600, 600, 40, 25}; // mm/s
+    Velocity max_feedrate[NUM_AXIS] = {600.0, 600.0, 40.0, 25.0}; // mm/s
     Velocity minimumfeedrate = 0.01;
-    Acceleration acceleration = 3000;
-    Acceleration max_acceleration[NUM_AXIS] = {9000, 9000, 100, 10000};
+    Acceleration acceleration = 3000.0;
+    Acceleration max_acceleration[NUM_AXIS] = {9000.0, 9000.0, 100.0, 10000.0};
     Velocity max_xy_jerk = 20.0;
     Velocity max_z_jerk = 0.4;
     Velocity max_e_jerk = 5.0;

--- a/include/timeEstimate.h
+++ b/include/timeEstimate.h
@@ -4,14 +4,14 @@
 #ifndef TIME_ESTIMATE_H
 #define TIME_ESTIMATE_H
 
-#include <stdint.h>
-#include <vector>
-#include <unordered_map>
-
 #include "PrintFeature.h"
 #include "settings/types/Duration.h" //Print time estimates.
-#include "settings/types/Velocity.h" //Speeds and accelerations at which we print.
 #include "settings/types/Ratio.h"
+#include "settings/types/Velocity.h" //Speeds and accelerations at which we print.
+
+#include <stdint.h>
+#include <unordered_map>
+#include <vector>
 
 namespace cura
 {
@@ -36,18 +36,31 @@ public:
     class Position
     {
     public:
-        Position() {for(unsigned int n=0;n<NUM_AXIS;n++) axis[n] = 0;}
-        Position(double x, double y, double z, double e) {axis[0] = x;axis[1] = y;axis[2] = z;axis[3] = e;}
+        Position()
+        {
+            for (unsigned int n = 0; n < NUM_AXIS; n++)
+                axis[n] = 0;
+        }
+        Position(double x, double y, double z, double e)
+        {
+            axis[0] = x;
+            axis[1] = y;
+            axis[2] = z;
+            axis[3] = e;
+        }
         double axis[NUM_AXIS];
-        
-        double& operator[](const int n) { return axis[n]; }
+
+        double& operator[](const int n)
+        {
+            return axis[n];
+        }
     };
 
     class Block
     {
     public:
         bool recalculate_flag;
-        
+
         double accelerate_until;
         double decelerate_after;
         Velocity initial_feedrate;
@@ -56,7 +69,7 @@ public:
         Velocity entry_speed;
         Velocity max_entry_speed;
         bool nominal_length_flag;
-        
+
         Velocity nominal_feedrate;
         double maxTravel;
         double distance;
@@ -68,21 +81,22 @@ public:
     };
 
 private:
-    Velocity max_feedrate[NUM_AXIS] = {600.0, 600.0, 40.0, 25.0}; // mm/s
+    Velocity max_feedrate[NUM_AXIS] = { 600.0, 600.0, 40.0, 25.0 }; // mm/s
     Velocity minimumfeedrate = 0.01;
     Acceleration acceleration = 3000.0;
-    Acceleration max_acceleration[NUM_AXIS] = {9000.0, 9000.0, 100.0, 10000.0};
+    Acceleration max_acceleration[NUM_AXIS] = { 9000.0, 9000.0, 100.0, 10000.0 };
     Velocity max_xy_jerk = 20.0;
     Velocity max_z_jerk = 0.4;
     Velocity max_e_jerk = 5.0;
     Duration extra_time = 0.0;
-    
+
     Position previous_feedrate;
     Velocity previous_nominal_feedrate;
 
     Position currentPosition;
 
     std::vector<Block> blocks;
+
 public:
     /*!
      * \brief Set the movement configuration of the firmware.
@@ -96,8 +110,9 @@ public:
     void setMaxXyJerk(const Velocity& jerk); //!< Set the max xy jerk to \p jerk
 
     void reset();
-    
+
     std::vector<Duration> calculate();
+
 private:
     void reversePass();
     void forwardPass();
@@ -108,14 +123,14 @@ private:
     void recalculateTrapezoids();
 
     // Calculates trapezoid parameters so that the entry- and exit-speed is compensated by the provided factors.
-    void calculateTrapezoidForBlock(Block *block, const Ratio entry_factor, const Ratio exit_factor);
+    void calculateTrapezoidForBlock(Block* block, const Ratio entry_factor, const Ratio exit_factor);
 
     // The kernel called by accelerationPlanner::calculate() when scanning the plan from last to first entry.
-    void plannerReversePassKernel(Block *previous, Block *current, Block *next);
+    void plannerReversePassKernel(Block* previous, Block* current, Block* next);
 
     // The kernel called by accelerationPlanner::calculate() when scanning the plan from first to last entry.
-    void plannerForwardPassKernel(Block *previous, Block *current, Block *next);
+    void plannerForwardPassKernel(Block* previous, Block* current, Block* next);
 };
 
-}//namespace cura
-#endif//TIME_ESTIMATE_H
+} // namespace cura
+#endif // TIME_ESTIMATE_H

--- a/include/utils/types/generic.h
+++ b/include/utils/types/generic.h
@@ -4,6 +4,8 @@
 #ifndef CURAENGINE_GENERIC_H
 #define CURAENGINE_GENERIC_H
 
+#include <range/v3/range/concepts.hpp>
+
 #include <concepts>
 #include <functional>
 #include <type_traits>
@@ -53,6 +55,9 @@ template<typename Tp>
 concept floating_point = std::floating_point<Tp>;
 #endif
 // clang-format on
+
+template<typename Tp>
+concept numeric = std::is_arithmetic_v<std::remove_cvref_t<Tp>>;
 } // namespace cura::utils
 
 #endif // CURAENGINE_GENERIC_H

--- a/include/utils/types/numeric_facade.h
+++ b/include/utils/types/numeric_facade.h
@@ -22,38 +22,30 @@ struct NumericFacade
     constexpr NumericFacade(const NumericFacade& other) noexcept = default;
     constexpr NumericFacade(NumericFacade&& other) noexcept = default;
 
-    constexpr NumericFacade(const floating_point auto value) noexcept
-    requires floating_point<value_type>
-        : value{ static_cast<value_type>(value) } {};
+    constexpr NumericFacade(const floating_point auto value) noexcept requires floating_point<value_type> : value{ static_cast<value_type>(value) } {};
 
-    constexpr NumericFacade(const integral auto value) noexcept
-    requires integral<value_type>
-        : value{ static_cast<value_type>(value) } {};
+    constexpr NumericFacade(const integral auto value) noexcept requires integral<value_type> : value{ static_cast<value_type>(value) } {};
 
     constexpr NumericFacade& operator=(const NumericFacade& other) noexcept = default;
 
-    constexpr NumericFacade& operator=(const floating_point auto& other) noexcept
-    requires floating_point<value_type>
+    constexpr NumericFacade& operator=(const floating_point auto& other) noexcept requires floating_point<value_type>
     {
         this->value = static_cast<value_type>(other);
         return *this;
     }
-    constexpr NumericFacade& operator=(const integral auto& other) noexcept
-    requires integral<value_type>
+    constexpr NumericFacade& operator=(const integral auto& other) noexcept requires integral<value_type>
     {
         this->value = static_cast<value_type>(other);
         return *this;
     }
 
     constexpr NumericFacade& operator=(NumericFacade&& other) noexcept = default;
-    constexpr NumericFacade& operator=(const integral auto&& other) noexcept
-    requires integral<value_type>
+    constexpr NumericFacade& operator=(const integral auto&& other) noexcept requires integral<value_type>
     {
         this->value = static_cast<value_type>(other);
         return *this;
     }
-    constexpr NumericFacade& operator=(const floating_point auto&& other) noexcept
-    requires floating_point<value_type>
+    constexpr NumericFacade& operator=(const floating_point auto&& other) noexcept requires floating_point<value_type>
     {
         this->value = static_cast<value_type>(other);
         return *this;
@@ -180,28 +172,24 @@ struct NumericFacade
         return { -value };
     }
 
-    constexpr NumericFacade& operator++() noexcept
-    requires integral<value_type>
+    constexpr NumericFacade& operator++() noexcept requires integral<value_type>
     {
         ++value;
         return *this;
     }
 
-    constexpr NumericFacade operator++(int) noexcept
-    requires integral<value_type>
+    constexpr NumericFacade operator++(int) noexcept requires integral<value_type>
     {
         return { value++ };
     }
 
-    constexpr NumericFacade& operator--() noexcept
-    requires integral<value_type>
+    constexpr NumericFacade& operator--() noexcept requires integral<value_type>
     {
         --value;
         return *this;
     }
 
-    constexpr NumericFacade operator--(int) noexcept
-    requires integral<value_type>
+    constexpr NumericFacade operator--(int) noexcept requires integral<value_type>
     {
         return { value-- };
     }

--- a/include/utils/types/numeric_facade.h
+++ b/include/utils/types/numeric_facade.h
@@ -22,9 +22,9 @@ struct NumericFacade
     constexpr NumericFacade(const NumericFacade& other) noexcept = default;
     constexpr NumericFacade(NumericFacade&& other) noexcept = default;
 
-    constexpr NumericFacade(const floating_point auto value) noexcept requires floating_point<value_type> : value{ static_cast<value_type>(value) } {};
+    constexpr NumericFacade(const floating_point auto val) noexcept requires floating_point<value_type> : value{ static_cast<value_type>(val) } {};
 
-    constexpr NumericFacade(const integral auto value) noexcept requires integral<value_type> : value{ static_cast<value_type>(value) } {};
+    constexpr NumericFacade(const integral auto val) noexcept requires integral<value_type> : value{ static_cast<value_type>(val) } {};
 
     constexpr NumericFacade& operator=(const NumericFacade& other) noexcept = default;
 

--- a/include/utils/types/numeric_facade.h
+++ b/include/utils/types/numeric_facade.h
@@ -1,0 +1,212 @@
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
+
+#ifndef UTILS_TYPES_ARITHMITIC_FACADE_H
+#define UTILS_TYPES_ARITHMITIC_FACADE_H
+
+#include "utils/types/generic.h"
+
+namespace cura::utils
+{
+
+template<numeric T>
+struct NumericFacade
+{
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+
+    value_type value{};
+
+    constexpr NumericFacade() noexcept = default;
+
+    constexpr NumericFacade(const NumericFacade& other) noexcept = default;
+    constexpr NumericFacade(NumericFacade&& other) noexcept = default;
+
+    constexpr NumericFacade(const floating_point auto value) noexcept
+    requires floating_point<value_type>
+        : value{ static_cast<value_type>(value) } {};
+
+    constexpr NumericFacade(const integral auto value) noexcept
+    requires integral<value_type>
+        : value{ static_cast<value_type>(value) } {};
+
+    constexpr NumericFacade& operator=(const NumericFacade& other) noexcept = default;
+
+    constexpr NumericFacade& operator=(const floating_point auto& other) noexcept
+    requires floating_point<value_type>
+    {
+        this->value = static_cast<value_type>(other);
+        return *this;
+    }
+    constexpr NumericFacade& operator=(const integral auto& other) noexcept
+    requires integral<value_type>
+    {
+        this->value = static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr NumericFacade& operator=(NumericFacade&& other) noexcept = default;
+    constexpr NumericFacade& operator=(const integral auto&& other) noexcept
+    requires integral<value_type>
+    {
+        this->value = static_cast<value_type>(other);
+        return *this;
+    }
+    constexpr NumericFacade& operator=(const floating_point auto&& other) noexcept
+    requires floating_point<value_type>
+    {
+        this->value = static_cast<value_type>(other);
+        return *this;
+    }
+
+    ~NumericFacade() noexcept = default;
+
+    constexpr operator value_type() const noexcept
+    {
+        return value;
+    }
+
+    constexpr bool operator==(const NumericFacade& other) const noexcept
+    {
+        return value == other.value;
+    }
+
+    constexpr bool operator==(const numeric auto& other) const noexcept
+    {
+        return value == static_cast<value_type>(other);
+    }
+
+    constexpr auto operator<=>(const NumericFacade& other) const noexcept = default;
+    constexpr auto operator<=>(const numeric auto& other) const noexcept
+    {
+        return value <=> static_cast<value_type>(other);
+    };
+
+    constexpr NumericFacade& operator+=(const NumericFacade& other) noexcept
+    {
+        value += other.value;
+        return *this;
+    }
+
+    constexpr NumericFacade& operator+=(const numeric auto& other) noexcept
+    {
+        value += static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr NumericFacade& operator-=(const NumericFacade& other) noexcept
+    {
+        value -= other.value;
+        return *this;
+    }
+
+    constexpr NumericFacade& operator-=(const numeric auto& other) noexcept
+    {
+        value -= static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr NumericFacade& operator*=(const NumericFacade& other) noexcept
+    {
+        value *= other.value;
+        return *this;
+    }
+
+    constexpr NumericFacade& operator*=(const numeric auto& other) noexcept
+    {
+        value *= static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr NumericFacade& operator/=(const NumericFacade& other)
+    {
+        value /= other.value;
+        return *this;
+    }
+
+    constexpr NumericFacade& operator/=(const numeric auto& other)
+    {
+        value /= static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr NumericFacade operator+(const NumericFacade& other) const noexcept
+    {
+        return { value + other.value };
+    }
+
+    constexpr NumericFacade operator+(NumericFacade&& other) const noexcept
+    {
+        return { value + other.value };
+    }
+
+    constexpr NumericFacade operator+(const numeric auto& other) const noexcept
+    {
+        return { value + static_cast<value_type>(other) };
+    }
+
+    constexpr NumericFacade operator-(const NumericFacade& other) const noexcept
+    {
+        return { value - other.value };
+    }
+
+    constexpr NumericFacade operator-(const numeric auto& other) const noexcept
+    {
+        return { value - static_cast<value_type>(other) };
+    }
+
+    constexpr NumericFacade operator*(const NumericFacade& other) const noexcept
+    {
+        return { value * other.value };
+    }
+
+    constexpr NumericFacade operator*(const numeric auto& other) const noexcept
+    {
+        return { value * static_cast<value_type>(other) };
+    }
+
+    constexpr NumericFacade operator/(const NumericFacade& other) const
+    {
+        return { value / other.value };
+    }
+
+    constexpr NumericFacade operator/(const numeric auto& other) const
+    {
+        return { value / static_cast<value_type>(other) };
+    }
+
+    constexpr NumericFacade operator-() const noexcept
+    {
+        return { -value };
+    }
+
+    constexpr NumericFacade& operator++() noexcept
+    requires integral<value_type>
+    {
+        ++value;
+        return *this;
+    }
+
+    constexpr NumericFacade operator++(int) noexcept
+    requires integral<value_type>
+    {
+        return { value++ };
+    }
+
+    constexpr NumericFacade& operator--() noexcept
+    requires integral<value_type>
+    {
+        --value;
+        return *this;
+    }
+
+    constexpr NumericFacade operator--(int) noexcept
+    requires integral<value_type>
+    {
+        return { value-- };
+    }
+};
+
+} // namespace cura::utils
+
+#endif // UTILS_TYPES_ARITHMITIC_FACADE_H

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1,17 +1,10 @@
 // Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
-#include <algorithm>
-#include <cstring>
-#include <numeric>
-#include <optional>
-
-#include <range/v3/algorithm/max_element.hpp>
-#include <spdlog/spdlog.h>
+#include "LayerPlan.h"
 
 #include "Application.h" //To communicate layer view data.
 #include "ExtruderTrain.h"
-#include "LayerPlan.h"
 #include "PathOrderMonotonic.h" //Monotonic ordering of skin lines.
 #include "Slice.h"
 #include "WipeScriptConfig.h"
@@ -25,34 +18,40 @@
 #include "utils/linearAlg2D.h"
 #include "utils/polygonUtils.h"
 
+#include <range/v3/algorithm/max_element.hpp>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cstring>
+#include <numeric>
+#include <optional>
+
 namespace cura
 {
 
 constexpr int MINIMUM_LINE_LENGTH = 5; // in uM. Generated lines shorter than this may be discarded
 constexpr int MINIMUM_SQUARED_LINE_LENGTH = MINIMUM_LINE_LENGTH * MINIMUM_LINE_LENGTH;
 
-ExtruderPlan::ExtruderPlan
-(
+ExtruderPlan::ExtruderPlan(
     const size_t extruder,
     const LayerIndex layer_nr,
     const bool is_initial_layer,
     const bool is_raft_layer,
     const coord_t layer_thickness,
     const FanSpeedLayerTimeSettings& fan_speed_layer_time_settings,
-    const RetractionConfig& retraction_config
-) :
-    heated_pre_travel_time(0),
-    required_start_temperature(-1),
-    extruder_nr(extruder),
-    layer_nr(layer_nr),
-    is_initial_layer(is_initial_layer),
-    is_raft_layer(is_raft_layer),
-    layer_thickness(layer_thickness),
-    fan_speed_layer_time_settings(fan_speed_layer_time_settings),
-    retraction_config(retraction_config),
-    extraTime(0.0),
-    temperatureFactor(0.0),
-    slowest_path_speed(0.0)
+    const RetractionConfig& retraction_config)
+    : heated_pre_travel_time(0)
+    , required_start_temperature(-1)
+    , extruder_nr(extruder)
+    , layer_nr(layer_nr)
+    , is_initial_layer(is_initial_layer)
+    , is_raft_layer(is_raft_layer)
+    , layer_thickness(layer_thickness)
+    , fan_speed_layer_time_settings(fan_speed_layer_time_settings)
+    , retraction_config(retraction_config)
+    , extraTime(0.0)
+    , temperatureFactor(0.0)
+    , slowest_path_speed(0.0)
 {
 }
 
@@ -99,19 +98,17 @@ void ExtruderPlan::applyBackPressureCompensation(const Ratio back_pressure_compe
     }
 }
 
-GCodePath* LayerPlan::getLatestPathWithConfig(const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio flow, const Ratio width_factor, bool spiralize, const Ratio speed_factor)
+GCodePath* LayerPlan::getLatestPathWithConfig(
+    const GCodePathConfig& config,
+    SpaceFillType space_fill_type,
+    const Ratio flow,
+    const Ratio width_factor,
+    bool spiralize,
+    const Ratio speed_factor)
 {
     std::vector<GCodePath>& paths = extruder_plans.back().paths;
-    if
-    (
-        paths.size() > 0 &&
-        paths.back().config == &config &&
-        ! paths.back().done &&
-        paths.back().flow == flow &&
-        paths.back().width_factor == width_factor &&
-        paths.back().speed_factor == speed_factor &&
-        paths.back().mesh == current_mesh
-    ) // spiralize can only change when a travel path is in between
+    if (paths.size() > 0 && paths.back().config == &config && ! paths.back().done && paths.back().flow == flow && paths.back().width_factor == width_factor
+        && paths.back().speed_factor == speed_factor && paths.back().mesh == current_mesh) // spiralize can only change when a travel path is in between
     {
         return &paths.back();
     }
@@ -133,8 +130,7 @@ void LayerPlan::forceNewPathStart()
         paths[paths.size() - 1].done = true;
 }
 
-LayerPlan::LayerPlan
-(
+LayerPlan::LayerPlan(
     const SliceDataStorage& storage,
     LayerIndex layer_nr,
     coord_t z,
@@ -143,26 +139,26 @@ LayerPlan::LayerPlan
     const std::vector<FanSpeedLayerTimeSettings>& fan_speed_layer_time_settings_per_extruder,
     coord_t comb_boundary_offset,
     coord_t comb_move_inside_distance,
-    coord_t travel_avoid_distance
-) :
-    configs_storage(storage, layer_nr, layer_thickness),
-    z(z),
-    final_travel_z(z),
-    mode_skip_agressive_merge(false),
-    storage(storage),
-    layer_nr(layer_nr),
-    is_initial_layer(layer_nr == 0 - static_cast<LayerIndex>(Raft::getTotalExtraLayers())),
-    is_raft_layer(layer_nr < 0 - static_cast<LayerIndex>(Raft::getFillerLayerCount())),
-    layer_thickness(layer_thickness),
-    has_prime_tower_planned_per_extruder(Application::getInstance().current_slice->scene.extruders.size(), false),
-    current_mesh(nullptr),
-    last_extruder_previous_layer(start_extruder),
-    last_planned_extruder(&Application::getInstance().current_slice->scene.extruders[start_extruder]),
-    first_travel_destination_is_inside(false), // set properly when addTravel is called for the first time (otherwise not set properly)
-    comb_boundary_minimum(computeCombBoundary(CombBoundary::MINIMUM)),
-    comb_boundary_preferred(computeCombBoundary(CombBoundary::PREFERRED)),
-    comb_move_inside_distance(comb_move_inside_distance),
-    fan_speed_layer_time_settings_per_extruder(fan_speed_layer_time_settings_per_extruder)
+    coord_t travel_avoid_distance)
+    : configs_storage(storage, layer_nr, layer_thickness)
+    , z(z)
+    , final_travel_z(z)
+    , mode_skip_agressive_merge(false)
+    , storage(storage)
+    , layer_nr(layer_nr)
+    , is_initial_layer(layer_nr == 0 - static_cast<LayerIndex>(Raft::getTotalExtraLayers()))
+    , is_raft_layer(layer_nr < 0 - static_cast<LayerIndex>(Raft::getFillerLayerCount()))
+    , layer_thickness(layer_thickness)
+    , has_prime_tower_planned_per_extruder(Application::getInstance().current_slice->scene.extruders.size(), false)
+    , current_mesh(nullptr)
+    , last_extruder_previous_layer(start_extruder)
+    , last_planned_extruder(&Application::getInstance().current_slice->scene.extruders[start_extruder])
+    , first_travel_destination_is_inside(false)
+    , // set properly when addTravel is called for the first time (otherwise not set properly)
+    comb_boundary_minimum(computeCombBoundary(CombBoundary::MINIMUM))
+    , comb_boundary_preferred(computeCombBoundary(CombBoundary::PREFERRED))
+    , comb_move_inside_distance(comb_move_inside_distance)
+    , fan_speed_layer_time_settings_per_extruder(fan_speed_layer_time_settings_per_extruder)
 {
     size_t current_extruder = start_extruder;
     was_inside = true; // not used, because the first travel move is bogus
@@ -180,7 +176,14 @@ LayerPlan::LayerPlan
         layer_start_pos_per_extruder.emplace_back(extruder.settings.get<coord_t>("layer_start_x"), extruder.settings.get<coord_t>("layer_start_y"));
     }
     extruder_plans.reserve(Application::getInstance().current_slice->scene.extruders.size());
-    extruder_plans.emplace_back(current_extruder, layer_nr, is_initial_layer, is_raft_layer, layer_thickness, fan_speed_layer_time_settings_per_extruder[current_extruder], storage.retraction_wipe_config_per_extruder[current_extruder].retraction_config);
+    extruder_plans.emplace_back(
+        current_extruder,
+        layer_nr,
+        is_initial_layer,
+        is_raft_layer,
+        layer_thickness,
+        fan_speed_layer_time_settings_per_extruder[current_extruder],
+        storage.retraction_wipe_config_per_extruder[current_extruder].retraction_config);
 
     for (size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
     { // Skirt and brim.
@@ -303,7 +306,14 @@ bool LayerPlan::setExtruder(const size_t extruder_nr)
     { // first extruder plan in a layer might be empty, cause it is made with the last extruder planned in the previous layer
         extruder_plans.back().extruder_nr = extruder_nr;
     }
-    extruder_plans.emplace_back(extruder_nr, layer_nr, is_initial_layer, is_raft_layer, layer_thickness, fan_speed_layer_time_settings_per_extruder[extruder_nr], storage.retraction_wipe_config_per_extruder[extruder_nr].retraction_config);
+    extruder_plans.emplace_back(
+        extruder_nr,
+        layer_nr,
+        is_initial_layer,
+        is_raft_layer,
+        layer_thickness,
+        fan_speed_layer_time_settings_per_extruder[extruder_nr],
+        storage.retraction_wipe_config_per_extruder[extruder_nr].retraction_config);
     assert(extruder_plans.size() <= Application::getInstance().current_slice->scene.extruders.size() && "Never use the same extruder twice on one layer!");
     last_planned_extruder = &Application::getInstance().current_slice->scene.extruders[extruder_nr];
 
@@ -374,7 +384,8 @@ GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
 {
     const GCodePathConfig& travel_config = configs_storage.travel_config_per_extruder[getExtruder()];
 
-    const RetractionConfig& retraction_config = current_mesh ? current_mesh->retraction_wipe_config.retraction_config : storage.retraction_wipe_config_per_extruder[getExtruder()].retraction_config;
+    const RetractionConfig& retraction_config
+        = current_mesh ? current_mesh->retraction_wipe_config.retraction_config : storage.retraction_wipe_config_per_extruder[getExtruder()].retraction_config;
 
     GCodePath* path = getLatestPathWithConfig(travel_config, SpaceFillType::None);
 
@@ -422,20 +433,17 @@ GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
         bool unretract_before_last_travel_move = false; // Decided when calculating the combing
         const bool perform_z_hops = mesh_or_extruder_settings.get<bool>("retraction_hop_enabled");
         const bool perform_z_hops_only_when_collides = mesh_or_extruder_settings.get<bool>("retraction_hop_only_when_collides");
-        combed =
-            comb->calc
-            (
-                perform_z_hops,
-                perform_z_hops_only_when_collides,
-                *extruder,
-                *last_planned_position,
-                p,
-                combPaths,
-                was_inside,
-                is_inside,
-                max_distance_ignored,
-                unretract_before_last_travel_move
-            );
+        combed = comb->calc(
+            perform_z_hops,
+            perform_z_hops_only_when_collides,
+            *extruder,
+            *last_planned_position,
+            p,
+            combPaths,
+            was_inside,
+            is_inside,
+            max_distance_ignored,
+            unretract_before_last_travel_move);
         if (combed)
         {
             bool retract = path->retract || (combPaths.size() > 1 && retraction_enable);
@@ -503,8 +511,9 @@ GCodePath& LayerPlan::addTravel(const Point p, const bool force_retract)
     {
         if (was_inside) // when the previous location was from printing something which is considered inside (not support or prime tower etc)
         { // then move inside the printed part, so that we don't ooze on the outer wall while retraction, but on the inside of the print.
-            assert (extruder != nullptr);
-            coord_t innermost_wall_line_width = mesh_or_extruder_settings.get<coord_t>((mesh_or_extruder_settings.get<size_t>("wall_line_count") > 1) ? "wall_line_width_x" : "wall_line_width_0");
+            assert(extruder != nullptr);
+            coord_t innermost_wall_line_width
+                = mesh_or_extruder_settings.get<coord_t>((mesh_or_extruder_settings.get<size_t>("wall_line_count") > 1) ? "wall_line_width_x" : "wall_line_width_0");
             if (layer_nr == 0)
             {
                 innermost_wall_line_width *= mesh_or_extruder_settings.get<Ratio>("initial_layer_line_width_factor");
@@ -550,7 +559,15 @@ void LayerPlan::planPrime(const float& prime_blob_wipe_length)
     forceNewPathStart();
 }
 
-void LayerPlan::addExtrusionMove(Point p, const GCodePathConfig& config, SpaceFillType space_fill_type, const Ratio& flow, const Ratio width_factor, bool spiralize, Ratio speed_factor, double fan_speed)
+void LayerPlan::addExtrusionMove(
+    Point p,
+    const GCodePathConfig& config,
+    SpaceFillType space_fill_type,
+    const Ratio& flow,
+    const Ratio width_factor,
+    bool spiralize,
+    Ratio speed_factor,
+    double fan_speed)
 {
     GCodePath* path = getLatestPathWithConfig(config, space_fill_type, flow, width_factor, spiralize, speed_factor);
     path->points.push_back(p);
@@ -562,7 +579,15 @@ void LayerPlan::addExtrusionMove(Point p, const GCodePathConfig& config, SpaceFi
     last_planned_position = p;
 }
 
-void LayerPlan::addPolygon(ConstPolygonRef polygon, int start_idx, const bool backwards, const GCodePathConfig& config, coord_t wall_0_wipe_dist, bool spiralize, const Ratio& flow_ratio, bool always_retract)
+void LayerPlan::addPolygon(
+    ConstPolygonRef polygon,
+    int start_idx,
+    const bool backwards,
+    const GCodePathConfig& config,
+    coord_t wall_0_wipe_dist,
+    bool spiralize,
+    const Ratio& flow_ratio,
+    bool always_retract)
 {
     constexpr Ratio width_ratio = 1.0_r; // Not printed with variable line width.
     Point p0 = polygon[start_idx];
@@ -610,15 +635,16 @@ void LayerPlan::addPolygon(ConstPolygonRef polygon, int start_idx, const bool ba
     }
 }
 
-void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons,
-                                       const GCodePathConfig& config,
-                                       const ZSeamConfig& z_seam_config,
-                                       coord_t wall_0_wipe_dist,
-                                       bool spiralize,
-                                       const Ratio flow_ratio,
-                                       bool always_retract,
-                                       bool reverse_order,
-                                       const std::optional<Point> start_near_location)
+void LayerPlan::addPolygonsByOptimizer(
+    const Polygons& polygons,
+    const GCodePathConfig& config,
+    const ZSeamConfig& z_seam_config,
+    coord_t wall_0_wipe_dist,
+    bool spiralize,
+    const Ratio flow_ratio,
+    bool always_retract,
+    bool reverse_order,
+    const std::optional<Point> start_near_location)
 {
     if (polygons.empty())
     {
@@ -650,16 +676,17 @@ void LayerPlan::addPolygonsByOptimizer(const Polygons& polygons,
 
 static constexpr float max_non_bridge_line_volume = MM2INT(100); // limit to accumulated "volume" of non-bridge lines which is proportional to distance x extrusion rate
 
-void LayerPlan::addWallLine(const Point& p0,
-                            const Point& p1,
-                            const Settings& settings,
-                            const GCodePathConfig& non_bridge_config,
-                            const GCodePathConfig& bridge_config,
-                            float flow,
-                            const Ratio width_factor,
-                            float& non_bridge_line_volume,
-                            Ratio speed_factor,
-                            double distance_to_bridge_start)
+void LayerPlan::addWallLine(
+    const Point& p0,
+    const Point& p1,
+    const Settings& settings,
+    const GCodePathConfig& non_bridge_config,
+    const GCodePathConfig& bridge_config,
+    float flow,
+    const Ratio width_factor,
+    float& non_bridge_line_volume,
+    Ratio speed_factor,
+    double distance_to_bridge_start)
 {
     const coord_t min_line_len = settings.get<coord_t>("meshfix_maximum_resolution") / 2; // Shouldn't cut up stuff (too much) below the required simplify resolution.
     const double acceleration_segment_len = MM2INT(1); // accelerate using segments of this length
@@ -685,7 +712,9 @@ void LayerPlan::addWallLine(const Point& p0,
         while (distance_to_line_end > min_line_len)
         {
             // if we are accelerating after a bridge line, the segment length is less than the whole line length
-            Point segment_end = (speed_factor == 1 || distance_to_line_end < acceleration_segment_len) ? line_end : cur_point + (line_end - cur_point) * acceleration_segment_len / distance_to_line_end;
+            Point segment_end = (speed_factor == 1 || distance_to_line_end < acceleration_segment_len)
+                                  ? line_end
+                                  : cur_point + (line_end - cur_point) * acceleration_segment_len / distance_to_line_end;
 
             // flow required for the next line segment - when accelerating after a bridge segment, the flow is increased in inverse proportion to the speed_factor
             // so the slower the feedrate, the greater the flow - the idea is to get the extruder back to normal pressure as quickly as possible
@@ -714,7 +743,14 @@ void LayerPlan::addWallLine(const Point& p0,
                     if ((len - coast_dist) > min_line_len)
                     {
                         // segment is longer than coast distance so extrude using non-bridge config to start of coast
-                        addExtrusionMove(segment_end + coast_dist * (cur_point - segment_end) / len, non_bridge_config, SpaceFillType::Polygons, segment_flow, width_factor, spiralize, speed_factor);
+                        addExtrusionMove(
+                            segment_end + coast_dist * (cur_point - segment_end) / len,
+                            non_bridge_config,
+                            SpaceFillType::Polygons,
+                            segment_flow,
+                            width_factor,
+                            spiralize,
+                            speed_factor);
                     }
                     // then coast to start of bridge segment
                     constexpr Ratio flow = 0.0_r; // Coasting has no flow rate.
@@ -723,13 +759,14 @@ void LayerPlan::addWallLine(const Point& p0,
                 else
                 {
                     // no coasting required, just normal segment using non-bridge config
-                    addExtrusionMove(segment_end,
-                                     non_bridge_config,
-                                     SpaceFillType::Polygons,
-                                     segment_flow,
-                                     width_factor,
-                                     spiralize,
-                                     (overhang_mask.empty() || (! overhang_mask.inside(p0, true) && ! overhang_mask.inside(p1, true))) ? speed_factor : overhang_speed_factor);
+                    addExtrusionMove(
+                        segment_end,
+                        non_bridge_config,
+                        SpaceFillType::Polygons,
+                        segment_flow,
+                        width_factor,
+                        spiralize,
+                        (overhang_mask.empty() || (! overhang_mask.inside(p0, true) && ! overhang_mask.inside(p1, true))) ? speed_factor : overhang_speed_factor);
                 }
 
                 distance_to_bridge_start -= len;
@@ -737,13 +774,14 @@ void LayerPlan::addWallLine(const Point& p0,
             else
             {
                 // no coasting required, just normal segment using non-bridge config
-                addExtrusionMove(segment_end,
-                                 non_bridge_config,
-                                 SpaceFillType::Polygons,
-                                 segment_flow,
-                                 width_factor,
-                                 spiralize,
-                                 (overhang_mask.empty() || (! overhang_mask.inside(p0, true) && ! overhang_mask.inside(p1, true))) ? speed_factor : overhang_speed_factor);
+                addExtrusionMove(
+                    segment_end,
+                    non_bridge_config,
+                    SpaceFillType::Polygons,
+                    segment_flow,
+                    width_factor,
+                    spiralize,
+                    (overhang_mask.empty() || (! overhang_mask.inside(p0, true) && ! overhang_mask.inside(p1, true))) ? speed_factor : overhang_speed_factor);
             }
             non_bridge_line_volume += vSize(cur_point - segment_end) * segment_flow * width_factor * speed_factor * non_bridge_config.getSpeed();
             cur_point = segment_end;
@@ -759,7 +797,14 @@ void LayerPlan::addWallLine(const Point& p0,
     if (bridge_wall_mask.empty())
     {
         // no bridges required
-        addExtrusionMove(p1, non_bridge_config, SpaceFillType::Polygons, flow, width_factor, spiralize, (overhang_mask.empty() || (! overhang_mask.inside(p0, true) && ! overhang_mask.inside(p1, true))) ? 1.0_r : overhang_speed_factor);
+        addExtrusionMove(
+            p1,
+            non_bridge_config,
+            SpaceFillType::Polygons,
+            flow,
+            width_factor,
+            spiralize,
+            (overhang_mask.empty() || (! overhang_mask.inside(p0, true) && ! overhang_mask.inside(p1, true))) ? 1.0_r : overhang_speed_factor);
     }
     else
     {
@@ -851,7 +896,15 @@ void LayerPlan::addWallLine(const Point& p0,
     }
 }
 
-void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const Settings& settings, const GCodePathConfig& non_bridge_config, const GCodePathConfig& bridge_config, coord_t wall_0_wipe_dist, float flow_ratio, bool always_retract)
+void LayerPlan::addWall(
+    ConstPolygonRef wall,
+    int start_idx,
+    const Settings& settings,
+    const GCodePathConfig& non_bridge_config,
+    const GCodePathConfig& bridge_config,
+    coord_t wall_0_wipe_dist,
+    float flow_ratio,
+    bool always_retract)
 {
     // TODO: Deprecated in favor of ExtrusionJunction version below.
     if (wall.size() < 3)
@@ -860,10 +913,18 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const Settings& set
     }
 
     constexpr size_t dummy_perimeter_id = 0; // <-- Here, don't care about which perimeter any more.
-    const coord_t nominal_line_width = non_bridge_config.getLineWidth(); // <-- The line width which it's 'supposed to' be will be used to adjust the flow ratio each time, this'll give a flow-ratio-multiplier of 1.
+    const coord_t nominal_line_width
+        = non_bridge_config
+              .getLineWidth(); // <-- The line width which it's 'supposed to' be will be used to adjust the flow ratio each time, this'll give a flow-ratio-multiplier of 1.
 
     ExtrusionLine ewall;
-    std::for_each(wall.begin(), wall.end(), [&dummy_perimeter_id, &nominal_line_width, &ewall](const Point& p) { ewall.emplace_back(p, nominal_line_width, dummy_perimeter_id); });
+    std::for_each(
+        wall.begin(),
+        wall.end(),
+        [&dummy_perimeter_id, &nominal_line_width, &ewall](const Point& p)
+        {
+            ewall.emplace_back(p, nominal_line_width, dummy_perimeter_id);
+        });
     ewall.emplace_back(*wall.begin(), nominal_line_width, dummy_perimeter_id);
     constexpr bool is_closed = true;
     constexpr bool is_reversed = false;
@@ -871,17 +932,18 @@ void LayerPlan::addWall(ConstPolygonRef wall, int start_idx, const Settings& set
     addWall(ewall, start_idx, settings, non_bridge_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract, is_closed, is_reversed, is_linked_path);
 }
 
-void LayerPlan::addWall(const ExtrusionLine& wall,
-                        int start_idx,
-                        const Settings& settings,
-                        const GCodePathConfig& non_bridge_config,
-                        const GCodePathConfig& bridge_config,
-                        coord_t wall_0_wipe_dist,
-                        float flow_ratio,
-                        bool always_retract,
-                        const bool is_closed,
-                        const bool is_reversed,
-                        const bool is_linked_path)
+void LayerPlan::addWall(
+    const ExtrusionLine& wall,
+    int start_idx,
+    const Settings& settings,
+    const GCodePathConfig& non_bridge_config,
+    const GCodePathConfig& bridge_config,
+    coord_t wall_0_wipe_dist,
+    float flow_ratio,
+    bool always_retract,
+    const bool is_closed,
+    const bool is_reversed,
+    const bool is_linked_path)
 {
     if (wall.empty())
     {
@@ -899,7 +961,9 @@ void LayerPlan::addWall(const ExtrusionLine& wall,
 
     const coord_t min_bridge_line_len = settings.get<coord_t>("bridge_wall_min_length");
 
-    const Ratio nominal_line_width_multiplier { 1.0 / Ratio { static_cast<Ratio::value_type>(non_bridge_config.getLineWidth()) } }; // we multiply the flow with the actual wanted line width (for that junction), and then multiply with this
+    const Ratio nominal_line_width_multiplier{
+        1.0 / Ratio{ static_cast<Ratio::value_type>(non_bridge_config.getLineWidth()) }
+    }; // we multiply the flow with the actual wanted line width (for that junction), and then multiply with this
 
     // helper function to calculate the distance from the start of the current wall line to the first bridge segment
 
@@ -1047,12 +1111,29 @@ void LayerPlan::addWall(const ExtrusionLine& wall,
             if (is_small_feature)
             {
                 constexpr bool spiralize = false;
-                addExtrusionMove(destination, non_bridge_config, SpaceFillType::Polygons, flow_ratio, line_width * nominal_line_width_multiplier, spiralize, small_feature_speed_factor);
+                addExtrusionMove(
+                    destination,
+                    non_bridge_config,
+                    SpaceFillType::Polygons,
+                    flow_ratio,
+                    line_width * nominal_line_width_multiplier,
+                    spiralize,
+                    small_feature_speed_factor);
             }
             else
             {
                 const Point origin = p0.p + normal(line_vector, piece_length * piece);
-                addWallLine(origin, destination, settings, non_bridge_config, bridge_config, flow_ratio, line_width * nominal_line_width_multiplier, non_bridge_line_volume, speed_factor, distance_to_bridge_start);
+                addWallLine(
+                    origin,
+                    destination,
+                    settings,
+                    non_bridge_config,
+                    bridge_config,
+                    flow_ratio,
+                    line_width * nominal_line_width_multiplier,
+                    non_bridge_line_volume,
+                    speed_factor,
+                    distance_to_bridge_start);
             }
         }
 
@@ -1109,7 +1190,7 @@ void LayerPlan::addInfillWall(const ExtrusionLine& wall, const GCodePathConfig& 
 
     for (const auto& junction_n : wall)
     {
-        const Ratio width_factor { static_cast<Ratio::value_type>(junction_n.w) / Ratio { static_cast<Ratio::value_type>(path_config.getLineWidth()) } };
+        const Ratio width_factor{ static_cast<Ratio::value_type>(junction_n.w) / Ratio{ static_cast<Ratio::value_type>(path_config.getLineWidth()) } };
         constexpr SpaceFillType space_fill_type = SpaceFillType::Polygons;
         constexpr Ratio flow = 1.0_r;
         addExtrusionMove(junction_n.p, path_config, space_fill_type, flow, width_factor);
@@ -1117,14 +1198,15 @@ void LayerPlan::addInfillWall(const ExtrusionLine& wall, const GCodePathConfig& 
     }
 }
 
-void LayerPlan::addWalls(const Polygons& walls,
-                         const Settings& settings,
-                         const GCodePathConfig& non_bridge_config,
-                         const GCodePathConfig& bridge_config,
-                         const ZSeamConfig& z_seam_config,
-                         coord_t wall_0_wipe_dist,
-                         float flow_ratio,
-                         bool always_retract)
+void LayerPlan::addWalls(
+    const Polygons& walls,
+    const Settings& settings,
+    const GCodePathConfig& non_bridge_config,
+    const GCodePathConfig& bridge_config,
+    const ZSeamConfig& z_seam_config,
+    coord_t wall_0_wipe_dist,
+    float flow_ratio,
+    bool always_retract)
 {
     // TODO: Deprecated in favor of ExtrusionJunction version below.
     PathOrderOptimizer<ConstPolygonPointer> orderOptimizer(getLastPlannedPositionOrStartingPosition(), z_seam_config);
@@ -1140,16 +1222,17 @@ void LayerPlan::addWalls(const Polygons& walls,
 }
 
 
-void LayerPlan::addLinesByOptimizer(const Polygons& polygons,
-                                    const GCodePathConfig& config,
-                                    const SpaceFillType space_fill_type,
-                                    const bool enable_travel_optimization,
-                                    const coord_t wipe_dist,
-                                    const Ratio flow_ratio,
-                                    const std::optional<Point> near_start_location,
-                                    const double fan_speed,
-                                    const bool reverse_print_direction,
-                                    const std::unordered_multimap<ConstPolygonPointer, ConstPolygonPointer>& order_requirements)
+void LayerPlan::addLinesByOptimizer(
+    const Polygons& polygons,
+    const GCodePathConfig& config,
+    const SpaceFillType space_fill_type,
+    const bool enable_travel_optimization,
+    const coord_t wipe_dist,
+    const Ratio flow_ratio,
+    const std::optional<Point> near_start_location,
+    const double fan_speed,
+    const bool reverse_print_direction,
+    const std::unordered_multimap<ConstPolygonPointer, ConstPolygonPointer>& order_requirements)
 {
     Polygons boundary;
     if (enable_travel_optimization && ! comb_boundary_minimum.empty())
@@ -1174,7 +1257,13 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons,
         boundary = Simplify(MM2INT(0.1), MM2INT(0.1), 0).polygon(boundary);
     }
     constexpr bool detect_loops = true;
-    PathOrderOptimizer<ConstPolygonPointer> order_optimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()), ZSeamConfig(), detect_loops, &boundary, reverse_print_direction, order_requirements);
+    PathOrderOptimizer<ConstPolygonPointer> order_optimizer(
+        near_start_location.value_or(getLastPlannedPositionOrStartingPosition()),
+        ZSeamConfig(),
+        detect_loops,
+        &boundary,
+        reverse_print_direction,
+        order_requirements);
     for (size_t line_idx = 0; line_idx < polygons.size(); line_idx++)
     {
         order_optimizer.addPolyline(polygons[line_idx]);
@@ -1185,7 +1274,13 @@ void LayerPlan::addLinesByOptimizer(const Polygons& polygons,
 }
 
 
-void LayerPlan::addLinesInGivenOrder(const std::vector<PathOrdering<ConstPolygonPointer>>& paths, const GCodePathConfig& config, const SpaceFillType space_fill_type, const coord_t wipe_dist, const Ratio flow_ratio, const double fan_speed)
+void LayerPlan::addLinesInGivenOrder(
+    const std::vector<PathOrdering<ConstPolygonPointer>>& paths,
+    const GCodePathConfig& config,
+    const SpaceFillType space_fill_type,
+    const coord_t wipe_dist,
+    const Ratio flow_ratio,
+    const double fan_speed)
 {
     coord_t half_line_width = config.getLineWidth() / 2;
     coord_t line_width_2 = half_line_width * half_line_width;
@@ -1282,16 +1377,17 @@ void LayerPlan::addLinesInGivenOrder(const std::vector<PathOrdering<ConstPolygon
     }
 }
 
-void LayerPlan::addLinesMonotonic(const Polygons& area,
-                                  const Polygons& polygons,
-                                  const GCodePathConfig& config,
-                                  const SpaceFillType space_fill_type,
-                                  const AngleRadians monotonic_direction,
-                                  const coord_t max_adjacent_distance,
-                                  const coord_t exclude_distance,
-                                  const coord_t wipe_dist,
-                                  const Ratio flow_ratio,
-                                  const double fan_speed)
+void LayerPlan::addLinesMonotonic(
+    const Polygons& area,
+    const Polygons& polygons,
+    const GCodePathConfig& config,
+    const SpaceFillType space_fill_type,
+    const AngleRadians monotonic_direction,
+    const coord_t max_adjacent_distance,
+    const coord_t exclude_distance,
+    const coord_t wipe_dist,
+    const Ratio flow_ratio,
+    const double fan_speed)
 {
     const Polygons exclude_areas = area.tubeShape(exclude_distance, exclude_distance);
     const coord_t exclude_dist2 = exclude_distance * exclude_distance;
@@ -1305,7 +1401,10 @@ void LayerPlan::addLinesMonotonic(const Polygons& area,
     }
     line_order.optimize();
 
-    const auto is_inside_exclusion = [&exclude_areas, &exclude_dist2](ConstPolygonRef path) { return vSize2(path[1] - path[0]) < exclude_dist2 && exclude_areas.inside((path[0] + path[1]) / 2); };
+    const auto is_inside_exclusion = [&exclude_areas, &exclude_dist2](ConstPolygonRef path)
+    {
+        return vSize2(path[1] - path[0]) < exclude_dist2 && exclude_areas.inside((path[0] + path[1]) / 2);
+    };
 
     // Order monotonically, except for line-segments which stay in the excluded areas (read: close to the walls) consecutively.
     PathOrderMonotonic<ConstPolygonPointer> order(monotonic_direction, max_adjacent_distance, last_position);
@@ -1335,7 +1434,14 @@ void LayerPlan::addLinesMonotonic(const Polygons& area,
     addLinesByOptimizer(left_over, config, space_fill_type, true, wipe_dist, flow_ratio, getLastPlannedPositionOrStartingPosition(), fan_speed);
 }
 
-void LayerPlan::spiralizeWallSlice(const GCodePathConfig& config, ConstPolygonRef wall, ConstPolygonRef last_wall, const int seam_vertex_idx, const int last_seam_vertex_idx, const bool is_top_layer, const bool is_bottom_layer)
+void LayerPlan::spiralizeWallSlice(
+    const GCodePathConfig& config,
+    ConstPolygonRef wall,
+    ConstPolygonRef last_wall,
+    const int seam_vertex_idx,
+    const int last_seam_vertex_idx,
+    const bool is_top_layer,
+    const bool is_bottom_layer)
 {
     const bool smooth_contours = Application::getInstance().current_slice->scene.current_mesh_group->settings.get<bool>("smooth_spiralized_contours");
     constexpr bool spiralize = true; // In addExtrusionMove calls, enable spiralize and use nominal line width.
@@ -1503,10 +1609,10 @@ void ExtruderPlan::forceMinimalLayerTime(double minTime, double time_other_extr_
 
         double factor = 0.0;
         double target_speed = 0.0;
-        std::function<double(const GCodePath&)> slow_down_func
-        {
-            [&target_speed](const GCodePath& path) { return std::min(target_speed / (path.config->getSpeed() * path.speed_factor), 1.0); }
-        };
+        std::function<double(const GCodePath&)> slow_down_func{ [&target_speed](const GCodePath& path)
+                                                                {
+                                                                    return std::min(target_speed / (path.config->getSpeed() * path.speed_factor), 1.0);
+                                                                } };
 
         if (minExtrudeTime >= total_extrude_time_at_minimum_speed)
         {
@@ -1525,8 +1631,9 @@ void ExtruderPlan::forceMinimalLayerTime(double minTime, double time_other_extr_
         {
             // Slowing down to the slowest path speed is not sufficient, need to slow down further to the minimum speed.
             // Linear interpolate between total_extrude_time_at_slowest_speed and total_extrude_time_at_minimum_speed
-            const double factor = (1/total_extrude_time_at_minimum_speed - 1/minExtrudeTime) / (1/total_extrude_time_at_minimum_speed - 1/total_extrude_time_at_slowest_speed);
-            target_speed = minimalSpeed * (1.0-factor) + slowest_path_speed * factor;
+            const double factor
+                = (1 / total_extrude_time_at_minimum_speed - 1 / minExtrudeTime) / (1 / total_extrude_time_at_minimum_speed - 1 / total_extrude_time_at_slowest_speed);
+            target_speed = minimalSpeed * (1.0 - factor) + slowest_path_speed * factor;
             temperatureFactor = 1.0 - factor;
 
             // Update stored naive time estimates
@@ -1536,13 +1643,12 @@ void ExtruderPlan::forceMinimalLayerTime(double minTime, double time_other_extr_
         {
             // Slowing down to the slowest_speed is sufficient to respect the minimum layer time.
             // Linear interpolate between extrudeTime and total_extrude_time_at_slowest_speed
-            factor = (1/total_extrude_time_at_slowest_speed - 1/minExtrudeTime) / (1/total_extrude_time_at_slowest_speed - 1/extrudeTime);
-            slow_down_func =
-                [&slowest_path_speed = slowest_path_speed, &factor](const GCodePath& path)
-                {
-                    const double target_speed = slowest_path_speed * (1.0 - factor) + (path.config->getSpeed() * path.speed_factor) * factor;
-                    return std::min(target_speed / (path.config->getSpeed() * path.speed_factor), 1.0);
-                };
+            factor = (1 / total_extrude_time_at_slowest_speed - 1 / minExtrudeTime) / (1 / total_extrude_time_at_slowest_speed - 1 / extrudeTime);
+            slow_down_func = [&slowest_path_speed = slowest_path_speed, &factor](const GCodePath& path)
+            {
+                const double target_speed = slowest_path_speed * (1.0 - factor) + (path.config->getSpeed() * path.speed_factor) * factor;
+                return std::min(target_speed / (path.config->getSpeed() * path.speed_factor), 1.0);
+            };
 
             // Update stored naive time estimates
             estimates.extrude_time = minExtrudeTime;
@@ -1577,17 +1683,14 @@ TimeMaterialEstimates ExtruderPlan::computeNaiveTimeEstimates(Point starting_pos
     Point p0 = starting_position;
 
     const double min_path_speed = fan_speed_layer_time_settings.cool_min_speed;
-    slowest_path_speed =
-        std::accumulate
-        (
-            paths.begin(),
-            paths.end(),
-            std::numeric_limits<double>::max(),
-            [](double value, const GCodePath& path)
-                {
-                    return path.isTravelPath() ? value : std::min(value, path.config->getSpeed().value * path.speed_factor);
-                }
-        );
+    slowest_path_speed = std::accumulate(
+        paths.begin(),
+        paths.end(),
+        std::numeric_limits<double>::max(),
+        [](double value, const GCodePath& path)
+        {
+            return path.isTravelPath() ? value : std::min(value, path.config->getSpeed().value * path.speed_factor);
+        });
 
     bool was_retracted = false; // wrong assumption; won't matter that much. (TODO)
     for (GCodePath& path : paths)
@@ -1706,19 +1809,27 @@ void ExtruderPlan::processFanSpeedForFirstLayers()
 
     */
     fan_speed = fan_speed_layer_time_settings.cool_fan_speed_min;
-    if (layer_nr < fan_speed_layer_time_settings.cool_fan_full_layer && fan_speed_layer_time_settings.cool_fan_full_layer > 0 // don't apply initial layer fan speed speedup if disabled.
+    if (layer_nr < fan_speed_layer_time_settings.cool_fan_full_layer
+        && fan_speed_layer_time_settings.cool_fan_full_layer > 0 // don't apply initial layer fan speed speedup if disabled.
         && ! is_raft_layer // don't apply initial layer fan speed speedup to raft, but to model layers
     )
     {
         // Slow down the fan on the layers below the [cool_fan_full_layer], where layer 0 is speed 0.
-        fan_speed = fan_speed_layer_time_settings.cool_fan_speed_0 + (fan_speed - fan_speed_layer_time_settings.cool_fan_speed_0) * std::max(LayerIndex(0), layer_nr) / fan_speed_layer_time_settings.cool_fan_full_layer;
+        fan_speed = fan_speed_layer_time_settings.cool_fan_speed_0
+                  + (fan_speed - fan_speed_layer_time_settings.cool_fan_speed_0) * std::max(LayerIndex(0), layer_nr) / fan_speed_layer_time_settings.cool_fan_full_layer;
     }
 }
 
 void LayerPlan::processFanSpeedAndMinimalLayerTime(Point starting_position)
 {
     // the minimum layer time behaviour is only applied to the last extruder.
-    const size_t last_extruder_nr = ranges::max_element(extruder_plans, [](const ExtruderPlan& a, const ExtruderPlan& b) { return a.extruder_nr < b.extruder_nr; })->extruder_nr;
+    const size_t last_extruder_nr = ranges::max_element(
+                                        extruder_plans,
+                                        [](const ExtruderPlan& a, const ExtruderPlan& b)
+                                        {
+                                            return a.extruder_nr < b.extruder_nr;
+                                        })
+                                        ->extruder_nr;
     Point starting_position_last_extruder;
     unsigned int last_extruder_idx;
     double other_extr_plan_time = 0.0;
@@ -1770,10 +1881,13 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
     // flow-rate compensation
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-    gcode.setFlowRateExtrusionSettings(mesh_group_settings.get<double>("flow_rate_max_extrusion_offset"), mesh_group_settings.get<Ratio>("flow_rate_extrusion_offset_factor")); // Offset is in mm.
+    gcode.setFlowRateExtrusionSettings(
+        mesh_group_settings.get<double>("flow_rate_max_extrusion_offset"),
+        mesh_group_settings.get<Ratio>("flow_rate_extrusion_offset_factor")); // Offset is in mm.
 
     static LayerIndex layer_1{ 1 - static_cast<LayerIndex>(Raft::getTotalExtraLayers()) };
-    if (layer_nr == layer_1 && mesh_group_settings.get<bool>("machine_heated_bed") && mesh_group_settings.get<Temperature>("material_bed_temperature") != mesh_group_settings.get<Temperature>("material_bed_temperature_layer_0"))
+    if (layer_nr == layer_1 && mesh_group_settings.get<bool>("machine_heated_bed")
+        && mesh_group_settings.get<Temperature>("material_bed_temperature") != mesh_group_settings.get<Temperature>("material_bed_temperature_layer_0"))
     {
         constexpr bool wait = false;
         gcode.writeBedTemperatureCommand(mesh_group_settings.get<Temperature>("material_bed_temperature"), wait);
@@ -1793,7 +1907,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
     for (size_t extruder_plan_idx = 0; extruder_plan_idx < extruder_plans.size(); extruder_plan_idx++)
     {
         ExtruderPlan& extruder_plan = extruder_plans[extruder_plan_idx];
-        const RetractionAndWipeConfig* retraction_config = current_mesh ? &current_mesh->retraction_wipe_config: &storage.retraction_wipe_config_per_extruder[extruder_plan.extruder_nr];
+        const RetractionAndWipeConfig* retraction_config
+            = current_mesh ? &current_mesh->retraction_wipe_config : &storage.retraction_wipe_config_per_extruder[extruder_plan.extruder_nr];
         coord_t z_hop_height = retraction_config->retraction_config.zHop;
 
         if (extruder_nr != extruder_plan.extruder_nr)
@@ -1866,8 +1981,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         bool update_extrusion_offset = true;
 
         double cumulative_path_time = 0.; // Time in seconds.
-        const std::function<void(const double, const int64_t)> insertTempOnTime =
-            [&](const double to_add, const int64_t path_idx)
+        const std::function<void(const double, const int64_t)> insertTempOnTime = [&](const double to_add, const int64_t path_idx)
         {
             cumulative_path_time += to_add;
             extruder_plan.handleInserts(path_idx, gcode, cumulative_path_time);
@@ -1990,7 +2104,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
             // for some movements such as prime tower purge, the speed may get changed by this factor
             speed *= path.speed_factor;
 
-            //This seems to be the best location to place this, but still not ideal.
+            // This seems to be the best location to place this, but still not ideal.
             if (path.mesh != current_mesh)
             {
                 current_mesh = path.mesh;
@@ -2102,7 +2216,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         if (extruder.settings.get<bool>("cool_lift_head") && extruder_plan.extraTime > 0.0)
         {
             gcode.writeComment("Small layer, adding delay");
-            const RetractionAndWipeConfig& retraction_config = current_mesh ? current_mesh->retraction_wipe_config: storage.retraction_wipe_config_per_extruder[gcode.getExtruderNr()];
+            const RetractionAndWipeConfig& retraction_config
+                = current_mesh ? current_mesh->retraction_wipe_config : storage.retraction_wipe_config_per_extruder[gcode.getExtruderNr()];
             gcode.writeRetraction(retraction_config.retraction_config);
             if (extruder_plan_idx == extruder_plans.size() - 1 || ! extruder.settings.get<bool>("machine_extruder_end_pos_abs"))
             { // only do the z-hop if it's the last extruder plan; otherwise it's already at the switching bay area
@@ -2154,7 +2269,12 @@ bool LayerPlan::makeRetractSwitchRetract(unsigned int extruder_plan_idx, unsigne
     }
 }
 
-bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, const size_t extruder_plan_idx, const size_t path_idx, const coord_t layer_thickness, const std::function<void(const double, const int64_t)> insertTempOnTime)
+bool LayerPlan::writePathWithCoasting(
+    GCodeExport& gcode,
+    const size_t extruder_plan_idx,
+    const size_t path_idx,
+    const coord_t layer_thickness,
+    const std::function<void(const double, const int64_t)> insertTempOnTime)
 {
     ExtruderPlan& extruder_plan = extruder_plans[extruder_plan_idx];
     const ExtruderTrain& extruder = Application::getInstance().current_slice->scene.extruders[extruder_plan.extruder_nr];
@@ -2174,9 +2294,11 @@ bool LayerPlan::writePathWithCoasting(GCodeExport& gcode, const size_t extruder_
 
     const double extrude_speed = path.config->getSpeed() * path.speed_factor * path.speed_back_pressure_factor;
 
-    const coord_t coasting_dist = MM2INT(MM2_2INT(coasting_volume) / layer_thickness) / path.config->getLineWidth(); // closing brackets of MM2INT at weird places for precision issues
+    const coord_t coasting_dist
+        = MM2INT(MM2_2INT(coasting_volume) / layer_thickness) / path.config->getLineWidth(); // closing brackets of MM2INT at weird places for precision issues
     const double coasting_min_volume = extruder.settings.get<double>("coasting_min_volume");
-    const coord_t coasting_min_dist = MM2INT(MM2_2INT(coasting_min_volume + coasting_volume) / layer_thickness) / path.config->getLineWidth(); // closing brackets of MM2INT at weird places for precision issues
+    const coord_t coasting_min_dist = MM2INT(MM2_2INT(coasting_min_volume + coasting_volume) / layer_thickness)
+                                    / path.config->getLineWidth(); // closing brackets of MM2INT at weird places for precision issues
     //           /\ the minimal distance when coasting will coast the full coasting volume instead of linearly less with linearly smaller paths
 
     std::vector<coord_t> accumulated_dist_per_point; // the first accumulated dist is that of the last point! (that of the last point is always zero...)
@@ -2281,7 +2403,8 @@ void LayerPlan::applyBackPressureCompensation()
 {
     for (auto& extruder_plan : extruder_plans)
     {
-        const Ratio back_pressure_compensation = Application::getInstance().current_slice->scene.extruders[extruder_plan.extruder_nr].settings.get<Ratio>("speed_equalize_flow_width_factor");
+        const Ratio back_pressure_compensation
+            = Application::getInstance().current_slice->scene.extruders[extruder_plan.extruder_nr].settings.get<Ratio>("speed_equalize_flow_width_factor");
         if (back_pressure_compensation != 0.0)
         {
             extruder_plan.applyBackPressureCompensation(back_pressure_compensation);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -750,7 +750,7 @@ void LayerPlan::addWallLine(const Point& p0,
             speed_factor = 1 - (1 - speed_factor) * acceleration_factor;
             if (speed_factor >= 0.9)
             {
-                speed_factor = 1;
+                speed_factor = 1.0;
             }
             distance_to_line_end = vSize(cur_point - line_end);
         }
@@ -899,7 +899,7 @@ void LayerPlan::addWall(const ExtrusionLine& wall,
 
     const coord_t min_bridge_line_len = settings.get<coord_t>("bridge_wall_min_length");
 
-    const Ratio nominal_line_width_multiplier = 1.0 / Ratio(non_bridge_config.getLineWidth()); // we multiply the flow with the actual wanted line width (for that junction), and then multiply with this
+    const Ratio nominal_line_width_multiplier { 1.0 / Ratio { static_cast<Ratio::value_type>(non_bridge_config.getLineWidth()) } }; // we multiply the flow with the actual wanted line width (for that junction), and then multiply with this
 
     // helper function to calculate the distance from the start of the current wall line to the first bridge segment
 
@@ -1109,7 +1109,7 @@ void LayerPlan::addInfillWall(const ExtrusionLine& wall, const GCodePathConfig& 
 
     for (const auto& junction_n : wall)
     {
-        const Ratio width_factor = junction_n.w / Ratio(path_config.getLineWidth());
+        const Ratio width_factor { static_cast<Ratio::value_type>(junction_n.w) / Ratio { static_cast<Ratio::value_type>(path_config.getLineWidth()) } };
         constexpr SpaceFillType space_fill_type = SpaceFillType::Polygons;
         constexpr Ratio flow = 1.0_r;
         addExtrusionMove(junction_n.p, path_config, space_fill_type, flow, width_factor);

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -1074,7 +1074,7 @@ void SkeletalTrapezoidation::generateTransitionEnds(edge_t& edge, coord_t mid_po
     const float transition_mid_position = beading_strategy.getTransitionAnchorPos(lower_bead_count);
     constexpr float inner_bead_width_ratio_after_transition = 1.0;
 
-    constexpr coord_t start_rest = 0;
+    constexpr Ratio start_rest { 0.0 };
     const float mid_rest = transition_mid_position * inner_bead_width_ratio_after_transition;
     constexpr float end_rest = inner_bead_width_ratio_after_transition;
 

--- a/src/SkeletalTrapezoidation.cpp
+++ b/src/SkeletalTrapezoidation.cpp
@@ -3,22 +3,24 @@
 
 #include "SkeletalTrapezoidation.h"
 
-#include <functional>
-#include <queue>
-#include <sstream>
-#include <stack>
-#include <unordered_set>
-
-#include <scripta/logger.h>
-#include <spdlog/spdlog.h>
-
 #include "BoostInterface.hpp"
 #include "settings/types/Ratio.h"
 #include "utils/VoronoiUtils.h"
 #include "utils/linearAlg2D.h"
 #include "utils/macros.h"
 
-#define SKELETAL_TRAPEZOIDATION_BEAD_SEARCH_MAX 1000 // A limit to how long it'll keep searching for adjacent beads. Increasing will re-use beadings more often (saving performance), but search longer for beading (costing performance).
+#include <scripta/logger.h>
+#include <spdlog/spdlog.h>
+
+#include <functional>
+#include <queue>
+#include <sstream>
+#include <stack>
+#include <unordered_set>
+
+#define SKELETAL_TRAPEZOIDATION_BEAD_SEARCH_MAX \
+    1000 // A limit to how long it'll keep searching for adjacent beads. Increasing will re-use beadings more often (saving performance), but search longer for beading (costing
+         // performance).
 
 namespace cura
 {
@@ -39,7 +41,15 @@ SkeletalTrapezoidation::node_t& SkeletalTrapezoidation::makeNode(vd_t::vertex_ty
     }
 }
 
-void SkeletalTrapezoidation::transferEdge(Point from, Point to, vd_t::edge_type& vd_edge, edge_t*& prev_edge, Point& start_source_point, Point& end_source_point, const std::vector<Point>& points, const std::vector<Segment>& segments)
+void SkeletalTrapezoidation::transferEdge(
+    Point from,
+    Point to,
+    vd_t::edge_type& vd_edge,
+    edge_t*& prev_edge,
+    Point& start_source_point,
+    Point& end_source_point,
+    const std::vector<Point>& points,
+    const std::vector<Segment>& segments)
 {
     auto he_edge_it = vd_edge_to_he_edge.find(vd_edge.twin());
     if (he_edge_it != vd_edge_to_he_edge.end())
@@ -107,7 +117,8 @@ void SkeletalTrapezoidation::transferEdge(Point from, Point to, vd_t::edge_type&
         {
             spdlog::warn("Previous edge doesn't go anywhere.");
         }
-        node_t* v0 = (prev_edge) ? prev_edge->to : &makeNode(*vd_edge.vertex0(), from); // TODO: investigate whether boost:voronoi can produce multiple verts and violates consistency
+        node_t* v0
+            = (prev_edge) ? prev_edge->to : &makeNode(*vd_edge.vertex0(), from); // TODO: investigate whether boost:voronoi can produce multiple verts and violates consistency
         Point p0 = discretized.front();
         for (size_t p1_idx = 1; p1_idx < discretized.size(); p1_idx++)
         {
@@ -254,13 +265,14 @@ std::vector<Point> SkeletalTrapezoidation::discretize(const vd_t::edge_type& vd_
 }
 
 
-bool SkeletalTrapezoidation::computePointCellRange(vd_t::cell_type& cell,
-                                                   Point& start_source_point,
-                                                   Point& end_source_point,
-                                                   vd_t::edge_type*& starting_vd_edge,
-                                                   vd_t::edge_type*& ending_vd_edge,
-                                                   const std::vector<Point>& points,
-                                                   const std::vector<Segment>& segments)
+bool SkeletalTrapezoidation::computePointCellRange(
+    vd_t::cell_type& cell,
+    Point& start_source_point,
+    Point& end_source_point,
+    vd_t::edge_type*& starting_vd_edge,
+    vd_t::edge_type*& ending_vd_edge,
+    const std::vector<Point>& points,
+    const std::vector<Segment>& segments)
 {
     if (cell.incident_edge()->is_infinite())
     {
@@ -298,7 +310,9 @@ bool SkeletalTrapezoidation::computePointCellRange(vd_t::cell_type& cell,
         }
         else
         {
-            assert((VoronoiUtils::p(vd_edge->vertex0()) == source_point || ! vd_edge->is_secondary()) && "point cells must end in the point! They cannot cross the point with an edge, because collinear edges are not allowed in the input.");
+            assert(
+                (VoronoiUtils::p(vd_edge->vertex0()) == source_point || ! vd_edge->is_secondary())
+                && "point cells must end in the point! They cannot cross the point with an edge, because collinear edges are not allowed in the input.");
         }
     } while (vd_edge = vd_edge->next(), vd_edge != cell.incident_edge());
     assert(starting_vd_edge && ending_vd_edge);
@@ -306,13 +320,14 @@ bool SkeletalTrapezoidation::computePointCellRange(vd_t::cell_type& cell,
     return true;
 }
 
-void SkeletalTrapezoidation::computeSegmentCellRange(vd_t::cell_type& cell,
-                                                     Point& start_source_point,
-                                                     Point& end_source_point,
-                                                     vd_t::edge_type*& starting_vd_edge,
-                                                     vd_t::edge_type*& ending_vd_edge,
-                                                     const std::vector<Point>& points,
-                                                     const std::vector<Segment>& segments)
+void SkeletalTrapezoidation::computeSegmentCellRange(
+    vd_t::cell_type& cell,
+    Point& start_source_point,
+    Point& end_source_point,
+    vd_t::edge_type*& starting_vd_edge,
+    vd_t::edge_type*& ending_vd_edge,
+    const std::vector<Point>& points,
+    const std::vector<Segment>& segments)
 {
     const Segment& source_segment = VoronoiUtils::getSourceSegment(cell, points, segments);
     Point from = source_segment.from();
@@ -357,15 +372,16 @@ void SkeletalTrapezoidation::computeSegmentCellRange(vd_t::cell_type& cell,
     end_source_point = source_segment.from();
 }
 
-SkeletalTrapezoidation::SkeletalTrapezoidation(const Polygons& polys,
-                                               const BeadingStrategy& beading_strategy,
-                                               AngleRadians transitioning_angle,
-                                               coord_t discretization_step_size,
-                                               coord_t transition_filter_dist,
-                                               coord_t allowed_filter_deviation,
-                                               coord_t beading_propagation_transition_dist,
-                                               int layer_idx,
-                                               SectionType section_type)
+SkeletalTrapezoidation::SkeletalTrapezoidation(
+    const Polygons& polys,
+    const BeadingStrategy& beading_strategy,
+    AngleRadians transitioning_angle,
+    coord_t discretization_step_size,
+    coord_t transition_filter_dist,
+    coord_t allowed_filter_deviation,
+    coord_t beading_propagation_transition_dist,
+    int layer_idx,
+    SectionType section_type)
     : transitioning_angle(transitioning_angle)
     , discretization_step_size(discretization_step_size)
     , transition_filter_dist(transition_filter_dist)
@@ -432,7 +448,15 @@ void SkeletalTrapezoidation::constructFromPolygons(const Polygons& polys)
 
         // Copy start to end edge to graph
         edge_t* prev_edge = nullptr;
-        transferEdge(start_source_point, VoronoiUtils::p(starting_vonoroi_edge->vertex1()), *starting_vonoroi_edge, prev_edge, start_source_point, end_source_point, points, segments);
+        transferEdge(
+            start_source_point,
+            VoronoiUtils::p(starting_vonoroi_edge->vertex1()),
+            *starting_vonoroi_edge,
+            prev_edge,
+            start_source_point,
+            end_source_point,
+            points,
+            segments);
         node_t* starting_node = vd_node_to_he_node[starting_vonoroi_edge->vertex0()];
         starting_node->data.distance_to_boundary = 0;
 
@@ -516,44 +540,164 @@ void SkeletalTrapezoidation::generateToolpaths(std::vector<VariableWidthLines>& 
     }
 
     updateBeadCount();
-    scripta::log("st_graph_0", graph, section_type, layer_idx,
-                 scripta::CellVDI{"is_central", [](const auto& edge){ return static_cast<int>(edge.data.is_central); } },
-                 scripta::CellVDI{"type", [](const auto& edge){ return static_cast<int>(edge.data.type); } },
-                 scripta::PointVDI{"distance_to_boundary", [](const auto& node){ return node->data.distance_to_boundary; } },
-                 scripta::PointVDI{"bead_count", [](const auto& node){ return node->data.bead_count; } },
-                 scripta::PointVDI{"transition_ratio", [](const auto& node){ return node->data.transition_ratio; } });
+    scripta::log(
+        "st_graph_0",
+        graph,
+        section_type,
+        layer_idx,
+        scripta::CellVDI{ "is_central",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.is_central);
+                          } },
+        scripta::CellVDI{ "type",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.type);
+                          } },
+        scripta::PointVDI{ "distance_to_boundary",
+                           [](const auto& node)
+                           {
+                               return node->data.distance_to_boundary;
+                           } },
+        scripta::PointVDI{ "bead_count",
+                           [](const auto& node)
+                           {
+                               return node->data.bead_count;
+                           } },
+        scripta::PointVDI{ "transition_ratio",
+                           [](const auto& node)
+                           {
+                               return node->data.transition_ratio;
+                           } });
 
     filterNoncentralRegions();
-    scripta::log("st_graph_1", graph, section_type, layer_idx,
-                 scripta::CellVDI{"is_central", [](const auto& edge){ return static_cast<int>(edge.data.is_central); } },
-                 scripta::CellVDI{"type", [](const auto& edge){ return static_cast<int>(edge.data.type); } },
-                 scripta::PointVDI{"distance_to_boundary", [](const auto& node){ return node->data.distance_to_boundary; } },
-                 scripta::PointVDI{"bead_count", [](const auto& node){ return node->data.bead_count; } },
-                 scripta::PointVDI{"transition_ratio", [](const auto& node){ return node->data.transition_ratio; } });
+    scripta::log(
+        "st_graph_1",
+        graph,
+        section_type,
+        layer_idx,
+        scripta::CellVDI{ "is_central",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.is_central);
+                          } },
+        scripta::CellVDI{ "type",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.type);
+                          } },
+        scripta::PointVDI{ "distance_to_boundary",
+                           [](const auto& node)
+                           {
+                               return node->data.distance_to_boundary;
+                           } },
+        scripta::PointVDI{ "bead_count",
+                           [](const auto& node)
+                           {
+                               return node->data.bead_count;
+                           } },
+        scripta::PointVDI{ "transition_ratio",
+                           [](const auto& node)
+                           {
+                               return node->data.transition_ratio;
+                           } });
 
     generateTransitioningRibs();
-    scripta::log("st_graph_2", graph, section_type, layer_idx,
-             scripta::CellVDI{"is_central", [](const auto& edge){ return static_cast<int>(edge.data.is_central); } },
-             scripta::CellVDI{"type", [](const auto& edge){ return static_cast<int>(edge.data.type); } },
-             scripta::PointVDI{"distance_to_boundary", [](const auto& node){ return node->data.distance_to_boundary; } },
-             scripta::PointVDI{"bead_count", [](const auto& node){ return node->data.bead_count; } },
-             scripta::PointVDI{"transition_ratio", [](const auto& node){ return node->data.transition_ratio; } });
+    scripta::log(
+        "st_graph_2",
+        graph,
+        section_type,
+        layer_idx,
+        scripta::CellVDI{ "is_central",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.is_central);
+                          } },
+        scripta::CellVDI{ "type",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.type);
+                          } },
+        scripta::PointVDI{ "distance_to_boundary",
+                           [](const auto& node)
+                           {
+                               return node->data.distance_to_boundary;
+                           } },
+        scripta::PointVDI{ "bead_count",
+                           [](const auto& node)
+                           {
+                               return node->data.bead_count;
+                           } },
+        scripta::PointVDI{ "transition_ratio",
+                           [](const auto& node)
+                           {
+                               return node->data.transition_ratio;
+                           } });
 
     generateExtraRibs();
-    scripta::log("st_graph_3", graph, section_type, layer_idx,
-             scripta::CellVDI{"is_central", [](const auto& edge){ return static_cast<int>(edge.data.is_central); } },
-             scripta::CellVDI{"type", [](const auto& edge){ return static_cast<int>(edge.data.type); } },
-             scripta::PointVDI{"distance_to_boundary", [](const auto& node){ return node->data.distance_to_boundary; } },
-             scripta::PointVDI{"bead_count", [](const auto& node){ return node->data.bead_count; } },
-             scripta::PointVDI{"transition_ratio", [](const auto& node){ return node->data.transition_ratio; } });
+    scripta::log(
+        "st_graph_3",
+        graph,
+        section_type,
+        layer_idx,
+        scripta::CellVDI{ "is_central",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.is_central);
+                          } },
+        scripta::CellVDI{ "type",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.type);
+                          } },
+        scripta::PointVDI{ "distance_to_boundary",
+                           [](const auto& node)
+                           {
+                               return node->data.distance_to_boundary;
+                           } },
+        scripta::PointVDI{ "bead_count",
+                           [](const auto& node)
+                           {
+                               return node->data.bead_count;
+                           } },
+        scripta::PointVDI{ "transition_ratio",
+                           [](const auto& node)
+                           {
+                               return node->data.transition_ratio;
+                           } });
 
     generateSegments();
-    scripta::log("st_graph_4", graph, section_type, layer_idx,
-                 scripta::CellVDI{"is_central", [](const auto& edge){ return static_cast<int>(edge.data.is_central); } },
-                 scripta::CellVDI{"type", [](const auto& edge){ return static_cast<int>(edge.data.type); } },
-                 scripta::PointVDI{"distance_to_boundary", [](const auto& node){ return node->data.distance_to_boundary; } },
-                 scripta::PointVDI{"bead_count", [](const auto& node){ return node->data.bead_count; } },
-                 scripta::PointVDI{"transition_ratio", [](const auto& node){ return node->data.transition_ratio; } });
+    scripta::log(
+        "st_graph_4",
+        graph,
+        section_type,
+        layer_idx,
+        scripta::CellVDI{ "is_central",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.is_central);
+                          } },
+        scripta::CellVDI{ "type",
+                          [](const auto& edge)
+                          {
+                              return static_cast<int>(edge.data.type);
+                          } },
+        scripta::PointVDI{ "distance_to_boundary",
+                           [](const auto& node)
+                           {
+                               return node->data.distance_to_boundary;
+                           } },
+        scripta::PointVDI{ "bead_count",
+                           [](const auto& node)
+                           {
+                               return node->data.bead_count;
+                           } },
+        scripta::PointVDI{ "transition_ratio",
+                           [](const auto& node)
+                           {
+                               return node->data.transition_ratio;
+                           } });
 }
 
 void SkeletalTrapezoidation::updateIsCentral()
@@ -920,7 +1064,8 @@ void SkeletalTrapezoidation::filterTransitionMids()
     }
 }
 
-std::list<SkeletalTrapezoidation::TransitionMidRef> SkeletalTrapezoidation::dissolveNearbyTransitions(edge_t* edge_to_start, TransitionMiddle& origin_transition, coord_t traveled_dist, coord_t max_dist, bool going_up)
+std::list<SkeletalTrapezoidation::TransitionMidRef>
+    SkeletalTrapezoidation::dissolveNearbyTransitions(edge_t* edge_to_start, TransitionMiddle& origin_transition, coord_t traveled_dist, coord_t max_dist, bool going_up)
 {
     std::list<TransitionMidRef> to_be_dissolved;
     if (traveled_dist > max_dist)
@@ -947,7 +1092,9 @@ std::list<SkeletalTrapezoidation::TransitionMidRef> SkeletalTrapezoidation::diss
         const coord_t radius_here = edge->from->data.distance_to_boundary;
         const bool dissolve_result_is_odd = bool(origin_transition.lower_bead_count % 2) == going_up;
         const coord_t width_deviation = std::abs(origin_radius - radius_here) * 2; // times by two because the deviation happens at both sides of the significant edge
-        const coord_t line_width_deviation = dissolve_result_is_odd ? width_deviation : width_deviation / 2; // assume the deviation will be split over either 1 or 2 lines, i.e. assume wall_distribution_count = 1
+        const coord_t line_width_deviation = dissolve_result_is_odd
+                                               ? width_deviation
+                                               : width_deviation / 2; // assume the deviation will be split over either 1 or 2 lines, i.e. assume wall_distribution_count = 1
         if (line_width_deviation > allowed_filter_deviation)
         {
             should_dissolve = false;
@@ -974,7 +1121,8 @@ std::list<SkeletalTrapezoidation::TransitionMidRef> SkeletalTrapezoidation::diss
         }
         if (should_dissolve && ! seen_transition_on_this_edge)
         {
-            std::list<SkeletalTrapezoidation::TransitionMidRef> to_be_dissolved_here = dissolveNearbyTransitions(edge, origin_transition, traveled_dist + ab_size, max_dist, going_up);
+            std::list<SkeletalTrapezoidation::TransitionMidRef> to_be_dissolved_here
+                = dissolveNearbyTransitions(edge, origin_transition, traveled_dist + ab_size, max_dist, going_up);
             if (to_be_dissolved_here.empty())
             { // The region is too long to be dissolved in this direction, so it cannot be dissolved in any direction.
                 to_be_dissolved.clear();
@@ -1074,7 +1222,7 @@ void SkeletalTrapezoidation::generateTransitionEnds(edge_t& edge, coord_t mid_po
     const float transition_mid_position = beading_strategy.getTransitionAnchorPos(lower_bead_count);
     constexpr float inner_bead_width_ratio_after_transition = 1.0;
 
-    constexpr Ratio start_rest { 0.0 };
+    constexpr Ratio start_rest{ 0.0 };
     const float mid_rest = transition_mid_position * inner_bead_width_ratio_after_transition;
     constexpr float end_rest = inner_bead_width_ratio_after_transition;
 
@@ -1100,14 +1248,15 @@ void SkeletalTrapezoidation::generateTransitionEnds(edge_t& edge, coord_t mid_po
     }
 }
 
-bool SkeletalTrapezoidation::generateTransitionEnd(edge_t& edge,
-                                                   coord_t start_pos,
-                                                   coord_t end_pos,
-                                                   coord_t transition_half_length,
-                                                   Ratio start_rest,
-                                                   Ratio end_rest,
-                                                   coord_t lower_bead_count,
-                                                   ptr_vector_t<std::list<TransitionEnd>>& edge_transition_ends)
+bool SkeletalTrapezoidation::generateTransitionEnd(
+    edge_t& edge,
+    coord_t start_pos,
+    coord_t end_pos,
+    coord_t transition_half_length,
+    Ratio start_rest,
+    Ratio end_rest,
+    coord_t lower_bead_count,
+    ptr_vector_t<std::list<TransitionEnd>>& edge_transition_ends)
 {
     Point a = edge.from->p;
     Point b = edge.to->p;
@@ -1299,7 +1448,11 @@ void SkeletalTrapezoidation::applyTransitions(ptr_vector_t<std::list<TransitionE
         assert(edge.data.isCentral());
 
         auto& transitions = *edge.data.getTransitionEnds();
-        transitions.sort([](const TransitionEnd& a, const TransitionEnd& b) { return a.pos < b.pos; });
+        transitions.sort(
+            [](const TransitionEnd& a, const TransitionEnd& b)
+            {
+                return a.pos < b.pos;
+            });
 
         node_t* from = edge.from;
         node_t* to = edge.to;
@@ -1358,7 +1511,8 @@ void SkeletalTrapezoidation::generateExtraRibs()
     //       The code was equivalent to a full loop over all the edges though, unless there was one edge or less, in which case it would produce undefined behaviour.
     for (auto& edge : graph.edges)
     {
-        if (! edge.data.isCentral() || shorterThen(edge.to->p - edge.from->p, discretization_step_size) || edge.from->data.distance_to_boundary >= edge.to->data.distance_to_boundary)
+        if (! edge.data.isCentral() || shorterThen(edge.to->p - edge.from->p, discretization_step_size)
+            || edge.from->data.distance_to_boundary >= edge.to->data.distance_to_boundary)
         {
             continue;
         }
@@ -1433,34 +1587,35 @@ void SkeletalTrapezoidation::generateSegments()
         }
     }
 
-    std::sort(upward_quad_mids.begin(),
-              upward_quad_mids.end(),
-              [this](edge_t* a, edge_t* b)
-              {
-                  if (a->to->data.distance_to_boundary == b->to->data.distance_to_boundary)
-                  { // PathOrdering between two 'upward' edges of the same distance is important when one of the edges is flat and connected to the other
-                      if (a->from->data.distance_to_boundary == a->to->data.distance_to_boundary && b->from->data.distance_to_boundary == b->to->data.distance_to_boundary)
-                      {
-                          coord_t max = std::numeric_limits<coord_t>::max();
-                          coord_t a_dist_from_up = std::min(a->distToGoUp().value_or(max), a->twin->distToGoUp().value_or(max)) - vSize(a->to->p - a->from->p);
-                          coord_t b_dist_from_up = std::min(b->distToGoUp().value_or(max), b->twin->distToGoUp().value_or(max)) - vSize(b->to->p - b->from->p);
-                          return a_dist_from_up < b_dist_from_up;
-                      }
-                      else if (a->from->data.distance_to_boundary == a->to->data.distance_to_boundary)
-                      {
-                          return true; // Edge a might be 'above' edge b
-                      }
-                      else if (b->from->data.distance_to_boundary == b->to->data.distance_to_boundary)
-                      {
-                          return false; // Edge b might be 'above' edge a
-                      }
-                      else
-                      {
-                          // PathOrdering is not important
-                      }
-                  }
-                  return a->to->data.distance_to_boundary > b->to->data.distance_to_boundary;
-              });
+    std::sort(
+        upward_quad_mids.begin(),
+        upward_quad_mids.end(),
+        [this](edge_t* a, edge_t* b)
+        {
+            if (a->to->data.distance_to_boundary == b->to->data.distance_to_boundary)
+            { // PathOrdering between two 'upward' edges of the same distance is important when one of the edges is flat and connected to the other
+                if (a->from->data.distance_to_boundary == a->to->data.distance_to_boundary && b->from->data.distance_to_boundary == b->to->data.distance_to_boundary)
+                {
+                    coord_t max = std::numeric_limits<coord_t>::max();
+                    coord_t a_dist_from_up = std::min(a->distToGoUp().value_or(max), a->twin->distToGoUp().value_or(max)) - vSize(a->to->p - a->from->p);
+                    coord_t b_dist_from_up = std::min(b->distToGoUp().value_or(max), b->twin->distToGoUp().value_or(max)) - vSize(b->to->p - b->from->p);
+                    return a_dist_from_up < b_dist_from_up;
+                }
+                else if (a->from->data.distance_to_boundary == a->to->data.distance_to_boundary)
+                {
+                    return true; // Edge a might be 'above' edge b
+                }
+                else if (b->from->data.distance_to_boundary == b->to->data.distance_to_boundary)
+                {
+                    return false; // Edge b might be 'above' edge a
+                }
+                else
+                {
+                    // PathOrdering is not important
+                }
+            }
+            return a->to->data.distance_to_boundary > b->to->data.distance_to_boundary;
+        });
 
     ptr_vector_t<BeadingPropagation> node_beadings;
     { // Store beading
@@ -1550,8 +1705,10 @@ void SkeletalTrapezoidation::propagateBeadingsUpward(std::vector<edge_t*>& upwar
         { // Only propagate to places where there is place
             continue;
         }
-        assert((upward_edge->from->data.distance_to_boundary != upward_edge->to->data.distance_to_boundary || shorterThen(upward_edge->to->p - upward_edge->from->p, central_filter_dist))
-               && "zero difference R edges should always be central");
+        assert(
+            (upward_edge->from->data.distance_to_boundary != upward_edge->to->data.distance_to_boundary
+             || shorterThen(upward_edge->to->p - upward_edge->from->p, central_filter_dist))
+            && "zero difference R edges should always be central");
         coord_t length = vSize(upward_edge->to->p - upward_edge->from->p);
         BeadingPropagation upper_beading = lower_beading;
         upper_beading.dist_to_bottom_source += length;
@@ -1570,7 +1727,8 @@ void SkeletalTrapezoidation::propagateBeadingsDownward(std::vector<edge_t*>& upw
         if (! upward_quad_mid->data.isCentral())
         {
             // for equidistant edge: propagate from known beading to node with unknown beading
-            if (upward_quad_mid->from->data.distance_to_boundary == upward_quad_mid->to->data.distance_to_boundary && upward_quad_mid->from->data.hasBeading() && ! upward_quad_mid->to->data.hasBeading())
+            if (upward_quad_mid->from->data.distance_to_boundary == upward_quad_mid->to->data.distance_to_boundary && upward_quad_mid->from->data.hasBeading()
+                && ! upward_quad_mid->to->data.hasBeading())
             {
                 propagateBeadingsDownward(upward_quad_mid->twin, node_beadings);
             }
@@ -1666,7 +1824,8 @@ SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beadin
         // f*(l-r) + r = s
         // f*(l-r) = s - r
         // f = (s-r) / (l-r)
-        float new_ratio = static_cast<float>(switching_radius - right.toolpath_locations[next_inset_idx]) / static_cast<float>(left.toolpath_locations[next_inset_idx] - right.toolpath_locations[next_inset_idx]);
+        float new_ratio = static_cast<float>(switching_radius - right.toolpath_locations[next_inset_idx])
+                        / static_cast<float>(left.toolpath_locations[next_inset_idx] - right.toolpath_locations[next_inset_idx]);
         new_ratio = std::min(1.0, new_ratio + 0.1);
         return interpolate(left, new_ratio, right);
     }
@@ -1814,12 +1973,17 @@ std::shared_ptr<SkeletalTrapezoidationJoint::BeadingPropagation> SkeletalTrapezo
     {
         edge_t* edge_to;
         coord_t dist;
-        DistEdge(edge_t* edge_to, coord_t dist) : edge_to(edge_to), dist(dist)
+        DistEdge(edge_t* edge_to, coord_t dist)
+            : edge_to(edge_to)
+            , dist(dist)
         {
         }
     };
 
-    auto compare = [](const DistEdge& l, const DistEdge& r) -> bool { return l.dist > r.dist; };
+    auto compare = [](const DistEdge& l, const DistEdge& r) -> bool
+    {
+        return l.dist > r.dist;
+    };
     std::priority_queue<DistEdge, std::vector<DistEdge>, decltype(compare)> further_edges(compare);
     bool first = true;
     for (edge_t* outgoing = node->incident_edge; outgoing && (first || outgoing != node->incident_edge); outgoing = outgoing->twin->next)
@@ -1864,19 +2028,21 @@ void SkeletalTrapezoidation::addToolpathSegment(const ExtrusionJunction& from, c
         generated_toolpaths.resize(inset_idx + 1);
     }
     assert((generated_toolpaths[inset_idx].empty() || ! generated_toolpaths[inset_idx].back().junctions.empty()) && "empty extrusion lines should never have been generated");
-    if (generated_toolpaths[inset_idx].empty() || generated_toolpaths[inset_idx].back().is_odd != is_odd || generated_toolpaths[inset_idx].back().junctions.back().perimeter_index != inset_idx // inset_idx should always be consistent
+    if (generated_toolpaths[inset_idx].empty() || generated_toolpaths[inset_idx].back().is_odd != is_odd
+        || generated_toolpaths[inset_idx].back().junctions.back().perimeter_index != inset_idx // inset_idx should always be consistent
     )
     {
         force_new_path = true;
     }
-    if (! force_new_path && shorterThen(generated_toolpaths[inset_idx].back().junctions.back().p - from.p, 10) && std::abs(generated_toolpaths[inset_idx].back().junctions.back().w - from.w) < 10
-        && ! from_is_3way // force new path at 3way intersection
+    if (! force_new_path && shorterThen(generated_toolpaths[inset_idx].back().junctions.back().p - from.p, 10)
+        && std::abs(generated_toolpaths[inset_idx].back().junctions.back().w - from.w) < 10 && ! from_is_3way // force new path at 3way intersection
     )
     {
         generated_toolpaths[inset_idx].back().junctions.push_back(to);
     }
-    else if (! force_new_path && shorterThen(generated_toolpaths[inset_idx].back().junctions.back().p - to.p, 10) && std::abs(generated_toolpaths[inset_idx].back().junctions.back().w - to.w) < 10
-             && ! to_is_3way // force new path at 3way intersection
+    else if (
+        ! force_new_path && shorterThen(generated_toolpaths[inset_idx].back().junctions.back().p - to.p, 10)
+        && std::abs(generated_toolpaths[inset_idx].back().junctions.back().w - to.w) < 10 && ! to_is_3way // force new path at 3way intersection
     )
     {
         if (! is_odd)
@@ -1973,7 +2139,10 @@ void SkeletalTrapezoidation::connectJunctions(ptr_vector_t<LineJunctions>& edge_
             assert(std::abs(int(from_junctions.size()) - int(to_junctions.size())) <= 1); // at transitions one end has more beads
             if (std::abs(int(from_junctions.size()) - int(to_junctions.size())) > 1)
             {
-                spdlog::warn("Can't create a transition when connecting two perimeters where the number of beads differs too much! {} vs. {}", from_junctions.size(), to_junctions.size());
+                spdlog::warn(
+                    "Can't create a transition when connecting two perimeters where the number of beads differs too much! {} vs. {}",
+                    from_junctions.size(),
+                    to_junctions.size());
             }
 
             size_t segment_count = std::min(from_junctions.size(), to_junctions.size());

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2021 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "TreeModelVolumes.h"
 #include "TreeSupport.h"
@@ -801,7 +801,7 @@ void TreeModelVolumes::calculateAccumulatedPlaceable0(const LayerIndex max_layer
         {
             start_layer++;
         }
-        start_layer = std::max(start_layer.value + 1, 1);
+        start_layer = std::max(LayerIndex { start_layer + 1 }, LayerIndex { 1 });
     }
     if (start_layer > max_layer)
     {
@@ -823,7 +823,7 @@ void TreeModelVolumes::calculateAccumulatedPlaceable0(const LayerIndex max_layer
     }
     cura::parallel_for<size_t>
        (
-           std::max(start_layer-1,LayerIndex(1)),
+           std::max(LayerIndex{ start_layer - 1 }, LayerIndex{ 1 }),
            data.size(),
            [&](const coord_t layer_idx)
            {

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -2,6 +2,7 @@
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "TreeModelVolumes.h"
+
 #include "TreeSupport.h"
 #include "TreeSupportEnums.h"
 #include "progress/Progress.h"
@@ -17,8 +18,7 @@
 namespace cura
 {
 
-TreeModelVolumes::TreeModelVolumes
-(
+TreeModelVolumes::TreeModelVolumes(
     const SliceDataStorage& storage,
     const coord_t max_move,
     const coord_t max_move_slow,
@@ -26,15 +26,16 @@ TreeModelVolumes::TreeModelVolumes
     size_t current_mesh_idx,
     double progress_multiplier,
     double progress_offset,
-    const std::vector<Polygons>& additional_excluded_areas
-) :
-    max_move_{ std::max(max_move - 2, coord_t(0)) },  // -2 to avoid rounding errors
-    max_move_slow_{ std::max(max_move_slow - 2, coord_t(0)) },  // -2 to avoid rounding errors
-    min_offset_per_step_{ min_offset_per_step },
-    progress_multiplier{ progress_multiplier },
-    progress_offset{ progress_offset },
-    machine_border_{ calculateMachineBorderCollision(storage.getMachineBorder())},
-    machine_area_ { storage.getMachineBorder()}
+    const std::vector<Polygons>& additional_excluded_areas)
+    : max_move_{ std::max(max_move - 2, coord_t(0)) }
+    , // -2 to avoid rounding errors
+    max_move_slow_{ std::max(max_move_slow - 2, coord_t(0)) }
+    , // -2 to avoid rounding errors
+    min_offset_per_step_{ min_offset_per_step }
+    , progress_multiplier{ progress_multiplier }
+    , progress_offset{ progress_offset }
+    , machine_border_{ calculateMachineBorderCollision(storage.getMachineBorder()) }
+    , machine_area_{ storage.getMachineBorder() }
 {
     anti_overhang_ = std::vector<Polygons>(storage.support.supportLayers.size(), Polygons());
     std::unordered_map<size_t, size_t> mesh_to_layeroutline_idx;
@@ -105,8 +106,7 @@ TreeModelVolumes::TreeModelVolumes
         const auto& mesh_l = mesh;
         // ^^^ Remove when fixed (and rename accordingly in the below parallel-for).
 
-        cura::parallel_for<coord_t>
-        (
+        cura::parallel_for<coord_t>(
             0,
             LayerIndex(layer_outlines_[mesh_to_layeroutline_idx[mesh_idx_l]].second.size()),
             [&](const LayerIndex layer_idx)
@@ -117,26 +117,22 @@ TreeModelVolumes::TreeModelVolumes
                 }
                 Polygons outline = extractOutlineFromMesh(mesh_l, layer_idx);
                 layer_outlines_[mesh_to_layeroutline_idx[mesh_idx_l]].second[layer_idx].add(outline);
-            }
-        );
+            });
     }
     // Merge all the layer outlines together.
     for (auto& layer_outline : layer_outlines_)
     {
-        cura::parallel_for<coord_t>
-        (
+        cura::parallel_for<coord_t>(
             0,
             LayerIndex(anti_overhang_.size()),
             [&](const LayerIndex layer_idx)
             {
                 layer_outline.second[layer_idx] = layer_outline.second[layer_idx].unionPolygons();
-            }
-        );
+            });
     }
 
     // Gather all excluded areas, like support-blockers and trees that where already generated.
-    cura::parallel_for<coord_t>
-    (
+    cura::parallel_for<coord_t>(
         0,
         LayerIndex(anti_overhang_.size()),
         [&](const LayerIndex layer_idx)
@@ -156,11 +152,11 @@ TreeModelVolumes::TreeModelVolumes
                 anti_overhang_[layer_idx].add(storage.primeTower.outer_poly);
             }
             anti_overhang_[layer_idx] = anti_overhang_[layer_idx].unionPolygons();
-        }
-    );
+        });
 
-    for (max_layer_idx_without_blocker =0; max_layer_idx_without_blocker +1<anti_overhang_.size(); max_layer_idx_without_blocker++){
-        if(!anti_overhang_[max_layer_idx_without_blocker +1].empty())
+    for (max_layer_idx_without_blocker = 0; max_layer_idx_without_blocker + 1 < anti_overhang_.size(); max_layer_idx_without_blocker++)
+    {
+        if (! anti_overhang_[max_layer_idx_without_blocker + 1].empty())
         {
             break;
         }
@@ -188,8 +184,9 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
         possible_tip_radiis.emplace(ceilRadius(config.getRadius(dtt)));
         possible_tip_radiis.emplace(ceilRadius(config.getRadius(dtt) + current_min_xy_dist_delta));
     }
-    // It theoretically may happen in the tip, that the radius can change so much in-between 2 layers, that a ceil step is skipped (as in there is a radius r so that ceilRadius(radius(dtt))<ceilRadius(r)<ceilRadius(radius(dtt+1))).
-    // As such a radius will not reasonable happen in the tree and it will most likely not be requested, there is no need to calculate them. So just skip these.
+    // It theoretically may happen in the tip, that the radius can change so much in-between 2 layers, that a ceil step is skipped (as in there is a radius r so that
+    // ceilRadius(radius(dtt))<ceilRadius(r)<ceilRadius(radius(dtt+1))). As such a radius will not reasonable happen in the tree and it will most likely not be requested, there is
+    // no need to calculate them. So just skip these.
     for (coord_t radius_eval = ceilRadius(1); radius_eval <= config.branch_radius; radius_eval = ceilRadius(radius_eval + 1))
     {
         if (! possible_tip_radiis.count(radius_eval))
@@ -204,8 +201,8 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
     // It may seem that the required avoidance can be of a smaller radius when going to model (no initial layer diameter for to model branches)
     // but as for every branch going towards the bp, the to model avoidance is required to check for possible merges with to model branches, this assumption is in-fact wrong.
     std::unordered_map<coord_t, LayerIndex> radius_until_layer;
-    // while it is possible to calculate, up to which layer the avoidance should be calculated, this simulation is easier to understand, and does not need to be adjusted if something of the radius calculation is changed.
-    // Tested overhead was neligable (milliseconds for thounds of layers).
+    // while it is possible to calculate, up to which layer the avoidance should be calculated, this simulation is easier to understand, and does not need to be adjusted if
+    // something of the radius calculation is changed. Tested overhead was neligable (milliseconds for thounds of layers).
     for (LayerIndex simulated_dtt = 0; simulated_dtt <= max_layer; simulated_dtt++)
     {
         const LayerIndex current_layer = max_layer - simulated_dtt;
@@ -235,7 +232,8 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
 
     // Append additional radiis needed for collision.
 
-    radius_until_layer[ceilRadius(increase_until_radius, false)] = max_layer; // To calculate collision holefree for every radius, the collision of radius increase_until_radius will be required.
+    radius_until_layer[ceilRadius(increase_until_radius, false)]
+        = max_layer; // To calculate collision holefree for every radius, the collision of radius increase_until_radius will be required.
     // Collision for radius 0 needs to be calculated everywhere, as it will be used to ensure valid xy_distance in drawAreas.
     radius_until_layer[0] = max_layer;
     if (current_min_xy_dist_delta != 0)
@@ -244,7 +242,10 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
     }
 
     std::deque<RadiusLayerPair> relevant_collision_radiis;
-    relevant_collision_radiis.insert(relevant_collision_radiis.end(), radius_until_layer.begin(), radius_until_layer.end()); // Now that required_avoidance_limit contains the maximum of old and regular required radius just copy.
+    relevant_collision_radiis.insert(
+        relevant_collision_radiis.end(),
+        radius_until_layer.begin(),
+        radius_until_layer.end()); // Now that required_avoidance_limit contains the maximum of old and regular required radius just copy.
 
     // ### Calculate the relevant collisions
     calculateCollision(relevant_collision_radiis);
@@ -253,7 +254,7 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
     std::deque<RadiusLayerPair> relevant_hole_collision_radiis;
     for (RadiusLayerPair key : relevant_avoidance_radiis)
     {
-        spdlog::debug("Calculating avoidance of radius {} up to layer {}",key.first,key.second);
+        spdlog::debug("Calculating avoidance of radius {} up to layer {}", key.first, key.second);
         if (key.first < increase_until_radius + current_min_xy_dist_delta)
         {
             relevant_hole_collision_radiis.emplace_back(key);
@@ -267,12 +268,10 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
     auto t_acc = std::chrono::high_resolution_clock::now();
 
 
-    if (max_layer_idx_without_blocker <max_layer && support_rests_on_model)
+    if (max_layer_idx_without_blocker < max_layer && support_rests_on_model)
     {
-
         calculateAccumulatedPlaceable0(max_layer);
         t_acc = std::chrono::high_resolution_clock::now();
-
     }
 
     // ### Calculate the relevant avoidances in parallel as far as possible
@@ -305,24 +304,27 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
     const auto t_avo = std::chrono::high_resolution_clock::now();
 
     auto t_colAvo = std::chrono::high_resolution_clock::now();
-    if (max_layer_idx_without_blocker <max_layer && support_rests_on_model)
+    if (max_layer_idx_without_blocker < max_layer && support_rests_on_model)
     {
         // FIXME: When nowait (parellel-for) is implemented, ensure here the following is calculated: calculateAccumulatedPlaceable0.
         calculateCollisionAvoidance(relevant_avoidance_radiis);
         t_colAvo = std::chrono::high_resolution_clock::now();
-
     }
 
-    precalculationFinished=true;
+    precalculationFinished = true;
     const auto dur_col = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_coll - t_start).count();
-    const auto dur_acc = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_acc-t_coll).count();
+    const auto dur_acc = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_acc - t_coll).count();
     const auto dur_avo = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_avo - t_acc).count();
     const auto dur_col_avo = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_colAvo - t_avo).count();
 
 
-    spdlog::info("Pre-calculating collision took {} ms. Pre-calculating avoidance took {} ms. Pre-calculating accumulated Placeables with radius 0 took {} ms. Pre-calculating collision-avoidance took {} ms. ", dur_col, dur_avo, dur_acc, dur_col_avo);
-
-
+    spdlog::info(
+        "Pre-calculating collision took {} ms. Pre-calculating avoidance took {} ms. Pre-calculating accumulated Placeables with radius 0 took {} ms. Pre-calculating "
+        "collision-avoidance took {} ms. ",
+        dur_col,
+        dur_avo,
+        dur_acc,
+        dur_col_avo);
 }
 
 const Polygons& TreeModelVolumes::getCollision(coord_t radius, LayerIndex layer_idx, bool min_xy_dist)
@@ -334,7 +336,8 @@ const Polygons& TreeModelVolumes::getCollision(coord_t radius, LayerIndex layer_
         radius += current_min_xy_dist_delta;
     }
 
-    // special case as if a radius 0 is requested it could be to ensure correct xy distance. As such it is beneficial if the collision is as close to the configured values as possible.
+    // special case as if a radius 0 is requested it could be to ensure correct xy distance. As such it is beneficial if the collision is as close to the configured values as
+    // possible.
     if (orig_radius != 0)
     {
         radius = ceilRadius(radius);
@@ -463,9 +466,14 @@ const Polygons& TreeModelVolumes::getAvoidance(coord_t radius, LayerIndex layer_
     }
     if (precalculated)
     {
-        spdlog::warn("Had to calculate Avoidance (to model-bool: {}) at radius {} and layer {} and type {}, but precalculate was called. Performance may suffer!", to_model, key.first, key.second,coord_t(type));
+        spdlog::warn(
+            "Had to calculate Avoidance (to model-bool: {}) at radius {} and layer {} and type {}, but precalculate was called. Performance may suffer!",
+            to_model,
+            key.first,
+            key.second,
+            coord_t(type));
     }
-    if(type == AvoidanceType::COLLISION)
+    if (type == AvoidanceType::COLLISION)
     {
         calculateCollisionAvoidance(key);
     }
@@ -528,7 +536,7 @@ const Polygons& TreeModelVolumes::getWallRestriction(coord_t radius, LayerIndex 
 
     std::unordered_map<RadiusLayerPair, Polygons>* cache_ptr = min_xy_dist ? &wall_restrictions_cache_min_ : &wall_restrictions_cache_;
     {
-        std::lock_guard<std::mutex> critical_section(min_xy_dist  ? *critical_wall_restrictions_cache_min_ : *critical_wall_restrictions_cache_);
+        std::lock_guard<std::mutex> critical_section(min_xy_dist ? *critical_wall_restrictions_cache_min_ : *critical_wall_restrictions_cache_);
         result = getArea(*cache_ptr, key);
     }
     if (result)
@@ -604,8 +612,7 @@ LayerIndex TreeModelVolumes::getMaxCalculatedLayer(coord_t radius, const std::un
 
 void TreeModelVolumes::calculateCollision(const std::deque<RadiusLayerPair>& keys)
 {
-    cura::parallel_for<size_t>
-    (
+    cura::parallel_for<size_t>(
         0,
         keys.size(),
         [&](const size_t i)
@@ -627,8 +634,8 @@ void TreeModelVolumes::calculateCollision(const std::deque<RadiusLayerPair>& key
                 const LayerIndex max_anti_overhang_layer = anti_overhang_.size() - 1;
                 const LayerIndex max_required_layer = keys[i].second + std::max(coord_t(1), z_distance_top_layers);
                 const coord_t xy_distance = outline_idx == current_outline_idx ? current_min_xy_dist : layer_outlines_[outline_idx].first.get<coord_t>("support_xy_distance");
-                // Technically this causes collision for the normal xy_distance to be larger by current_min_xy_dist_delta for all not currently processing meshes as this delta will be added at request time.
-                // Avoiding this would require saving each collision for each outline_idx separately,
+                // Technically this causes collision for the normal xy_distance to be larger by current_min_xy_dist_delta for all not currently processing meshes as this delta will
+                // be added at request time. Avoiding this would require saving each collision for each outline_idx separately,
                 //   and later for each avoidance... But avoidance calculation has to be for the whole scene and can NOT be done for each outline_idx separately and combined later.
                 // So avoiding this inaccuracy seems infeasible as it would require 2x the avoidance calculations => 0.5x the performance.
                 coord_t min_layer_bottom;
@@ -649,7 +656,9 @@ void TreeModelVolumes::calculateCollision(const std::deque<RadiusLayerPair>& key
                     {
                         collision_areas.add(layer_outlines_[outline_idx].second[layer_idx]);
                     }
-                    collision_areas = collision_areas.offset(radius + xy_distance); // jtRound is not needed here, as the overshoot can not cause errors in the algorithm, because no assumptions are made about the model.
+                    collision_areas = collision_areas.offset(
+                        radius
+                        + xy_distance); // jtRound is not needed here, as the overshoot can not cause errors in the algorithm, because no assumptions are made about the model.
                     data[key].add(collision_areas); // if a key does not exist when it is accessed it is added!
                 }
 
@@ -661,13 +670,14 @@ void TreeModelVolumes::calculateCollision(const std::deque<RadiusLayerPair>& key
                     {
                         data[key].add(data[RadiusLayerPair(radius, layer_idx - layer_offset)]);
                     }
-                    //Placeable areas also have to be calculated when a collision has to be calculated if called outside of precalculate to prevent an infinite loop when they are invalidly requested...
-                    if ((support_rests_on_this_model||precalculationFinished||!precalculated) && radius == 0 && layer_idx < coord_t(1 + keys[i].second))
+                    // Placeable areas also have to be calculated when a collision has to be calculated if called outside of precalculate to prevent an infinite loop when they are
+                    // invalidly requested...
+                    if ((support_rests_on_this_model || precalculationFinished || ! precalculated) && radius == 0 && layer_idx < coord_t(1 + keys[i].second))
                     {
                         data[key] = data[key].unionPolygons();
                         Polygons above = data[RadiusLayerPair(radius, layer_idx + 1)];
                         above = above.unionPolygons(max_anti_overhang_layer >= layer_idx + 1 ? anti_overhang_[layer_idx] : Polygons());
-                       // Empty polygons on condition: Just to be sure the area is correctly unioned as otherwise difference may behave unexpectedly.
+                        // Empty polygons on condition: Just to be sure the area is correctly unioned as otherwise difference may behave unexpectedly.
 
                         Polygons placeable = data[key].unionPolygons().difference(above);
                         data_placeable[RadiusLayerPair(radius, layer_idx + 1)] = data_placeable[RadiusLayerPair(radius, layer_idx + 1)].unionPolygons(placeable);
@@ -678,7 +688,9 @@ void TreeModelVolumes::calculateCollision(const std::deque<RadiusLayerPair>& key
                 for (const auto layer_idx : ranges::views::iota(min_layer_bottom, max_required_layer + 1))
                 {
                     key.second = layer_idx;
-                    for (coord_t layer_offset = 1; layer_offset <= z_distance_top_layers && layer_offset + layer_idx < std::min(coord_t(layer_outlines_[outline_idx].second.size()), coord_t(max_required_layer + 1)); layer_offset++)
+                    for (coord_t layer_offset = 1; layer_offset <= z_distance_top_layers
+                                                   && layer_offset + layer_idx < std::min(coord_t(layer_outlines_[outline_idx].second.size()), coord_t(max_required_layer + 1));
+                         layer_offset++)
                     {
                         // If just the collision (including the xy distance) of the layers above is accumulated, it leads to the following issue:
                         // Example: assuming the z distance is 2 layer
@@ -693,20 +705,20 @@ void TreeModelVolumes::calculateCollision(const std::deque<RadiusLayerPair>& key
                         // If just the collision above is accumulated the overhang will get overwritten by the xy_distance of the layer below the overhang...
                         //
                         // This only causes issues if the overhang area is thinner than xy_distance
-                        // Just accumulating areas of the model above without the xy distance is also problematic, as then support may get closer to the model (on the diagonal downwards) than the user intended.
-                        // Example (s = support):
+                        // Just accumulating areas of the model above without the xy distance is also problematic, as then support may get closer to the model (on the diagonal
+                        // downwards) than the user intended. Example (s = support):
                         //  +-----+
                         //   +-----+
                         //   +-----+
                         //   s+-----+
 
-                        // Technically the calculation below is off by one layer, as the actual distance between plastic one layer down is 0 not layer height, as this layer is filled with said plastic.
-                        // But otherwise a part of the overhang that is expected to be supported is overwritten by the remaining part of the xy distance of the layer below the to be supported area.
+                        // Technically the calculation below is off by one layer, as the actual distance between plastic one layer down is 0 not layer height, as this layer is
+                        // filled with said plastic. But otherwise a part of the overhang that is expected to be supported is overwritten by the remaining part of the xy distance
+                        // of the layer below the to be supported area.
                         const coord_t required_range_x = coord_t(xy_distance - ((layer_offset - (z_distance_top_layers == 1 ? 0.5 : 0)) * xy_distance / z_distance_top_layers));
                         // ^^^ The conditional -0.5 ensures that plastic can never touch on the diagonal downward when the z_distance_top_layers = 1.
                         //      It is assumed to be better to not support an overhang<90� than to risk fusing to it.
                         data[key].add(layer_outlines_[outline_idx].second[layer_idx + layer_offset].offset(radius + required_range_x));
-
                     }
                     data[key] = data[key].unionPolygons(max_anti_overhang_layer >= layer_idx ? anti_overhang_[layer_idx].offset(radius) : Polygons());
                 }
@@ -752,8 +764,7 @@ void TreeModelVolumes::calculateCollision(const std::deque<RadiusLayerPair>& key
                     placeable_areas_cache_.insert(data_placeable_outer.begin(), data_placeable_outer.end());
                 }
             }
-        }
-    );
+        });
 }
 
 void TreeModelVolumes::calculateCollisionHolefree(const std::deque<RadiusLayerPair>& keys)
@@ -764,8 +775,7 @@ void TreeModelVolumes::calculateCollisionHolefree(const std::deque<RadiusLayerPa
         max_layer = std::max(max_layer, keys[i].second);
     }
 
-    cura::parallel_for<coord_t>
-    (
+    cura::parallel_for<coord_t>(
         0,
         LayerIndex(max_layer + 1),
         [&](const LayerIndex layer_idx)
@@ -786,8 +796,7 @@ void TreeModelVolumes::calculateCollisionHolefree(const std::deque<RadiusLayerPa
                 std::lock_guard<std::mutex> critical_section(*critical_collision_cache_holefree_);
                 collision_cache_holefree_.insert(data.begin(), data.end());
             }
-        }
-    );
+        });
 }
 
 void TreeModelVolumes::calculateAccumulatedPlaceable0(const LayerIndex max_layer)
@@ -801,14 +810,15 @@ void TreeModelVolumes::calculateAccumulatedPlaceable0(const LayerIndex max_layer
         {
             start_layer++;
         }
-        start_layer = std::max(LayerIndex { start_layer + 1 }, LayerIndex { 1 });
+        start_layer = std::max(LayerIndex{ start_layer + 1 }, LayerIndex{ 1 });
     }
     if (start_layer > max_layer)
     {
         spdlog::debug("Requested calculation for value already calculated ?");
         return;
     }
-    Polygons accumulated_placeable_0 = start_layer == 1 ? machine_area_ : getAccumulatedPlaceable0(start_layer - 1).offset(FUDGE_LENGTH + (current_min_xy_dist + current_min_xy_dist_delta));
+    Polygons accumulated_placeable_0
+        = start_layer == 1 ? machine_area_ : getAccumulatedPlaceable0(start_layer - 1).offset(FUDGE_LENGTH + (current_min_xy_dist + current_min_xy_dist_delta));
     // ^^^ The calculation here is done on the areas that are increased by xy_distance, but the result is saved without xy_distance,
     // so here it "restores" the previous state to continue calculating from about where it ended.
     // It would be better to ensure placeable areas of radius 0 do not include the xy distance, and removing the code compensating for it here and in calculatePlaceables.
@@ -821,75 +831,73 @@ void TreeModelVolumes::calculateAccumulatedPlaceable0(const LayerIndex max_layer
         accumulated_placeable_0 = simplifier.polygon(accumulated_placeable_0);
         data[layer] = std::pair(layer, accumulated_placeable_0);
     }
-    cura::parallel_for<size_t>
-       (
-           std::max(LayerIndex{ start_layer - 1 }, LayerIndex{ 1 }),
-           data.size(),
-           [&](const coord_t layer_idx)
-           {
-            data[layer_idx].second = data[layer_idx].second.offset(-(current_min_xy_dist+current_min_xy_dist_delta));
-           });
+    cura::parallel_for<size_t>(
+        std::max(LayerIndex{ start_layer - 1 }, LayerIndex{ 1 }),
+        data.size(),
+        [&](const coord_t layer_idx)
+        {
+            data[layer_idx].second = data[layer_idx].second.offset(-(current_min_xy_dist + current_min_xy_dist_delta));
+        });
     {
-        std::lock_guard<std::mutex> critical_section(* critical_accumulated_placeables_cache_radius_0_);
+        std::lock_guard<std::mutex> critical_section(*critical_accumulated_placeables_cache_radius_0_);
         accumulated_placeables_cache_radius_0_.insert(data.begin(), data.end());
     }
 }
 
 
-
 void TreeModelVolumes::calculateCollisionAvoidance(const std::deque<RadiusLayerPair>& keys)
 {
-    cura::parallel_for<size_t>
-        (
-            0,
-            keys.size(),
-            [&, keys](const size_t key_idx)
+    cura::parallel_for<size_t>(
+        0,
+        keys.size(),
+        [&, keys](const size_t key_idx)
+        {
+            const coord_t radius = keys[key_idx].first;
+            const LayerIndex max_required_layer = keys[key_idx].second;
+            const coord_t max_step_move = std::max(1.9 * radius, current_min_xy_dist * 1.9);
+            LayerIndex start_layer = 0;
             {
+                std::lock_guard<std::mutex> critical_section(*critical_avoidance_cache_collision_);
+                start_layer = 1 + std::max(getMaxCalculatedLayer(radius, avoidance_cache_collision_), max_layer_idx_without_blocker);
+            }
 
-        const coord_t radius = keys[key_idx].first;
-        const LayerIndex max_required_layer = keys[key_idx].second;
-        const coord_t max_step_move = std::max(1.9 * radius, current_min_xy_dist * 1.9);
-        LayerIndex start_layer = 0;
-        {
-            std::lock_guard<std::mutex> critical_section(*critical_avoidance_cache_collision_);
-            start_layer = 1 + std::max(getMaxCalculatedLayer(radius, avoidance_cache_collision_), max_layer_idx_without_blocker);
-        }
+            if (start_layer > max_required_layer)
+            {
+                return;
+            }
 
-        if(start_layer>max_required_layer)
-        {
-            return;
-        }
+            std::vector<std::pair<RadiusLayerPair, Polygons>> data(max_required_layer + 1, std::pair<RadiusLayerPair, Polygons>(RadiusLayerPair(radius, -1), Polygons()));
+            RadiusLayerPair key(radius, 0);
 
-        std::vector<std::pair<RadiusLayerPair, Polygons>> data(max_required_layer + 1, std::pair<RadiusLayerPair, Polygons>(RadiusLayerPair(radius, -1), Polygons()));
-        RadiusLayerPair key(radius, 0);
+            Polygons latest_avoidance = getAvoidance(radius, start_layer - 1, AvoidanceType::COLLISION, true, true);
+            for (const LayerIndex layer : ranges::views::iota(static_cast<size_t>(start_layer), max_required_layer + 1UL))
+            {
+                key.second = layer;
+                Polygons col = getCollision(radius, layer, true);
+                latest_avoidance = safeOffset(latest_avoidance, -max_move_, ClipperLib::jtRound, -max_step_move, col);
 
-        Polygons latest_avoidance = getAvoidance(radius,start_layer-1,AvoidanceType::COLLISION,true,true);
-        for (const LayerIndex layer : ranges::views::iota(static_cast<size_t>(start_layer), max_required_layer + 1UL))
-        {
-            key.second = layer;
-            Polygons col = getCollision(radius, layer, true);
-            latest_avoidance = safeOffset(latest_avoidance, -max_move_, ClipperLib::jtRound, -max_step_move, col);
+                Polygons placeable0RadiusCompensated = getAccumulatedPlaceable0(layer).offset(-std::max(radius, increase_until_radius), ClipperLib::jtRound);
+                latest_avoidance = latest_avoidance.difference(placeable0RadiusCompensated).unionPolygons(getCollision(radius, layer, true));
 
-            Polygons placeable0RadiusCompensated = getAccumulatedPlaceable0(layer).offset(-std::max(radius,increase_until_radius), ClipperLib::jtRound);
-            latest_avoidance = latest_avoidance.difference(placeable0RadiusCompensated).unionPolygons(getCollision(radius,layer,true));
+                Polygons next_latest_avoidance = simplifier.polygon(latest_avoidance);
+                latest_avoidance = next_latest_avoidance.unionPolygons(latest_avoidance);
+                // ^^^ Ensure the simplification only causes the avoidance to become larger.
+                // If the deviation of the simplification causes the avoidance to become smaller than it should be it can cause issues, if it is larger the worst case is that the
+                // xy distance is effectively increased by deviation. If there would be an option to ensure the resulting polygon only gets larger by simplifying, it should improve
+                // performance further.
+                data[layer] = std::pair<RadiusLayerPair, Polygons>(key, latest_avoidance);
+            }
 
-            Polygons next_latest_avoidance = simplifier.polygon(latest_avoidance);
-            latest_avoidance = next_latest_avoidance.unionPolygons(latest_avoidance);
-            // ^^^ Ensure the simplification only causes the avoidance to become larger.
-            // If the deviation of the simplification causes the avoidance to become smaller than it should be it can cause issues, if it is larger the worst case is that the xy distance is effectively increased by deviation.
-            // If there would be an option to ensure the resulting polygon only gets larger by simplifying, it should improve performance further.
-            data[layer] = std::pair<RadiusLayerPair, Polygons>(key, latest_avoidance);
-        }
-
-        {
-            std::lock_guard<std::mutex> critical_section(* critical_avoidance_cache_collision_);
-            avoidance_cache_collision_.insert(data.begin(), data.end());
-        }
-            });
+            {
+                std::lock_guard<std::mutex> critical_section(*critical_avoidance_cache_collision_);
+                avoidance_cache_collision_.insert(data.begin(), data.end());
+            }
+        });
 }
 
 
-// Ensures offsets are only done in sizes with a max step size per offset while adding the collision offset after each step, this ensures that areas cannot glitch through walls defined by the collision when offsetting to fast.
+// Ensures offsets are only done in sizes with a max step size per offset while adding the collision offset after each step, this ensures that areas cannot glitch through walls
+// defined by the collision when offsetting to fast.
 Polygons TreeModelVolumes::safeOffset(const Polygons& me, coord_t distance, ClipperLib::JoinType jt, coord_t max_safe_step_distance, const Polygons& collision) const
 {
     const size_t steps = std::abs(distance / std::max(min_offset_per_step_, std::abs(max_safe_step_distance)));
@@ -909,9 +917,9 @@ void TreeModelVolumes::calculateAvoidance(const std::deque<RadiusLayerPair>& key
 {
     // For every RadiusLayer pair there are 3 avoidances that have to be calculate, calculated in the same paralell_for loop for better parallelization.
     const std::vector<AvoidanceType> all_types = { AvoidanceType::SLOW, AvoidanceType::FAST_SAFE, AvoidanceType::FAST };
-    // TODO: This should be a parallel for nowait (non-blocking), but as the parallel-for situation (as in, proper compiler support) continues to change, we're using the 'normal' one right now.
-    cura::parallel_for<size_t>
-    (
+    // TODO: This should be a parallel for nowait (non-blocking), but as the parallel-for situation (as in, proper compiler support) continues to change, we're using the 'normal'
+    // one right now.
+    cura::parallel_for<size_t>(
         0,
         keys.size() * 3,
         [&, keys, all_types](const size_t iter_idx)
@@ -949,7 +957,8 @@ void TreeModelVolumes::calculateAvoidance(const std::deque<RadiusLayerPair>& key
             start_layer = std::max(start_layer, LayerIndex(1)); // Ensure StartLayer is at least 1 as if no avoidance was calculated getMaxCalculatedLayer returns -1
             std::vector<std::pair<RadiusLayerPair, Polygons>> data(max_required_layer + 1, std::pair<RadiusLayerPair, Polygons>(RadiusLayerPair(radius, -1), Polygons()));
 
-            latest_avoidance = getAvoidance(radius, start_layer - 1, type, false, true); // minDist as the delta was already added, also avoidance for layer 0 will return the collision.
+            latest_avoidance
+                = getAvoidance(radius, start_layer - 1, type, false, true); // minDist as the delta was already added, also avoidance for layer 0 will return the collision.
 
             // ### main loop doing the calculation
             for (const LayerIndex layer : ranges::views::iota(static_cast<size_t>(start_layer), max_required_layer + 1UL))
@@ -969,8 +978,9 @@ void TreeModelVolumes::calculateAvoidance(const std::deque<RadiusLayerPair>& key
                 Polygons next_latest_avoidance = simplifier.polygon(latest_avoidance);
                 latest_avoidance = next_latest_avoidance.unionPolygons(latest_avoidance);
                 // ^^^ Ensure the simplification only causes the avoidance to become larger.
-                // If the deviation of the simplification causes the avoidance to become smaller than it should be it can cause issues, if it is larger the worst case is that the xy distance is effectively increased by deviation.
-                // If there would be an option to ensure the resulting polygon only gets larger by simplifying, it should improve performance further.
+                // If the deviation of the simplification causes the avoidance to become smaller than it should be it can cause issues, if it is larger the worst case is that the
+                // xy distance is effectively increased by deviation. If there would be an option to ensure the resulting polygon only gets larger by simplifying, it should improve
+                // performance further.
                 data[layer] = std::pair<RadiusLayerPair, Polygons>(key, latest_avoidance);
             }
 
@@ -988,15 +998,14 @@ void TreeModelVolumes::calculateAvoidance(const std::deque<RadiusLayerPair>& key
                 std::lock_guard<std::mutex> critical_section(*(slow ? critical_avoidance_cache_slow_ : holefree ? critical_avoidance_cache_holefree_ : critical_avoidance_cache_));
                 (slow ? avoidance_cache_slow_ : holefree ? avoidance_cache_hole_ : avoidance_cache_).insert(data.begin(), data.end());
             }
-        }
-    );
+        });
 }
 
 void TreeModelVolumes::calculatePlaceables(const std::deque<RadiusLayerPair>& keys)
 {
-    // TODO: This should be a parallel for nowait (non-blocking), but as the parallel-for situation (as in, proper compiler support) continues to change, we're using the 'normal' one right now.
-    cura::parallel_for<size_t>
-    (
+    // TODO: This should be a parallel for nowait (non-blocking), but as the parallel-for situation (as in, proper compiler support) continues to change, we're using the 'normal'
+    // one right now.
+    cura::parallel_for<size_t>(
         0,
         keys.size(),
         [&, keys](const size_t key_idx)
@@ -1046,8 +1055,7 @@ void TreeModelVolumes::calculatePlaceables(const std::deque<RadiusLayerPair>& ke
                 std::lock_guard<std::mutex> critical_section(*critical_placeable_areas_cache_);
                 placeable_areas_cache_.insert(data.begin(), data.end());
             }
-        }
-    );
+        });
 }
 
 
@@ -1055,9 +1063,9 @@ void TreeModelVolumes::calculateAvoidanceToModel(const std::deque<RadiusLayerPai
 {
     // For every RadiusLayer pair there are 3 avoidances that have to be calculated, calculated in the same parallel_for loop for better parallelization.
     const std::vector<AvoidanceType> all_types = { AvoidanceType::SLOW, AvoidanceType::FAST_SAFE, AvoidanceType::FAST };
-    // TODO: This should be a parallel for nowait (non-blocking), but as the parallel-for situation (as in, proper compiler support) continues to change, we're using the 'normal' one right now.
-    cura::parallel_for<size_t>
-    (
+    // TODO: This should be a parallel for nowait (non-blocking), but as the parallel-for situation (as in, proper compiler support) continues to change, we're using the 'normal'
+    // one right now.
+    cura::parallel_for<size_t>(
         0,
         keys.size() * 3,
         [&, keys, all_types](const size_t iter_idx)
@@ -1085,7 +1093,10 @@ void TreeModelVolumes::calculateAvoidanceToModel(const std::deque<RadiusLayerPai
             LayerIndex start_layer;
 
             {
-                std::lock_guard<std::mutex> critical_section(*(slow ? critical_avoidance_cache_to_model_slow_ : holefree ? critical_avoidance_cache_holefree_to_model_ : critical_avoidance_cache_to_model_));
+                std::lock_guard<std::mutex> critical_section(
+                    *(slow       ? critical_avoidance_cache_to_model_slow_
+                      : holefree ? critical_avoidance_cache_holefree_to_model_
+                                 : critical_avoidance_cache_to_model_));
                 start_layer = 1 + getMaxCalculatedLayer(radius, slow ? avoidance_cache_to_model_slow_ : holefree ? avoidance_cache_hole_to_model_ : avoidance_cache_to_model_);
             }
             if (start_layer > max_required_layer)
@@ -1094,7 +1105,8 @@ void TreeModelVolumes::calculateAvoidanceToModel(const std::deque<RadiusLayerPai
                 return;
             }
             start_layer = std::max(start_layer, LayerIndex(1));
-            latest_avoidance = getAvoidance(radius, start_layer - 1, type, true, true); // minDist as the delta was already added, also avoidance for layer 0 will return the collision.
+            latest_avoidance
+                = getAvoidance(radius, start_layer - 1, type, true, true); // minDist as the delta was already added, also avoidance for layer 0 will return the collision.
 
             // ### main loop doing the calculation
             for (const LayerIndex layer : ranges::views::iota(static_cast<size_t>(start_layer), max_required_layer + 1))
@@ -1115,8 +1127,9 @@ void TreeModelVolumes::calculateAvoidanceToModel(const std::deque<RadiusLayerPai
                 Polygons next_latest_avoidance = simplifier.polygon(latest_avoidance);
                 latest_avoidance = next_latest_avoidance.unionPolygons(latest_avoidance);
                 // ^^^ Ensure the simplification only causes the avoidance to become larger.
-                // If the deviation of the simplification causes the avoidance to become smaller than it should be it can cause issues, if it is larger the worst case is that the xy distance is effectively increased by deviation.
-                // If there would be an option to ensure the resulting polygon only gets larger by simplifying, it should improve performance further.
+                // If the deviation of the simplification causes the avoidance to become smaller than it should be it can cause issues, if it is larger the worst case is that the
+                // xy distance is effectively increased by deviation. If there would be an option to ensure the resulting polygon only gets larger by simplifying, it should improve
+                // performance further.
                 data[layer] = std::pair<RadiusLayerPair, Polygons>(key, latest_avoidance);
             }
 
@@ -1131,18 +1144,20 @@ void TreeModelVolumes::calculateAvoidanceToModel(const std::deque<RadiusLayerPai
             }
 
             {
-                std::lock_guard<std::mutex> critical_section(*(slow ? critical_avoidance_cache_to_model_slow_ : holefree ? critical_avoidance_cache_holefree_to_model_ : critical_avoidance_cache_to_model_));
+                std::lock_guard<std::mutex> critical_section(
+                    *(slow       ? critical_avoidance_cache_to_model_slow_
+                      : holefree ? critical_avoidance_cache_holefree_to_model_
+                                 : critical_avoidance_cache_to_model_));
                 (slow ? avoidance_cache_to_model_slow_ : holefree ? avoidance_cache_hole_to_model_ : avoidance_cache_to_model_).insert(data.begin(), data.end());
             }
-        }
-    );
+        });
 }
 
 void TreeModelVolumes::calculateWallRestrictions(const std::deque<RadiusLayerPair>& keys)
 {
-    // Wall restrictions are mainly important when they represent actual walls that are printed, and not "just" the configured z_distance, because technically valid placement is no excuse for moving through a wall.
-    // As they exist to prevent accidentially moving though a wall at high speed between layers like thie (x = wall,i = influence area,o= empty space,d = blocked area because of z distance)
-    // Assume maximum movement distance is two characters and maximum safe movement distance of one character
+    // Wall restrictions are mainly important when they represent actual walls that are printed, and not "just" the configured z_distance, because technically valid placement is no
+    // excuse for moving through a wall. As they exist to prevent accidentially moving though a wall at high speed between layers like thie (x = wall,i = influence area,o= empty
+    // space,d = blocked area because of z distance) Assume maximum movement distance is two characters and maximum safe movement distance of one character
 
     /* Potential issue addressed by the wall restrictions: Influence area may lag through a wall
      *  layer z+1:iiiiiiiiiiioooo
@@ -1150,7 +1165,8 @@ void TreeModelVolumes::calculateWallRestrictions(const std::deque<RadiusLayerPai
      *  layer z-1:ooooixxxxxxxxxx
      */
 
-    // The radius for the upper collission has to be 0 as otherwise one may not enter areas that may be forbidden on layer_idx but not one below (c = not an influence area even though it should ):
+    // The radius for the upper collission has to be 0 as otherwise one may not enter areas that may be forbidden on layer_idx but not one below (c = not an influence area even
+    // though it should ):
     /*
      *  layer z+1:xxxxxiiiiiioo
      *  layer z+0:dddddiiiiiiio
@@ -1175,9 +1191,9 @@ void TreeModelVolumes::calculateWallRestrictions(const std::deque<RadiusLayerPai
      *  layer z-1: ixiiiiiiiiiii
      */
 
-     // FIXME: This should be a parallel-for nowait (non-blocking), but as the parallel-for situation (as in, proper compiler support) continues to change, we're using the 'normal' one right now.
-    cura::parallel_for<size_t>
-    (
+    // FIXME: This should be a parallel-for nowait (non-blocking), but as the parallel-for situation (as in, proper compiler support) continues to change, we're using the 'normal'
+    // one right now.
+    cura::parallel_for<size_t>(
         0,
         keys.size(),
         [&, keys](const size_t key_idx)
@@ -1201,7 +1217,8 @@ void TreeModelVolumes::calculateWallRestrictions(const std::deque<RadiusLayerPai
             {
                 key.second = layer_idx;
                 const LayerIndex layer_idx_below = layer_idx - 1;
-                Polygons wall_restriction = simplifier.polygon(getCollision(0, layer_idx, false).intersection(getCollision(radius, layer_idx_below, true))); // radius contains current_min_xy_dist_delta already if required
+                Polygons wall_restriction = simplifier.polygon(
+                    getCollision(0, layer_idx, false).intersection(getCollision(radius, layer_idx_below, true))); // radius contains current_min_xy_dist_delta already if required
                 data.emplace(key, wall_restriction);
                 if (current_min_xy_dist_delta > 0)
                 {
@@ -1219,8 +1236,7 @@ void TreeModelVolumes::calculateWallRestrictions(const std::deque<RadiusLayerPai
                 std::lock_guard<std::mutex> critical_section(*critical_wall_restrictions_cache_min_);
                 wall_restrictions_cache_min_.insert(data_min.begin(), data_min.end());
             }
-        }
-    );
+        });
 }
 
 coord_t TreeModelVolumes::ceilRadius(coord_t radius) const
@@ -1240,7 +1256,7 @@ coord_t TreeModelVolumes::ceilRadius(coord_t radius) const
     for (const auto step : ranges::views::iota(0UL, SUPPORT_TREE_PRE_EXPONENTIAL_STEPS))
     {
         result += stepsize;
-        if (result >= radius && !ignorable_radii_.count(result))
+        if (result >= radius && ! ignorable_radii_.count(result))
         {
             return result;
         }
@@ -1253,7 +1269,7 @@ coord_t TreeModelVolumes::ceilRadius(coord_t radius) const
     return exponential_result;
 }
 
-template <typename KEY>
+template<typename KEY>
 const std::optional<std::reference_wrapper<const Polygons>> TreeModelVolumes::getArea(const std::unordered_map<KEY, Polygons>& cache, const KEY key) const
 {
     const auto it = cache.find(key);

--- a/src/TreeSupportTipGenerator.cpp
+++ b/src/TreeSupportTipGenerator.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
+
 #include "TreeSupportTipGenerator.h"
 #include "Application.h" //To get settings.
 #include "infill/SierpinskiFillProvider.h"
@@ -518,7 +521,7 @@ void TreeSupportTipGenerator::calculateRoofAreas(const cura::SliceMeshStorage& m
 
                         // the roof will be combined with roof above and below, to see if a part of this roof may be part of a valid roof further up/down.
                         // This prevents the situation where a roof gets removed even tough its area would contribute to a (better) printable roof area further down.
-                        for (const LayerIndex layer_offset : ranges::views::iota(-LayerIndex(std::min(size_t(layer_idx),support_roof_layers)), LayerIndex(std::min(size_t(potential_support_roofs.size()-layer_idx),support_roof_layers+1))))
+                        for (const LayerIndex layer_offset : ranges::views::iota(-LayerIndex { std::min(layer_idx, LayerIndex { support_roof_layers }) }, LayerIndex { std::min(LayerIndex { potential_support_roofs.size() - layer_idx }, LayerIndex{ support_roof_layers + 1} ) }))
                         {
                             fuzzy_area.add(support_roof_drawn[layer_idx+layer_offset]);
                             fuzzy_area.add(potential_support_roofs[layer_idx+layer_offset]);

--- a/src/TreeSupportTipGenerator.cpp
+++ b/src/TreeSupportTipGenerator.cpp
@@ -2,55 +2,64 @@
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "TreeSupportTipGenerator.h"
+
 #include "Application.h" //To get settings.
+#include "TreeSupportUtils.h"
 #include "infill/SierpinskiFillProvider.h"
 #include "settings/EnumSettings.h"
-#include "utils/algorithm.h"
 #include "utils/Simplify.h"
+#include "utils/ThreadPool.h"
+#include "utils/algorithm.h"
 #include "utils/math.h" //For round_up_divide and PI.
 #include "utils/polygonUtils.h" //For moveInside.
-#include "utils/ThreadPool.h"
-#include "TreeSupportUtils.h"
 
-#include <chrono>
-#include <fstream>
-#include <spdlog/spdlog.h>
-#include <stdio.h>
-#include <string>
 #include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/reverse.hpp>
+#include <spdlog/spdlog.h>
 
+#include <chrono>
+#include <fstream>
+#include <stdio.h>
+#include <string>
 
 
 namespace cura
 {
 
-TreeSupportTipGenerator::TreeSupportTipGenerator(const SliceDataStorage& storage, const SliceMeshStorage& mesh, TreeModelVolumes& volumes_s):
-    config(mesh.settings),
-    use_fake_roof(!mesh.settings.get<bool>("support_roof_enable")),
-    minimum_roof_area(!use_fake_roof? mesh.settings.get<double>("minimum_roof_area"): SUPPORT_TREE_MINIMUM_FAKE_ROOF_AREA),
-    minimum_support_area(mesh.settings.get<double>("minimum_support_area")),
-    support_roof_layers(mesh.settings.get<bool>("support_roof_enable") ? round_divide(mesh.settings.get<coord_t>("support_roof_height"), config.layer_height) : use_fake_roof ? SUPPORT_TREE_MINIMUM_FAKE_ROOF_LAYERS : 0),
-    connect_length((config.support_line_width * 100 / mesh.settings.get<double>("support_tree_top_rate")) + std::max(2 * config.min_radius - 1.0 * config.support_line_width, 0.0)),
-    support_tree_branch_distance((config.support_pattern == EFillMethod::TRIANGLES ? 3 : (config.support_pattern == EFillMethod::GRID ? 2 : 1)) * connect_length),
-    support_roof_line_distance( use_fake_roof ? (config.support_pattern == EFillMethod::TRIANGLES ? 3 : (config.support_pattern == EFillMethod::GRID ? 2 : 1)) * (config.support_line_width * 100 / mesh.settings.get<double>("support_tree_top_rate")) : mesh.settings.get<coord_t>("support_roof_line_distance")), //todo propper
-    support_outset(0), // Since we disable support offset when tree support is enabled we use an offset of 0 rather than the setting value mesh.settings.get<coord_t>("support_offset")
-    roof_outset(use_fake_roof ? support_outset: mesh.settings.get<coord_t>("support_roof_offset")),
-    force_tip_to_roof((config.min_radius * config.min_radius * M_PI > minimum_roof_area * (1000 * 1000)) && support_roof_layers && !use_fake_roof),
-    support_tree_limit_branch_reach(mesh.settings.get<bool>("support_tree_limit_branch_reach")),
-    support_tree_branch_reach_limit(support_tree_limit_branch_reach ? mesh.settings.get<coord_t>("support_tree_branch_reach_limit") : 0),
-    z_distance_delta(std::min(config.z_distance_top_layers+1,mesh.overhang_areas.size())),
-    xy_overrides(config.support_overrides == SupportDistPriority::XY_OVERRIDES_Z),
-    tip_roof_size(force_tip_to_roof?config.min_radius * config.min_radius * M_PI:0),
-    already_inserted(mesh.overhang_areas.size()),
-    support_roof_drawn(mesh.overhang_areas.size(),Polygons()),
-    roof_tips_drawn(mesh.overhang_areas.size(),Polygons()),
-    volumes_(volumes_s),
-    force_minimum_roof_area(use_fake_roof || SUPPORT_TREE_MINIMUM_ROOF_AREA_HARD_LIMIT)
+TreeSupportTipGenerator::TreeSupportTipGenerator(const SliceDataStorage& storage, const SliceMeshStorage& mesh, TreeModelVolumes& volumes_s)
+    : config(mesh.settings)
+    , use_fake_roof(! mesh.settings.get<bool>("support_roof_enable"))
+    , minimum_roof_area(! use_fake_roof ? mesh.settings.get<double>("minimum_roof_area") : SUPPORT_TREE_MINIMUM_FAKE_ROOF_AREA)
+    , minimum_support_area(mesh.settings.get<double>("minimum_support_area"))
+    , support_roof_layers(
+          mesh.settings.get<bool>("support_roof_enable") ? round_divide(mesh.settings.get<coord_t>("support_roof_height"), config.layer_height)
+          : use_fake_roof                                ? SUPPORT_TREE_MINIMUM_FAKE_ROOF_LAYERS
+                                                         : 0)
+    , connect_length(
+          (config.support_line_width * 100 / mesh.settings.get<double>("support_tree_top_rate")) + std::max(2 * config.min_radius - 1.0 * config.support_line_width, 0.0))
+    , support_tree_branch_distance((config.support_pattern == EFillMethod::TRIANGLES ? 3 : (config.support_pattern == EFillMethod::GRID ? 2 : 1)) * connect_length)
+    , support_roof_line_distance(
+          use_fake_roof ? (config.support_pattern == EFillMethod::TRIANGLES ? 3 : (config.support_pattern == EFillMethod::GRID ? 2 : 1))
+                              * (config.support_line_width * 100 / mesh.settings.get<double>("support_tree_top_rate"))
+                        : mesh.settings.get<coord_t>("support_roof_line_distance"))
+    , // todo propper
+    support_outset(0)
+    , // Since we disable support offset when tree support is enabled we use an offset of 0 rather than the setting value mesh.settings.get<coord_t>("support_offset")
+    roof_outset(use_fake_roof ? support_outset : mesh.settings.get<coord_t>("support_roof_offset"))
+    , force_tip_to_roof((config.min_radius * config.min_radius * M_PI > minimum_roof_area * (1000 * 1000)) && support_roof_layers && ! use_fake_roof)
+    , support_tree_limit_branch_reach(mesh.settings.get<bool>("support_tree_limit_branch_reach"))
+    , support_tree_branch_reach_limit(support_tree_limit_branch_reach ? mesh.settings.get<coord_t>("support_tree_branch_reach_limit") : 0)
+    , z_distance_delta(std::min(config.z_distance_top_layers + 1, mesh.overhang_areas.size()))
+    , xy_overrides(config.support_overrides == SupportDistPriority::XY_OVERRIDES_Z)
+    , tip_roof_size(force_tip_to_roof ? config.min_radius * config.min_radius * M_PI : 0)
+    , already_inserted(mesh.overhang_areas.size())
+    , support_roof_drawn(mesh.overhang_areas.size(), Polygons())
+    , roof_tips_drawn(mesh.overhang_areas.size(), Polygons())
+    , volumes_(volumes_s)
+    , force_minimum_roof_area(use_fake_roof || SUPPORT_TREE_MINIMUM_ROOF_AREA_HARD_LIMIT)
 {
-
     const double support_overhang_angle = mesh.settings.get<AngleRadians>("support_angle");
     const coord_t max_overhang_speed = (support_overhang_angle < TAU / 4) ? (coord_t)(tan(support_overhang_angle) * config.layer_height) : std::numeric_limits<coord_t>::max();
 
@@ -61,9 +70,10 @@ TreeSupportTipGenerator::TreeSupportTipGenerator(const SliceDataStorage& storage
     else
     {
         max_overhang_insert_lag = std::max((size_t)round_up_divide(config.xy_distance, max_overhang_speed / 2), 2 * config.z_distance_top_layers);
-        // ^^^ Cap for how much layer below the overhang a new support point may be added, as other than with regular support every new inserted point may cause extra material and time cost.
-        //     Could also be an user setting or differently calculated. Idea is that if an overhang does not turn valid in double the amount of layers a slope of support angle would take to travel xy_distance, nothing reasonable will come from it.
-        //     The 2*z_distance_delta is only a catch for when the support angle is very high.
+        // ^^^ Cap for how much layer below the overhang a new support point may be added, as other than with regular support every new inserted point may cause extra material and
+        // time cost.
+        //     Could also be an user setting or differently calculated. Idea is that if an overhang does not turn valid in double the amount of layers a slope of support angle
+        //     would take to travel xy_distance, nothing reasonable will come from it. The 2*z_distance_delta is only a catch for when the support angle is very high.
     }
 
     cross_fill_provider = generateCrossFillProvider(mesh, support_tree_branch_distance, config.support_line_width);
@@ -79,9 +89,9 @@ TreeSupportTipGenerator::TreeSupportTipGenerator(const SliceDataStorage& storage
 
     coord_t dtt_when_tips_can_merge = 1;
 
-    if(config.branch_radius * config.diameter_angle_scale_factor < 2 * config.maximum_move_distance_slow)
+    if (config.branch_radius * config.diameter_angle_scale_factor < 2 * config.maximum_move_distance_slow)
     {
-        while((2 * config.maximum_move_distance_slow * dtt_when_tips_can_merge - config.support_line_width)  < config.getRadius(dtt_when_tips_can_merge))
+        while ((2 * config.maximum_move_distance_slow * dtt_when_tips_can_merge - config.support_line_width) < config.getRadius(dtt_when_tips_can_merge))
         {
             dtt_when_tips_can_merge++;
         }
@@ -97,8 +107,10 @@ TreeSupportTipGenerator::TreeSupportTipGenerator(const SliceDataStorage& storage
 std::vector<TreeSupportTipGenerator::LineInformation> TreeSupportTipGenerator::convertLinesToInternal(Polygons polylines, LayerIndex layer_idx)
 {
     // NOTE: The volumes below (on which '.inside(p, true)' is called each time below) are the same each time. The values being calculated here are strictly local as well.
-    //       So they could in theory be pre-calculated here (outside of the loop). However, when I refatored it to be that way, it seemed to cause deadlocks each time for some settings.
-    // NOTE2: When refactoring ensure that avoidance to buildplate is only requested when support_rest_preference == RestPreference::BUILDPLATE as otherwise it has not been precalculated (causing long delays while it is calculated when requested here).
+    //       So they could in theory be pre-calculated here (outside of the loop). However, when I refatored it to be that way, it seemed to cause deadlocks each time for some
+    //       settings.
+    // NOTE2: When refactoring ensure that avoidance to buildplate is only requested when support_rest_preference == RestPreference::BUILDPLATE as otherwise it has not been
+    // precalculated (causing long delays while it is calculated when requested here).
 
     std::vector<LineInformation> result;
     // Also checks if the position is valid, if it is NOT, it deletes that point
@@ -107,23 +119,26 @@ std::vector<TreeSupportTipGenerator::LineInformation> TreeSupportTipGenerator::c
         LineInformation res_line;
         for (const Point& p : line)
         {
-            if (config.support_rest_preference == RestPreference::BUILDPLATE && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::FAST_SAFE, false, !xy_overrides).inside(p, true))
+            if (config.support_rest_preference == RestPreference::BUILDPLATE
+                && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::FAST_SAFE, false, ! xy_overrides).inside(p, true))
             {
                 res_line.emplace_back(p, LineStatus::TO_BP_SAFE);
             }
-            else if (config.support_rest_preference == RestPreference::BUILDPLATE && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::FAST, false, !xy_overrides).inside(p, true))
+            else if (
+                config.support_rest_preference == RestPreference::BUILDPLATE
+                && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::FAST, false, ! xy_overrides).inside(p, true))
             {
                 res_line.emplace_back(p, LineStatus::TO_BP);
             }
-            else if (config.support_rests_on_model && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::FAST_SAFE, true, !xy_overrides).inside(p, true))
+            else if (config.support_rests_on_model && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::FAST_SAFE, true, ! xy_overrides).inside(p, true))
             {
                 res_line.emplace_back(p, LineStatus::TO_MODEL_GRACIOUS_SAFE);
             }
-            else if (config.support_rests_on_model && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::FAST, true, !xy_overrides).inside(p, true))
+            else if (config.support_rests_on_model && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::FAST, true, ! xy_overrides).inside(p, true))
             {
                 res_line.emplace_back(p, LineStatus::TO_MODEL_GRACIOUS);
             }
-            else if (config.support_rests_on_model && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::COLLISION, true, !xy_overrides).inside(p, true))
+            else if (config.support_rests_on_model && ! volumes_.getAvoidance(config.getRadius(0), layer_idx, AvoidanceType::COLLISION, true, ! xy_overrides).inside(p, true))
             {
                 res_line.emplace_back(p, LineStatus::TO_MODEL);
             }
@@ -133,7 +148,7 @@ std::vector<TreeSupportTipGenerator::LineInformation> TreeSupportTipGenerator::c
                 res_line.clear();
             }
         }
-        if (!res_line.empty())
+        if (! res_line.empty())
         {
             result.emplace_back(res_line);
             res_line.clear();
@@ -160,10 +175,17 @@ Polygons TreeSupportTipGenerator::convertInternalToLines(std::vector<TreeSupport
 
 std::function<bool(std::pair<Point, TreeSupportTipGenerator::LineStatus>)> TreeSupportTipGenerator::getEvaluatePointForNextLayerFunction(size_t current_layer)
 {
-    std::function<bool(std::pair<Point, LineStatus>)> evaluatePoint =
-        [=](std::pair<Point, LineStatus> p)
+    std::function<bool(std::pair<Point, LineStatus>)> evaluatePoint = [=](std::pair<Point, LineStatus> p)
     {
-        if (config.support_rest_preference != RestPreference::GRACEFUL && ! volumes_.getAvoidance(config.getRadius(0), current_layer - 1, p.second == LineStatus::TO_BP_SAFE ? AvoidanceType::FAST_SAFE : AvoidanceType::FAST, false, !xy_overrides).inside(p.first, true))
+        if (config.support_rest_preference != RestPreference::GRACEFUL
+            && ! volumes_
+                     .getAvoidance(
+                         config.getRadius(0),
+                         current_layer - 1,
+                         p.second == LineStatus::TO_BP_SAFE ? AvoidanceType::FAST_SAFE : AvoidanceType::FAST,
+                         false,
+                         ! xy_overrides)
+                     .inside(p.first, true))
         {
             return true;
         }
@@ -171,11 +193,18 @@ std::function<bool(std::pair<Point, TreeSupportTipGenerator::LineStatus>)> TreeS
         {
             if (p.second == LineStatus::TO_MODEL_GRACIOUS || p.second == LineStatus::TO_MODEL_GRACIOUS_SAFE)
             {
-                return ! volumes_.getAvoidance(config.getRadius(0), current_layer - 1, p.second == LineStatus::TO_MODEL_GRACIOUS_SAFE ? AvoidanceType::FAST_SAFE : AvoidanceType::FAST, true, !xy_overrides).inside(p.first, true);
+                return ! volumes_
+                             .getAvoidance(
+                                 config.getRadius(0),
+                                 current_layer - 1,
+                                 p.second == LineStatus::TO_MODEL_GRACIOUS_SAFE ? AvoidanceType::FAST_SAFE : AvoidanceType::FAST,
+                                 true,
+                                 ! xy_overrides)
+                             .inside(p.first, true);
             }
             else
             {
-                return ! volumes_.getAvoidance(config.getRadius(0), current_layer - 1, AvoidanceType::COLLISION, true, !xy_overrides).inside(p.first, true);
+                return ! volumes_.getAvoidance(config.getRadius(0), current_layer - 1, AvoidanceType::COLLISION, true, ! xy_overrides).inside(p.first, true);
             }
         }
         return false;
@@ -183,7 +212,9 @@ std::function<bool(std::pair<Point, TreeSupportTipGenerator::LineStatus>)> TreeS
     return evaluatePoint;
 }
 
-std::pair<std::vector<TreeSupportTipGenerator::LineInformation>, std::vector<TreeSupportTipGenerator::LineInformation>> TreeSupportTipGenerator::splitLines(std::vector<TreeSupportTipGenerator::LineInformation> lines, std::function<bool(std::pair<Point, TreeSupportTipGenerator::LineStatus>)> evaluatePoint)
+std::pair<std::vector<TreeSupportTipGenerator::LineInformation>, std::vector<TreeSupportTipGenerator::LineInformation>> TreeSupportTipGenerator::splitLines(
+    std::vector<TreeSupportTipGenerator::LineInformation> lines,
+    std::function<bool(std::pair<Point, TreeSupportTipGenerator::LineStatus>)> evaluatePoint)
 {
     // Assumes all Points on the current line are valid.
 
@@ -205,7 +236,7 @@ std::pair<std::vector<TreeSupportTipGenerator::LineInformation>, std::vector<Tre
                     (current == KEEPING ? keep : set_free).emplace_back(resulting_line);
                     resulting_line.clear();
                 }
-                current = !current;
+                current = ! current;
             }
             resulting_line.emplace_back(me);
         }
@@ -214,10 +245,12 @@ std::pair<std::vector<TreeSupportTipGenerator::LineInformation>, std::vector<Tre
             (current == KEEPING ? keep : set_free).emplace_back(resulting_line);
         }
     }
-    return std::pair<std::vector<std::vector<std::pair<Point, TreeSupportTipGenerator::LineStatus>>>, std::vector<std::vector<std::pair<Point, TreeSupportTipGenerator::LineStatus>>>>(keep, set_free);
+    return std::pair<
+        std::vector<std::vector<std::pair<Point, TreeSupportTipGenerator::LineStatus>>>,
+        std::vector<std::vector<std::pair<Point, TreeSupportTipGenerator::LineStatus>>>>(keep, set_free);
 }
 
-Polygons TreeSupportTipGenerator::ensureMaximumDistancePolyline(const Polygons& input, coord_t distance, size_t min_points,  bool enforce_distance) const
+Polygons TreeSupportTipGenerator::ensureMaximumDistancePolyline(const Polygons& input, coord_t distance, size_t min_points, bool enforce_distance) const
 {
     Polygons result;
     for (auto part : input)
@@ -242,9 +275,9 @@ Polygons TreeSupportTipGenerator::ensureMaximumDistancePolyline(const Polygons& 
             if (part.front() == part.back())
             {
                 size_t optimal_start_index = 0;
-                // If the polyline was a polygon, there is a high chance it was an overhang. Overhangs that are <60 degree tend to be very thin areas, so lets get the beginning and end of them and ensure that they are supported.
-                // The first point of the line will always be supported, so rotate the order of points in this polyline that one of the two corresponding points that are furthest from each other is in the beginning.
-                // The other will be manually added (optimal_end_index)
+                // If the polyline was a polygon, there is a high chance it was an overhang. Overhangs that are <60 degree tend to be very thin areas, so lets get the beginning and
+                // end of them and ensure that they are supported. The first point of the line will always be supported, so rotate the order of points in this polyline that one of
+                // the two corresponding points that are furthest from each other is in the beginning. The other will be manually added (optimal_end_index)
                 coord_t max_dist2_between_vertices = 0;
                 for (auto [idx, p_a] : part | ranges::views::enumerate | ranges::views::drop_last(1))
                 {
@@ -270,13 +303,14 @@ Polygons TreeSupportTipGenerator::ensureMaximumDistancePolyline(const Polygons& 
                 line.add(part[0]);
 
                 bool should_add_endpoint = min_points > 1 || vSize2(part[0] - part[optimal_end_index]) > (current_distance * current_distance);
-                bool added_endpoint = !should_add_endpoint; // If no endpoint should be added all endpoints are already added.
+                bool added_endpoint = ! should_add_endpoint; // If no endpoint should be added all endpoints are already added.
 
                 size_t current_index = 0;
                 GivenDistPoint next_point;
                 coord_t next_distance = current_distance;
                 // Get points so that at least min_points are added and they each are current_distance away from each other. If that is impossible, decrease current_distance a bit.
-                // (Regarding the while-loop) The input are lines, that means that the line from the last to the first vertex does not have to exist, so exclude all points that are on this line!
+                // (Regarding the while-loop) The input are lines, that means that the line from the last to the first vertex does not have to exist, so exclude all points that are
+                // on this line!
                 while (PolygonUtils::getNextPointWithDistance(current_point, next_distance, part, current_index, 0, next_point) && next_point.pos < coord_t(part.size()) - 1)
                 {
                     if (! added_endpoint && next_point.pos >= optimal_end_index)
@@ -292,14 +326,14 @@ Polygons TreeSupportTipGenerator::ensureMaximumDistancePolyline(const Polygons& 
                     // So this ensures that the points are actually a certain distance from each other.
                     // This assurance is only made on a per polygon basis, as different but close polygon may not be able to use support below the other polygon.
                     coord_t min_distance_to_existing_point_sqd = std::numeric_limits<coord_t>::max();
-                    if(enforce_distance)
+                    if (enforce_distance)
                     {
                         for (Point p : line)
                         {
                             min_distance_to_existing_point_sqd = std::min(min_distance_to_existing_point_sqd, vSize2(p - next_point.location));
                         }
                     }
-                    if (!enforce_distance || min_distance_to_existing_point_sqd >= (current_distance * current_distance))
+                    if (! enforce_distance || min_distance_to_existing_point_sqd >= (current_distance * current_distance))
                     {
                         // viable point was found. Add to possible result.
                         line.add(next_point.location);
@@ -312,7 +346,9 @@ Polygons TreeSupportTipGenerator::ensureMaximumDistancePolyline(const Polygons& 
                         if (current_point == next_point.location)
                         {
                             // In case a fixpoint is encountered, better aggressively overcompensate so the code does not become stuck here...
-                            spdlog::warn("Tree Support: Encountered a fixpoint in getNextPointWithDistance. This is expected to happen if the distance (currently {}) is smaller than 100", next_distance);
+                            spdlog::warn(
+                                "Tree Support: Encountered a fixpoint in getNextPointWithDistance. This is expected to happen if the distance (currently {}) is smaller than 100",
+                                next_distance);
                             if (next_distance > 2 * current_distance)
                             {
                                 // This case should never happen, but better safe than sorry.
@@ -344,7 +380,6 @@ Polygons TreeSupportTipGenerator::ensureMaximumDistancePolyline(const Polygons& 
 
 SierpinskiFillProvider* TreeSupportTipGenerator::generateCrossFillProvider(const SliceMeshStorage& mesh, coord_t line_distance, coord_t line_width) const
 {
-
     if (config.support_pattern == EFillMethod::CROSS || config.support_pattern == EFillMethod::CROSS_3D)
     {
         AABB3D aabb;
@@ -374,200 +409,231 @@ SierpinskiFillProvider* TreeSupportTipGenerator::generateCrossFillProvider(const
     return nullptr;
 }
 
-void TreeSupportTipGenerator::dropOverhangAreas(const SliceMeshStorage& mesh, std::vector<Polygons>& result, bool roof )
+void TreeSupportTipGenerator::dropOverhangAreas(const SliceMeshStorage& mesh, std::vector<Polygons>& result, bool roof)
 {
-
     std::mutex critical;
 
-    //this is ugly, but as far as i can see there is not way to ensure a parallel_for loop is calculated for each iteration up to a certain point before it continues;
-    cura::parallel_for<coord_t>
-        (
-            1,
-            mesh.overhang_areas.size() - z_distance_delta,
-            [&](const LayerIndex layer_idx)
+    // this is ugly, but as far as i can see there is not way to ensure a parallel_for loop is calculated for each iteration up to a certain point before it continues;
+    cura::parallel_for<coord_t>(
+        1,
+        mesh.overhang_areas.size() - z_distance_delta,
+        [&](const LayerIndex layer_idx)
+        {
+            if (mesh.overhang_areas[layer_idx + z_distance_delta].empty() || result.size() < layer_idx)
             {
-                if (mesh.overhang_areas[layer_idx + z_distance_delta].empty() || result.size()<layer_idx)
+                return; // This is a continue if imagined in a loop context.
+            }
+
+            Polygons relevant_forbidden = volumes_.getCollision(roof ? 0 : config.getRadius(0), layer_idx, ! xy_overrides);
+            // ^^^ Take the least restrictive avoidance possible
+
+            // Technically this also makes support blocker smaller, which is wrong as they do not have a xy_distance, but it should be good enough.
+            Polygons model_outline = volumes_.getCollision(0, layer_idx, ! xy_overrides).offset(-config.xy_min_distance, ClipperLib::jtRound);
+
+            Polygons overhang_regular = TreeSupportUtils::safeOffsetInc(
+                mesh.overhang_areas[layer_idx + z_distance_delta],
+                roof ? roof_outset : support_outset,
+                relevant_forbidden,
+                config.min_radius * 1.75 + config.xy_min_distance,
+                0,
+                1,
+                config.support_line_distance / 2,
+                &config.simplifier);
+            Polygons remaining_overhang = mesh.overhang_areas[layer_idx + z_distance_delta]
+                                              .offset(roof ? roof_outset : support_outset)
+                                              .difference(overhang_regular)
+                                              .intersection(relevant_forbidden)
+                                              .difference(model_outline);
+            for (size_t lag_ctr = 1; lag_ctr <= max_overhang_insert_lag && layer_idx - coord_t(lag_ctr) >= 1 && ! remaining_overhang.empty(); lag_ctr++)
+            {
                 {
-                    return; // This is a continue if imagined in a loop context.
+                    std::lock_guard<std::mutex> critical_section_storage(critical);
+                    result[layer_idx - lag_ctr].add(remaining_overhang);
                 }
 
-                Polygons relevant_forbidden = volumes_.getCollision(roof ? 0 : config.getRadius(0), layer_idx, ! xy_overrides);
-                // ^^^ Take the least restrictive avoidance possible
-
-                // Technically this also makes support blocker smaller, which is wrong as they do not have a xy_distance, but it should be good enough.
-                Polygons model_outline = volumes_.getCollision(0, layer_idx, ! xy_overrides).offset(-config.xy_min_distance, ClipperLib::jtRound);
-
-                Polygons overhang_regular =
-                    TreeSupportUtils::safeOffsetInc(mesh.overhang_areas[layer_idx + z_distance_delta], roof ? roof_outset : support_outset, relevant_forbidden, config.min_radius * 1.75 + config.xy_min_distance, 0, 1, config.support_line_distance / 2, &config.simplifier);
-                Polygons remaining_overhang =
-                    mesh.overhang_areas[layer_idx + z_distance_delta].offset(roof ? roof_outset : support_outset).difference(overhang_regular).intersection(relevant_forbidden).difference(model_outline);
-                for (size_t lag_ctr = 1; lag_ctr <= max_overhang_insert_lag && layer_idx - coord_t(lag_ctr) >= 1 && !remaining_overhang.empty(); lag_ctr++)
-                {
-                    {
-                        std::lock_guard<std::mutex> critical_section_storage(critical);
-                        result[layer_idx-lag_ctr].add(remaining_overhang);
-                    }
-
-                    Polygons relevant_forbidden_below =
-                        volumes_.getCollision(roof ? 0 : config.getRadius(0), layer_idx - lag_ctr, ! xy_overrides).offset(EPSILON);
-                    remaining_overhang=remaining_overhang.intersection(relevant_forbidden_below).unionPolygons().difference(model_outline);
-                }
+                Polygons relevant_forbidden_below = volumes_.getCollision(roof ? 0 : config.getRadius(0), layer_idx - lag_ctr, ! xy_overrides).offset(EPSILON);
+                remaining_overhang = remaining_overhang.intersection(relevant_forbidden_below).unionPolygons().difference(model_outline);
             }
-        );
+        });
 
-    cura::parallel_for<coord_t>
-        (
-            0,
-            result.size(),
-            [&](const LayerIndex layer_idx)
-            {
-                result[layer_idx]=result[layer_idx].unionPolygons();
-            }
-        );
-
-
-
+    cura::parallel_for<coord_t>(
+        0,
+        result.size(),
+        [&](const LayerIndex layer_idx)
+        {
+            result[layer_idx] = result[layer_idx].unionPolygons();
+        });
 }
 
 void TreeSupportTipGenerator::calculateRoofAreas(const cura::SliceMeshStorage& mesh)
 {
-    std::vector<Polygons> potential_support_roofs(mesh.overhang_areas.size(),Polygons());
+    std::vector<Polygons> potential_support_roofs(mesh.overhang_areas.size(), Polygons());
     std::mutex critical_potential_support_roofs;
-    std::vector<Polygons> dropped_overhangs(mesh.overhang_areas.size(),Polygons());
+    std::vector<Polygons> dropped_overhangs(mesh.overhang_areas.size(), Polygons());
 
     if (xy_overrides)
     {
         dropOverhangAreas(mesh, dropped_overhangs, true);
     }
 
-    cura::parallel_for<coord_t>
-        (
-            0,
-            mesh.overhang_areas.size() - z_distance_delta,
-            [&](const LayerIndex layer_idx)
+    cura::parallel_for<coord_t>(
+        0,
+        mesh.overhang_areas.size() - z_distance_delta,
+        [&](const LayerIndex layer_idx)
+        {
+            if (mesh.overhang_areas[layer_idx + z_distance_delta].empty())
             {
-                if (mesh.overhang_areas[layer_idx + z_distance_delta].empty())
-                {
-                    return; // This is a continue if imagined in a loop context.
-                }
-
-                // Roof does not have a radius, so remove it using offset. Note that there is no 0 radius avoidance, and it would not be identical with the avoidance offset with -radius.
-                // This is intentional here, as support roof is still valid if only a part of the tip may reach it.
-                Polygons forbidden_here =
-                    volumes_.getAvoidance(config.getRadius(0), layer_idx, (only_gracious||!config.support_rests_on_model)? AvoidanceType::FAST : AvoidanceType::COLLISION, config.support_rests_on_model, ! xy_overrides).offset(-config.getRadius(0),ClipperLib::jtRound);
-
-                // todo Since arachnea the assumption that an area smaller then line_width is not printed is no longer true all such safeOffset should have config.support_line_width replaced with another setting. It should still work in most cases, but it should be possible to create a situation where a overhang outset lags though a wall.
-                // I will take a look at this later.
-                Polygons full_overhang_area  =  TreeSupportUtils::safeOffsetInc(mesh.full_overhang_areas[layer_idx + z_distance_delta].unionPolygons(dropped_overhangs[layer_idx]),roof_outset,forbidden_here, config.support_line_width, 0, 1, config.support_line_distance / 2, &config.simplifier);
-
-                for (LayerIndex dtt_roof = 0; dtt_roof < support_roof_layers && layer_idx - dtt_roof >= 1; dtt_roof++)
-                {
-                    const Polygons forbidden_next =
-                        volumes_.getAvoidance(config.getRadius(0), layer_idx - (dtt_roof + 1), (only_gracious||!config.support_rests_on_model)? AvoidanceType::FAST : AvoidanceType::COLLISION, config.support_rests_on_model, ! xy_overrides).offset(-config.getRadius(0),ClipperLib::jtRound);
-
-                    full_overhang_area = full_overhang_area.difference(forbidden_next);
-
-                    if(force_minimum_roof_area)
-                    {
-                        full_overhang_area.removeSmallAreas(minimum_roof_area);
-                    }
-
-                    if (full_overhang_area.area()>EPSILON)
-                    {
-                        std::lock_guard<std::mutex> critical_section_potential_support_roofs(critical_potential_support_roofs);
-                        potential_support_roofs[layer_idx-dtt_roof].add((full_overhang_area));
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-
+                return; // This is a continue if imagined in a loop context.
             }
-        );
 
-    cura::parallel_for<coord_t>
-    (
+            // Roof does not have a radius, so remove it using offset. Note that there is no 0 radius avoidance, and it would not be identical with the avoidance offset with
+            // -radius. This is intentional here, as support roof is still valid if only a part of the tip may reach it.
+            Polygons forbidden_here = volumes_
+                                          .getAvoidance(
+                                              config.getRadius(0),
+                                              layer_idx,
+                                              (only_gracious || ! config.support_rests_on_model) ? AvoidanceType::FAST : AvoidanceType::COLLISION,
+                                              config.support_rests_on_model,
+                                              ! xy_overrides)
+                                          .offset(-config.getRadius(0), ClipperLib::jtRound);
+
+            // todo Since arachnea the assumption that an area smaller then line_width is not printed is no longer true all such safeOffset should have config.support_line_width
+            // replaced with another setting. It should still work in most cases, but it should be possible to create a situation where a overhang outset lags though a wall. I will
+            // take a look at this later.
+            Polygons full_overhang_area = TreeSupportUtils::safeOffsetInc(
+                mesh.full_overhang_areas[layer_idx + z_distance_delta].unionPolygons(dropped_overhangs[layer_idx]),
+                roof_outset,
+                forbidden_here,
+                config.support_line_width,
+                0,
+                1,
+                config.support_line_distance / 2,
+                &config.simplifier);
+
+            for (LayerIndex dtt_roof = 0; dtt_roof < support_roof_layers && layer_idx - dtt_roof >= 1; dtt_roof++)
+            {
+                const Polygons forbidden_next = volumes_
+                                                    .getAvoidance(
+                                                        config.getRadius(0),
+                                                        layer_idx - (dtt_roof + 1),
+                                                        (only_gracious || ! config.support_rests_on_model) ? AvoidanceType::FAST : AvoidanceType::COLLISION,
+                                                        config.support_rests_on_model,
+                                                        ! xy_overrides)
+                                                    .offset(-config.getRadius(0), ClipperLib::jtRound);
+
+                full_overhang_area = full_overhang_area.difference(forbidden_next);
+
+                if (force_minimum_roof_area)
+                {
+                    full_overhang_area.removeSmallAreas(minimum_roof_area);
+                }
+
+                if (full_overhang_area.area() > EPSILON)
+                {
+                    std::lock_guard<std::mutex> critical_section_potential_support_roofs(critical_potential_support_roofs);
+                    potential_support_roofs[layer_idx - dtt_roof].add((full_overhang_area));
+                }
+                else
+                {
+                    break;
+                }
+            }
+        });
+
+    cura::parallel_for<coord_t>(
         0,
         potential_support_roofs.size(),
         [&](const LayerIndex layer_idx)
         {
-            // Now, because the avoidance/collision was subtracted above, the overhang parts that are of xy distance were removed, so to merge areas that should have been one offset by xy_min_distance and then undo it.
-            // In a perfect world the offset here would be of a mode that makes sure that area.offset(config.xy_min_distance).unionPolygons().offset(-config.xy_min_distance) = area if there is only one polygon in said area.
-            // I have not encountered issues with using the default mitered here. Could be that i just have not encountered an issue with it yet though.
-            potential_support_roofs[layer_idx]=potential_support_roofs[layer_idx].unionPolygons().offset(config.xy_min_distance).unionPolygons().offset(-config.xy_min_distance).unionPolygons(potential_support_roofs[layer_idx]);
+            // Now, because the avoidance/collision was subtracted above, the overhang parts that are of xy distance were removed, so to merge areas that should have been one
+            // offset by xy_min_distance and then undo it. In a perfect world the offset here would be of a mode that makes sure that
+            // area.offset(config.xy_min_distance).unionPolygons().offset(-config.xy_min_distance) = area if there is only one polygon in said area. I have not encountered issues
+            // with using the default mitered here. Could be that i just have not encountered an issue with it yet though.
+            potential_support_roofs[layer_idx] = potential_support_roofs[layer_idx]
+                                                     .unionPolygons()
+                                                     .offset(config.xy_min_distance)
+                                                     .unionPolygons()
+                                                     .offset(-config.xy_min_distance)
+                                                     .unionPolygons(potential_support_roofs[layer_idx]);
+        });
 
-        }
-    );
+    std::vector<Polygons> additional_support_roofs(mesh.overhang_areas.size(), Polygons());
 
-    std::vector<Polygons> additional_support_roofs(mesh.overhang_areas.size(),Polygons());
-
-    cura::parallel_for<coord_t>
-        (
-            0,
-            potential_support_roofs.size(),
-            [&](const LayerIndex layer_idx)
+    cura::parallel_for<coord_t>(
+        0,
+        potential_support_roofs.size(),
+        [&](const LayerIndex layer_idx)
+        {
+            if (! potential_support_roofs[layer_idx].empty())
             {
-                if (!potential_support_roofs[layer_idx].empty())
+                // Roof does not have a radius, so remove it using offset. Note that there is no 0 radius avoidance, and it would not be identical with the avoidance offset with
+                // -radius. This is intentional here, as support roof is still valid if only a part of the tip may reach it.
+                Polygons forbidden_here = volumes_
+                                              .getAvoidance(
+                                                  config.getRadius(0),
+                                                  layer_idx,
+                                                  (only_gracious || ! config.support_rests_on_model) ? AvoidanceType::FAST : AvoidanceType::COLLISION,
+                                                  config.support_rests_on_model,
+                                                  ! xy_overrides)
+                                              .offset(-(config.getRadius(0)), ClipperLib::jtRound);
+
+                if (! force_minimum_roof_area)
                 {
-                    // Roof does not have a radius, so remove it using offset. Note that there is no 0 radius avoidance, and it would not be identical with the avoidance offset with -radius.
-                    // This is intentional here, as support roof is still valid if only a part of the tip may reach it.
-                    Polygons forbidden_here =
-                        volumes_.getAvoidance(config.getRadius(0), layer_idx, (only_gracious||!config.support_rests_on_model)? AvoidanceType::FAST : AvoidanceType::COLLISION, config.support_rests_on_model, ! xy_overrides).offset(-(config.getRadius(0)),ClipperLib::jtRound);
+                    Polygons fuzzy_area = Polygons();
 
-                    if (!force_minimum_roof_area)
+                    // the roof will be combined with roof above and below, to see if a part of this roof may be part of a valid roof further up/down.
+                    // This prevents the situation where a roof gets removed even tough its area would contribute to a (better) printable roof area further down.
+                    for (const LayerIndex layer_offset : ranges::views::iota(
+                             -LayerIndex{ std::min(layer_idx, LayerIndex{ support_roof_layers }) },
+                             LayerIndex{ std::min(LayerIndex{ potential_support_roofs.size() - layer_idx }, LayerIndex{ support_roof_layers + 1 }) }))
                     {
-                        Polygons fuzzy_area = Polygons();
-
-                        // the roof will be combined with roof above and below, to see if a part of this roof may be part of a valid roof further up/down.
-                        // This prevents the situation where a roof gets removed even tough its area would contribute to a (better) printable roof area further down.
-                        for (const LayerIndex layer_offset : ranges::views::iota(-LayerIndex { std::min(layer_idx, LayerIndex { support_roof_layers }) }, LayerIndex { std::min(LayerIndex { potential_support_roofs.size() - layer_idx }, LayerIndex{ support_roof_layers + 1} ) }))
-                        {
-                            fuzzy_area.add(support_roof_drawn[layer_idx+layer_offset]);
-                            fuzzy_area.add(potential_support_roofs[layer_idx+layer_offset]);
-                        }
-                        fuzzy_area=fuzzy_area.unionPolygons();
-                        fuzzy_area.removeSmallAreas(std::max(minimum_roof_area,tip_roof_size));
-
-                        for (Polygons potential_roof:potential_support_roofs[layer_idx].difference(forbidden_here).splitIntoParts())
-                        {
-
-                            if (!potential_roof.intersection(fuzzy_area).empty())
-                            {
-                                additional_support_roofs[layer_idx].add(potential_roof);
-                            }
-
-                        }
+                        fuzzy_area.add(support_roof_drawn[layer_idx + layer_offset]);
+                        fuzzy_area.add(potential_support_roofs[layer_idx + layer_offset]);
                     }
-                    else
+                    fuzzy_area = fuzzy_area.unionPolygons();
+                    fuzzy_area.removeSmallAreas(std::max(minimum_roof_area, tip_roof_size));
+
+                    for (Polygons potential_roof : potential_support_roofs[layer_idx].difference(forbidden_here).splitIntoParts())
                     {
-                        Polygons valid_roof = potential_support_roofs[layer_idx].difference(forbidden_here);
-                        valid_roof.removeSmallAreas(std::max(minimum_roof_area,tip_roof_size));
-                        additional_support_roofs[layer_idx].add(valid_roof);
+                        if (! potential_roof.intersection(fuzzy_area).empty())
+                        {
+                            additional_support_roofs[layer_idx].add(potential_roof);
+                        }
                     }
                 }
+                else
+                {
+                    Polygons valid_roof = potential_support_roofs[layer_idx].difference(forbidden_here);
+                    valid_roof.removeSmallAreas(std::max(minimum_roof_area, tip_roof_size));
+                    additional_support_roofs[layer_idx].add(valid_roof);
+                }
             }
-        );
+        });
 
-    cura::parallel_for<coord_t>
-        (
-            0,
-            additional_support_roofs.size(),
-            [&](const LayerIndex layer_idx)
-            {
-                support_roof_drawn[layer_idx] = support_roof_drawn[layer_idx].unionPolygons(additional_support_roofs[layer_idx]);
-            }
-        );
-
+    cura::parallel_for<coord_t>(
+        0,
+        additional_support_roofs.size(),
+        [&](const LayerIndex layer_idx)
+        {
+            support_roof_drawn[layer_idx] = support_roof_drawn[layer_idx].unionPolygons(additional_support_roofs[layer_idx]);
+        });
 }
 
 
-void TreeSupportTipGenerator::addPointAsInfluenceArea(std::vector<std::set<TreeSupportElement *>>& move_bounds, std::pair<Point, TreeSupportTipGenerator::LineStatus> p, size_t dtt, LayerIndex insert_layer, size_t dont_move_until, bool roof, bool skip_ovalisation, std::vector<Point> additional_ovalization_targets)
+void TreeSupportTipGenerator::addPointAsInfluenceArea(
+    std::vector<std::set<TreeSupportElement*>>& move_bounds,
+    std::pair<Point, TreeSupportTipGenerator::LineStatus> p,
+    size_t dtt,
+    LayerIndex insert_layer,
+    size_t dont_move_until,
+    bool roof,
+    bool skip_ovalisation,
+    std::vector<Point> additional_ovalization_targets)
 {
     const bool to_bp = p.second == LineStatus::TO_BP || p.second == LineStatus::TO_BP_SAFE;
     const bool gracious = to_bp || p.second == LineStatus::TO_MODEL_GRACIOUS || p.second == LineStatus::TO_MODEL_GRACIOUS_SAFE;
     const bool safe_radius = p.second == LineStatus::TO_BP_SAFE || p.second == LineStatus::TO_MODEL_GRACIOUS_SAFE;
-    if (! config.support_rests_on_model && !to_bp)
+    if (! config.support_rests_on_model && ! to_bp)
     {
         spdlog::warn("Tried to add an invalid support point");
         return;
@@ -585,23 +651,20 @@ void TreeSupportTipGenerator::addPointAsInfluenceArea(std::vector<std::set<TreeS
         {
             // Normalize the point a bit to also catch points which are so close that inserting it would achieve nothing.
             already_inserted[insert_layer].emplace(p.first / ((config.min_radius + 1) / 10));
-            TreeSupportElement* elem =
-                new TreeSupportElement
-                (
-                    dtt,
-                    insert_layer,
-                    p.first,
-                    to_bp,
-                    gracious,
-                    ! xy_overrides,
-                    dont_move_until,
-                    roof,
-                    safe_radius,
-                    force_tip_to_roof,
-                    skip_ovalisation,
-                    support_tree_limit_branch_reach,
-                    support_tree_branch_reach_limit
-                );
+            TreeSupportElement* elem = new TreeSupportElement(
+                dtt,
+                insert_layer,
+                p.first,
+                to_bp,
+                gracious,
+                ! xy_overrides,
+                dont_move_until,
+                roof,
+                safe_radius,
+                force_tip_to_roof,
+                skip_ovalisation,
+                support_tree_limit_branch_reach,
+                support_tree_branch_reach_limit);
             elem->area = new Polygons(area);
 
             for (Point p : additional_ovalization_targets)
@@ -615,9 +678,17 @@ void TreeSupportTipGenerator::addPointAsInfluenceArea(std::vector<std::set<TreeS
 }
 
 
-void TreeSupportTipGenerator::addLinesAsInfluenceAreas(std::vector<std::set<TreeSupportElement *>>& move_bounds, std::vector<TreeSupportTipGenerator::LineInformation> lines, size_t roof_tip_layers, LayerIndex insert_layer_idx, bool supports_roof, size_t dont_move_until, bool connect_points)
+void TreeSupportTipGenerator::addLinesAsInfluenceAreas(
+    std::vector<std::set<TreeSupportElement*>>& move_bounds,
+    std::vector<TreeSupportTipGenerator::LineInformation> lines,
+    size_t roof_tip_layers,
+    LayerIndex insert_layer_idx,
+    bool supports_roof,
+    size_t dont_move_until,
+    bool connect_points)
 {
-    // Add tip area as roof (happens when minimum roof area > minimum tip area) if possible. This is required as there is no guarantee that if support_roof_wall_count == 0 that a certain roof area will actually have lines.
+    // Add tip area as roof (happens when minimum roof area > minimum tip area) if possible. This is required as there is no guarantee that if support_roof_wall_count == 0 that a
+    // certain roof area will actually have lines.
     size_t dtt_roof_tip = 0;
     if (config.support_roof_wall_count == 0)
     {
@@ -631,11 +702,12 @@ void TreeSupportTipGenerator::addLinesAsInfluenceAreas(std::vector<std::set<Tree
                     roof_circle.add(p.first + corner * std::max(config.min_radius / TreeSupportBaseCircle::base_radius, coord_t(1)));
                 }
                 Polygons area = roof_circle.offset(0);
-                return !TreeSupportUtils::generateSupportInfillLines(area, config, true, insert_layer_idx - dtt_roof_tip,support_roof_line_distance,cross_fill_provider,true).empty();
+                return ! TreeSupportUtils::generateSupportInfillLines(area, config, true, insert_layer_idx - dtt_roof_tip, support_roof_line_distance, cross_fill_provider, true)
+                             .empty();
             };
 
-            std::pair<std::vector<TreeSupportTipGenerator::LineInformation>, std::vector<TreeSupportTipGenerator::LineInformation>> split =
-                splitLines(lines, getEvaluatePointForNextLayerFunction(insert_layer_idx - dtt_roof_tip)); // Keep all lines that are still valid on the next layer.
+            std::pair<std::vector<TreeSupportTipGenerator::LineInformation>, std::vector<TreeSupportTipGenerator::LineInformation>> split
+                = splitLines(lines, getEvaluatePointForNextLayerFunction(insert_layer_idx - dtt_roof_tip)); // Keep all lines that are still valid on the next layer.
 
             for (LineInformation line : split.second) // Add all points that would not be valid.
             {
@@ -683,8 +755,9 @@ void TreeSupportTipGenerator::addLinesAsInfluenceAreas(std::vector<std::set<Tree
     for (LineInformation line : lines)
     {
         // If a line consists of enough tips, the assumption is that it is not a single tip, but part of a simulated support pattern.
-        // Ovalisation should be disabled if they may be placed close to each other to prevent tip-areas merging. If the tips has to turn into roof, the area is most likely not large enough for this to cause issues.
-        const bool disable_ovalization =  !connect_points && config.min_radius < 3 * config.support_line_width && roof_tip_layers == 0 && dtt_roof_tip == 0;
+        // Ovalisation should be disabled if they may be placed close to each other to prevent tip-areas merging. If the tips has to turn into roof, the area is most likely not
+        // large enough for this to cause issues.
+        const bool disable_ovalization = ! connect_points && config.min_radius < 3 * config.support_line_width && roof_tip_layers == 0 && dtt_roof_tip == 0;
         for (auto [idx, point_data] : line | ranges::views::enumerate)
         {
             std::vector<Point> additional_ovalization_targets;
@@ -699,305 +772,380 @@ void TreeSupportTipGenerator::addLinesAsInfluenceAreas(std::vector<std::set<Tree
                     additional_ovalization_targets.emplace_back(line[idx + 1].first);
                 }
             }
-            addPointAsInfluenceArea
-                (
-                    move_bounds,
-                    point_data,
-                    0,
-                    insert_layer_idx - dtt_roof_tip,
-                    dont_move_until > dtt_roof_tip ? dont_move_until - dtt_roof_tip : 0,
-                    dtt_roof_tip != 0 || supports_roof, disable_ovalization,
-                    additional_ovalization_targets
-                );
+            addPointAsInfluenceArea(
+                move_bounds,
+                point_data,
+                0,
+                insert_layer_idx - dtt_roof_tip,
+                dont_move_until > dtt_roof_tip ? dont_move_until - dtt_roof_tip : 0,
+                dtt_roof_tip != 0 || supports_roof,
+                disable_ovalization,
+                additional_ovalization_targets);
         }
     }
 }
 
 
-void TreeSupportTipGenerator::removeUselessAddedPoints(std::vector<std::set<TreeSupportElement *>>& move_bounds,SliceDataStorage& storage, std::vector<Polygons>& additional_support_areas)
+void TreeSupportTipGenerator::removeUselessAddedPoints(
+    std::vector<std::set<TreeSupportElement*>>& move_bounds,
+    SliceDataStorage& storage,
+    std::vector<Polygons>& additional_support_areas)
 {
-
-    cura::parallel_for<coord_t>
-        (
-            0,
-            move_bounds.size(),
-            [&](const LayerIndex layer_idx)
+    cura::parallel_for<coord_t>(
+        0,
+        move_bounds.size(),
+        [&](const LayerIndex layer_idx)
+        {
+            if (layer_idx + 1 < storage.support.supportLayers.size())
             {
+                std::vector<TreeSupportElement*> to_be_removed;
+                Polygons roof_on_layer_above = use_fake_roof ? support_roof_drawn[layer_idx + 1]
+                                                             : storage.support.supportLayers[layer_idx + 1].support_roof.unionPolygons(additional_support_areas[layer_idx + 1]);
+                Polygons roof_on_layer
+                    = use_fake_roof ? support_roof_drawn[layer_idx] : storage.support.supportLayers[layer_idx].support_roof.unionPolygons(additional_support_areas[layer_idx]);
 
-                if(layer_idx+1 < storage.support.supportLayers.size())
+                for (TreeSupportElement* elem : move_bounds[layer_idx])
                 {
-                    std::vector<TreeSupportElement *> to_be_removed;
-                    Polygons roof_on_layer_above = use_fake_roof ? support_roof_drawn[layer_idx+1] : storage.support.supportLayers[layer_idx+1].support_roof.unionPolygons(additional_support_areas[layer_idx+1]);
-                    Polygons roof_on_layer = use_fake_roof ? support_roof_drawn[layer_idx] : storage.support.supportLayers[layer_idx].support_roof.unionPolygons(additional_support_areas[layer_idx]);
-
-                    for (TreeSupportElement* elem : move_bounds[layer_idx])
+                    if (roof_on_layer.inside(elem->result_on_layer)) // Remove branches that start inside of support interface
                     {
-                        if (roof_on_layer.inside(elem->result_on_layer)) // Remove branches that start inside of support interface
+                        to_be_removed.emplace_back(elem);
+                    }
+                    else if (elem->supports_roof)
+                    {
+                        Point from = elem->result_on_layer;
+                        PolygonUtils::moveInside(roof_on_layer_above, from);
+                        // Remove branches should have interface above them, but dont. Should never happen.
+                        if (roof_on_layer_above.empty()
+                            || (! roof_on_layer_above.inside(elem->result_on_layer)
+                                && vSize2(from - elem->result_on_layer) > config.getRadius(0) * config.getRadius(0) + FUDGE_LENGTH * FUDGE_LENGTH))
                         {
                             to_be_removed.emplace_back(elem);
-                        }
-                        else if(elem->supports_roof)
-                        {
-                            Point from = elem->result_on_layer;
-                            PolygonUtils::moveInside(roof_on_layer_above,from);
-                            // Remove branches should have interface above them, but dont. Should never happen.
-                            if (roof_on_layer_above.empty()  ||
-                                (!roof_on_layer_above.inside(elem->result_on_layer) && vSize2(from-elem->result_on_layer)>config.getRadius(0)*config.getRadius(0) + FUDGE_LENGTH * FUDGE_LENGTH))
-                            {
-                                to_be_removed.emplace_back(elem);
-                                spdlog::warn("Removing already placed tip that should have roof above it?");
-                            }
+                            spdlog::warn("Removing already placed tip that should have roof above it?");
                         }
                     }
+                }
 
-                    for (auto elem : to_be_removed)
-                    {
-                        move_bounds[layer_idx].erase(elem);
-                        delete elem->area;
-                        delete elem;
-                    }
-
+                for (auto elem : to_be_removed)
+                {
+                    move_bounds[layer_idx].erase(elem);
+                    delete elem->area;
+                    delete elem;
                 }
             }
-        );
+        });
 }
 
 
-void TreeSupportTipGenerator::generateTips(SliceDataStorage& storage,const SliceMeshStorage& mesh, std::vector<std::set<TreeSupportElement*>>& move_bounds, std::vector<Polygons>& additional_support_areas, std::vector<Polygons>& placed_support_lines_support_areas)
+void TreeSupportTipGenerator::generateTips(
+    SliceDataStorage& storage,
+    const SliceMeshStorage& mesh,
+    std::vector<std::set<TreeSupportElement*>>& move_bounds,
+    std::vector<Polygons>& additional_support_areas,
+    std::vector<Polygons>& placed_support_lines_support_areas)
 {
     std::vector<std::set<TreeSupportElement*>> new_tips(move_bounds.size());
 
-    const coord_t circle_length_to_half_linewidth_change = config.min_radius < config.support_line_width ? config.min_radius / 2 : sqrt(square(config.min_radius) - square(config.min_radius - config.support_line_width / 2));
-    // ^^^ As r*r=x*x+y*y (circle equation): If a circle with center at (0,0) the top most point is at (0,r) as in y=r. This calculates how far one has to move on the x-axis so that y=r-support_line_width/2.
-    //     In other words how far does one need to move on the x-axis to be support_line_width/2 away from the circle line. As a circle is round this length is identical for every axis as long as the 90� angle between both remains.
+    const coord_t circle_length_to_half_linewidth_change
+        = config.min_radius < config.support_line_width ? config.min_radius / 2 : sqrt(square(config.min_radius) - square(config.min_radius - config.support_line_width / 2));
+    // ^^^ As r*r=x*x+y*y (circle equation): If a circle with center at (0,0) the top most point is at (0,r) as in y=r. This calculates how far one has to move on the x-axis so
+    // that y=r-support_line_width/2.
+    //     In other words how far does one need to move on the x-axis to be support_line_width/2 away from the circle line. As a circle is round this length is identical for every
+    //     axis as long as the 90� angle between both remains.
 
     const coord_t extra_outset = std::max(coord_t(0), config.min_radius - config.support_line_width / 2) + (xy_overrides ? 0 : config.support_line_width / 2);
-    // ^^^ Extra support offset to compensate for larger tip radiis. Also outset a bit more when z overwrites xy, because supporting something with a part of a support line is better than not supporting it at all.
+    // ^^^ Extra support offset to compensate for larger tip radiis. Also outset a bit more when z overwrites xy, because supporting something with a part of a support line is
+    // better than not supporting it at all.
 
     if (support_roof_layers)
     {
         calculateRoofAreas(mesh);
     }
 
-    cura::parallel_for<coord_t>
-        (
-            1,
-            mesh.overhang_areas.size() - z_distance_delta,
-            [&](const LayerIndex layer_idx)
+    cura::parallel_for<coord_t>(
+        1,
+        mesh.overhang_areas.size() - z_distance_delta,
+        [&](const LayerIndex layer_idx)
+        {
+            if (mesh.overhang_areas[layer_idx + z_distance_delta].empty() && (layer_idx + 1 >= support_roof_drawn.size() || support_roof_drawn[layer_idx + 1].empty()))
             {
-                if (mesh.overhang_areas[layer_idx + z_distance_delta].empty() && (layer_idx+1 >= support_roof_drawn.size() || support_roof_drawn[layer_idx+1].empty()))
+                return; // This is a continue if imagined in a loop context.
+            }
+
+            Polygons relevant_forbidden = volumes_.getAvoidance(
+                config.getRadius(0),
+                layer_idx,
+                (only_gracious || ! config.support_rests_on_model) ? AvoidanceType::FAST : AvoidanceType::COLLISION,
+                config.support_rests_on_model,
+                ! xy_overrides);
+            // ^^^ Take the least restrictive avoidance possible
+            relevant_forbidden
+                = relevant_forbidden.offset(EPSILON)
+                      .unionPolygons(); // Prevent rounding errors down the line, points placed directly on the line of the forbidden area may not be added otherwise.
+
+            std::function<Polygons(const Polygons&, bool, LayerIndex)> generateLines = [&](const Polygons& area, bool roof, LayerIndex layer_idx)
+            {
+                coord_t upper_line_distance = support_supporting_branch_distance;
+                coord_t line_distance = std::max(roof ? support_roof_line_distance : support_tree_branch_distance, upper_line_distance);
+
+
+                return TreeSupportUtils::generateSupportInfillLines(
+                    area,
+                    config,
+                    roof && ! use_fake_roof,
+                    layer_idx,
+                    line_distance,
+                    cross_fill_provider,
+                    roof && ! use_fake_roof,
+                    line_distance == upper_line_distance);
+            };
+
+
+            std::vector<std::pair<Polygons, bool>> overhang_processing;
+            // ^^^ Every overhang has saved if a roof should be generated for it.
+            //     This can NOT be done in the for loop as an area may NOT have a roof even if it is larger than the minimum_roof_area when it is only larger because of the support
+            //     horizontal expansion and it would not have a roof if the overhang is offset by support roof horizontal expansion instead. (At least this is the current behavior
+            //     of the regular support)
+
+            Polygons core_overhang = mesh.overhang_areas[layer_idx + z_distance_delta];
+
+
+            if (support_roof_layers && layer_idx + 1 < support_roof_drawn.size())
+            {
+                core_overhang = core_overhang.difference(support_roof_drawn[layer_idx]);
+                for (Polygons roof_part : support_roof_drawn[layer_idx + 1]
+                                              .difference(support_roof_drawn[layer_idx])
+                                              .splitIntoParts(true)) // If there is a roof, the roof will be one layer above the tips.
                 {
-                    return; // This is a continue if imagined in a loop context.
-                }
-
-                Polygons relevant_forbidden =
-                    volumes_.getAvoidance(config.getRadius(0), layer_idx, (only_gracious || !config.support_rests_on_model)? AvoidanceType::FAST : AvoidanceType::COLLISION , config.support_rests_on_model, ! xy_overrides);
-                // ^^^ Take the least restrictive avoidance possible
-                relevant_forbidden = relevant_forbidden.offset(EPSILON).unionPolygons(); // Prevent rounding errors down the line, points placed directly on the line of the forbidden area may not be added otherwise.
-
-                std::function<Polygons(const Polygons&, bool, LayerIndex)> generateLines =
-                    [&](const Polygons& area, bool roof, LayerIndex layer_idx)
-                {
-
-                    coord_t upper_line_distance = support_supporting_branch_distance;
-                    coord_t line_distance = std::max(roof ? support_roof_line_distance : support_tree_branch_distance, upper_line_distance );
-
-
-                    return TreeSupportUtils::generateSupportInfillLines(area, config, roof && !use_fake_roof, layer_idx, line_distance , cross_fill_provider, roof && !use_fake_roof, line_distance == upper_line_distance);
-                };
-
-
-                std::vector<std::pair<Polygons, bool>> overhang_processing;
-                // ^^^ Every overhang has saved if a roof should be generated for it.
-                //     This can NOT be done in the for loop as an area may NOT have a roof even if it is larger than the minimum_roof_area when it is only larger because of the support horizontal expansion and it would not have a roof if the overhang is offset by support roof horizontal expansion instead.
-                //     (At least this is the current behavior of the regular support)
-
-                Polygons core_overhang=mesh.overhang_areas[layer_idx + z_distance_delta];
-
-
-                if (support_roof_layers && layer_idx+1 < support_roof_drawn.size())
-                {
-                    core_overhang = core_overhang.difference(support_roof_drawn[layer_idx]);
-                    for (Polygons roof_part : support_roof_drawn[layer_idx+1].difference(support_roof_drawn[layer_idx]).splitIntoParts(true)) //If there is a roof, the roof will be one layer above the tips.
-                    {
-                        //^^^Technically one should also subtract the avoidance of radius 0 (similarly how calculated in calculateRoofArea), as there can be some rounding errors introduced since then. But this does not fully prevent some rounding errors either way, so just handle the error later.
-                        overhang_processing.emplace_back(roof_part, true);
-                    }
-                }
-
-                Polygons overhang_regular =
-                    TreeSupportUtils::safeOffsetInc(core_overhang, support_outset, relevant_forbidden, config.min_radius * 1.75 + config.xy_min_distance, 0, 1, config.support_line_distance / 2, &config.simplifier);
-                Polygons remaining_overhang =
-                    core_overhang.offset(support_outset).difference(overhang_regular.offset(config.support_line_width * 0.5)).intersection(relevant_forbidden);
-
-
-                // Offset ensures that areas that could be supported by a part of a support line, are not considered unsupported overhang
-                coord_t extra_total_offset_acc = 0;
-
-                // Offset the area to compensate for large tip radiis. Offset happens in multiple steps to ensure the tip is as close to the original overhang as possible.
-                while (extra_total_offset_acc + config.support_line_width / 8 < extra_outset) //+mesh_config.support_line_width / 8  to avoid calculating very small (useless) offsets because of rounding errors.
-                {
-                    coord_t offset_current_step =
-                        extra_total_offset_acc + 2 * config.support_line_width > config.min_radius ?
-                                                                                                             std::min(config.support_line_width / 8, extra_outset - extra_total_offset_acc) :
-                                                                                                             std::min(circle_length_to_half_linewidth_change, extra_outset - extra_total_offset_acc);
-                    extra_total_offset_acc += offset_current_step;
-                    Polygons overhang_offset = TreeSupportUtils::safeOffsetInc(overhang_regular, 1.5 * extra_total_offset_acc, volumes_.getCollision(0, layer_idx, true), config.xy_min_distance + config.support_line_width, 0, 1, config.support_line_distance / 2, &config.simplifier);
-                    remaining_overhang = remaining_overhang.difference(overhang_offset.unionPolygons(support_roof_drawn[layer_idx].offset(1.5 * extra_total_offset_acc))).unionPolygons(); //overhang_offset is combined with roof, as all area that has a roof, is already supported by said roof.
-                    Polygons next_overhang = TreeSupportUtils::safeOffsetInc(remaining_overhang, extra_total_offset_acc, volumes_.getCollision(0, layer_idx, true), config.xy_min_distance + config.support_line_width, 0, 1, config.support_line_distance / 2, &config.simplifier);
-                    overhang_regular = overhang_regular.unionPolygons(next_overhang.difference(relevant_forbidden));
-                }
-
-                // If the xy distance overrides the z distance, some support needs to be inserted further down.
-                //=> Analyze which support points do not fit on this layer and check if they will fit a few layers down
-                //   (while adding them an infinite amount of layers down would technically be closer the setting description, it would not produce reasonable results. )
-                if (xy_overrides)
-                {
-
-                    for (Polygons& remaining_overhang_part:remaining_overhang.splitIntoParts(false))
-                    {
-
-                        std::vector<LineInformation> overhang_lines;
-                        Polygons polylines = ensureMaximumDistancePolyline(generateLines(remaining_overhang_part, false, layer_idx), config.min_radius, 1, false);
-                        // ^^^ Support_line_width to form a line here as otherwise most will be unsupported.
-                        // Technically this violates branch distance, but not only is this the only reasonable choice,
-                        //   but it ensures consistent behavior as some infill patterns generate each line segment as its own polyline part causing a similar line forming behavior.
-                        // Also it is assumed that the area that is valid a layer below is to small for support roof.
-                        if (polylines.pointCount() <= 3)
-                        {
-                            // Add the outer wall to ensure it is correct supported instead.
-                            polylines = ensureMaximumDistancePolyline(TreeSupportUtils::toPolylines(remaining_overhang_part), connect_length, 3, true);
-                        }
-
-                        for (auto line : polylines)
-                        {
-                            LineInformation res_line;
-                            for (Point p : line)
-                            {
-                                res_line.emplace_back(p, LineStatus::INVALID);
-                            }
-                            overhang_lines.emplace_back(res_line);
-                        }
-
-                        for (size_t lag_ctr = 1; lag_ctr <= max_overhang_insert_lag && !overhang_lines.empty() && layer_idx - coord_t(lag_ctr) >= 1; lag_ctr++)
-                        {
-                            // get least restricted avoidance for layer_idx-lag_ctr
-                            Polygons relevant_forbidden_below =
-                                volumes_.getAvoidance(config.getRadius(0), layer_idx - lag_ctr, (only_gracious||!config.support_rests_on_model) ? AvoidanceType::FAST : AvoidanceType::COLLISION, config.support_rests_on_model, ! xy_overrides);
-                            // It is not required to offset the forbidden area here as the points won't change:
-                            // If points here are not inside the forbidden area neither will they be later when placing these points, as these are the same points.
-                            std::function<bool(std::pair<Point, LineStatus>)> evaluatePoint =
-                                [&](std::pair<Point, LineStatus> p) { return relevant_forbidden_below.inside(p.first, true); };
-
-                            if (support_roof_layers)
-                            {
-                                //Remove all points that are for some reason part of a roof area, as the point is already supported by roof
-                                std::function<bool(std::pair<Point, LineStatus>)> evaluatePartOfRoof =
-                                    [&](std::pair<Point, LineStatus> p) { return support_roof_drawn[layer_idx-lag_ctr].inside(p.first, true); };
-
-                                overhang_lines = splitLines(overhang_lines, evaluatePartOfRoof).second;
-                            }
-                            std::pair<std::vector<TreeSupportTipGenerator::LineInformation>, std::vector<TreeSupportTipGenerator::LineInformation>> split = splitLines(overhang_lines, evaluatePoint); // Keep all lines that are invalid.
-                            overhang_lines = split.first;
-                            std::vector<LineInformation> fresh_valid_points = convertLinesToInternal(convertInternalToLines(split.second), layer_idx - lag_ctr);
-                            // ^^^ Set all now valid lines to their correct LineStatus. Easiest way is to just discard Avoidance information for each point and evaluate them again.
-
-                            addLinesAsInfluenceAreas(new_tips,fresh_valid_points, (force_tip_to_roof && lag_ctr <= support_roof_layers) ? support_roof_layers : 0, layer_idx - lag_ctr, false, support_roof_layers, false);
-                        }
-                    }
-                }
-
-                overhang_regular.removeSmallAreas(minimum_support_area);
-
-                for (Polygons support_part : overhang_regular.splitIntoParts(true))
-                {
-                    overhang_processing.emplace_back(support_part, false);
-                }
-
-                for (std::pair<Polygons, bool> overhang_pair : overhang_processing)
-                {
-                    const bool roof_allowed_for_this_part = overhang_pair.second;
-                    Polygons overhang_outset = overhang_pair.first;
-                    const size_t min_support_points = std::max(coord_t(1), std::min(coord_t(EPSILON), overhang_outset.polygonLength() / connect_length));
-                    std::vector<LineInformation> overhang_lines;
-
-                    bool only_lines = true;
-
-                    // The tip positions are determined here.
-                    // todo can cause inconsistent support density if a line exactly aligns with the model
-                    Polygons polylines =
-                        ensureMaximumDistancePolyline
-                        (
-                            generateLines(overhang_outset, roof_allowed_for_this_part, layer_idx + roof_allowed_for_this_part), !roof_allowed_for_this_part ? config.min_radius * 2 : use_fake_roof ? support_supporting_branch_distance : connect_length , 1, false
-                        );
-
-
-                    // support_line_width to form a line here as otherwise most will be unsupported.
-                    // Technically this violates branch distance, but not only is this the only reasonable choice,
-                    //   but it ensures consistent behaviour as some infill patterns generate each line segment as its own polyline part causing a similar line forming behaviour.
-                    // This is not done when a roof is above as the roof will support the model and the trees only need to support the roof
-
-                    if (polylines.pointCount() <= min_support_points)
-                    {
-                        only_lines = false;
-                        // Add the outer wall (of the overhang) to ensure it is correct supported instead.
-                        // Try placing the support points in a way that they fully support the outer wall, instead of just the with half of the support line width.
-                        Polygons reduced_overhang_outset = overhang_outset.offset(-config.support_line_width / 2.2);
-                        // ^^^ It's assumed that even small overhangs are over one line width wide, so lets try to place the support points in a way that the full support area generated from them will support the overhang.
-                        //     (If this is not done it may only be half). This WILL NOT be the case when supporting an angle of about < 60� so there is a fallback, as some support is better than none.)
-                        if (! reduced_overhang_outset.empty() && overhang_outset.difference(reduced_overhang_outset.offset(std::max(config.support_line_width, connect_length))).area() < 1)
-                        {
-                            polylines = ensureMaximumDistancePolyline(TreeSupportUtils::toPolylines(reduced_overhang_outset), connect_length, min_support_points, true);
-                        }
-                        else
-                        {
-                            polylines = ensureMaximumDistancePolyline(TreeSupportUtils::toPolylines(overhang_outset), connect_length, min_support_points, true);
-                        }
-                    }
-
-                    if (roof_allowed_for_this_part) //Some roof may only be supported by a part of a tip
-                    {
-                        polylines = TreeSupportUtils::movePointsOutside(polylines,relevant_forbidden,config.getRadius(0)+FUDGE_LENGTH/2);
-                    }
-
-                    overhang_lines = convertLinesToInternal(polylines, layer_idx );
-
-                    if(overhang_lines.empty()) //some error handling and logging
-                    {
-                        Polygons enlarged_overhang_outset = overhang_outset.offset(config.getRadius(0)+FUDGE_LENGTH/2,ClipperLib::jtRound).difference(relevant_forbidden);
-                        polylines = ensureMaximumDistancePolyline(TreeSupportUtils::toPolylines(enlarged_overhang_outset), connect_length, min_support_points, true);
-                        overhang_lines = convertLinesToInternal(polylines, layer_idx );
-
-                        if(!overhang_lines.empty())
-                        {
-                            spdlog::debug("Compensated for overhang area that had no valid tips. Now has a tip.");
-                        }
-                        else
-                        {
-                            spdlog::warn("Overhang area has no valid tips! Was roof: {} On Layer: {}", roof_allowed_for_this_part,layer_idx);
-                        }
-                    }
-
-                    size_t dont_move_for_layers = support_roof_layers ? (force_tip_to_roof ? support_roof_layers : (roof_allowed_for_this_part ? 0 : support_roof_layers)) : 0;
-                    addLinesAsInfluenceAreas(new_tips, overhang_lines, force_tip_to_roof ? support_roof_layers : 0, layer_idx, roof_allowed_for_this_part, dont_move_for_layers, only_lines);
+                    //^^^Technically one should also subtract the avoidance of radius 0 (similarly how calculated in calculateRoofArea), as there can be some rounding errors
+                    //introduced since then. But this does not fully prevent some rounding errors either way, so just handle the error later.
+                    overhang_processing.emplace_back(roof_part, true);
                 }
             }
-        );
 
-    cura::parallel_for<coord_t>
-    (
+            Polygons overhang_regular = TreeSupportUtils::safeOffsetInc(
+                core_overhang,
+                support_outset,
+                relevant_forbidden,
+                config.min_radius * 1.75 + config.xy_min_distance,
+                0,
+                1,
+                config.support_line_distance / 2,
+                &config.simplifier);
+            Polygons remaining_overhang
+                = core_overhang.offset(support_outset).difference(overhang_regular.offset(config.support_line_width * 0.5)).intersection(relevant_forbidden);
+
+
+            // Offset ensures that areas that could be supported by a part of a support line, are not considered unsupported overhang
+            coord_t extra_total_offset_acc = 0;
+
+            // Offset the area to compensate for large tip radiis. Offset happens in multiple steps to ensure the tip is as close to the original overhang as possible.
+            while (extra_total_offset_acc + config.support_line_width / 8
+                   < extra_outset) //+mesh_config.support_line_width / 8  to avoid calculating very small (useless) offsets because of rounding errors.
+            {
+                coord_t offset_current_step = extra_total_offset_acc + 2 * config.support_line_width > config.min_radius
+                                                ? std::min(config.support_line_width / 8, extra_outset - extra_total_offset_acc)
+                                                : std::min(circle_length_to_half_linewidth_change, extra_outset - extra_total_offset_acc);
+                extra_total_offset_acc += offset_current_step;
+                Polygons overhang_offset = TreeSupportUtils::safeOffsetInc(
+                    overhang_regular,
+                    1.5 * extra_total_offset_acc,
+                    volumes_.getCollision(0, layer_idx, true),
+                    config.xy_min_distance + config.support_line_width,
+                    0,
+                    1,
+                    config.support_line_distance / 2,
+                    &config.simplifier);
+                remaining_overhang = remaining_overhang.difference(overhang_offset.unionPolygons(support_roof_drawn[layer_idx].offset(1.5 * extra_total_offset_acc)))
+                                         .unionPolygons(); // overhang_offset is combined with roof, as all area that has a roof, is already supported by said roof.
+                Polygons next_overhang = TreeSupportUtils::safeOffsetInc(
+                    remaining_overhang,
+                    extra_total_offset_acc,
+                    volumes_.getCollision(0, layer_idx, true),
+                    config.xy_min_distance + config.support_line_width,
+                    0,
+                    1,
+                    config.support_line_distance / 2,
+                    &config.simplifier);
+                overhang_regular = overhang_regular.unionPolygons(next_overhang.difference(relevant_forbidden));
+            }
+
+            // If the xy distance overrides the z distance, some support needs to be inserted further down.
+            //=> Analyze which support points do not fit on this layer and check if they will fit a few layers down
+            //   (while adding them an infinite amount of layers down would technically be closer the setting description, it would not produce reasonable results. )
+            if (xy_overrides)
+            {
+                for (Polygons& remaining_overhang_part : remaining_overhang.splitIntoParts(false))
+                {
+                    std::vector<LineInformation> overhang_lines;
+                    Polygons polylines = ensureMaximumDistancePolyline(generateLines(remaining_overhang_part, false, layer_idx), config.min_radius, 1, false);
+                    // ^^^ Support_line_width to form a line here as otherwise most will be unsupported.
+                    // Technically this violates branch distance, but not only is this the only reasonable choice,
+                    //   but it ensures consistent behavior as some infill patterns generate each line segment as its own polyline part causing a similar line forming behavior.
+                    // Also it is assumed that the area that is valid a layer below is to small for support roof.
+                    if (polylines.pointCount() <= 3)
+                    {
+                        // Add the outer wall to ensure it is correct supported instead.
+                        polylines = ensureMaximumDistancePolyline(TreeSupportUtils::toPolylines(remaining_overhang_part), connect_length, 3, true);
+                    }
+
+                    for (auto line : polylines)
+                    {
+                        LineInformation res_line;
+                        for (Point p : line)
+                        {
+                            res_line.emplace_back(p, LineStatus::INVALID);
+                        }
+                        overhang_lines.emplace_back(res_line);
+                    }
+
+                    for (size_t lag_ctr = 1; lag_ctr <= max_overhang_insert_lag && ! overhang_lines.empty() && layer_idx - coord_t(lag_ctr) >= 1; lag_ctr++)
+                    {
+                        // get least restricted avoidance for layer_idx-lag_ctr
+                        Polygons relevant_forbidden_below = volumes_.getAvoidance(
+                            config.getRadius(0),
+                            layer_idx - lag_ctr,
+                            (only_gracious || ! config.support_rests_on_model) ? AvoidanceType::FAST : AvoidanceType::COLLISION,
+                            config.support_rests_on_model,
+                            ! xy_overrides);
+                        // It is not required to offset the forbidden area here as the points won't change:
+                        // If points here are not inside the forbidden area neither will they be later when placing these points, as these are the same points.
+                        std::function<bool(std::pair<Point, LineStatus>)> evaluatePoint = [&](std::pair<Point, LineStatus> p)
+                        {
+                            return relevant_forbidden_below.inside(p.first, true);
+                        };
+
+                        if (support_roof_layers)
+                        {
+                            // Remove all points that are for some reason part of a roof area, as the point is already supported by roof
+                            std::function<bool(std::pair<Point, LineStatus>)> evaluatePartOfRoof = [&](std::pair<Point, LineStatus> p)
+                            {
+                                return support_roof_drawn[layer_idx - lag_ctr].inside(p.first, true);
+                            };
+
+                            overhang_lines = splitLines(overhang_lines, evaluatePartOfRoof).second;
+                        }
+                        std::pair<std::vector<TreeSupportTipGenerator::LineInformation>, std::vector<TreeSupportTipGenerator::LineInformation>> split
+                            = splitLines(overhang_lines, evaluatePoint); // Keep all lines that are invalid.
+                        overhang_lines = split.first;
+                        std::vector<LineInformation> fresh_valid_points = convertLinesToInternal(convertInternalToLines(split.second), layer_idx - lag_ctr);
+                        // ^^^ Set all now valid lines to their correct LineStatus. Easiest way is to just discard Avoidance information for each point and evaluate them again.
+
+                        addLinesAsInfluenceAreas(
+                            new_tips,
+                            fresh_valid_points,
+                            (force_tip_to_roof && lag_ctr <= support_roof_layers) ? support_roof_layers : 0,
+                            layer_idx - lag_ctr,
+                            false,
+                            support_roof_layers,
+                            false);
+                    }
+                }
+            }
+
+            overhang_regular.removeSmallAreas(minimum_support_area);
+
+            for (Polygons support_part : overhang_regular.splitIntoParts(true))
+            {
+                overhang_processing.emplace_back(support_part, false);
+            }
+
+            for (std::pair<Polygons, bool> overhang_pair : overhang_processing)
+            {
+                const bool roof_allowed_for_this_part = overhang_pair.second;
+                Polygons overhang_outset = overhang_pair.first;
+                const size_t min_support_points = std::max(coord_t(1), std::min(coord_t(EPSILON), overhang_outset.polygonLength() / connect_length));
+                std::vector<LineInformation> overhang_lines;
+
+                bool only_lines = true;
+
+                // The tip positions are determined here.
+                // todo can cause inconsistent support density if a line exactly aligns with the model
+                Polygons polylines = ensureMaximumDistancePolyline(
+                    generateLines(overhang_outset, roof_allowed_for_this_part, layer_idx + roof_allowed_for_this_part),
+                    ! roof_allowed_for_this_part ? config.min_radius * 2
+                    : use_fake_roof              ? support_supporting_branch_distance
+                                                 : connect_length,
+                    1,
+                    false);
+
+
+                // support_line_width to form a line here as otherwise most will be unsupported.
+                // Technically this violates branch distance, but not only is this the only reasonable choice,
+                //   but it ensures consistent behaviour as some infill patterns generate each line segment as its own polyline part causing a similar line forming behaviour.
+                // This is not done when a roof is above as the roof will support the model and the trees only need to support the roof
+
+                if (polylines.pointCount() <= min_support_points)
+                {
+                    only_lines = false;
+                    // Add the outer wall (of the overhang) to ensure it is correct supported instead.
+                    // Try placing the support points in a way that they fully support the outer wall, instead of just the with half of the support line width.
+                    Polygons reduced_overhang_outset = overhang_outset.offset(-config.support_line_width / 2.2);
+                    // ^^^ It's assumed that even small overhangs are over one line width wide, so lets try to place the support points in a way that the full support area
+                    // generated from them will support the overhang.
+                    //     (If this is not done it may only be half). This WILL NOT be the case when supporting an angle of about < 60� so there is a fallback, as some support is
+                    //     better than none.)
+                    if (! reduced_overhang_outset.empty()
+                        && overhang_outset.difference(reduced_overhang_outset.offset(std::max(config.support_line_width, connect_length))).area() < 1)
+                    {
+                        polylines = ensureMaximumDistancePolyline(TreeSupportUtils::toPolylines(reduced_overhang_outset), connect_length, min_support_points, true);
+                    }
+                    else
+                    {
+                        polylines = ensureMaximumDistancePolyline(TreeSupportUtils::toPolylines(overhang_outset), connect_length, min_support_points, true);
+                    }
+                }
+
+                if (roof_allowed_for_this_part) // Some roof may only be supported by a part of a tip
+                {
+                    polylines = TreeSupportUtils::movePointsOutside(polylines, relevant_forbidden, config.getRadius(0) + FUDGE_LENGTH / 2);
+                }
+
+                overhang_lines = convertLinesToInternal(polylines, layer_idx);
+
+                if (overhang_lines.empty()) // some error handling and logging
+                {
+                    Polygons enlarged_overhang_outset = overhang_outset.offset(config.getRadius(0) + FUDGE_LENGTH / 2, ClipperLib::jtRound).difference(relevant_forbidden);
+                    polylines = ensureMaximumDistancePolyline(TreeSupportUtils::toPolylines(enlarged_overhang_outset), connect_length, min_support_points, true);
+                    overhang_lines = convertLinesToInternal(polylines, layer_idx);
+
+                    if (! overhang_lines.empty())
+                    {
+                        spdlog::debug("Compensated for overhang area that had no valid tips. Now has a tip.");
+                    }
+                    else
+                    {
+                        spdlog::warn("Overhang area has no valid tips! Was roof: {} On Layer: {}", roof_allowed_for_this_part, layer_idx);
+                    }
+                }
+
+                size_t dont_move_for_layers = support_roof_layers ? (force_tip_to_roof ? support_roof_layers : (roof_allowed_for_this_part ? 0 : support_roof_layers)) : 0;
+                addLinesAsInfluenceAreas(
+                    new_tips,
+                    overhang_lines,
+                    force_tip_to_roof ? support_roof_layers : 0,
+                    layer_idx,
+                    roof_allowed_for_this_part,
+                    dont_move_for_layers,
+                    only_lines);
+            }
+        });
+
+    cura::parallel_for<coord_t>(
         0,
         support_roof_drawn.size(),
         [&](const LayerIndex layer_idx)
         {
             // Sometimes roofs could be empty as the pattern does not generate lines if the area is narrow enough.
-            // If there is a roof could have zero lines in its area (as it has no wall), rand a support area would very likely be printed (because there are walls for the support areas), replace non printable roofs with support
+            // If there is a roof could have zero lines in its area (as it has no wall), rand a support area would very likely be printed (because there are walls for the support
+            // areas), replace non printable roofs with support
             if (! use_fake_roof && config.support_wall_count > 0 && config.support_roof_wall_count == 0)
             {
                 for (auto roof_area : support_roof_drawn[layer_idx].unionPolygons(roof_tips_drawn[layer_idx]).splitIntoParts())
                 {
-                    // technically there is no guarantee that a drawn roof tip has lines, as it could be unioned with another roof area that has, but this has to be enough hopefully.
-                    if (layer_idx < additional_support_areas.size() && TreeSupportUtils::generateSupportInfillLines(roof_area, config, true, layer_idx, support_roof_line_distance, cross_fill_provider, false).empty())
+                    // technically there is no guarantee that a drawn roof tip has lines, as it could be unioned with another roof area that has, but this has to be enough
+                    // hopefully.
+                    if (layer_idx < additional_support_areas.size()
+                        && TreeSupportUtils::generateSupportInfillLines(roof_area, config, true, layer_idx, support_roof_line_distance, cross_fill_provider, false).empty())
                     {
                         additional_support_areas[layer_idx].add(roof_area);
                     }
@@ -1018,8 +1166,15 @@ void TreeSupportTipGenerator::generateTips(SliceDataStorage& storage,const Slice
                     {
                         storage.support.supportLayers[layer_idx].support_infill_parts.emplace_back(part, config.support_line_width, 0, support_roof_line_distance);
                     }
-                    placed_support_lines_support_areas[layer_idx].add(
-                        TreeSupportUtils::generateSupportInfillLines(support_roof_drawn[layer_idx], config, false, layer_idx, support_roof_line_distance, cross_fill_provider, false).offsetPolyLine(config.support_line_width / 2));
+                    placed_support_lines_support_areas[layer_idx].add(TreeSupportUtils::generateSupportInfillLines(
+                                                                          support_roof_drawn[layer_idx],
+                                                                          config,
+                                                                          false,
+                                                                          layer_idx,
+                                                                          support_roof_line_distance,
+                                                                          cross_fill_provider,
+                                                                          false)
+                                                                          .offsetPolyLine(config.support_line_width / 2));
                 }
                 else
                 {
@@ -1029,7 +1184,7 @@ void TreeSupportTipGenerator::generateTips(SliceDataStorage& storage,const Slice
             }
         });
 
-    removeUselessAddedPoints(new_tips ,storage , additional_support_areas);
+    removeUselessAddedPoints(new_tips, storage, additional_support_areas);
 
     for (auto [layer_idx, tips_on_layer] : new_tips | ranges::views::enumerate)
     {
@@ -1038,6 +1193,4 @@ void TreeSupportTipGenerator::generateTips(SliceDataStorage& storage,const Slice
 }
 
 
-
-}// namespace cura
-
+} // namespace cura

--- a/src/TreeSupportTipGenerator.cpp
+++ b/src/TreeSupportTipGenerator.cpp
@@ -917,7 +917,7 @@ void TreeSupportTipGenerator::generateTips(
                                               .splitIntoParts(true)) // If there is a roof, the roof will be one layer above the tips.
                 {
                     //^^^Technically one should also subtract the avoidance of radius 0 (similarly how calculated in calculateRoofArea), as there can be some rounding errors
-                    //introduced since then. But this does not fully prevent some rounding errors either way, so just handle the error later.
+                    // introduced since then. But this does not fully prevent some rounding errors either way, so just handle the error later.
                     overhang_processing.emplace_back(roof_part, true);
                 }
             }

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifdef ARCUS
@@ -133,7 +133,7 @@ public:
         }
         else if (initial_point != last_point)
         {
-            addLineSegment(PrintFeatureType::NoneType, initial_point, 1, 0, 0);
+            addLineSegment(PrintFeatureType::NoneType, initial_point, 1, 0, 0.0);
         }
     }
 

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -3,24 +3,25 @@
 
 #ifdef ARCUS
 
-#include <Arcus/Socket.h> //The socket to communicate to.
-#include <thread> //To sleep while waiting for the connection.
-#include <unordered_map> //To map settings to their extruder numbers for limit_to_extruder.
-
-#include <spdlog/spdlog.h>
+#include "communication/ArcusCommunication.h"
 
 #include "Application.h" //To get and set the current slice command.
 #include "ExtruderTrain.h"
 #include "FffProcessor.h" //To start a slice.
 #include "PrintFeature.h"
 #include "Slice.h" //To process slices.
-#include "communication/ArcusCommunication.h"
 #include "communication/ArcusCommunicationPrivate.h" //Our PIMPL.
 #include "communication/Listener.h" //To listen to the Arcus socket.
 #include "communication/SliceDataStruct.h" //To store sliced layer data.
 #include "settings/types/LayerIndex.h" //To point to layers.
 #include "settings/types/Velocity.h" //To send to layer view how fast stuff is printing.
 #include "utils/polygon.h"
+
+#include <Arcus/Socket.h> //The socket to communicate to.
+#include <spdlog/spdlog.h>
+
+#include <thread> //To sleep while waiting for the connection.
+#include <unordered_map> //To map settings to their extruder numbers for limit_to_extruder.
 
 namespace cura
 {
@@ -47,7 +48,8 @@ class ArcusCommunication::PathCompiler
     std::vector<float> line_widths; //!< Line widths for the line segments stored, the size of this vector is N.
     std::vector<float> line_thicknesses; //!< Line thicknesses for the line segments stored, the size of this vector is N.
     std::vector<float> line_velocities; //!< Line feedrates for the line segments stored, the size of this vector is N.
-    std::vector<float> points; //!< The points used to define the line segments, the size of this vector is D*(N+1) as each line segment is defined from one point to the next. D is the dimensionality of the point.
+    std::vector<float> points; //!< The points used to define the line segments, the size of this vector is D*(N+1) as each line segment is defined from one point to the next. D is
+                               //!< the dimensionality of the point.
 
     Point last_point;
 
@@ -281,7 +283,9 @@ private:
     }
 };
 
-ArcusCommunication::ArcusCommunication() : private_data(new Private), path_compiler(new PathCompiler(*private_data))
+ArcusCommunication::ArcusCommunication()
+    : private_data(new Private)
+    , path_compiler(new PathCompiler(*private_data))
 {
 }
 
@@ -422,7 +426,12 @@ void ArcusCommunication::sendOptimizedLayerData()
     data.slice_data.clear();
 }
 
-void ArcusCommunication::sendPolygon(const PrintFeatureType& type, const ConstPolygonRef& polygon, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity)
+void ArcusCommunication::sendPolygon(
+    const PrintFeatureType& type,
+    const ConstPolygonRef& polygon,
+    const coord_t& line_width,
+    const coord_t& line_thickness,
+    const Velocity& velocity)
 {
     path_compiler->sendPolygon(type, polygon, line_width, line_thickness, velocity);
 }

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <assert.h>
@@ -45,10 +45,10 @@ GCodeExport::GCodeExport() : output_stream(&std::cout), currentPosition(0, 0, MM
 
     total_print_times = std::vector<Duration>(static_cast<unsigned char>(PrintFeatureType::NumPrintFeatureTypes), 0.0);
 
-    currentSpeed = 1;
-    current_print_acceleration = -1;
-    current_travel_acceleration = -1;
-    current_jerk = -1;
+    currentSpeed = 1.0;
+    current_print_acceleration = -1.0;
+    current_travel_acceleration = -1.0;
+    current_jerk = -1.0;
 
     is_z_hopped = 0;
     setFlavor(EGCodeFlavor::MARLIN);
@@ -1122,7 +1122,7 @@ void GCodeExport::writeRetraction(const RetractionConfig& config, bool force, bo
         *output_stream << new_line;
         // Assume default UM2 retraction settings.
         estimateCalculator.plan(TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value + retraction_diff_e_amount)),
-                                25,
+                                25.0,
                                 PrintFeatureType::MoveRetraction); // TODO: hardcoded values!
     }
     else

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1,12 +1,7 @@
 // Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
-#include <assert.h>
-#include <cmath>
-#include <iomanip>
-#include <stdarg.h>
-
-#include <spdlog/spdlog.h>
+#include "gcodeExport.h"
 
 #include "Application.h" //To send layer view data.
 #include "ExtruderTrain.h"
@@ -15,10 +10,16 @@
 #include "Slice.h"
 #include "WipeScriptConfig.h"
 #include "communication/Communication.h" //To send layer view data.
-#include "gcodeExport.h"
 #include "settings/types/LayerIndex.h"
 #include "utils/Date.h"
 #include "utils/string.h" // MMtoStream, PrecisionedDouble
+
+#include <spdlog/spdlog.h>
+
+#include <assert.h>
+#include <cmath>
+#include <iomanip>
+#include <stdarg.h>
 
 namespace cura
 {
@@ -35,7 +36,11 @@ std::string transliterate(const std::string& text)
     return stream.str();
 }
 
-GCodeExport::GCodeExport() : output_stream(&std::cout), currentPosition(0, 0, MM2INT(20)), layer_nr(0), relative_extrusion(false)
+GCodeExport::GCodeExport()
+    : output_stream(&std::cout)
+    , currentPosition(0, 0, MM2INT(20))
+    , layer_nr(0)
+    , relative_extrusion(false)
 {
     *output_stream << std::fixed;
 
@@ -85,7 +90,8 @@ void GCodeExport::preSetup(const size_t start_extruder)
         const ExtruderTrain& train = scene.extruders[extruder_nr];
         setFilamentDiameter(extruder_nr, train.settings.get<coord_t>("material_diameter"));
 
-        extruder_attr[extruder_nr].last_retraction_prime_speed = train.settings.get<Velocity>("retraction_prime_speed"); // the alternative would be switch_extruder_prime_speed, but dual extrusion might not even be configured...
+        extruder_attr[extruder_nr].last_retraction_prime_speed
+            = train.settings.get<Velocity>("retraction_prime_speed"); // the alternative would be switch_extruder_prime_speed, but dual extrusion might not even be configured...
         extruder_attr[extruder_nr].fan_number = train.settings.get<size_t>("machine_extruder_cooling_fan_number");
     }
 
@@ -160,7 +166,11 @@ const std::string GCodeExport::flavorToString(const EGCodeFlavor& flavor) const
     }
 }
 
-std::string GCodeExport::getFileHeader(const std::vector<bool>& extruder_is_used, const Duration* print_time, const std::vector<double>& filament_used, const std::vector<std::string>& mat_ids)
+std::string GCodeExport::getFileHeader(
+    const std::vector<bool>& extruder_is_used,
+    const Duration* print_time,
+    const std::vector<double>& filament_used,
+    const std::vector<std::string>& mat_ids)
 {
     std::ostringstream prefix;
 
@@ -387,8 +397,10 @@ double GCodeExport::getCurrentExtrudedVolume() const
     const Settings& extruder_settings = Application::getInstance().current_slice->scene.extruders[current_extruder].settings;
     if (! extruder_settings.get<bool>("machine_firmware_retract"))
     { // no E values are changed to perform a retraction
-        extrusion_amount -= extruder_attr[current_extruder].retraction_e_amount_at_e_start; // subtract the increment in E which was used for the first unretraction instead of extrusion
-        extrusion_amount += extruder_attr[current_extruder].retraction_e_amount_current; // add the decrement in E which the filament is behind on extrusion due to the last retraction
+        extrusion_amount
+            -= extruder_attr[current_extruder].retraction_e_amount_at_e_start; // subtract the increment in E which was used for the first unretraction instead of extrusion
+        extrusion_amount
+            += extruder_attr[current_extruder].retraction_e_amount_current; // add the decrement in E which the filament is behind on extrusion due to the last retraction
     }
     if (is_volumetric)
     {
@@ -616,7 +628,8 @@ bool GCodeExport::initializeExtruderTrains(const SliceDataStorage& storage, cons
     bool should_prime_extruder = true;
     const Settings& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
 
-    if (Application::getInstance().communication->isSequential()) // If we must output the g-code sequentially, we must already place the g-code header here even if we don't know the exact time/material usages yet.
+    if (Application::getInstance().communication->isSequential()) // If we must output the g-code sequentially, we must already place the g-code header here even if we don't know
+                                                                  // the exact time/material usages yet.
     {
         std::string prefix = getFileHeader(storage.getExtrudersUsed());
         writeCode(prefix.c_str());
@@ -719,7 +732,9 @@ void GCodeExport::processInitialLayerTemperature(const SliceDataStorage& storage
         {
             const Temperature bed_temp = scene.current_mesh_group->settings.get<Temperature>("material_bed_temperature_layer_0");
             if (scene.current_mesh_group == scene.mesh_groups.begin() // Always write bed temperature for first mesh group.
-                || bed_temp != (scene.current_mesh_group - 1)->settings.get<Temperature>("material_bed_temperature")) // Don't write bed temperature if identical to temperature of previous group.
+                || bed_temp
+                       != (scene.current_mesh_group - 1)
+                              ->settings.get<Temperature>("material_bed_temperature")) // Don't write bed temperature if identical to temperature of previous group.
             {
                 if (bed_temp != 0)
                 {
@@ -874,14 +889,18 @@ void GCodeExport::writeMoveBFB(const int x, const int y, const int z, const Velo
         if (! extruder_attr[current_extruder].retraction_e_amount_current)
         {
             *output_stream << "M103" << new_line;
-            extruder_attr[current_extruder].retraction_e_amount_current = 1.0; // 1.0 used as stub; BFB doesn't use the actual retraction amount; it performs retraction on the firmware automatically
+            extruder_attr[current_extruder].retraction_e_amount_current
+                = 1.0; // 1.0 used as stub; BFB doesn't use the actual retraction amount; it performs retraction on the firmware automatically
         }
     }
     *output_stream << "G1 X" << MMtoStream{ gcode_pos.X } << " Y" << MMtoStream{ gcode_pos.Y } << " Z" << MMtoStream{ z };
     *output_stream << " F" << PrecisionedDouble{ 1, fspeed } << new_line;
 
     currentPosition = Point3(x, y, z);
-    estimateCalculator.plan(TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)), speed, feature);
+    estimateCalculator.plan(
+        TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)),
+        speed,
+        feature);
 }
 
 void GCodeExport::writeTravel(const coord_t x, const coord_t y, const coord_t z, const Velocity& speed)
@@ -907,7 +926,14 @@ void GCodeExport::writeTravel(const coord_t x, const coord_t y, const coord_t z,
     writeFXYZE(speed, x, y, z, current_e_value, travel_move_type);
 }
 
-void GCodeExport::writeExtrusion(const coord_t x, const coord_t y, const coord_t z, const Velocity& speed, const double extrusion_mm3_per_mm, const PrintFeatureType& feature, const bool update_extrusion_offset)
+void GCodeExport::writeExtrusion(
+    const coord_t x,
+    const coord_t y,
+    const coord_t z,
+    const Velocity& speed,
+    const double extrusion_mm3_per_mm,
+    const PrintFeatureType& feature,
+    const bool update_extrusion_offset)
 {
     if (currentPosition.x == x && currentPosition.y == y && currentPosition.z == z)
     {
@@ -1021,33 +1047,45 @@ void GCodeExport::writeUnretractionAndPrime()
             if (prime_volume != 0)
             {
                 const double output_e = (relative_extrusion) ? prime_volume_e : current_e_value;
-                *output_stream << "G1 F" << PrecisionedDouble{ 1, extruder_attr[current_extruder].last_retraction_prime_speed * 60 } << " " << extruder_attr[current_extruder].extruderCharacter << PrecisionedDouble{ 5, output_e }
-                               << new_line;
+                *output_stream << "G1 F" << PrecisionedDouble{ 1, extruder_attr[current_extruder].last_retraction_prime_speed * 60 } << " "
+                               << extruder_attr[current_extruder].extruderCharacter << PrecisionedDouble{ 5, output_e } << new_line;
                 currentSpeed = extruder_attr[current_extruder].last_retraction_prime_speed;
             }
-            estimateCalculator.plan(TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)), 25.0, PrintFeatureType::MoveRetraction);
+            estimateCalculator.plan(
+                TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)),
+                25.0,
+                PrintFeatureType::MoveRetraction);
         }
         else
         {
             current_e_value += extruder_attr[current_extruder].retraction_e_amount_current;
             const double output_e = (relative_extrusion) ? extruder_attr[current_extruder].retraction_e_amount_current + prime_volume_e : current_e_value;
-            *output_stream << "G1 F" << PrecisionedDouble{ 1, extruder_attr[current_extruder].last_retraction_prime_speed * 60 } << " " << extruder_attr[current_extruder].extruderCharacter << PrecisionedDouble{ 5, output_e } << new_line;
+            *output_stream << "G1 F" << PrecisionedDouble{ 1, extruder_attr[current_extruder].last_retraction_prime_speed * 60 } << " "
+                           << extruder_attr[current_extruder].extruderCharacter << PrecisionedDouble{ 5, output_e } << new_line;
             currentSpeed = extruder_attr[current_extruder].last_retraction_prime_speed;
-            estimateCalculator.plan(TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)), currentSpeed, PrintFeatureType::MoveRetraction);
+            estimateCalculator.plan(
+                TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)),
+                currentSpeed,
+                PrintFeatureType::MoveRetraction);
         }
     }
     else if (prime_volume != 0.0)
     {
         const double output_e = (relative_extrusion) ? prime_volume_e : current_e_value;
-        *output_stream << "G1 F" << PrecisionedDouble{ 1, extruder_attr[current_extruder].last_retraction_prime_speed * 60 } << " " << extruder_attr[current_extruder].extruderCharacter;
+        *output_stream << "G1 F" << PrecisionedDouble{ 1, extruder_attr[current_extruder].last_retraction_prime_speed * 60 } << " "
+                       << extruder_attr[current_extruder].extruderCharacter;
         *output_stream << PrecisionedDouble{ 5, output_e } << new_line;
         currentSpeed = extruder_attr[current_extruder].last_retraction_prime_speed;
-        estimateCalculator.plan(TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)), currentSpeed, PrintFeatureType::NoneType);
+        estimateCalculator.plan(
+            TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)),
+            currentSpeed,
+            PrintFeatureType::NoneType);
     }
     extruder_attr[current_extruder].prime_volume = 0.0;
 
     if (getCurrentExtrudedVolume() > 10000.0 && flavor != EGCodeFlavor::BFB
-        && flavor != EGCodeFlavor::MAKERBOT) // According to https://github.com/Ultimaker/CuraEngine/issues/14 having more then 21m of extrusion causes inaccuracies. So reset it every 10m, just to be sure.
+        && flavor != EGCodeFlavor::MAKERBOT) // According to https://github.com/Ultimaker/CuraEngine/issues/14 having more then 21m of extrusion causes inaccuracies. So reset it
+                                             // every 10m, just to be sure.
     {
         resetExtrusionValue();
     }
@@ -1121,9 +1159,10 @@ void GCodeExport::writeRetraction(const RetractionConfig& config, bool force, bo
         }
         *output_stream << new_line;
         // Assume default UM2 retraction settings.
-        estimateCalculator.plan(TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value + retraction_diff_e_amount)),
-                                25.0,
-                                PrintFeatureType::MoveRetraction); // TODO: hardcoded values!
+        estimateCalculator.plan(
+            TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value + retraction_diff_e_amount)),
+            25.0,
+            PrintFeatureType::MoveRetraction); // TODO: hardcoded values!
     }
     else
     {
@@ -1132,7 +1171,10 @@ void GCodeExport::writeRetraction(const RetractionConfig& config, bool force, bo
         const double output_e = (relative_extrusion) ? retraction_diff_e_amount : current_e_value;
         *output_stream << "G1 F" << PrecisionedDouble{ 1, speed * 60 } << " " << extr_attr.extruderCharacter << PrecisionedDouble{ 5, output_e } << new_line;
         currentSpeed = speed;
-        estimateCalculator.plan(TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)), currentSpeed, PrintFeatureType::MoveRetraction);
+        estimateCalculator.plan(
+            TimeEstimateCalculator::Position(INT2MM(currentPosition.x), INT2MM(currentPosition.y), INT2MM(currentPosition.z), eToMm(current_e_value)),
+            currentSpeed,
+            PrintFeatureType::MoveRetraction);
         extr_attr.last_retraction_prime_speed = config.primeSpeed;
     }
 
@@ -1286,7 +1328,10 @@ void GCodeExport::writePrimeTrain(const Velocity& travel_speed)
         // ideally the prime position would be respected whether we do a blob or not,
         // but the frontend currently doesn't support a value function of an extruder setting depending on an fdmprinter setting,
         // which is needed to automatically ignore the prime position for the printer when blob is disabled
-        Point3 prime_pos(extruder_settings.get<coord_t>("extruder_prime_pos_x"), extruder_settings.get<coord_t>("extruder_prime_pos_y"), extruder_settings.get<coord_t>("extruder_prime_pos_z"));
+        Point3 prime_pos(
+            extruder_settings.get<coord_t>("extruder_prime_pos_x"),
+            extruder_settings.get<coord_t>("extruder_prime_pos_y"),
+            extruder_settings.get<coord_t>("extruder_prime_pos_z"));
         if (! extruder_settings.get<bool>("extruder_prime_pos_abs"))
         {
             // currentPosition.z can be already z hopped

--- a/src/infill/SubDivCube.cpp
+++ b/src/infill/SubDivCube.cpp
@@ -1,5 +1,5 @@
-//Copyright (c) 2022 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "infill/SubDivCube.h"
 
@@ -201,7 +201,7 @@ bool SubDivCube::isValidSubdivision(SliceMeshStorage& mesh, Point3& center, coor
     int top_layer = (center.z + radius) / layer_height;
     for (int test_layer = bottom_layer; test_layer <= top_layer; test_layer += 3) // steps of three. Low-hanging speed gain.
     {
-        part_dist = static_cast<Ratio>(test_layer * layer_height - center.z) / radius;
+        part_dist = Ratio { static_cast<Ratio::value_type>(test_layer * layer_height - center.z) } / radius;
         sphere_slice_radius2 = radius * radius * (1.0 - (part_dist * part_dist));
         Point loc(center.x, center.y);
 

--- a/src/infill/SubDivCube.cpp
+++ b/src/infill/SubDivCube.cpp
@@ -3,17 +3,17 @@
 
 #include "infill/SubDivCube.h"
 
-#include <functional>
-
-#include "sliceDataStorage.h"
 #include "settings/types/Angle.h" //For the infill angle.
+#include "sliceDataStorage.h"
 #include "utils/math.h"
 #include "utils/polygonUtils.h"
 
-#define ONE_OVER_SQRT_2 0.7071067811865475244008443621048490392848359376884740 //1 / sqrt(2)
-#define ONE_OVER_SQRT_3 0.577350269189625764509148780501957455647601751270126876018 //1 / sqrt(3)
-#define ONE_OVER_SQRT_6 0.408248290463863016366214012450981898660991246776111688072 //1 / sqrt(6)
-#define SQRT_TWO_THIRD 0.816496580927726032732428024901963797321982493552223376144 //sqrt(2 / 3)
+#include <functional>
+
+#define ONE_OVER_SQRT_2 0.7071067811865475244008443621048490392848359376884740 // 1 / sqrt(2)
+#define ONE_OVER_SQRT_3 0.577350269189625764509148780501957455647601751270126876018 // 1 / sqrt(3)
+#define ONE_OVER_SQRT_6 0.408248290463863016366214012450981898660991246776111688072 // 1 / sqrt(6)
+#define SQRT_TWO_THIRD 0.816496580927726032732428024901963797321982493552223376144 // sqrt(2 / 3)
 
 namespace cura
 {
@@ -40,9 +40,10 @@ void SubDivCube::precomputeOctree(SliceMeshStorage& mesh, const Point& infill_or
 
     // if infill_angles is not empty use the first value, otherwise use 0
     const std::vector<AngleDegrees> infill_angles = mesh.settings.get<std::vector<AngleDegrees>>("infill_angles");
-    const AngleDegrees infill_angle = (!infill_angles.empty()) ? infill_angles[0] : AngleDegrees(0);
+    const AngleDegrees infill_angle = (! infill_angles.empty()) ? infill_angles[0] : AngleDegrees(0);
 
-    const coord_t furthest_dist_from_origin = std::sqrt(square(mesh.settings.get<coord_t>("machine_height")) + square(mesh.settings.get<coord_t>("machine_depth") / 2) + square(mesh.settings.get<coord_t>("machine_width") / 2));
+    const coord_t furthest_dist_from_origin = std::sqrt(
+        square(mesh.settings.get<coord_t>("machine_height")) + square(mesh.settings.get<coord_t>("machine_depth") / 2) + square(mesh.settings.get<coord_t>("machine_width") / 2));
     const coord_t max_side_length = furthest_dist_from_origin * 2;
 
     size_t curr_recursion_depth = 0;
@@ -75,9 +76,15 @@ void SubDivCube::precomputeOctree(SliceMeshStorage& mesh, const Point& infill_or
     //             /  .O.  \                           |                        .
     //            /.~'   '~.\                          O---->X                  .
     //          X """"""""""" Y                                                 .
-    tilt.matrix[0] = -ONE_OVER_SQRT_2;  tilt.matrix[1] = ONE_OVER_SQRT_2; tilt.matrix[2] = 0;
-    tilt.matrix[3] = -ONE_OVER_SQRT_6; tilt.matrix[4] = -ONE_OVER_SQRT_6; tilt.matrix[5] = SQRT_TWO_THIRD ;
-    tilt.matrix[6] = ONE_OVER_SQRT_3;  tilt.matrix[7] = ONE_OVER_SQRT_3;  tilt.matrix[8] = ONE_OVER_SQRT_3;
+    tilt.matrix[0] = -ONE_OVER_SQRT_2;
+    tilt.matrix[1] = ONE_OVER_SQRT_2;
+    tilt.matrix[2] = 0;
+    tilt.matrix[3] = -ONE_OVER_SQRT_6;
+    tilt.matrix[4] = -ONE_OVER_SQRT_6;
+    tilt.matrix[5] = SQRT_TWO_THIRD;
+    tilt.matrix[6] = ONE_OVER_SQRT_3;
+    tilt.matrix[7] = ONE_OVER_SQRT_3;
+    tilt.matrix[8] = ONE_OVER_SQRT_3;
 
     infill_rotation_matrix = PointMatrix(infill_angle);
     Point3Matrix infill_angle_mat(infill_rotation_matrix);
@@ -89,7 +96,7 @@ void SubDivCube::precomputeOctree(SliceMeshStorage& mesh, const Point& infill_or
 
 void SubDivCube::generateSubdivisionLines(const coord_t z, Polygons& result)
 {
-    if (cube_properties_per_recursion_step.empty()) //Infill is set to 0%.
+    if (cube_properties_per_recursion_step.empty()) // Infill is set to 0%.
     {
         return;
     }
@@ -126,7 +133,7 @@ void SubDivCube::generateSubdivisionLines(const coord_t z, Polygons (&directiona
         relative_b.Y = relative_a.Y;
         rotatePointInitial(relative_a);
         rotatePointInitial(relative_b);
-        for (int dir_idx = 0; dir_idx < 3; dir_idx++)//!< draw the line, then rotate 120 degrees.
+        for (int dir_idx = 0; dir_idx < 3; dir_idx++) //!< draw the line, then rotate 120 degrees.
         {
             a.X = center.x + relative_a.X;
             a.Y = center.y + relative_a.Y;
@@ -158,7 +165,7 @@ SubDivCube::SubDivCube(SliceMeshStorage& mesh, Point3& center, size_t depth)
     {
         return;
     }
-    if (depth >= cube_properties_per_recursion_step.size()) //Depth is out of bounds of what we pre-computed.
+    if (depth >= cube_properties_per_recursion_step.size()) // Depth is out of bounds of what we pre-computed.
     {
         return;
     }
@@ -191,17 +198,17 @@ SubDivCube::SubDivCube(SliceMeshStorage& mesh, Point3& center, size_t depth)
 bool SubDivCube::isValidSubdivision(SliceMeshStorage& mesh, Point3& center, coord_t radius)
 {
     coord_t distance2 = 0;
-    coord_t sphere_slice_radius2;//!< squared radius of bounding sphere slice on target layer
+    coord_t sphere_slice_radius2; //!< squared radius of bounding sphere slice on target layer
     bool inside_somewhere = false;
     bool outside_somewhere = false;
     int inside;
-    Ratio part_dist;//what percentage of the radius the target layer is away from the center along the z axis. 0 - 1
+    Ratio part_dist; // what percentage of the radius the target layer is away from the center along the z axis. 0 - 1
     const coord_t layer_height = mesh.settings.get<coord_t>("layer_height");
     int bottom_layer = (center.z - radius) / layer_height;
     int top_layer = (center.z + radius) / layer_height;
     for (int test_layer = bottom_layer; test_layer <= top_layer; test_layer += 3) // steps of three. Low-hanging speed gain.
     {
-        part_dist = Ratio { static_cast<Ratio::value_type>(test_layer * layer_height - center.z) } / radius;
+        part_dist = Ratio{ static_cast<Ratio::value_type>(test_layer * layer_height - center.z) } / radius;
         sphere_slice_radius2 = radius * radius * (1.0 - (part_dist * part_dist));
         Point loc(center.x, center.y);
 
@@ -259,7 +266,7 @@ void SubDivCube::rotatePointInitial(Point& target)
 
 void SubDivCube::rotatePoint120(Point& target)
 {
-    //constexpr double sqrt_three_fourths = sqrt(3.0 / 4.0); //TODO: Reactivate once MacOS is upgraded to a more modern compiler.
+    // constexpr double sqrt_three_fourths = sqrt(3.0 / 4.0); //TODO: Reactivate once MacOS is upgraded to a more modern compiler.
 #define sqrt_three_fourths 0.86602540378443864676372317
     const coord_t x = -0.5 * target.X - sqrt_three_fourths * target.Y;
     target.Y = -0.5 * target.Y + sqrt_three_fourths * target.X;
@@ -289,4 +296,4 @@ void SubDivCube::addLineAndCombine(Polygons& group, Point from, Point to)
     group.addLine(from, to);
 }
 
-}//namespace cura
+} // namespace cura

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <cctype>
@@ -162,6 +162,12 @@ Temperature Settings::get<Temperature>(const std::string& key) const
 
 template<>
 Velocity Settings::get<Velocity>(const std::string& key) const
+{
+    return get<double>(key);
+}
+
+template<>
+Acceleration Settings::get<Acceleration>(const std::string& key) const
 {
     return get<double>(key);
 }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -175,7 +175,7 @@ void SkinInfillAreaComputation::calculateBottomSkin(const SliceLayerPart& part, 
     {
         return; // don't subtract anything form the downskin
     }
-    LayerIndex bottom_check_start_layer_idx = std::max(LayerIndex(0), layer_nr - bottom_layer_count);
+    LayerIndex bottom_check_start_layer_idx { std::max(LayerIndex { 0 }, LayerIndex { layer_nr - bottom_layer_count }) };
     Polygons not_air = getOutlineOnLayer(part, bottom_check_start_layer_idx);
     if (!no_small_gaps_heuristic)
     {

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -1,20 +1,21 @@
 // Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
-#include <cmath> // std::ceil
+#include "skin.h"
 
 #include "Application.h" //To get settings.
-#include "Slice.h"
 #include "ExtruderTrain.h"
-#include "skin.h"
+#include "Slice.h"
+#include "WallToolPaths.h"
 #include "infill.h"
-#include "sliceDataStorage.h"
 #include "settings/EnumSettings.h" //For EFillMethod.
 #include "settings/types/Angle.h" //For the infill support angle.
 #include "settings/types/Ratio.h"
+#include "sliceDataStorage.h"
 #include "utils/math.h"
 #include "utils/polygonUtils.h"
-#include "WallToolPaths.h"
+
+#include <cmath> // std::ceil
 
 #define MIN_AREA_SIZE (0.4 * 0.4)
 
@@ -33,18 +34,18 @@ coord_t SkinInfillAreaComputation::getSkinLineWidth(const SliceMeshStorage& mesh
 }
 
 SkinInfillAreaComputation::SkinInfillAreaComputation(const LayerIndex& layer_nr, SliceMeshStorage& mesh, bool process_infill)
-: layer_nr(layer_nr)
-, mesh(mesh)
-, bottom_layer_count(mesh.settings.get<size_t>("bottom_layers"))
-, initial_bottom_layer_count(mesh.settings.get<size_t>("initial_bottom_layers"))
-, top_layer_count(mesh.settings.get<size_t>("top_layers"))
-, skin_line_width(getSkinLineWidth(mesh, layer_nr))
-, no_small_gaps_heuristic(mesh.settings.get<bool>("skin_no_small_gaps_heuristic"))
-, process_infill(process_infill)
-, top_skin_preshrink(mesh.settings.get<coord_t>("top_skin_preshrink"))
-, bottom_skin_preshrink(mesh.settings.get<coord_t>("bottom_skin_preshrink"))
-, top_skin_expand_distance(mesh.settings.get<coord_t>("top_skin_expand_distance"))
-, bottom_skin_expand_distance(mesh.settings.get<coord_t>("bottom_skin_expand_distance"))
+    : layer_nr(layer_nr)
+    , mesh(mesh)
+    , bottom_layer_count(mesh.settings.get<size_t>("bottom_layers"))
+    , initial_bottom_layer_count(mesh.settings.get<size_t>("initial_bottom_layers"))
+    , top_layer_count(mesh.settings.get<size_t>("top_layers"))
+    , skin_line_width(getSkinLineWidth(mesh, layer_nr))
+    , no_small_gaps_heuristic(mesh.settings.get<bool>("skin_no_small_gaps_heuristic"))
+    , process_infill(process_infill)
+    , top_skin_preshrink(mesh.settings.get<coord_t>("top_skin_preshrink"))
+    , bottom_skin_preshrink(mesh.settings.get<coord_t>("bottom_skin_preshrink"))
+    , top_skin_expand_distance(mesh.settings.get<coord_t>("top_skin_expand_distance"))
+    , bottom_skin_expand_distance(mesh.settings.get<coord_t>("bottom_skin_expand_distance"))
 {
 }
 
@@ -105,12 +106,12 @@ void SkinInfillAreaComputation::generateSkinAndInfillAreas()
 {
     SliceLayer& layer = mesh.layers[layer_nr];
 
-    if (!process_infill && bottom_layer_count == 0 && top_layer_count == 0)
+    if (! process_infill && bottom_layer_count == 0 && top_layer_count == 0)
     {
         return;
     }
 
-    for(SliceLayerPart& part : layer.parts)
+    for (SliceLayerPart& part : layer.parts)
     {
         generateSkinAndInfillAreas(part);
     }
@@ -124,7 +125,7 @@ void SkinInfillAreaComputation::generateSkinAndInfillAreas()
  */
 void SkinInfillAreaComputation::generateSkinAndInfillAreas(SliceLayerPart& part)
 {
-    //Make a copy of the outline which we later intersect and union with the resized skins to ensure the resized skin isn't too large or removed completely.
+    // Make a copy of the outline which we later intersect and union with the resized skins to ensure the resized skin isn't too large or removed completely.
     Polygons top_skin;
     if (top_layer_count > 0)
     {
@@ -141,7 +142,7 @@ void SkinInfillAreaComputation::generateSkinAndInfillAreas(SliceLayerPart& part)
 
     applySkinExpansion(part.inner_area, top_skin, bottom_skin);
 
-    //Now combine the resized top skin and bottom skin.
+    // Now combine the resized top skin and bottom skin.
     Polygons skin = top_skin.unionPolygons(bottom_skin);
 
     skin.removeSmallAreas(MIN_AREA_SIZE);
@@ -175,9 +176,9 @@ void SkinInfillAreaComputation::calculateBottomSkin(const SliceLayerPart& part, 
     {
         return; // don't subtract anything form the downskin
     }
-    LayerIndex bottom_check_start_layer_idx { std::max(LayerIndex { 0 }, LayerIndex { layer_nr - bottom_layer_count }) };
+    LayerIndex bottom_check_start_layer_idx{ std::max(LayerIndex{ 0 }, LayerIndex{ layer_nr - bottom_layer_count }) };
     Polygons not_air = getOutlineOnLayer(part, bottom_check_start_layer_idx);
-    if (!no_small_gaps_heuristic)
+    if (! no_small_gaps_heuristic)
     {
         for (int downskin_layer_nr = bottom_check_start_layer_idx + 1; downskin_layer_nr < layer_nr; downskin_layer_nr++)
         {
@@ -194,15 +195,15 @@ void SkinInfillAreaComputation::calculateBottomSkin(const SliceLayerPart& part, 
 
 void SkinInfillAreaComputation::calculateTopSkin(const SliceLayerPart& part, Polygons& upskin)
 {
-    if(layer_nr > LayerIndex(mesh.layers.size()) - top_layer_count || top_layer_count <= 0)
+    if (layer_nr > LayerIndex(mesh.layers.size()) - top_layer_count || top_layer_count <= 0)
     {
-        //If we're in the very top layers (less than top_layer_count from the top of the mesh) everything will be top skin anyway, so no need to generate infill. Just take the original inner contour.
-        //If top_layer_count is 0, no need to calculate anything either.
+        // If we're in the very top layers (less than top_layer_count from the top of the mesh) everything will be top skin anyway, so no need to generate infill. Just take the
+        // original inner contour. If top_layer_count is 0, no need to calculate anything either.
         return;
     }
 
     Polygons not_air = getOutlineOnLayer(part, layer_nr + top_layer_count);
-    if (!no_small_gaps_heuristic)
+    if (! no_small_gaps_heuristic)
     {
         for (int upskin_layer_nr = layer_nr + 1; upskin_layer_nr < layer_nr + top_layer_count; upskin_layer_nr++)
         {
@@ -230,17 +231,17 @@ void SkinInfillAreaComputation::applySkinExpansion(const Polygons& original_outl
     const coord_t min_width = mesh.settings.get<coord_t>("min_skin_width_for_expansion") / 2;
 
     // Expand some areas of the skin for Skin Expand Distance.
-    if(min_width > 0)
+    if (min_width > 0)
     {
         // This performs an opening operation by first insetting by the minimum width, then offsetting with the same width.
         // The expansion is only applied to that opened shape.
-        if(bottom_skin_expand_distance != 0)
+        if (bottom_skin_expand_distance != 0)
         {
             const Polygons expanded = downskin.offset(-min_width).offset(min_width + bottom_skin_expand_distance);
             // And then re-joined with the original part that was not offset, to retain parts smaller than min_width.
             downskin = downskin.unionPolygons(expanded);
         }
-        if(top_skin_expand_distance != 0)
+        if (top_skin_expand_distance != 0)
         {
             const Polygons expanded = upskin.offset(-min_width).offset(min_width + top_skin_expand_distance);
             upskin = upskin.unionPolygons(expanded);
@@ -248,11 +249,11 @@ void SkinInfillAreaComputation::applySkinExpansion(const Polygons& original_outl
     }
     else // No need to pay attention to minimum width. Just expand.
     {
-        if(bottom_skin_expand_distance != 0)
+        if (bottom_skin_expand_distance != 0)
         {
             downskin = downskin.offset(bottom_skin_expand_distance);
         }
-        if(top_skin_expand_distance != 0)
+        if (top_skin_expand_distance != 0)
         {
             upskin = upskin.offset(top_skin_expand_distance);
         }
@@ -276,22 +277,24 @@ void SkinInfillAreaComputation::applySkinExpansion(const Polygons& original_outl
     // as the final polygon is limited (intersected) with the original polygon.
     constexpr double MITER_LIMIT = 10000000.0;
     // Remove thin pieces of support for Skin Removal Width.
-    if(bottom_skin_preshrink > 0 || (min_width == 0 && bottom_skin_expand_distance != 0))
+    if (bottom_skin_preshrink > 0 || (min_width == 0 && bottom_skin_expand_distance != 0))
     {
-        downskin = downskin.offset(-bottom_skin_preshrink / 2, ClipperLib::jtMiter, MITER_LIMIT).offset(bottom_skin_preshrink / 2, ClipperLib::jtMiter, MITER_LIMIT).intersection(downskin);
-        should_bottom_be_clipped = true;  // Rounding errors can lead to propagation of errors. This could mean that skin goes beyond the original outline
+        downskin = downskin.offset(-bottom_skin_preshrink / 2, ClipperLib::jtMiter, MITER_LIMIT)
+                       .offset(bottom_skin_preshrink / 2, ClipperLib::jtMiter, MITER_LIMIT)
+                       .intersection(downskin);
+        should_bottom_be_clipped = true; // Rounding errors can lead to propagation of errors. This could mean that skin goes beyond the original outline
     }
-    if(top_skin_preshrink > 0 || (min_width == 0 && top_skin_expand_distance != 0))
+    if (top_skin_preshrink > 0 || (min_width == 0 && top_skin_expand_distance != 0))
     {
         upskin = upskin.offset(-top_skin_preshrink / 2, ClipperLib::jtMiter, MITER_LIMIT).offset(top_skin_preshrink / 2, ClipperLib::jtMiter, MITER_LIMIT);
-        should_top_be_clipped = true;  // Rounding errors can lead to propagation of errors. This could mean that skin goes beyond the original outline
+        should_top_be_clipped = true; // Rounding errors can lead to propagation of errors. This could mean that skin goes beyond the original outline
     }
 
-    if(should_bottom_be_clipped)
+    if (should_bottom_be_clipped)
     {
         downskin = downskin.intersection(original_outline);
     }
-    if(should_top_be_clipped)
+    if (should_top_be_clipped)
     {
         upskin = upskin.intersection(original_outline);
     }
@@ -305,7 +308,7 @@ void SkinInfillAreaComputation::applySkinExpansion(const Polygons& original_outl
  */
 void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polygons& skin)
 {
-    part.infill_area = part.inner_area.difference(skin); //Generate infill everywhere where there wasn't any skin.
+    part.infill_area = part.inner_area.difference(skin); // Generate infill everywhere where there wasn't any skin.
     part.infill_area.removeSmallAreas(MIN_AREA_SIZE);
 }
 
@@ -317,7 +320,7 @@ void SkinInfillAreaComputation::generateInfill(SliceLayerPart& part, const Polyg
  */
 void SkinInfillAreaComputation::generateRoofingFillAndSkinFill(SliceLayerPart& part)
 {
-    for(SkinPart& skin_part : part.skin_parts)
+    for (SkinPart& skin_part : part.skin_parts)
     {
         const size_t roofing_layer_count = std::min(mesh.settings.get<size_t>("roofing_layer_count"), mesh.settings.get<size_t>("top_layers"));
         const coord_t skin_overlap = mesh.settings.get<coord_t>("skin_overlap_mm");
@@ -345,7 +348,7 @@ Polygons SkinInfillAreaComputation::generateFilledAreaAbove(SliceLayerPart& part
     const size_t wall_idx = std::min(size_t(2), mesh.settings.get<size_t>("wall_line_count"));
 
     Polygons filled_area_above = getOutlineOnLayer(part, layer_nr + roofing_layer_count);
-    if (!no_small_gaps_heuristic)
+    if (! no_small_gaps_heuristic)
     {
         for (int layer_nr_above = layer_nr + 1; layer_nr_above < layer_nr + roofing_layer_count; layer_nr_above++)
         {
@@ -363,7 +366,7 @@ Polygons SkinInfillAreaComputation::generateFilledAreaAbove(SliceLayerPart& part
         // set air_below to the skin area for the current layer that has air below it
         Polygons air_below = getOutlineOnLayer(part, layer_nr).difference(getOutlineOnLayer(part, layer_nr - 1));
 
-        if (!air_below.empty())
+        if (! air_below.empty())
         {
             // add the polygons that have air below to the no air above polygons
             filled_area_above = filled_area_above.unionPolygons(air_below);
@@ -378,34 +381,34 @@ Polygons SkinInfillAreaComputation::generateFilledAreaAbove(SliceLayerPart& part
  *
  * this function may only read the skin and infill from the *current* layer.
  */
-    Polygons SkinInfillAreaComputation::generateFilledAreaBelow(SliceLayerPart& part, size_t flooring_layer_count)
+Polygons SkinInfillAreaComputation::generateFilledAreaBelow(SliceLayerPart& part, size_t flooring_layer_count)
+{
+    if (layer_nr < flooring_layer_count)
     {
-        if (layer_nr < flooring_layer_count)
-        {
-            return {};
-        }
-        constexpr size_t min_wall_line_count = 2;
-        const int lowest_flooring_layer = layer_nr - flooring_layer_count;
-        Polygons filled_area_below = getOutlineOnLayer(part, lowest_flooring_layer);
-
-        if (!no_small_gaps_heuristic)
-        {
-            const int next_lowest_flooring_layer = lowest_flooring_layer + 1;
-            for (int layer_nr_below = next_lowest_flooring_layer; layer_nr_below < layer_nr; layer_nr_below++)
-            {
-                Polygons outlines_below = getOutlineOnLayer(part, layer_nr_below);
-                filled_area_below = filled_area_below.intersection(outlines_below);
-            }
-        }
-        return filled_area_below;
+        return {};
     }
+    constexpr size_t min_wall_line_count = 2;
+    const int lowest_flooring_layer = layer_nr - flooring_layer_count;
+    Polygons filled_area_below = getOutlineOnLayer(part, lowest_flooring_layer);
+
+    if (! no_small_gaps_heuristic)
+    {
+        const int next_lowest_flooring_layer = lowest_flooring_layer + 1;
+        for (int layer_nr_below = next_lowest_flooring_layer; layer_nr_below < layer_nr; layer_nr_below++)
+        {
+            Polygons outlines_below = getOutlineOnLayer(part, layer_nr_below);
+            filled_area_below = filled_area_below.intersection(outlines_below);
+        }
+    }
+    return filled_area_below;
+}
 
 void SkinInfillAreaComputation::generateInfillSupport(SliceMeshStorage& mesh)
 {
     const coord_t layer_height = mesh.settings.get<coord_t>("layer_height");
     const AngleRadians support_angle = mesh.settings.get<AngleRadians>("infill_support_angle");
-    const double tan_angle = tan(support_angle) - 0.01;  //The X/Y component of the support angle. 0.01 to make 90 degrees work too.
-    const coord_t max_dist_from_lower_layer = tan_angle * layer_height; //Maximum horizontal distance that can be bridged.
+    const double tan_angle = tan(support_angle) - 0.01; // The X/Y component of the support angle. 0.01 to make 90 degrees work too.
+    const coord_t max_dist_from_lower_layer = tan_angle * layer_height; // Maximum horizontal distance that can be bridged.
 
     for (int layer_idx = mesh.layers.size() - 2; layer_idx >= 0; layer_idx--)
     {
@@ -443,15 +446,17 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
 {
     // no early-out for this function; it needs to initialize the [infill_area_per_combine_per_density]
     float layer_skip_count = 8; // skip every so many layers as to ignore small gaps in the model making computation more easy
-    if (!mesh.settings.get<bool>("skin_no_small_gaps_heuristic"))
+    if (! mesh.settings.get<bool>("skin_no_small_gaps_heuristic"))
     {
         layer_skip_count = 1;
     }
     const coord_t gradual_infill_step_height = mesh.settings.get<coord_t>("gradual_infill_step_height");
-    const size_t gradual_infill_step_layer_count = round_divide(gradual_infill_step_height, mesh.settings.get<coord_t>("layer_height")); // The difference in layer count between consecutive density infill areas
+    const size_t gradual_infill_step_layer_count
+        = round_divide(gradual_infill_step_height, mesh.settings.get<coord_t>("layer_height")); // The difference in layer count between consecutive density infill areas
 
     // make gradual_infill_step_height divisible by layer_skip_count
-    float n_skip_steps_per_gradual_step = std::max(1.0f, std::ceil(gradual_infill_step_layer_count / layer_skip_count)); // only decrease layer_skip_count to make it a divisor of gradual_infill_step_layer_count
+    float n_skip_steps_per_gradual_step
+        = std::max(1.0f, std::ceil(gradual_infill_step_layer_count / layer_skip_count)); // only decrease layer_skip_count to make it a divisor of gradual_infill_step_layer_count
     layer_skip_count = gradual_infill_step_layer_count / n_skip_steps_per_gradual_step;
     const size_t max_infill_steps = mesh.settings.get<size_t>("gradual_infill_steps");
 
@@ -469,7 +474,15 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
         {
             assert((part.infill_area_per_combine_per_density.empty() && "infill_area_per_combine_per_density is supposed to be uninitialized"));
 
-            const Polygons& infill_area = Infill::generateWallToolPaths(part.infill_wall_toolpaths, part.getOwnInfillArea(), infill_wall_count, infill_wall_width, infill_overlap, mesh.settings, layer_idx, SectionType::SKIN);
+            const Polygons& infill_area = Infill::generateWallToolPaths(
+                part.infill_wall_toolpaths,
+                part.getOwnInfillArea(),
+                infill_wall_count,
+                infill_wall_width,
+                infill_overlap,
+                mesh.settings,
+                layer_idx,
+                SectionType::SKIN);
 
             if (infill_area.empty() || layer_idx < min_layer || layer_idx > max_layer)
             { // initialize infill_area_per_combine_per_density empty
@@ -495,7 +508,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
                     Polygons relevent_upper_polygons;
                     for (const SliceLayerPart& upper_layer_part : upper_layer.parts)
                     {
-                        if (!upper_layer_part.boundaryBox.hit(part.boundaryBox))
+                        if (! upper_layer_part.boundaryBox.hit(part.boundaryBox))
                         {
                             continue;
                         }
@@ -517,21 +530,26 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
             std::vector<Polygons>& infill_area_per_combine_current_density = part.infill_area_per_combine_per_density.back();
             infill_area_per_combine_current_density.push_back(infill_area);
             part.infill_area_own = std::nullopt; // clear infill_area_own, it's not needed any more.
-            assert(!part.infill_area_per_combine_per_density.empty() && "infill_area_per_combine_per_density is now initialized");
+            assert(! part.infill_area_per_combine_per_density.empty() && "infill_area_per_combine_per_density is now initialized");
         }
     }
 }
 
 void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
 {
-    if (mesh.layers.empty() || mesh.layers.size() - 1 < static_cast<size_t>(mesh.settings.get<size_t>("top_layers")) || mesh.settings.get<coord_t>("infill_line_distance") == 0) //No infill is even generated.
+    if (mesh.layers.empty() || mesh.layers.size() - 1 < static_cast<size_t>(mesh.settings.get<size_t>("top_layers"))
+        || mesh.settings.get<coord_t>("infill_line_distance") == 0) // No infill is even generated.
     {
         return;
     }
 
     const coord_t layer_height = mesh.settings.get<coord_t>("layer_height");
-    const size_t amount = std::max(uint64_t(1), round_divide(mesh.settings.get<coord_t>("infill_sparse_thickness"), std::max(layer_height, coord_t(1)))); //How many infill layers to combine to obtain the requested sparse thickness.
-    if(amount <= 1) //If we must combine 1 layer, nothing needs to be combined. Combining 0 layers is invalid.
+    const size_t amount = std::max(
+        uint64_t(1),
+        round_divide(
+            mesh.settings.get<coord_t>("infill_sparse_thickness"),
+            std::max(layer_height, coord_t(1)))); // How many infill layers to combine to obtain the requested sparse thickness.
+    if (amount <= 1) // If we must combine 1 layer, nothing needs to be combined. Combining 0 layers is invalid.
     {
         return;
     }
@@ -542,15 +560,15 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
     other. */
     size_t bottom_most_layers = mesh.settings.get<size_t>("initial_bottom_layers");
     LayerIndex min_layer = static_cast<LayerIndex>(bottom_most_layers + amount) - 1;
-    min_layer -= min_layer % amount; //Round upwards to the nearest layer divisible by infill_sparse_combine.
+    min_layer -= min_layer % amount; // Round upwards to the nearest layer divisible by infill_sparse_combine.
     LayerIndex max_layer = static_cast<LayerIndex>(mesh.layers.size()) - 1 - mesh.settings.get<size_t>("top_layers");
-    max_layer -= max_layer % amount; //Round downwards to the nearest layer divisible by infill_sparse_combine.
-    for(LayerIndex layer_idx = min_layer; layer_idx <= max_layer; layer_idx += amount) //Skip every few layers, but extrude more.
+    max_layer -= max_layer % amount; // Round downwards to the nearest layer divisible by infill_sparse_combine.
+    for (LayerIndex layer_idx = min_layer; layer_idx <= max_layer; layer_idx += amount) // Skip every few layers, but extrude more.
     {
         SliceLayer* layer = &mesh.layers[layer_idx];
-        for(size_t combine_count_here = 1; combine_count_here < amount; combine_count_here++)
+        for (size_t combine_count_here = 1; combine_count_here < amount; combine_count_here++)
         {
-            if(layer_idx < static_cast<LayerIndex>(combine_count_here))
+            if (layer_idx < static_cast<LayerIndex>(combine_count_here))
             {
                 break;
             }
@@ -571,10 +589,10 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
                     {
                         if (part.boundaryBox.hit(lower_layer_part.boundaryBox))
                         {
-
                             Polygons intersection = infill_area_per_combine[combine_count_here - 1].intersection(lower_layer_part.infill_area).offset(-200).offset(200);
                             result.add(intersection); // add area to be thickened
-                            infill_area_per_combine[combine_count_here - 1] = infill_area_per_combine[combine_count_here - 1].difference(intersection); // remove thickened area from less thick layer here
+                            infill_area_per_combine[combine_count_here - 1]
+                                = infill_area_per_combine[combine_count_here - 1].difference(intersection); // remove thickened area from less thick layer here
                             unsigned int max_lower_density_idx = density_idx;
                             // Generally: remove only from *same density* areas on layer below
                             // If there are no same density areas, then it's ok to print them anyway
@@ -588,10 +606,13 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
                                 // of the lower layer with the same or higher density index
                                 max_lower_density_idx = lower_layer_part.infill_area_per_combine_per_density.size() - 1;
                             }
-                            for (size_t lower_density_idx = density_idx; lower_density_idx <= max_lower_density_idx && lower_density_idx < lower_layer_part.infill_area_per_combine_per_density.size(); lower_density_idx++)
+                            for (size_t lower_density_idx = density_idx;
+                                 lower_density_idx <= max_lower_density_idx && lower_density_idx < lower_layer_part.infill_area_per_combine_per_density.size();
+                                 lower_density_idx++)
                             {
                                 std::vector<Polygons>& lower_infill_area_per_combine = lower_layer_part.infill_area_per_combine_per_density[lower_density_idx];
-                                lower_infill_area_per_combine[0] = lower_infill_area_per_combine[0].difference(intersection); // remove thickened area from lower (single thickness) layer
+                                lower_infill_area_per_combine[0]
+                                    = lower_infill_area_per_combine[0].difference(intersection); // remove thickened area from lower (single thickness) layer
                             }
                         }
                     }
@@ -610,9 +631,10 @@ void SkinInfillAreaComputation::combineInfillLayers(SliceMeshStorage& mesh)
  * this function may only read/write the skin and infill from the *current* layer.
  */
 
-void SkinInfillAreaComputation::generateTopAndBottomMostSkinFill(SliceLayerPart &part) {
-
-    for (SkinPart& skin_part : part.skin_parts) {
+void SkinInfillAreaComputation::generateTopAndBottomMostSkinFill(SliceLayerPart& part)
+{
+    for (SkinPart& skin_part : part.skin_parts)
+    {
         Polygons filled_area_above = generateFilledAreaAbove(part, 1);
         skin_part.top_most_surface_fill = skin_part.outline.difference(filled_area_above);
 
@@ -622,4 +644,4 @@ void SkinInfillAreaComputation::generateTopAndBottomMostSkinFill(SliceLayerPart 
 }
 
 
-}//namespace cura
+} // namespace cura

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1,20 +1,7 @@
 // Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
-#include <cmath> // sqrt, round
-#include <deque>
-#include <fstream> // ifstream.good()
-#include <utility> // pair
-
-#include <range/v3/numeric/accumulate.hpp>
-#include <range/v3/view/drop.hpp>
-#include <range/v3/view/drop_last.hpp>
-#include <range/v3/view/enumerate.hpp>
-#include <range/v3/view/filter.hpp>
-#include <range/v3/view/slice.hpp>
-#include <range/v3/view/zip.hpp>
-#include <scripta/logger.h>
-#include <spdlog/spdlog.h>
+#include "support.h"
 
 #include "Application.h" //To get settings.
 #include "BoostInterface.hpp"
@@ -31,12 +18,26 @@
 #include "settings/types/Ratio.h"
 #include "sliceDataStorage.h"
 #include "slicer.h"
-#include "support.h"
 #include "utils/Simplify.h"
 #include "utils/ThreadPool.h"
 #include "utils/VoronoiUtils.h"
 #include "utils/math.h"
 #include "utils/views/get.h"
+
+#include <range/v3/numeric/accumulate.hpp>
+#include <range/v3/view/drop.hpp>
+#include <range/v3/view/drop_last.hpp>
+#include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/slice.hpp>
+#include <range/v3/view/zip.hpp>
+#include <scripta/logger.h>
+#include <spdlog/spdlog.h>
+
+#include <cmath> // sqrt, round
+#include <deque>
+#include <fstream> // ifstream.good()
+#include <utility> // pair
 
 namespace cura
 {
@@ -53,7 +54,8 @@ bool AreaSupport::handleSupportModifierMesh(SliceDataStorage& storage, const Set
         SUPPORT_DROP_DOWN,
         SUPPORT_VANILLA
     };
-    ModifierType modifier_type = (mesh_settings.get<bool>("anti_overhang_mesh")) ? ANTI_OVERHANG : ((mesh_settings.get<bool>("support_mesh_drop_down")) ? SUPPORT_DROP_DOWN : SUPPORT_VANILLA);
+    ModifierType modifier_type
+        = (mesh_settings.get<bool>("anti_overhang_mesh")) ? ANTI_OVERHANG : ((mesh_settings.get<bool>("support_mesh_drop_down")) ? SUPPORT_DROP_DOWN : SUPPORT_VANILLA);
     for (unsigned int layer_nr = 0; layer_nr < slicer->layers.size(); layer_nr++)
     {
         SupportLayer& support_layer = storage.support.supportLayers[layer_nr];
@@ -75,7 +77,10 @@ bool AreaSupport::handleSupportModifierMesh(SliceDataStorage& storage, const Set
 }
 
 
-void AreaSupport::splitGlobalSupportAreasIntoSupportInfillParts(SliceDataStorage& storage, const std::vector<Polygons>& global_support_areas_per_layer, unsigned int total_layer_count)
+void AreaSupport::splitGlobalSupportAreasIntoSupportInfillParts(
+    SliceDataStorage& storage,
+    const std::vector<Polygons>& global_support_areas_per_layer,
+    unsigned int total_layer_count)
 {
     if (total_layer_count == 0)
     {
@@ -192,11 +197,13 @@ void AreaSupport::generateGradualSupport(SliceDataStorage& storage)
     const coord_t wall_width = infill_extruder.settings.get<coord_t>("support_line_width");
 
     // no early-out for this function; it needs to initialize the [infill_area_per_combine_per_density]
-    double layer_skip_count { 8.0 }; // skip every so many layers as to ignore small gaps in the model making computation more easy
-    size_t gradual_support_step_layer_count = round_divide(gradual_support_step_height, mesh_group_settings.get<coord_t>("layer_height")); // The difference in layer count between consecutive density infill areas.
+    double layer_skip_count{ 8.0 }; // skip every so many layers as to ignore small gaps in the model making computation more easy
+    size_t gradual_support_step_layer_count
+        = round_divide(gradual_support_step_height, mesh_group_settings.get<coord_t>("layer_height")); // The difference in layer count between consecutive density infill areas.
 
     // make gradual_support_step_height divisable by layer_skip_count
-    const auto n_skip_steps_per_gradual_step = std::max(1.0, std::ceil(gradual_support_step_layer_count / layer_skip_count)); // only decrease layer_skip_count to make it a divisor of gradual_support_step_layer_count
+    const auto n_skip_steps_per_gradual_step
+        = std::max(1.0, std::ceil(gradual_support_step_layer_count / layer_skip_count)); // only decrease layer_skip_count to make it a divisor of gradual_support_step_layer_count
     layer_skip_count = gradual_support_step_layer_count / n_skip_steps_per_gradual_step;
 
     LayerIndex min_layer = 0;
@@ -222,15 +229,23 @@ void AreaSupport::generateGradualSupport(SliceDataStorage& storage)
                 continue;
             }
             // NOTE: This both generates the walls _and_ returns the _actual_ infill area (the one _without_ walls) for use in the rest of the method.
-            const Polygons infill_area = Infill::generateWallToolPaths(support_infill_part.wall_toolpaths, original_area, support_infill_part.inset_count_to_generate, wall_width, 0, infill_extruder.settings, layer_nr, SectionType::SUPPORT);
+            const Polygons infill_area = Infill::generateWallToolPaths(
+                support_infill_part.wall_toolpaths,
+                original_area,
+                support_infill_part.inset_count_to_generate,
+                wall_width,
+                0,
+                infill_extruder.settings,
+                layer_nr,
+                SectionType::SUPPORT);
             const AABB& this_part_boundary_box = support_infill_part.outline_boundary_box;
 
             // calculate density areas for this island
             Polygons less_dense_support = infill_area; // one step less dense with each density_step
             for (unsigned int density_step = 0; density_step < max_density_steps; ++density_step)
             {
-                LayerIndex min_layer { layer_nr + density_step * gradual_support_step_layer_count + static_cast<LayerIndex::value_type>(layer_skip_count) };
-                LayerIndex max_layer { layer_nr + (density_step + 1) * gradual_support_step_layer_count };
+                LayerIndex min_layer{ layer_nr + density_step * gradual_support_step_layer_count + static_cast<LayerIndex::value_type>(layer_skip_count) };
+                LayerIndex max_layer{ layer_nr + (density_step + 1) * gradual_support_step_layer_count };
 
                 for (float upper_layer_idx = min_layer; upper_layer_idx <= max_layer; upper_layer_idx += layer_skip_count)
                 {
@@ -311,7 +326,8 @@ void AreaSupport::combineSupportInfillLayers(SliceDataStorage& storage)
     const coord_t layer_height = mesh_group_settings.get<coord_t>("layer_height");
     // How many support infill layers to combine to obtain the requested sparse thickness.
     const ExtruderTrain& infill_extruder = mesh_group_settings.get<ExtruderTrain&>("support_infill_extruder_nr");
-    const size_t combine_layers_amount = std::max(uint64_t(1), round_divide(infill_extruder.settings.get<coord_t>("support_infill_sparse_thickness"), std::max(layer_height, coord_t(1))));
+    const size_t combine_layers_amount
+        = std::max(uint64_t(1), round_divide(infill_extruder.settings.get<coord_t>("support_infill_sparse_thickness"), std::max(layer_height, coord_t(1))));
     if (combine_layers_amount <= 1)
     {
         return;
@@ -373,7 +389,8 @@ void AreaSupport::combineSupportInfillLayers(SliceDataStorage& storage)
                         }
 
                         result.add(intersection); // add area to be thickened
-                        infill_area_per_combine[combine_count_here - 1] = infill_area_per_combine[combine_count_here - 1].difference(intersection); // remove thickened area from less thick layer here
+                        infill_area_per_combine[combine_count_here - 1]
+                            = infill_area_per_combine[combine_count_here - 1].difference(intersection); // remove thickened area from less thick layer here
 
                         unsigned int max_lower_density_idx = density_idx;
                         // Generally: remove only from *same density* areas on layer below
@@ -388,10 +405,13 @@ void AreaSupport::combineSupportInfillLayers(SliceDataStorage& storage)
                             // of the lower layer with the same or higher density index
                             max_lower_density_idx = lower_layer_part.infill_area_per_combine_per_density.size() - 1;
                         }
-                        for (unsigned int lower_density_idx = density_idx; lower_density_idx <= max_lower_density_idx && lower_density_idx < lower_layer_part.infill_area_per_combine_per_density.size(); lower_density_idx++)
+                        for (unsigned int lower_density_idx = density_idx;
+                             lower_density_idx <= max_lower_density_idx && lower_density_idx < lower_layer_part.infill_area_per_combine_per_density.size();
+                             lower_density_idx++)
                         {
                             std::vector<Polygons>& lower_infill_area_per_combine = lower_layer_part.infill_area_per_combine_per_density[lower_density_idx];
-                            lower_infill_area_per_combine[0] = lower_infill_area_per_combine[0].difference(intersection); // remove thickened area from lower (single thickness) layer
+                            lower_infill_area_per_combine[0]
+                                = lower_infill_area_per_combine[0].difference(intersection); // remove thickened area from lower (single thickness) layer
                         }
                     }
 
@@ -497,7 +517,7 @@ Polygons AreaSupport::join(const SliceDataStorage& storage, const Polygons& supp
         const std::vector<bool> is_extruder_used = storage.getExtrudersUsed();
         for (size_t extruder_nr = 0; extruder_nr < Application::getInstance().current_slice->scene.extruders.size(); extruder_nr++)
         {
-            if (! is_extruder_used[extruder_nr]) //Unused extruders and the primary adhesion extruder don't generate an extra skirt line.
+            if (! is_extruder_used[extruder_nr]) // Unused extruders and the primary adhesion extruder don't generate an extra skirt line.
             {
                 continue;
             }
@@ -517,13 +537,15 @@ Polygons AreaSupport::join(const SliceDataStorage& storage, const Polygons& supp
             for (ExtruderTrain* skirt_brim_extruder_p : skirt_brim_extruders)
             {
                 ExtruderTrain& skirt_brim_extruder = *skirt_brim_extruder_p;
-                adhesion_size = std::max(adhesion_size, coord_t(
-                    skirt_brim_extruder.settings.get<coord_t>(adhesion_width_str)
-                    + skirt_brim_extruder.settings.get<coord_t>("skirt_brim_line_width")
-                    * (skirt_brim_extruder.settings.get<size_t>(adhesion_line_count_str) - 1) // - 1 because the line is also included in extra_skirt_line_width
-                    * skirt_brim_extruder.settings.get<Ratio>("initial_layer_line_width_factor")
-                    + extra_skirt_line_width));
-                }
+                adhesion_size = std::max(
+                    adhesion_size,
+                    coord_t(
+                        skirt_brim_extruder.settings.get<coord_t>(adhesion_width_str)
+                        + skirt_brim_extruder.settings.get<coord_t>("skirt_brim_line_width")
+                              * (skirt_brim_extruder.settings.get<size_t>(adhesion_line_count_str) - 1) // - 1 because the line is also included in extra_skirt_line_width
+                              * skirt_brim_extruder.settings.get<Ratio>("initial_layer_line_width_factor")
+                        + extra_skirt_line_width));
+            }
             break;
         case EPlatformAdhesion::RAFT:
         {
@@ -563,11 +585,10 @@ Polygons AreaSupport::join(const SliceDataStorage& storage, const Polygons& supp
         const coord_t min_even_wall_line_width = infill_settings.get<coord_t>("min_even_wall_line_width");
         auto half_min_feature_width = min_even_wall_line_width + 10;
 
-        joined = joined
-             .offset(-half_min_feature_width)
-             .offset(join_distance + half_min_feature_width, ClipperLib::jtRound)
-             .offset(-join_distance, ClipperLib::jtRound)
-             .unionPolygons(joined);
+        joined = joined.offset(-half_min_feature_width)
+                     .offset(join_distance + half_min_feature_width, ClipperLib::jtRound)
+                     .offset(-join_distance, ClipperLib::jtRound)
+                     .unionPolygons(joined);
     }
 
     const Simplify simplify(infill_settings);
@@ -634,7 +655,8 @@ void AreaSupport::generateSupportAreas(SliceDataStorage& storage)
         Settings* bottom_settings = &storage.meshes[mesh_idx].settings;
         if (mesh.settings.get<bool>("support_mesh"))
         {
-            if ((mesh.settings.get<bool>("support_mesh_drop_down") && support_meshes_drop_down_handled) || (! mesh.settings.get<bool>("support_mesh_drop_down") && support_meshes_handled))
+            if ((mesh.settings.get<bool>("support_mesh_drop_down") && support_meshes_drop_down_handled)
+                || (! mesh.settings.get<bool>("support_mesh_drop_down") && support_meshes_handled))
             { // handle all support_mesh and support_mesh_drop_down areas only once
                 continue;
             }
@@ -727,8 +749,11 @@ void AreaSupport::precomputeCrossInfillTree(SliceDataStorage& storage)
         std::ifstream cross_fs(cross_subdisivion_spec_image_file.c_str());
         if (cross_subdisivion_spec_image_file != "" && cross_fs.good())
         {
-            storage.support.cross_fill_provider =
-                new SierpinskiFillProvider(aabb, infill_extruder.settings.get<coord_t>("support_line_distance"), infill_extruder.settings.get<coord_t>("support_line_width"), cross_subdisivion_spec_image_file);
+            storage.support.cross_fill_provider = new SierpinskiFillProvider(
+                aabb,
+                infill_extruder.settings.get<coord_t>("support_line_distance"),
+                infill_extruder.settings.get<coord_t>("support_line_width"),
+                cross_subdisivion_spec_image_file);
         }
         else
         {
@@ -736,7 +761,8 @@ void AreaSupport::precomputeCrossInfillTree(SliceDataStorage& storage)
             {
                 spdlog::error("Cannot find density image: {}.", cross_subdisivion_spec_image_file);
             }
-            storage.support.cross_fill_provider = new SierpinskiFillProvider(aabb, infill_extruder.settings.get<coord_t>("support_line_distance"), infill_extruder.settings.get<coord_t>("support_line_width"));
+            storage.support.cross_fill_provider
+                = new SierpinskiFillProvider(aabb, infill_extruder.settings.get<coord_t>("support_line_distance"), infill_extruder.settings.get<coord_t>("support_line_width"));
         }
     }
 }
@@ -780,22 +806,23 @@ void AreaSupport::generateOverhangAreasForMesh(SliceDataStorage& storage, SliceM
     }
 
     // Generate the actual areas and store them in the mesh.
-    cura::parallel_for<size_t>(1,
-                               storage.print_layer_count,
-                               [&](const size_t layer_idx)
-                               {
-                                   std::pair<Polygons, Polygons> basic_and_full_overhang = computeBasicAndFullOverhang(storage, mesh, layer_idx);
-                                   mesh.overhang_areas[layer_idx] = basic_and_full_overhang.first; // Store the results.
-                                   mesh.full_overhang_areas[layer_idx] = basic_and_full_overhang.second;
-                                   scripta::log("support_basic_overhang_area", basic_and_full_overhang.first, SectionType::SUPPORT, layer_idx);
-                                   scripta::log("support_full_overhang_area", basic_and_full_overhang.second, SectionType::SUPPORT, layer_idx);
-                               });
+    cura::parallel_for<size_t>(
+        1,
+        storage.print_layer_count,
+        [&](const size_t layer_idx)
+        {
+            std::pair<Polygons, Polygons> basic_and_full_overhang = computeBasicAndFullOverhang(storage, mesh, layer_idx);
+            mesh.overhang_areas[layer_idx] = basic_and_full_overhang.first; // Store the results.
+            mesh.full_overhang_areas[layer_idx] = basic_and_full_overhang.second;
+            scripta::log("support_basic_overhang_area", basic_and_full_overhang.first, SectionType::SUPPORT, layer_idx);
+            scripta::log("support_full_overhang_area", basic_and_full_overhang.second, SectionType::SUPPORT, layer_idx);
+        });
 }
 
 Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& storage, const Settings& infill_settings, const LayerIndex layer_idx)
 {
     const auto& mesh_group_settings = Application::getInstance().current_slice->scene.current_mesh_group->settings;
-    const Simplify simplify { mesh_group_settings };
+    const Simplify simplify{ mesh_group_settings };
     const auto layer_thickness = mesh_group_settings.get<coord_t>("layer_height");
     const auto support_distance_top = static_cast<double>(mesh_group_settings.get<coord_t>("support_top_distance"));
     const auto support_distance_bot = static_cast<double>(mesh_group_settings.get<coord_t>("support_bottom_distance"));
@@ -807,9 +834,7 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
     constexpr coord_t close_dist = snap_radius + 5; // needs to be larger than the snap radius!
     constexpr coord_t search_radius = 0;
 
-    auto layer_current = simplify.polygon(storage.layers[layer_idx].getOutlines()
-                                              .offset(-close_dist)
-                                              .offset(close_dist));
+    auto layer_current = simplify.polygon(storage.layers[layer_idx].getOutlines().offset(-close_dist).offset(close_dist));
 
     // sparse grid for storing the offset distances at each point. For each point there can be multiple offset
     // values as multiple may be calculated when multiple layers are used for z-smoothing of the offsets.
@@ -818,7 +843,7 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
     // equal to commutative_offset / n.
     using point_pair_t = std::pair<size_t, double>;
     using grid_t = SparsePointGridInclusive<point_pair_t>;
-    grid_t offset_dist_at_point { snap_radius };
+    grid_t offset_dist_at_point{ snap_radius };
 
     // Collection of the various areas we used to calculate the areas for. This is a combination
     //  - the support distance (this is the support top distance for overhang areas, and support
@@ -829,46 +854,26 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
     //    here either the slope or overhang area is stored
     std::vector<std::tuple<double, double, Polygons>> z_distances_layer_deltas;
 
-    constexpr LayerIndex layer_index_offset { 1 };
+    constexpr LayerIndex layer_index_offset{ 1 };
 
-    const LayerIndex layer_idx_below { std::max(LayerIndex{ layer_idx - layer_index_offset }, LayerIndex { 0 }) };
+    const LayerIndex layer_idx_below{ std::max(LayerIndex{ layer_idx - layer_index_offset }, LayerIndex{ 0 }) };
     if (layer_idx_below != layer_idx)
     {
-        auto layer_below = simplify.polygon(storage.layers[layer_idx_below].getOutlines()
-                                                .offset(-close_dist)
-                                                .offset(close_dist));
+        auto layer_below = simplify.polygon(storage.layers[layer_idx_below].getOutlines().offset(-close_dist).offset(close_dist));
 
-        z_distances_layer_deltas.emplace_back(
-            support_distance_top,
-            static_cast<double>(layer_index_offset * layer_thickness),
-            layer_current.difference(layer_below)
-        );
+        z_distances_layer_deltas.emplace_back(support_distance_top, static_cast<double>(layer_index_offset * layer_thickness), layer_current.difference(layer_below));
 
-        z_distances_layer_deltas.emplace_back(
-            support_distance_bot,
-            static_cast<double>(layer_index_offset * layer_thickness),
-            layer_below.difference(layer_current)
-        );
+        z_distances_layer_deltas.emplace_back(support_distance_bot, static_cast<double>(layer_index_offset * layer_thickness), layer_below.difference(layer_current));
     }
 
-    const LayerIndex layer_idx_above { std::min(LayerIndex{ layer_idx + layer_index_offset }, LayerIndex { storage.layers.size() - 1 }) };
+    const LayerIndex layer_idx_above{ std::min(LayerIndex{ layer_idx + layer_index_offset }, LayerIndex{ storage.layers.size() - 1 }) };
     if (layer_idx_above != layer_idx)
     {
-        auto layer_above = simplify.polygon(storage.layers[layer_idx_below].getOutlines()
-                                                .offset(-close_dist)
-                                                .offset(close_dist));
+        auto layer_above = simplify.polygon(storage.layers[layer_idx_below].getOutlines().offset(-close_dist).offset(close_dist));
 
-        z_distances_layer_deltas.emplace_back(
-            support_distance_bot,
-            static_cast<double>(layer_index_offset * layer_thickness),
-            layer_current.difference(layer_above)
-        );
+        z_distances_layer_deltas.emplace_back(support_distance_bot, static_cast<double>(layer_index_offset * layer_thickness), layer_current.difference(layer_above));
 
-        z_distances_layer_deltas.emplace_back(
-            support_distance_top,
-            static_cast<double>(layer_index_offset * layer_thickness),
-            layer_above.difference(layer_current)
-        );
+        z_distances_layer_deltas.emplace_back(support_distance_top, static_cast<double>(layer_index_offset * layer_thickness), layer_above.difference(layer_current));
     }
 
     for (auto& [support_distance, delta_z, layer_delta_] : z_distances_layer_deltas)
@@ -885,14 +890,14 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
         }
 
         // grid for storing the "slope" (wall overhang area at that specific point in the polygon)
-        grid_t slope_at_point { snap_radius };
+        grid_t slope_at_point{ snap_radius };
 
         // construct a voronoi diagram. The slope is calculated based
         // on the edge length from the boundary to the center edge(s)
         std::vector<SkeletalTrapezoidation::Segment> segments;
-        for (auto [poly_idx, poly]: layer_delta | ranges::views::enumerate)
+        for (auto [poly_idx, poly] : layer_delta | ranges::views::enumerate)
         {
-            for (auto [point_idx, _p]: poly | ranges::views::enumerate)
+            for (auto [point_idx, _p] : poly | ranges::views::enumerate)
             {
                 segments.emplace_back(&layer_delta, poly_idx, point_idx);
             }
@@ -901,7 +906,7 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
         boost::polygon::voronoi_diagram<double> vonoroi_diagram;
         boost::polygon::construct_voronoi(segments.begin(), segments.end(), &vonoroi_diagram);
 
-        for (const auto& edge: vonoroi_diagram.edges())
+        for (const auto& edge : vonoroi_diagram.edges())
         {
             if (edge.is_infinite())
             {
@@ -931,8 +936,8 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
             auto slope = dist_to_boundary / delta_z;
 
             auto nearby_vals = slope_at_point.getNearbyVals(p0, search_radius);
-            auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0);
-            auto cumulative_slope = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.);
+            auto n = ranges::accumulate(nearby_vals | views::get(&point_pair_t::first), 0);
+            auto cumulative_slope = ranges::accumulate(nearby_vals | views::get(&point_pair_t::second), 0.);
 
             n += 1;
             cumulative_slope += slope;
@@ -941,13 +946,13 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
             slope_at_point.insert(p0, { n, cumulative_slope });
         }
 
-        for (const auto& poly: layer_current)
+        for (const auto& poly : layer_current)
         {
-            for (const auto& point: poly)
+            for (const auto& point : poly)
             {
                 auto nearby_vals = slope_at_point.getNearbyVals(point, search_radius);
-                auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0);
-                auto cumulative_slope = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.);
+                auto n = ranges::accumulate(nearby_vals | views::get(&point_pair_t::first), 0);
+                auto cumulative_slope = ranges::accumulate(nearby_vals | views::get(&point_pair_t::second), 0.);
 
                 if (n != 0)
                 {
@@ -960,26 +965,26 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
                     auto nearby_vals_offset_dist = offset_dist_at_point.getNearbyVals(point, search_radius);
 
                     // update and insert cumulative varying xy distance in one go
-                    offset_dist_at_point.insert(point, {
-                                                       ranges::accumulate(nearby_vals_offset_dist | views::get( &point_pair_t::first ), 0) + 1,
-                                                       ranges::accumulate(nearby_vals_offset_dist | views::get( &point_pair_t::second ), 0.) + xy_distance_varying
-                                                   });
+                    offset_dist_at_point.insert(
+                        point,
+                        { ranges::accumulate(nearby_vals_offset_dist | views::get(&point_pair_t::first), 0) + 1,
+                          ranges::accumulate(nearby_vals_offset_dist | views::get(&point_pair_t::second), 0.) + xy_distance_varying });
                 }
             }
         }
     }
 
     std::vector<coord_t> varying_offsets;
-    for (const auto& poly: layer_current)
+    for (const auto& poly : layer_current)
     {
         for (const auto& point : poly)
         {
             auto nearby_vals = offset_dist_at_point.getNearbyVals(point, search_radius);
 
-            auto n = ranges::accumulate(nearby_vals | views::get( &point_pair_t::first ), 0);
-            auto cumulative_offset_dist = ranges::accumulate(nearby_vals | views::get( &point_pair_t::second ), 0.);
+            auto n = ranges::accumulate(nearby_vals | views::get(&point_pair_t::first), 0);
+            auto cumulative_offset_dist = ranges::accumulate(nearby_vals | views::get(&point_pair_t::second), 0.);
 
-            double offset_dist {};
+            double offset_dist{};
             if (n == 0)
             {
                 // if there are no offset dists generated for a vertex $p$ this must mean that vertex $p$ was not
@@ -1005,7 +1010,8 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
                                                // close operation to smooth the x/y disallowed area boundary. With varying xy distances we see some jumps in the boundary.
                                                // As the x/y disallowed areas "cut in" to support the xy-disallowed area may propagate through the support area. If the
                                                // x/y disallowed area is not smoothed boost has trouble generating a voronoi diagram.
-                                               .offset(smooth_dist).offset(-smooth_dist);
+                                               .offset(smooth_dist)
+                                               .offset(-smooth_dist);
     scripta::log("support_varying_xy_disallowed_areas", varying_xy_disallowed_areas, SectionType::SUPPORT, layer_idx);
     return varying_xy_disallowed_areas;
 }
@@ -1016,23 +1022,26 @@ Polygons AreaSupport::generateVaryingXYDisallowedArea(const SliceMeshStorage& st
  * - find overhang by looking at the difference between two consecutive layers
  * - join with support areas from layer above
  * - subtract current layer
- * - use the result for the next lower support layer (without doing XY-distance and Z bottom distance, so that a single support beam may move around the model a bit => more stability)
+ * - use the result for the next lower support layer (without doing XY-distance and Z bottom distance, so that a single support beam may move around the model a bit => more
+ * stability)
  * - perform inset using X/Y-distance and bottom Z distance
  *
  * for support buildplate only: purge all support not connected to build plate
  */
-void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
-                                              const Settings& infill_settings,
-                                              const Settings& roof_settings,
-                                              const Settings& bottom_settings,
-                                              const size_t mesh_idx,
-                                              const size_t layer_count,
-                                              std::vector<Polygons>& support_areas)
+void AreaSupport::generateSupportAreasForMesh(
+    SliceDataStorage& storage,
+    const Settings& infill_settings,
+    const Settings& roof_settings,
+    const Settings& bottom_settings,
+    const size_t mesh_idx,
+    const size_t layer_count,
+    std::vector<Polygons>& support_areas)
 {
     SliceMeshStorage& mesh = storage.meshes[mesh_idx];
 
     const ESupportStructure support_structure = mesh.settings.get<ESupportStructure>("support_structure");
-    const bool is_support_mesh_place_holder = mesh.settings.get<bool>("support_mesh"); // whether this mesh has empty SliceMeshStorage and this function is now called to only generate support for all support meshes
+    const bool is_support_mesh_place_holder
+        = mesh.settings.get<bool>("support_mesh"); // whether this mesh has empty SliceMeshStorage and this function is now called to only generate support for all support meshes
     if ((! mesh.settings.get<bool>("support_enable") || support_structure != ESupportStructure::NORMAL) && ! is_support_mesh_place_holder)
     {
         return;
@@ -1062,7 +1071,8 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
     // simplified processing for bottom layer - just ensure support clears part by XY distance
     const coord_t xy_distance = infill_settings.get<coord_t>("support_xy_distance");
     const coord_t xy_distance_overhang = infill_settings.get<coord_t>("support_xy_distance_overhang");
-    const bool use_xy_distance_overhang = infill_settings.get<SupportDistPriority>("support_xy_overrides_z") == SupportDistPriority::Z_OVERRIDES_XY; // whether to use a different xy distance at overhangs
+    const bool use_xy_distance_overhang
+        = infill_settings.get<SupportDistPriority>("support_xy_overrides_z") == SupportDistPriority::Z_OVERRIDES_XY; // whether to use a different xy distance at overhangs
     const AngleRadians angle = ((mesh.settings.get<bool>("support_roof_enable")) ? roof_settings : infill_settings).get<AngleRadians>("support_angle");
     const double tan_angle = tan(angle) - 0.01; // the XY-component of the supportAngle
     constexpr bool no_support = false;
@@ -1077,48 +1087,53 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
     // The maximum width of an odd wall = 2 * minimum even wall width.
     auto half_min_feature_width = min_even_wall_line_width + 10;
 
-    cura::parallel_for<size_t>(1,
-                               layer_count,
-                               [&](const size_t layer_idx)
-                               {
-                                   const Polygons outlines = storage.getLayerOutlines(layer_idx, no_support, no_prime_tower);
+    cura::parallel_for<size_t>(
+        1,
+        layer_count,
+        [&](const size_t layer_idx)
+        {
+            const Polygons outlines = storage.getLayerOutlines(layer_idx, no_support, no_prime_tower);
 
-                                   // Build sloped areas. We need this for the stair-stepping later on.
-                                   // Specifically, sloped areass are used in 'moveUpFromModel' to prevent a stair step happening over an area where there isn't a slope.
-                                   // This part here only concerns the slope between two layers. This will be post-processed later on (see the other parallel loop below).
-                                   sloped_areas_per_layer[layer_idx] =
-                                       // Take the outer areas of the previous layer, where the outer areas are (mostly) just _inside_ the shape.
-                                       storage.getLayerOutlines(layer_idx - 1, no_support, no_prime_tower)
-                                           .tubeShape(sloped_area_detection_width, 10)
-                                           // Intersect those with the outer areas of the current layer, where the outer areas are (mostly) _outside_ the shape.
-                                           // This will detect every slope (and some/most vertical walls) between those two layers.
-                                           .intersection(outlines.tubeShape(10, sloped_area_detection_width))
-                                           // Do an opening operation so we're not stuck with tiny patches.
-                                           // The later offset is extended with the line-width, so all patches are merged together if there's less than a line-width between them.
-                                           .offset(-10)
-                                           .offset(10 + sloped_area_detection_width);
-                                   // The sloped areas are now ready to be post-processed.
-                                   scripta::log("support_sloped_areas", sloped_areas_per_layer[layer_idx], SectionType::SUPPORT, layer_idx,
-                                                scripta::CellVDI{"sloped_area_detection_width", sloped_area_detection_width });
+            // Build sloped areas. We need this for the stair-stepping later on.
+            // Specifically, sloped areass are used in 'moveUpFromModel' to prevent a stair step happening over an area where there isn't a slope.
+            // This part here only concerns the slope between two layers. This will be post-processed later on (see the other parallel loop below).
+            sloped_areas_per_layer[layer_idx] =
+                // Take the outer areas of the previous layer, where the outer areas are (mostly) just _inside_ the shape.
+                storage.getLayerOutlines(layer_idx - 1, no_support, no_prime_tower)
+                    .tubeShape(sloped_area_detection_width, 10)
+                    // Intersect those with the outer areas of the current layer, where the outer areas are (mostly) _outside_ the shape.
+                    // This will detect every slope (and some/most vertical walls) between those two layers.
+                    .intersection(outlines.tubeShape(10, sloped_area_detection_width))
+                    // Do an opening operation so we're not stuck with tiny patches.
+                    // The later offset is extended with the line-width, so all patches are merged together if there's less than a line-width between them.
+                    .offset(-10)
+                    .offset(10 + sloped_area_detection_width);
+            // The sloped areas are now ready to be post-processed.
+            scripta::log(
+                "support_sloped_areas",
+                sloped_areas_per_layer[layer_idx],
+                SectionType::SUPPORT,
+                layer_idx,
+                scripta::CellVDI{ "sloped_area_detection_width", sloped_area_detection_width });
 
-                                   if (! is_support_mesh_place_holder)
-                                   { // don't compute overhang for support meshes
-                                       if (use_xy_distance_overhang) // Z overrides XY distance.
-                                       {
-                                           // we also want to use the min XY distance when the support is resting on a sloped surface so we calculate the area of the
-                                           // layer below that protrudes beyond the current layer's area and combine it with the current layer's overhang disallowed area
+            if (! is_support_mesh_place_holder)
+            { // don't compute overhang for support meshes
+                if (use_xy_distance_overhang) // Z overrides XY distance.
+                {
+                    // we also want to use the min XY distance when the support is resting on a sloped surface so we calculate the area of the
+                    // layer below that protrudes beyond the current layer's area and combine it with the current layer's overhang disallowed area
 
-                                           Polygons minimum_xy_disallowed_areas = xy_disallowed_per_layer[layer_idx].offset(xy_distance_overhang);
-                                           Polygons varying_xy_disallowed_areas = generateVaryingXYDisallowedArea(mesh, infill_settings, layer_idx);
-                                           xy_disallowed_per_layer[layer_idx] = minimum_xy_disallowed_areas.unionPolygons(varying_xy_disallowed_areas);
-                                           scripta::log("support_xy_disallowed_areas", xy_disallowed_per_layer[layer_idx], SectionType::SUPPORT, layer_idx);
-                                       }
-                                   }
-                                   if (is_support_mesh_place_holder || ! use_xy_distance_overhang)
-                                   {
-                                       xy_disallowed_per_layer[layer_idx] = outlines.offset(xy_distance);
-                                   }
-                               });
+                    Polygons minimum_xy_disallowed_areas = xy_disallowed_per_layer[layer_idx].offset(xy_distance_overhang);
+                    Polygons varying_xy_disallowed_areas = generateVaryingXYDisallowedArea(mesh, infill_settings, layer_idx);
+                    xy_disallowed_per_layer[layer_idx] = minimum_xy_disallowed_areas.unionPolygons(varying_xy_disallowed_areas);
+                    scripta::log("support_xy_disallowed_areas", xy_disallowed_per_layer[layer_idx], SectionType::SUPPORT, layer_idx);
+                }
+            }
+            if (is_support_mesh_place_holder || ! use_xy_distance_overhang)
+            {
+                xy_disallowed_per_layer[layer_idx] = outlines.offset(xy_distance);
+            }
+        });
 
     std::vector<Polygons> tower_roofs;
     Polygons stair_removal; // polygons to subtract from support because of stair-stepping
@@ -1155,7 +1170,8 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
     const coord_t z_distance_bottom = ((mesh.settings.get<bool>("support_bottom_enable")) ? bottom_settings : infill_settings).get<coord_t>("support_bottom_distance");
     const size_t bottom_empty_layer_count = round_up_divide(z_distance_bottom, layer_thickness); // number of empty layers between support and model
     const coord_t bottom_stair_step_height = std::max(static_cast<coord_t>(0), mesh.settings.get<coord_t>("support_bottom_stair_step_height"));
-    const size_t bottom_stair_step_layer_count = bottom_stair_step_height / layer_thickness + 1; // the difference in layers between two stair steps. One is normal support (not stair-like)
+    const size_t bottom_stair_step_layer_count
+        = bottom_stair_step_height / layer_thickness + 1; // the difference in layers between two stair steps. One is normal support (not stair-like)
 
     // Post-process the sloped areas's. (Skip if no stair-stepping anyway.)
     // The idea here is to 'add up' all the sloped 'areas' so they form actual areas per each stair-step height.
@@ -1219,7 +1235,8 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
         { // join with support from layer up
             const Polygons empty;
             const Polygons* layer_above = (layer_idx < support_areas.size()) ? &support_areas[layer_idx + 1] : &empty;
-            const Polygons model_mesh_on_layer = (layer_idx > 0) && ! is_support_mesh_nondrop_place_holder ? storage.getLayerOutlines(layer_idx, no_support, no_prime_tower) : empty;
+            const Polygons model_mesh_on_layer
+                = (layer_idx > 0) && ! is_support_mesh_nondrop_place_holder ? storage.getLayerOutlines(layer_idx, no_support, no_prime_tower) : empty;
             if (is_support_mesh_nondrop_place_holder)
             {
                 layer_above = &empty;
@@ -1233,9 +1250,7 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
         {
             for (PolygonsPart poly : layer_this.splitIntoParts())
             {
-                const auto polygon_part = poly.difference(xy_disallowed_per_layer[layer_idx])
-                                        .offset(-half_min_feature_width)
-                                        .offset(half_min_feature_width);
+                const auto polygon_part = poly.difference(xy_disallowed_per_layer[layer_idx]).offset(-half_min_feature_width).offset(half_min_feature_width);
 
                 const int64_t part_area = polygon_part.area();
                 if (part_area == 0 || part_area > max_tower_supported_diameter * max_tower_supported_diameter)
@@ -1259,7 +1274,15 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
         }
 
         // Move up from model, handle stair-stepping.
-        moveUpFromModel(storage, stair_removal, sloped_areas_per_layer[layer_idx], layer_this, layer_idx, bottom_empty_layer_count, bottom_stair_step_layer_count, bottom_stair_step_width);
+        moveUpFromModel(
+            storage,
+            stair_removal,
+            sloped_areas_per_layer[layer_idx],
+            layer_this,
+            layer_idx,
+            bottom_empty_layer_count,
+            bottom_stair_step_layer_count,
+            bottom_stair_step_width);
 
         support_areas[layer_idx] = layer_this;
         Progress::messageProgress(Progress::Stage::SUPPORT, layer_count * (mesh_idx + 1) - layer_idx, layer_count * storage.meshes.size());
@@ -1335,24 +1358,26 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
         // this is performed after the main support generation loop above, because it affects the joining of polygons
         // if this would be performed in the main loop then some support would not have been generated under the overhangs and consequently no support is generated for that,
         // meaning almost no support would be generated in some cases which definitely need support.
-        const int max_checking_layer_idx = std::max(0, std::min(static_cast<int>(storage.support.supportLayers.size()), static_cast<int>(layer_count - (layer_z_distance_top - 1))));
+        const int max_checking_layer_idx
+            = std::max(0, std::min(static_cast<int>(storage.support.supportLayers.size()), static_cast<int>(layer_count - (layer_z_distance_top - 1))));
 
-        cura::parallel_for<size_t>(0,
-                                   max_checking_layer_idx,
-                                   [&](const size_t layer_idx)
-                                   {
-                                       constexpr bool no_support = false;
-                                       constexpr bool no_prime_tower = false;
-                                       support_areas[layer_idx] = support_areas[layer_idx].difference(storage.getLayerOutlines(layer_idx + layer_z_distance_top - 1, no_support, no_prime_tower));
-                                   });
+        cura::parallel_for<size_t>(
+            0,
+            max_checking_layer_idx,
+            [&](const size_t layer_idx)
+            {
+                constexpr bool no_support = false;
+                constexpr bool no_prime_tower = false;
+                support_areas[layer_idx] = support_areas[layer_idx].difference(storage.getLayerOutlines(layer_idx + layer_z_distance_top - 1, no_support, no_prime_tower));
+            });
     }
 
     // Procedure to remove floating support
-    for (size_t layer_idx = 1; layer_idx < layer_count - 1; layer_idx ++)
+    for (size_t layer_idx = 1; layer_idx < layer_count - 1; layer_idx++)
     {
         Polygons& layer_this = support_areas[layer_idx];
 
-        if (!layer_this.empty())
+        if (! layer_this.empty())
         {
             Polygons& layer_below = support_areas[layer_idx - 1];
             Polygons& layer_above = support_areas[layer_idx + 1];
@@ -1373,14 +1398,15 @@ void AreaSupport::generateSupportAreasForMesh(SliceDataStorage& storage,
     storage.support.generated = true;
 }
 
-void AreaSupport::moveUpFromModel(const SliceDataStorage& storage,
-                                  Polygons& stair_removal,
-                                  Polygons& sloped_areas,
-                                  Polygons& support_areas,
-                                  const size_t layer_idx,
-                                  const size_t bottom_empty_layer_count,
-                                  const size_t bottom_stair_step_layer_count,
-                                  const coord_t support_bottom_stair_step_width)
+void AreaSupport::moveUpFromModel(
+    const SliceDataStorage& storage,
+    Polygons& stair_removal,
+    Polygons& sloped_areas,
+    Polygons& support_areas,
+    const size_t layer_idx,
+    const size_t bottom_empty_layer_count,
+    const size_t bottom_stair_step_layer_count,
+    const coord_t support_bottom_stair_step_width)
 {
     // The idea behind support bottom stairs:
     //
@@ -1416,7 +1442,8 @@ void AreaSupport::moveUpFromModel(const SliceDataStorage& storage,
     //                                                    support
     // ############################################################################     ┐
     // AAAAAxxxxxxxxxxxxx                                                               │
-    // CCCCCCCCCCCCCCCCCC##########################################################     │           >>>>>>>>>   result only applies stair step to first layer(s) of what woud normally be the stair step
+    // CCCCCCCCCCCCCCCCCC##########################################################     │           >>>>>>>>>   result only applies stair step to first layer(s) of what woud
+    // normally be the stair step
     //      ^^--..__                                                                    │
     //              ^^--..__#######################################################     ├> stair step height
     // ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺  ^^--..__                                                    │
@@ -1486,8 +1513,8 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
     constexpr bool no_support = false;
     constexpr bool no_prime_tower = false;
 
-    constexpr double smooth_height = 0.4; //mm
-    const LayerIndex layers_below { static_cast<LayerIndex::value_type>(std::round(smooth_height / mesh.settings.get<double>("layer_height"))) };
+    constexpr double smooth_height = 0.4; // mm
+    const LayerIndex layers_below{ static_cast<LayerIndex::value_type>(std::round(smooth_height / mesh.settings.get<double>("layer_height"))) };
 
     const coord_t layer_height = mesh.settings.get<coord_t>("layer_height");
     const AngleRadians support_angle = mesh.settings.get<AngleRadians>("support_angle");
@@ -1498,23 +1525,17 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
     // To avoids generating support for textures on vertical surfaces, a moving average
     // is taken over smooth_height. The smooth_height is currently an educated guess
     // that we might want to expose to the frontend in the future.
-    Polygons outlines_below =
-        storage.getLayerOutlines(layer_idx - 1, no_support, no_prime_tower)
-        .offset(max_dist_from_lower_layer);
-    for (int layer_idx_offset = 2; layer_idx - layer_idx_offset >= 0 && layer_idx_offset <= layers_below; layer_idx_offset ++)
+    Polygons outlines_below = storage.getLayerOutlines(layer_idx - 1, no_support, no_prime_tower).offset(max_dist_from_lower_layer);
+    for (int layer_idx_offset = 2; layer_idx - layer_idx_offset >= 0 && layer_idx_offset <= layers_below; layer_idx_offset++)
     {
-        auto outlines_below_ =
-            storage.getLayerOutlines(layer_idx - layer_idx_offset, no_support, no_prime_tower)
-            .offset(max_dist_from_lower_layer * layer_idx_offset);
+        auto outlines_below_ = storage.getLayerOutlines(layer_idx - layer_idx_offset, no_support, no_prime_tower).offset(max_dist_from_lower_layer * layer_idx_offset);
         outlines_below = outlines_below.unionPolygons(outlines_below_);
     }
 
-    Polygons basic_overhang =
-        outlines
-        .difference(outlines_below);
+    Polygons basic_overhang = outlines.difference(outlines_below);
 
     const SupportLayer& support_layer = storage.support.supportLayers[layer_idx];
-    if (!support_layer.anti_overhang.empty())
+    if (! support_layer.anti_overhang.empty())
     {
         // Merge anti overhang into one polygon, otherwise overlapping polygons
         // will create opposite effect.
@@ -1523,10 +1544,9 @@ std::pair<Polygons, Polygons> AreaSupport::computeBasicAndFullOverhang(const Sli
         basic_overhang = basic_overhang.difference(merged_polygons);
     }
 
-    Polygons overhang_extended =
-        basic_overhang
-        // +0.1mm for easier joining with support from layer above
-        .offset(max_dist_from_lower_layer * layers_below + MM2INT(0.1));
+    Polygons overhang_extended = basic_overhang
+                                     // +0.1mm for easier joining with support from layer above
+                                     .offset(max_dist_from_lower_layer * layers_below + MM2INT(0.1));
     Polygons full_overhang = overhang_extended.intersection(outlines);
 
     return std::make_pair(basic_overhang, full_overhang);
@@ -1570,7 +1590,14 @@ void AreaSupport::detectOverhangPoints(const SliceDataStorage& storage, SliceMes
     }
 }
 
-void AreaSupport::handleTowers(const Settings& settings, const Polygons& xy_disallowed_area, Polygons& supportLayer_this, std::vector<Polygons>& tower_roofs, std::vector<std::vector<Polygons>>& overhang_points, LayerIndex layer_idx, size_t layer_count)
+void AreaSupport::handleTowers(
+    const Settings& settings,
+    const Polygons& xy_disallowed_area,
+    Polygons& supportLayer_this,
+    std::vector<Polygons>& tower_roofs,
+    std::vector<std::vector<Polygons>>& overhang_points,
+    LayerIndex layer_idx,
+    size_t layer_count)
 {
     LayerIndex layer_overhang_point = layer_idx + 1; // Start tower 1 layer below overhang point.
     if (layer_overhang_point >= static_cast<LayerIndex>(layer_count) - 1)
@@ -1621,7 +1648,12 @@ void AreaSupport::handleTowers(const Settings& settings, const Polygons& xy_disa
         tower_roof_expansion_distance = layer_thickness / tan_tower_roof_angle;
     }
 
-    for (Polygons& tower_roof: tower_roofs | ranges::views::filter([](const auto& poly){ return ! poly.empty(); }))
+    for (Polygons& tower_roof : tower_roofs
+                                    | ranges::views::filter(
+                                        [](const auto& poly)
+                                        {
+                                            return ! poly.empty();
+                                        }))
     {
         supportLayer_this = supportLayer_this.unionPolygons(tower_roof);
 
@@ -1721,12 +1753,15 @@ void AreaSupport::generateSupportBottom(SliceDataStorage& storage, const SliceMe
         return;
     }
     const coord_t z_distance_bottom = round_up_divide(mesh.settings.get<coord_t>("support_bottom_distance"), layer_height); // Number of layers between support bottom and model.
-    const size_t skip_layer_count = std::max(uint64_t(1), round_divide(mesh.settings.get<coord_t>("support_interface_skip_height"), layer_height)); // Resolution of generating support bottoms above model.
+    const size_t skip_layer_count
+        = std::max(uint64_t(1), round_divide(mesh.settings.get<coord_t>("support_interface_skip_height"), layer_height)); // Resolution of generating support bottoms above model.
     const coord_t bottom_line_width = mesh_group_settings.get<ExtruderTrain&>("support_bottom_extruder_nr").settings.get<coord_t>("support_bottom_line_width");
     const coord_t bottom_outline_offset = mesh_group_settings.get<ExtruderTrain&>("support_bottom_extruder_nr").settings.get<coord_t>("support_bottom_offset");
 
     const size_t scan_count = std::max(size_t(1), (bottom_layer_count - 1) / skip_layer_count); // How many measurements to take to generate bottom areas.
-    const float z_skip = std::max(1.0f, float(bottom_layer_count - 1) / float(scan_count)); // How many layers to skip between measurements. Using float for better spread, but this is later rounded.
+    const float z_skip = std::max(
+        1.0f,
+        float(bottom_layer_count - 1) / float(scan_count)); // How many layers to skip between measurements. Using float for better spread, but this is later rounded.
     const double minimum_bottom_area = mesh.settings.get<double>("minimum_bottom_area");
 
     std::vector<SupportLayer>& support_layers = storage.support.supportLayers;
@@ -1755,18 +1790,23 @@ void AreaSupport::generateSupportRoof(SliceDataStorage& storage, const SliceMesh
         return;
     }
     const coord_t z_distance_top = round_up_divide(mesh.settings.get<coord_t>("support_top_distance"), layer_height); // Number of layers between support roof and model.
-    const size_t skip_layer_count = std::max(uint64_t(1), round_divide(mesh.settings.get<coord_t>("support_interface_skip_height"), layer_height)); // Resolution of generating support roof below model.
+    const size_t skip_layer_count
+        = std::max(uint64_t(1), round_divide(mesh.settings.get<coord_t>("support_interface_skip_height"), layer_height)); // Resolution of generating support roof below model.
     const coord_t roof_line_width = mesh_group_settings.get<ExtruderTrain&>("support_roof_extruder_nr").settings.get<coord_t>("support_roof_line_width");
     const coord_t roof_outline_offset = mesh_group_settings.get<ExtruderTrain&>("support_roof_extruder_nr").settings.get<coord_t>("support_roof_offset");
 
     const size_t scan_count = std::max(size_t(1), (roof_layer_count - 1) / skip_layer_count); // How many measurements to take to generate roof areas.
-    const float z_skip = std::max(1.0f, float(roof_layer_count - 1) / float(scan_count)); // How many layers to skip between measurements. Using float for better spread, but this is later rounded.
+    const float z_skip = std::max(
+        1.0f,
+        float(roof_layer_count - 1) / float(scan_count)); // How many layers to skip between measurements. Using float for better spread, but this is later rounded.
     const double minimum_roof_area = mesh.settings.get<double>("minimum_roof_area");
 
     std::vector<SupportLayer>& support_layers = storage.support.supportLayers;
     for (LayerIndex layer_idx = 0; layer_idx < static_cast<int>(support_layers.size() - z_distance_top); layer_idx++)
     {
-        const LayerIndex top_layer_idx_above { std::min(LayerIndex { support_layers.size() - 1 }, LayerIndex{ layer_idx + roof_layer_count + z_distance_top }) }; // Maximum layer of the model that generates support roof.
+        const LayerIndex top_layer_idx_above{
+            std::min(LayerIndex{ support_layers.size() - 1 }, LayerIndex{ layer_idx + roof_layer_count + z_distance_top })
+        }; // Maximum layer of the model that generates support roof.
         Polygons mesh_outlines;
         for (float layer_idx_above = top_layer_idx_above; layer_idx_above > layer_idx + z_distance_top; layer_idx_above -= z_skip)
         {
@@ -1779,10 +1819,7 @@ void AreaSupport::generateSupportRoof(SliceDataStorage& storage, const SliceMesh
     }
 
     // Remove support in between the support roof and the model. Subtracts the roof polygons from the support polygons on the layers above it.
-    for (auto [layer_idx, support_layer] : support_layers
-                                               | ranges::views::enumerate
-                                               | ranges::views::drop(1)
-                                               | ranges::views::drop_last(z_distance_top))
+    for (auto [layer_idx, support_layer] : support_layers | ranges::views::enumerate | ranges::views::drop(1) | ranges::views::drop_last(z_distance_top))
     {
         Polygons roof = support_layer.support_roof;
 
@@ -1800,7 +1837,13 @@ void AreaSupport::generateSupportRoof(SliceDataStorage& storage, const SliceMesh
     }
 }
 
-void AreaSupport::generateSupportInterfaceLayer(Polygons& support_areas, const Polygons colliding_mesh_outlines, const coord_t safety_offset, const coord_t outline_offset, const double minimum_interface_area, Polygons& interface_polygons)
+void AreaSupport::generateSupportInterfaceLayer(
+    Polygons& support_areas,
+    const Polygons colliding_mesh_outlines,
+    const coord_t safety_offset,
+    const coord_t outline_offset,
+    const double minimum_interface_area,
+    Polygons& interface_polygons)
 {
     Polygons model = colliding_mesh_outlines.unionPolygons();
     interface_polygons = support_areas.offset(safety_offset / 2).intersection(model);

--- a/src/timeEstimate.cpp
+++ b/src/timeEstimate.cpp
@@ -1,14 +1,15 @@
 // Copyright (c) 2023 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
+#include "timeEstimate.h"
+
+#include "settings/Settings.h"
+#include "utils/math.h"
+
+#include <algorithm>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
-#include <algorithm>
-
-#include "timeEstimate.h"
-#include "utils/math.h"
-#include "settings/Settings.h"
 
 namespace cura
 {
@@ -59,7 +60,7 @@ void TimeEstimateCalculator::reset()
     blocks.clear();
 }
 
-// Calculates the maximum allowable speed at this point when you must be able to reach target_velocity using the 
+// Calculates the maximum allowable speed at this point when you must be able to reach target_velocity using the
 // acceleration within the allotted distance.
 static inline Velocity maxAllowableSpeed(const Acceleration& acceleration, const Velocity& target_velocity, double distance)
 {
@@ -76,7 +77,7 @@ static inline float estimateAccelerationDistance(const Velocity& initial_rate, c
     return (square(target_rate) - square(initial_rate)) / (2.0 * acceleration);
 }
 
-// This function gives you the point at which you must start braking (at the rate of -acceleration) if 
+// This function gives you the point at which you must start braking (at the rate of -acceleration) if
 // you started at speed initial_rate and accelerated until this point and want to end at the final_rate after
 // a total travel of distance. This can be used to compute the intersection point between acceleration and
 // deceleration in the cases where the trapezoid has no plateau (i.e. never reaches maximum speed)
@@ -122,13 +123,13 @@ static inline double intersectionDistance(const Velocity& initial_rate, const Ve
 static inline double accelerationTimeFromDistance(const Velocity& initial_feedrate, const Velocity& distance, const Acceleration& acceleration)
 {
     double discriminant = square(initial_feedrate) - 2 * acceleration * -distance;
-    //If discriminant is negative, we're moving in the wrong direction.
-    //Making the discriminant 0 then gives the extremum of the parabola instead of the intersection.
+    // If discriminant is negative, we're moving in the wrong direction.
+    // Making the discriminant 0 then gives the extremum of the parabola instead of the intersection.
     discriminant = std::max(0.0, discriminant);
     return (-initial_feedrate + sqrt(discriminant)) / acceleration;
 }
 
-void TimeEstimateCalculator::calculateTrapezoidForBlock(Block *block, const Ratio entry_factor, const Ratio exit_factor)
+void TimeEstimateCalculator::calculateTrapezoidForBlock(Block* block, const Ratio entry_factor, const Ratio exit_factor)
 {
     const Velocity initial_feedrate = block->nominal_feedrate * entry_factor;
     const Velocity final_feedrate = block->nominal_feedrate * exit_factor;
@@ -137,7 +138,7 @@ void TimeEstimateCalculator::calculateTrapezoidForBlock(Block *block, const Rati
     const double decelerate_distance = estimateAccelerationDistance(block->nominal_feedrate, final_feedrate, -block->acceleration);
 
     // Calculate the size of Plateau of Nominal Rate.
-    double plateau_distance = block->distance-accelerate_distance - decelerate_distance;
+    double plateau_distance = block->distance - accelerate_distance - decelerate_distance;
 
     // Is the Plateau of Nominal Rate smaller than nothing? That means no cruising, and we will
     // have to use intersection_distance() to calculate when to abort acceleration and start braking
@@ -146,7 +147,7 @@ void TimeEstimateCalculator::calculateTrapezoidForBlock(Block *block, const Rati
     {
         accelerate_distance = intersectionDistance(initial_feedrate, final_feedrate, block->acceleration, block->distance);
         accelerate_distance = std::max(accelerate_distance, 0.0); // Check limits due to numerical round-off
-        accelerate_distance = std::min(accelerate_distance, block->distance);//(We can cast here to unsigned, because the above line ensures that we are above zero)
+        accelerate_distance = std::min(accelerate_distance, block->distance); //(We can cast here to unsigned, because the above line ensures that we are above zero)
         plateau_distance = 0;
     }
 
@@ -163,8 +164,8 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
 
     block.feature = feature;
 
-    //block.maxTravel = 0; //Done by memset.
-    for(size_t n = 0; n < NUM_AXIS; n++)
+    // block.maxTravel = 0; //Done by memset.
+    for (size_t n = 0; n < NUM_AXIS; n++)
     {
         block.delta[n] = newPos[n] - currentPosition[n];
         block.absDelta[n] = std::abs(block.delta[n]);
@@ -184,11 +185,11 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
         block.distance = block.absDelta[3];
     }
     block.nominal_feedrate = feedrate;
-    
+
     Position current_feedrate;
     Position current_abs_feedrate;
     Ratio feedrate_factor = 1.0;
-    for(size_t n = 0; n < NUM_AXIS; n++)
+    for (size_t n = 0; n < NUM_AXIS; n++)
     {
         current_feedrate[n] = (block.delta[n] * feedrate) / block.distance;
         current_abs_feedrate[n] = std::abs(current_feedrate[n]);
@@ -197,32 +198,32 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
             feedrate_factor = std::min(feedrate_factor, Ratio(max_feedrate[n] / current_abs_feedrate[n]));
         }
     }
-    //TODO: XY_FREQUENCY_LIMIT
-    
+    // TODO: XY_FREQUENCY_LIMIT
+
     if (feedrate_factor < 1.0)
     {
-        for(size_t n = 0; n < NUM_AXIS; n++)
+        for (size_t n = 0; n < NUM_AXIS; n++)
         {
             current_feedrate[n] *= feedrate_factor;
             current_abs_feedrate[n] *= feedrate_factor;
         }
         block.nominal_feedrate *= feedrate_factor;
     }
-    
+
     block.acceleration = acceleration;
-    for(size_t n = 0; n < NUM_AXIS; n++)
+    for (size_t n = 0; n < NUM_AXIS; n++)
     {
         if (block.acceleration * (block.absDelta[n] / block.distance) > max_acceleration[n])
         {
             block.acceleration = max_acceleration[n];
         }
     }
-    
-    Velocity vmax_junction { max_xy_jerk / 2.0 };
-    Ratio vmax_junction_factor { 1.0 };
+
+    Velocity vmax_junction{ max_xy_jerk / 2.0 };
+    Ratio vmax_junction_factor{ 1.0 };
     if (current_abs_feedrate[Z_AXIS] > max_z_jerk / 2.0)
     {
-        vmax_junction = std::min(vmax_junction, Velocity { max_z_jerk / 2.0 });
+        vmax_junction = std::min(vmax_junction, Velocity{ max_z_jerk / 2.0 });
     }
     if (current_abs_feedrate[E_AXIS] > max_e_jerk / 2.0)
     {
@@ -230,7 +231,7 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
     }
     vmax_junction = std::min(vmax_junction, block.nominal_feedrate);
     const Velocity safe_speed = vmax_junction;
-    
+
     if ((blocks.size() > 0) && (previous_nominal_feedrate > 0.0001))
     {
         const Velocity xy_jerk = sqrt(square(current_feedrate[X_AXIS] - previous_feedrate[X_AXIS]) + square(current_feedrate[Y_AXIS] - previous_feedrate[Y_AXIS]));
@@ -249,7 +250,7 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
         {
             vmax_junction_factor = std::min(vmax_junction_factor, Ratio(max_e_jerk / e_jerk));
         }
-        vmax_junction = std::min(previous_nominal_feedrate, Velocity { vmax_junction * vmax_junction_factor }); // Limit speed to max previous speed
+        vmax_junction = std::min(previous_nominal_feedrate, Velocity{ vmax_junction * vmax_junction_factor }); // Limit speed to max previous speed
     }
 
     block.max_entry_speed = vmax_junction;
@@ -274,10 +275,10 @@ std::vector<Duration> TimeEstimateCalculator::calculate()
     reversePass();
     forwardPass();
     recalculateTrapezoids();
-    
+
     std::vector<Duration> totals(static_cast<unsigned char>(PrintFeatureType::NumPrintFeatureTypes), 0.0);
     totals[static_cast<unsigned char>(PrintFeatureType::NoneType)] = extra_time; // Extra time (pause for minimum layer time, etc) is marked as NoneType
-    for(unsigned int n = 0; n < blocks.size(); n++)
+    for (unsigned int n = 0; n < blocks.size(); n++)
     {
         const Block& block = blocks[n];
         const double plateau_distance = block.decelerate_after - block.accelerate_until;
@@ -289,10 +290,10 @@ std::vector<Duration> TimeEstimateCalculator::calculate()
     return totals;
 }
 
-void TimeEstimateCalculator::plannerReversePassKernel(Block *previous, Block *current, Block *next)
+void TimeEstimateCalculator::plannerReversePassKernel(Block* previous, Block* current, Block* next)
 {
     (void)previous;
-    if (!current || !next)
+    if (! current || ! next)
     {
         return;
     }
@@ -304,7 +305,7 @@ void TimeEstimateCalculator::plannerReversePassKernel(Block *previous, Block *cu
     {
         // If nominal length true, max junction speed is guaranteed to be reached. Only compute
         // for max allowable speed if block is decelerating and nominal length is false.
-        if ((!current->nominal_length_flag) && (current->max_entry_speed > next->entry_speed))
+        if ((! current->nominal_length_flag) && (current->max_entry_speed > next->entry_speed))
         {
             current->entry_speed = std::min(current->max_entry_speed, maxAllowableSpeed(-current->acceleration, next->entry_speed, current->distance));
         }
@@ -318,20 +319,20 @@ void TimeEstimateCalculator::plannerReversePassKernel(Block *previous, Block *cu
 
 void TimeEstimateCalculator::reversePass()
 {
-    Block* block[3] = {nullptr, nullptr, nullptr};
-    for(size_t n = blocks.size() - 1; int(n) >= 0; n--)
+    Block* block[3] = { nullptr, nullptr, nullptr };
+    for (size_t n = blocks.size() - 1; int(n) >= 0; n--)
     {
-        block[2]= block[1];
-        block[1]= block[0];
+        block[2] = block[1];
+        block[1] = block[0];
         block[0] = &blocks[n];
         plannerReversePassKernel(block[0], block[1], block[2]);
     }
 }
 
-void TimeEstimateCalculator::plannerForwardPassKernel(Block *previous, Block *current, Block *next)
+void TimeEstimateCalculator::plannerForwardPassKernel(Block* previous, Block* current, Block* next)
 {
     (void)next;
-    if (!previous)
+    if (! previous)
     {
         return;
     }
@@ -340,7 +341,7 @@ void TimeEstimateCalculator::plannerForwardPassKernel(Block *previous, Block *cu
     // full speed change within the block, we need to adjust the entry speed accordingly. Entry
     // speeds have already been reset, maximized, and reverse planned by reverse planner.
     // If nominal length is true, max junction speed is guaranteed to be reached. No need to recheck.
-    if (!previous->nominal_length_flag)
+    if (! previous->nominal_length_flag)
     {
         if (previous->entry_speed < current->entry_speed)
         {
@@ -358,11 +359,11 @@ void TimeEstimateCalculator::plannerForwardPassKernel(Block *previous, Block *cu
 
 void TimeEstimateCalculator::forwardPass()
 {
-    Block* block[3] = {nullptr, nullptr, nullptr};
-    for(size_t n = 0; n < blocks.size(); n++)
+    Block* block[3] = { nullptr, nullptr, nullptr };
+    for (size_t n = 0; n < blocks.size(); n++)
     {
-        block[0]= block[1];
-        block[1]= block[2];
+        block[0] = block[1];
+        block[1] = block[2];
         block[2] = &blocks[n];
         plannerForwardPassKernel(block[0], block[1], block[2]);
     }
@@ -371,10 +372,10 @@ void TimeEstimateCalculator::forwardPass()
 
 void TimeEstimateCalculator::recalculateTrapezoids()
 {
-    Block *current;
-    Block *next = nullptr;
+    Block* current;
+    Block* next = nullptr;
 
-    for(unsigned int n=0; n<blocks.size(); n++)
+    for (unsigned int n = 0; n < blocks.size(); n++)
     {
         current = next;
         next = &blocks[n];
@@ -397,4 +398,4 @@ void TimeEstimateCalculator::recalculateTrapezoids()
     }
 }
 
-}//namespace cura
+} // namespace cura

--- a/src/timeEstimate.cpp
+++ b/src/timeEstimate.cpp
@@ -1,5 +1,5 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include <math.h>
 #include <stdio.h>
@@ -9,7 +9,6 @@
 #include "timeEstimate.h"
 #include "utils/math.h"
 #include "settings/Settings.h"
-#include "settings/types/Ratio.h"
 
 namespace cura
 {
@@ -44,7 +43,7 @@ void TimeEstimateCalculator::addTime(const Duration& time)
     extra_time += time;
 }
 
-void TimeEstimateCalculator::setAcceleration(const Velocity& acc)
+void TimeEstimateCalculator::setAcceleration(const Acceleration& acc)
 {
     acceleration = acc;
 }
@@ -219,15 +218,15 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
         }
     }
     
-    Velocity vmax_junction = max_xy_jerk / 2;
-    Ratio vmax_junction_factor = 1.0;
-    if (current_abs_feedrate[Z_AXIS] > max_z_jerk / 2)
+    Velocity vmax_junction { max_xy_jerk / 2.0 };
+    Ratio vmax_junction_factor { 1.0 };
+    if (current_abs_feedrate[Z_AXIS] > max_z_jerk / 2.0)
     {
-        vmax_junction = std::min(vmax_junction, max_z_jerk / 2);
+        vmax_junction = std::min(vmax_junction, Velocity { max_z_jerk / 2.0 });
     }
-    if (current_abs_feedrate[E_AXIS] > max_e_jerk / 2)
+    if (current_abs_feedrate[E_AXIS] > max_e_jerk / 2.0)
     {
-        vmax_junction = std::min(vmax_junction, max_e_jerk / 2);
+        vmax_junction = std::min(vmax_junction, Velocity{ max_e_jerk / 2.0 });
     }
     vmax_junction = std::min(vmax_junction, block.nominal_feedrate);
     const Velocity safe_speed = vmax_junction;
@@ -250,7 +249,7 @@ void TimeEstimateCalculator::plan(Position newPos, Velocity feedrate, PrintFeatu
         {
             vmax_junction_factor = std::min(vmax_junction_factor, Ratio(max_e_jerk / e_jerk));
         }
-        vmax_junction = std::min(previous_nominal_feedrate, vmax_junction * vmax_junction_factor); // Limit speed to max previous speed
+        vmax_junction = std::min(previous_nominal_feedrate, Velocity { vmax_junction * vmax_junction_factor }); // Limit speed to max previous speed
     }
 
     block.max_entry_speed = vmax_junction;

--- a/tests/ExtruderPlanTest.cpp
+++ b/tests/ExtruderPlanTest.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "LayerPlan.h" //Code under test.
 #include <gtest/gtest.h>
@@ -69,15 +69,15 @@ public:
     GCodePathConfig travel_config;
 
     ExtruderPlanTestPathCollection()
-        : extrusion_config(PrintFeatureType::OuterWall, 400, 100, 1.0_r, GCodePathConfig::SpeedDerivatives(50, 1000, 10))
-        , travel_config(PrintFeatureType::MoveCombing, 0, 100, 0.0_r, GCodePathConfig::SpeedDerivatives(120, 5000, 30))
+        : extrusion_config(PrintFeatureType::OuterWall, 400, 100, 1.0_r, GCodePathConfig::SpeedDerivatives(50.0, 1000.0, 10.0))
+        , travel_config(PrintFeatureType::MoveCombing, 0, 100, 0.0_r, GCodePathConfig::SpeedDerivatives(120.0, 5000.0, 30.0))
     {
         const SliceMeshStorage* mesh = nullptr;
         constexpr Ratio flow_1 = 1.0_r;
         constexpr Ratio width_1 = 1.0_r;
         constexpr bool no_spiralize = false;
         constexpr Ratio speed_1 = 1.0_r;
-        square.assign({ GCodePath(extrusion_config, mesh, SpaceFillType::PolyLines, flow_1, no_spiralize, speed_1) });
+        square.assign({ GCodePath(extrusion_config, mesh, SpaceFillType::PolyLines, flow_1, width_1, no_spiralize, speed_1) });
         square.back().points =
         {
             Point(0, 0),
@@ -89,11 +89,11 @@ public:
 
         lines.assign
         ({
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1)
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1)
         });
         lines[0].points = { Point(0, 0), Point(1000, 0) };
         lines[1].points = { Point(1000, 0), Point(1000, 400) };
@@ -106,11 +106,11 @@ public:
         constexpr Ratio flow_04 = 0.4_r;
         decreasing_flow.assign
         ({
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_12, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_08, no_spiralize, speed_1),
-            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_04, no_spiralize, speed_1)
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_12, width_1, no_spiralize, speed_1),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_08, width_1, no_spiralize, speed_1),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_04, width_1, no_spiralize, speed_1)
         });
         decreasing_flow[0].points = { Point(0, 0), Point(1000, 0) };
         decreasing_flow[1].points = { Point(1000, 0), Point(1000, 400) };
@@ -123,11 +123,11 @@ public:
         constexpr Ratio speed_04 = 0.4_r;
         decreasing_speed.assign
         ({
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_12),
-            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_08),
-            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_04)
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_12),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_08),
+            GCodePath(travel_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_04)
         });
         decreasing_speed[0].points = { Point(0, 0), Point(1000, 0) };
         decreasing_speed[1].points = { Point(1000, 0), Point(1000, 400) };
@@ -137,12 +137,12 @@ public:
 
         variable_width.assign
         ({
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.8_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.6_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.4_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.2_r, no_spiralize, speed_1),
-            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.0_r, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, flow_1, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.8_r, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.6_r, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.4_r, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.2_r, width_1, no_spiralize, speed_1),
+            GCodePath(extrusion_config, mesh, SpaceFillType::Lines, 0.0_r, width_1, no_spiralize, speed_1),
         });
         variable_width[0].points = { Point(0, 0), Point(1000, 0) };
         variable_width[1].points = { Point(1000, 0), Point(2000, 0) };

--- a/tests/GCodeExportTest.cpp
+++ b/tests/GCodeExportTest.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "gcodeExport.h" // The unit under test.
 #include "Application.h" // To set up a slice with settings.
@@ -7,7 +7,6 @@
 #include "Slice.h" // To set up a slice with settings.
 #include "WipeScriptConfig.h" // For wipe script tests.
 #include "arcus/MockCommunication.h" // To prevent calls to any missing Communication class.
-#include "settings/types/LayerIndex.h"
 #include "utils/Coord_t.h"
 #include "utils/Date.h" // To check the Griffin header.
 #include <gtest/gtest.h>
@@ -52,10 +51,10 @@ public:
         gcode.current_extruder = 0;
         gcode.current_fan_speed = -1;
         gcode.total_print_times = std::vector<Duration>(static_cast<unsigned char>(PrintFeatureType::NumPrintFeatureTypes), 0.0);
-        gcode.currentSpeed = 1;
-        gcode.current_print_acceleration = -1;
-        gcode.current_travel_acceleration = -1;
-        gcode.current_jerk = -1;
+        gcode.currentSpeed = 1.0;
+        gcode.current_print_acceleration = -1.0;
+        gcode.current_travel_acceleration = -1.0;
+        gcode.current_jerk = -1.0;
         gcode.is_z_hopped = 0;
         gcode.setFlavor(EGCodeFlavor::MARLIN);
         gcode.bed_temperature = 0;
@@ -210,10 +209,10 @@ public:
         gcode.current_extruder = 0;
         gcode.current_fan_speed = -1;
         gcode.total_print_times = std::vector<Duration>(static_cast<unsigned char>(PrintFeatureType::NumPrintFeatureTypes), 0.0);
-        gcode.currentSpeed = 1;
-        gcode.current_print_acceleration = -1;
-        gcode.current_travel_acceleration = -1;
-        gcode.current_jerk = -1;
+        gcode.currentSpeed = 1.0;
+        gcode.current_print_acceleration = -1.0;
+        gcode.current_travel_acceleration = -1.0;
+        gcode.current_jerk = -1.0;
         gcode.is_z_hopped = 0;
         gcode.setFlavor(EGCodeFlavor::MARLIN);
         gcode.initial_bed_temp = 0;
@@ -493,7 +492,7 @@ TEST_F(GCodeExportTest, WriteZHopStartCustomSpeed)
     Application::getInstance().current_slice->scene.extruders[gcode.current_extruder].settings.add("speed_z_hop", "1"); // 60mm/min.
     gcode.current_layer_z = 2000;
     constexpr coord_t hop_height = 3000;
-    constexpr Velocity speed = 4; // 240 mm/min.
+    constexpr Velocity speed { 4.0 }; // 240 mm/min.
     gcode.writeZhopStart(hop_height, speed);
     EXPECT_EQ(std::string("G1 F240 Z5\n"), output.str()) << "Custom provided speed should be used.";
 }
@@ -521,7 +520,7 @@ TEST_F(GCodeExportTest, WriteZHopEndCustomSpeed)
     Application::getInstance().current_slice->scene.extruders[gcode.current_extruder].settings.add("speed_z_hop", "1");
     gcode.current_layer_z = 2000;
     gcode.is_z_hopped = 3000;
-    constexpr Velocity speed = 4; // 240 mm/min.
+    constexpr Velocity speed { 4.0 }; // 240 mm/min.
     gcode.writeZhopEnd(speed);
     EXPECT_EQ(std::string("G1 F240 Z2\n"), output.str()) << "Custom provided speed should be used.";
 }
@@ -539,7 +538,7 @@ TEST_F(GCodeExportTest, insertWipeScriptSingleMove)
     config.brush_pos_x = 2000;
     config.repeat_count = 1;
     config.move_distance = 500;
-    config.move_speed = 10;
+    config.move_speed = 10.0;
     config.pause = 0;
 
     EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
@@ -571,7 +570,7 @@ TEST_F(GCodeExportTest, insertWipeScriptMultipleMoves)
     config.brush_pos_x = 2000;
     config.repeat_count = 4;
     config.move_distance = 500;
-    config.move_speed = 10;
+    config.move_speed = 10.0;
     config.pause = 0;
 
     EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(6);
@@ -609,7 +608,7 @@ TEST_F(GCodeExportTest, insertWipeScriptOptionalDelay)
     config.brush_pos_x = 2000;
     config.repeat_count = 1;
     config.move_distance = 500;
-    config.move_speed = 10;
+    config.move_speed = 10.0;
     config.pause = 1.5; // 1.5 sec = 1500 ms.
 
     EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
@@ -637,7 +636,7 @@ TEST_F(GCodeExportTest, insertWipeScriptRetractionEnable)
     gcode.current_extruder = 0;
     gcode.extruder_attr[0].filament_area = 10.0;
     gcode.relative_extrusion = false;
-    gcode.currentSpeed = 1;
+    gcode.currentSpeed = 1.0;
     Application::getInstance().current_slice->scene.current_mesh_group->settings.add("layer_height", "0.2");
     Application::getInstance().current_slice->scene.extruders.emplace_back(0, &Application::getInstance().current_slice->scene.current_mesh_group->settings);
     Application::getInstance().current_slice->scene.extruders.back().settings.add("machine_firmware_retract", "false");
@@ -645,8 +644,8 @@ TEST_F(GCodeExportTest, insertWipeScriptRetractionEnable)
     WipeScriptConfig config;
     config.retraction_enable = true;
     config.retraction_config.distance = 1;
-    config.retraction_config.speed = 2; // 120 mm/min.
-    config.retraction_config.primeSpeed = 3; // 180 mm/min.
+    config.retraction_config.speed = 2.0; // 120 mm/min.
+    config.retraction_config.primeSpeed = 3.0; // 180 mm/min.
     config.retraction_config.prime_volume = gcode.extruder_attr[0].filament_area * 4; // 4mm in linear dimensions
     config.retraction_config.retraction_count_max = 100; // Practically no limit.
     config.retraction_config.retraction_extrusion_window = 1;
@@ -655,7 +654,7 @@ TEST_F(GCodeExportTest, insertWipeScriptRetractionEnable)
     config.brush_pos_x = 2000;
     config.repeat_count = 1;
     config.move_distance = 500;
-    config.move_speed = 10;
+    config.move_speed = 10.0;
     config.pause = 0;
 
     EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
@@ -680,18 +679,18 @@ TEST_F(GCodeExportTest, insertWipeScriptHopEnable)
     gcode.currentPosition = Point3(1000, 1000, 1000);
     gcode.current_layer_z = 1000;
     gcode.use_extruder_offset_to_offset_coords = false;
-    gcode.currentSpeed = 1;
+    gcode.currentSpeed = 1.0;
     Application::getInstance().current_slice->scene.current_mesh_group->settings.add("layer_height", "0.2");
 
     WipeScriptConfig config;
     config.retraction_enable = false;
     config.hop_enable = true;
-    config.hop_speed = 2; // 120 mm/min.
+    config.hop_speed = 2.0; // 120 mm/min.
     config.hop_amount = 300;
     config.brush_pos_x = 2000;
     config.repeat_count = 1;
     config.move_distance = 500;
-    config.move_speed = 10;
+    config.move_speed = 10.0;
     config.pause = 0;
 
     EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);

--- a/tests/TimeEstimateCalculatorTest.cpp
+++ b/tests/TimeEstimateCalculatorTest.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "PrintFeature.h" //We get time estimates per print feature.
 #include "settings/Settings.h" //To set firmware settings.
@@ -144,7 +144,7 @@ TEST_F(TimeEstimateCalculatorTest, MoveToCurrentLocation)
     Duration estimate = std::accumulate(result.begin(), result.end(), Duration(0.0));
     EXPECT_NEAR(Duration(0.0), estimate, EPSILON) << "setPosition should not add any time to the estimate.";
 
-    calculator.plan(position, Velocity(10), PrintFeatureType::Infill);
+    calculator.plan(position, Velocity { 10.0 }, PrintFeatureType::Infill);
 
     result = calculator.calculate();
     estimate = std::accumulate(result.begin(), result.end(), Duration(0.0));

--- a/tests/settings/SettingsTest.cpp
+++ b/tests/settings/SettingsTest.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2022 Ultimaker B.V.
-// CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "settings/Settings.h" //The class under test.
 #include "Application.h" //To test extruder train settings.
@@ -139,25 +139,25 @@ TEST_F(SettingsTest, AddSettingTemperature)
 TEST_F(SettingsTest, AddSettingVelocity)
 {
     settings.add("test_setting", "12.345");
-    EXPECT_DOUBLE_EQ(Velocity(12.345), settings.get<Velocity>("test_setting"));
+    EXPECT_DOUBLE_EQ(Velocity { 12.345 }, settings.get<Velocity>("test_setting"));
 
     settings.add("test_setting", "-78");
-    EXPECT_DOUBLE_EQ(Velocity(-78), settings.get<Velocity>("test_setting"));
+    EXPECT_DOUBLE_EQ(Velocity{ -78.0 }, settings.get<Velocity>("test_setting"));
 }
 
 TEST_F(SettingsTest, AddSettingRatio)
 {
     settings.add("test_setting", "1.618");
-    EXPECT_DOUBLE_EQ(Ratio(0.01618), settings.get<Ratio>("test_setting")) << "With ratios, the input is interpreted in percentages.";
+    EXPECT_DOUBLE_EQ(Ratio { 0.01618 }, settings.get<Ratio>("test_setting")) << "With ratios, the input is interpreted in percentages.";
 }
 
 TEST_F(SettingsTest, AddSettingDuration)
 {
     settings.add("test_setting", "1234.5678");
-    EXPECT_DOUBLE_EQ(Duration(1234.5678), settings.get<Duration>("test_setting"));
+    EXPECT_DOUBLE_EQ(Duration { 1234.5678 }, settings.get<Duration>("test_setting"));
 
     settings.add("test_setting", "-1234.5678");
-    EXPECT_DOUBLE_EQ(Duration(0), settings.get<Duration>("test_setting")) << "Negative duration doesn't exist, so it gets rounded to 0.";
+    EXPECT_DOUBLE_EQ(Duration { 0 }, settings.get<Duration>("test_setting")) << "Negative duration doesn't exist, so it gets rounded to 0.";
 }
 
 TEST_F(SettingsTest, AddSettingFlowTempGraph)


### PR DESCRIPTION
…tion

Numeric data types in the codebase are now defined as a numeric facade, providing greater type safety and reducing code repetition. This encompasses the `Acceleration`, `Velocity`, `Ratio`, and `LayerIndex` types.

This change updates the constructor and assignment operators, and ensures the facade can be used in a consistent manner with standard arithmetic types. It also supports user-defined type conversions to provide interoperability with built-in types.

In addition, correct type suffixes are added to numeric literals in a number of places to avoid potential bugs due to unexpected promotions or type coercions.

As part of this refactor, we also standardized the category of numeric types applied throughout the codebase, ensuring compatibility with these new types.

This refactor is needed to prep the GCodePaths/GCodePathConfigs for the plugin system. Since the changes for this refactor all over the placed, decided to make a seperate branch against main.

Contributes to CURA-10466

# Benchmark
## This PR
![image](https://github.com/Ultimaker/CuraEngine/assets/8535734/f631d3e7-68e9-43d8-9135-34d6a36a5e14)
## main
![image](https://github.com/Ultimaker/CuraEngine/assets/8535734/ce6645e1-da83-4b3a-8c42-b2d8ec898261)
