### PR TITLE
Cura 10916 fix layer index

### DIFF
--- a/include/communication/ArcusCommunication.h
+++ b/include/communication/ArcusCommunication.h
@@ -117,7 +117,7 @@ public:
      * \param z The z-coordinate of the top side of the layer.
      * \param thickness The thickness of the layer.
      */
-    void sendLayerComplete(const LayerIndex& layer_nr, const coord_t& z, const coord_t& thickness) override;
+    void sendLayerComplete(const LayerIndex::value_type& layer_nr, const coord_t& z, const coord_t& thickness) override;
 
     /*
      * \brief Send a line to the front-end to display in layer view.
@@ -192,7 +192,7 @@ public:
      * \param layer_nr The index of the layer to send data for. This is zero-
      * indexed but may be negative for raft layers.
      */
-    void setLayerForSend(const LayerIndex& layer_nr) override;
+    void setLayerForSend(const LayerIndex::value_type& layer_nr) override;
 
     /*
      * \brief Slice the next scene that the front-end wants us to slice.

--- a/include/communication/ArcusCommunication.h
+++ b/include/communication/ArcusCommunication.h
@@ -6,17 +6,17 @@
 #ifdef ARCUS
 
 #ifdef BUILD_TESTS
-    #include <gtest/gtest_prod.h>
+#include <gtest/gtest_prod.h>
 #endif
-#include <memory> //For unique_ptr and shared_ptr.
-
 #include "Communication.h" //The class we're implementing.
 #include "Cura.pb.h" //To create Protobuf messages for Cura's front-end.
 
-//Forward declarations to speed up compilation.
+#include <memory> //For unique_ptr and shared_ptr.
+
+// Forward declarations to speed up compilation.
 namespace Arcus
 {
-    class Socket;
+class Socket;
 }
 
 namespace cura
@@ -227,7 +227,7 @@ private:
     const std::unique_ptr<PathCompiler> path_compiler;
 };
 
-} //namespace cura
+} // namespace cura
 
-#endif //ARCUS
-#endif //ARCUSCOMMUNICATION_H
+#endif // ARCUS
+#endif // ARCUSCOMMUNICATION_H

--- a/include/communication/ArcusCommunicationPrivate.h
+++ b/include/communication/ArcusCommunicationPrivate.h
@@ -27,7 +27,7 @@ public:
      * \param layer_nr The layer number to get the optimised layer data for.
      * \return The optimised layer data for that layer.
      */
-    std::shared_ptr<proto::LayerOptimized> getOptimizedLayerById(LayerIndex layer_nr);
+    std::shared_ptr<proto::LayerOptimized> getOptimizedLayerById(LayerIndex::value_type layer_nr);
 
     /*
      * Reads the global settings from a Protobuf message.

--- a/include/communication/CommandLine.h
+++ b/include/communication/CommandLine.h
@@ -86,7 +86,7 @@ public:
      * The command line doesn't do anything with that information so this is
      * ignored.
      */
-    void sendLayerComplete(const LayerIndex&, const coord_t&, const coord_t&) override;
+    void sendLayerComplete(const LayerIndex::value_type&, const coord_t&, const coord_t&) override;
 
     /*
      * \brief Send a line for display.
@@ -143,7 +143,7 @@ public:
      * This has no effect though because we don't shwo these three functions
      * because the command line doesn't show layer view.
      */
-    void setLayerForSend(const LayerIndex&) override;
+    void setLayerForSend(const LayerIndex::value_type&) override;
 
     /*
      * \brief Slice the next scene that the command line commands us to slice.

--- a/include/communication/CommandLine.h
+++ b/include/communication/CommandLine.h
@@ -4,12 +4,12 @@
 #ifndef COMMANDLINE_H
 #define COMMANDLINE_H
 
+#include "Communication.h" //The class we're implementing.
+
 #include <rapidjson/document.h> //Loading JSON documents to get settings from them.
 #include <string> //To store the command line arguments.
 #include <unordered_set>
 #include <vector> //To store the command line arguments.
-
-#include "Communication.h" //The class we're implementing.
 
 namespace cura
 {
@@ -188,14 +188,12 @@ private:
      * \return Error code. If it's 0, the document was successfully loaded. If
      * it's 1, some inheriting file could not be opened.
      */
-    int loadJSON
-    (
+    int loadJSON(
         const rapidjson::Document& document,
         const std::unordered_set<std::string>& search_directories,
         Settings& settings,
         bool force_read_parent = false,
-        bool force_read_nondefault = false
-    );
+        bool force_read_nondefault = false);
 
     /*
      * \brief Load an element containing a list of settings.
@@ -216,6 +214,6 @@ private:
     const std::string findDefinitionFile(const std::string& definition_id, const std::unordered_set<std::string>& search_directories);
 };
 
-} //namespace cura
+} // namespace cura
 
-#endif //COMMANDLINE_H
+#endif // COMMANDLINE_H

--- a/include/communication/Communication.h
+++ b/include/communication/Communication.h
@@ -62,7 +62,7 @@ public:
      * \param z The z-coordinate of the top side of the layer.
      * \param thickness The thickness of the layer.
      */
-    virtual void sendLayerComplete(const LayerIndex& layer_nr, const coord_t& z, const coord_t& thickness) = 0;
+    virtual void sendLayerComplete(const LayerIndex::value_type& layer_nr, const coord_t& z, const coord_t& thickness) = 0;
 
     /*
      * \brief Send polygons to the user to visualise.
@@ -126,7 +126,7 @@ public:
      * \param layer_nr The index of the layer to send data for. This is zero-
      * indexed but may be negative for raft layers.
      */
-    virtual void setLayerForSend(const LayerIndex& layer_nr) = 0;
+    virtual void setLayerForSend(const LayerIndex::value_type& layer_nr) = 0;
 
     /*
      * \brief Send the sliced layer data through this communication after the

--- a/include/settings/types/LayerIndex.h
+++ b/include/settings/types/LayerIndex.h
@@ -4,26 +4,190 @@
 #ifndef LAYERINDEX_H
 #define LAYERINDEX_H
 
-#include "utils/types/numeric_facade.h"
+#include "utils/types/generic.h"
 
 #include <functional>
 
 namespace cura
 {
 
-/*
- * \brief Struct behaving like a layer number.
- *
- * This is a facade. It behaves exactly like an integer but is used to indicate
- * that it is a layer number.
- */
-struct LayerIndex : public utils::NumericFacade<int64_t>
+struct LayerIndex
 {
-    using base_type = utils::NumericFacade<int64_t>;
-    using base_type::NumericFacade;
+    using value_type = int64_t;
+    using difference_type = std::ptrdiff_t;
 
-    constexpr LayerIndex(const base_type& base) noexcept
-        : base_type{ base } {};
+    value_type value{};
+
+    constexpr LayerIndex() noexcept = default;
+
+    constexpr LayerIndex(const LayerIndex& other) noexcept = default;
+    constexpr LayerIndex(LayerIndex&& other) noexcept = default;
+
+    constexpr explicit LayerIndex(const utils::floating_point auto val) noexcept : value{ static_cast<value_type>(val) } {};
+
+    constexpr LayerIndex(const utils::integral auto val) noexcept : value{ static_cast<value_type>(val) } {};
+
+    constexpr LayerIndex& operator=(const LayerIndex& other) noexcept = default;
+
+    constexpr LayerIndex& operator=(const utils::integral auto& other) noexcept
+    {
+        this->value = static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr LayerIndex& operator=(LayerIndex&& other) noexcept = default;
+    constexpr LayerIndex& operator=(const utils::integral auto&& other) noexcept
+    {
+        this->value = static_cast<value_type>(other);
+        return *this;
+    }
+
+    ~LayerIndex() noexcept = default;
+
+    constexpr operator value_type() const noexcept
+    {
+        return value;
+    }
+
+    constexpr bool operator==(const LayerIndex& other) const noexcept
+    {
+        return value == other.value;
+    }
+
+    constexpr bool operator==(const utils::integral auto& other) const noexcept
+    {
+        return value == static_cast<value_type>(other);
+    }
+
+    constexpr auto operator<=>(const LayerIndex& other) const noexcept = default;
+    constexpr auto operator<=>(const utils::integral auto& other) const noexcept
+    {
+        return value <=> static_cast<value_type>(other);
+    };
+
+    constexpr LayerIndex& operator+=(const LayerIndex& other) noexcept
+    {
+        value += other.value;
+        return *this;
+    }
+
+    constexpr LayerIndex& operator+=(const utils::integral auto& other) noexcept
+    {
+        value += static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr LayerIndex& operator-=(const LayerIndex& other) noexcept
+    {
+        value -= other.value;
+        return *this;
+    }
+
+    constexpr LayerIndex& operator-=(const utils::integral auto& other) noexcept
+    {
+        value -= static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr LayerIndex& operator*=(const LayerIndex& other) noexcept
+    {
+        value *= other.value;
+        return *this;
+    }
+
+    constexpr LayerIndex& operator*=(const utils::integral auto& other) noexcept
+    {
+        value *= static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr LayerIndex& operator/=(const LayerIndex& other)
+    {
+        value /= other.value;
+        return *this;
+    }
+
+    constexpr LayerIndex& operator/=(const utils::integral auto& other)
+    {
+        value /= static_cast<value_type>(other);
+        return *this;
+    }
+
+    constexpr LayerIndex operator+(const LayerIndex& other) const noexcept
+    {
+        return { value + other.value };
+    }
+
+    constexpr LayerIndex operator+(LayerIndex&& other) const noexcept
+    {
+        return { value + other.value };
+    }
+
+    constexpr LayerIndex operator+(const utils::integral auto& other) const noexcept
+    {
+        return { value + static_cast<value_type>(other) };
+    }
+
+    constexpr LayerIndex operator-(const LayerIndex& other) const noexcept
+    {
+        return { value - other.value };
+    }
+
+    constexpr LayerIndex operator-(const utils::integral auto& other) const noexcept
+    {
+        return { value - static_cast<value_type>(other) };
+    }
+
+    constexpr LayerIndex operator*(const LayerIndex& other) const noexcept
+    {
+        return { value * other.value };
+    }
+
+    constexpr LayerIndex operator*(const utils::integral auto& other) const noexcept
+    {
+        return { value * static_cast<value_type>(other) };
+    }
+
+    constexpr LayerIndex operator/(const LayerIndex& other) const
+    {
+        return { value / other.value };
+    }
+
+    constexpr LayerIndex operator/(const utils::integral auto& other) const
+    {
+        return { value / static_cast<value_type>(other) };
+    }
+
+    constexpr LayerIndex operator-() const noexcept
+    {
+        return { -value };
+    }
+
+    constexpr LayerIndex& operator++() noexcept
+    {
+        ++value;
+        return *this;
+    }
+
+    LayerIndex operator++(int) noexcept
+    {
+        LayerIndex tmp{ *this };
+        operator++();
+        return tmp;
+    }
+
+    constexpr LayerIndex& operator--() noexcept
+    {
+        --value;
+        return *this;
+    }
+
+    LayerIndex operator--(int) noexcept
+    {
+        LayerIndex tmp{ *this };
+        operator--();
+        return tmp;
+    }
 };
 
 } // namespace cura

--- a/include/settings/types/LayerIndex.h
+++ b/include/settings/types/LayerIndex.h
@@ -23,9 +23,11 @@ struct LayerIndex
     constexpr LayerIndex(const LayerIndex& other) noexcept = default;
     constexpr LayerIndex(LayerIndex&& other) noexcept = default;
 
-    constexpr explicit LayerIndex(const utils::floating_point auto val) noexcept : value{ static_cast<value_type>(val) } {};
+    constexpr explicit LayerIndex(const utils::floating_point auto val) noexcept
+        : value{ static_cast<value_type>(val) } {};
 
-    constexpr LayerIndex(const utils::integral auto val) noexcept : value{ static_cast<value_type>(val) } {};
+    constexpr LayerIndex(const utils::integral auto val) noexcept
+        : value{ static_cast<value_type>(val) } {};
 
     constexpr LayerIndex& operator=(const LayerIndex& other) noexcept = default;
 

--- a/include/utils/types/numeric_facade.h
+++ b/include/utils/types/numeric_facade.h
@@ -21,8 +21,10 @@ struct NumericFacade
     constexpr NumericFacade(const NumericFacade& other) noexcept = default;
     constexpr NumericFacade(NumericFacade&& other) noexcept = default;
 
-    constexpr NumericFacade(const floating_point auto val) noexcept : value{ static_cast<value_type>(val) } {};
-    constexpr explicit NumericFacade(const integral auto val) noexcept : value{ static_cast<value_type>(val) } {};
+    constexpr NumericFacade(const floating_point auto val) noexcept
+        : value{ static_cast<value_type>(val) } {};
+    constexpr explicit NumericFacade(const integral auto val) noexcept
+        : value{ static_cast<value_type>(val) } {};
 
     constexpr NumericFacade& operator=(const NumericFacade& other) noexcept = default;
 
@@ -160,7 +162,6 @@ struct NumericFacade
     {
         return { -value };
     }
-
 };
 
 } // namespace cura::utils

--- a/include/utils/types/numeric_facade.h
+++ b/include/utils/types/numeric_facade.h
@@ -9,11 +9,10 @@
 namespace cura::utils
 {
 
-template<numeric T>
+template<floating_point T>
 struct NumericFacade
 {
     using value_type = T;
-    using difference_type = std::ptrdiff_t;
 
     value_type value{};
 
@@ -22,30 +21,20 @@ struct NumericFacade
     constexpr NumericFacade(const NumericFacade& other) noexcept = default;
     constexpr NumericFacade(NumericFacade&& other) noexcept = default;
 
-    constexpr NumericFacade(const floating_point auto val) noexcept requires floating_point<value_type> : value{ static_cast<value_type>(val) } {};
-
-    constexpr NumericFacade(const integral auto val) noexcept requires integral<value_type> : value{ static_cast<value_type>(val) } {};
+    constexpr NumericFacade(const floating_point auto val) noexcept : value{ static_cast<value_type>(val) } {};
+    constexpr explicit NumericFacade(const integral auto val) noexcept : value{ static_cast<value_type>(val) } {};
 
     constexpr NumericFacade& operator=(const NumericFacade& other) noexcept = default;
 
-    constexpr NumericFacade& operator=(const floating_point auto& other) noexcept requires floating_point<value_type>
-    {
-        this->value = static_cast<value_type>(other);
-        return *this;
-    }
-    constexpr NumericFacade& operator=(const integral auto& other) noexcept requires integral<value_type>
+    constexpr NumericFacade& operator=(const floating_point auto& other) noexcept
     {
         this->value = static_cast<value_type>(other);
         return *this;
     }
 
     constexpr NumericFacade& operator=(NumericFacade&& other) noexcept = default;
-    constexpr NumericFacade& operator=(const integral auto&& other) noexcept requires integral<value_type>
-    {
-        this->value = static_cast<value_type>(other);
-        return *this;
-    }
-    constexpr NumericFacade& operator=(const floating_point auto&& other) noexcept requires floating_point<value_type>
+
+    constexpr NumericFacade& operator=(const floating_point auto&& other) noexcept
     {
         this->value = static_cast<value_type>(other);
         return *this;
@@ -63,13 +52,13 @@ struct NumericFacade
         return value == other.value;
     }
 
-    constexpr bool operator==(const numeric auto& other) const noexcept
+    constexpr bool operator==(const floating_point auto& other) const noexcept
     {
         return value == static_cast<value_type>(other);
     }
 
     constexpr auto operator<=>(const NumericFacade& other) const noexcept = default;
-    constexpr auto operator<=>(const numeric auto& other) const noexcept
+    constexpr auto operator<=>(const floating_point auto& other) const noexcept
     {
         return value <=> static_cast<value_type>(other);
     };
@@ -80,7 +69,7 @@ struct NumericFacade
         return *this;
     }
 
-    constexpr NumericFacade& operator+=(const numeric auto& other) noexcept
+    constexpr NumericFacade& operator+=(const floating_point auto& other) noexcept
     {
         value += static_cast<value_type>(other);
         return *this;
@@ -92,7 +81,7 @@ struct NumericFacade
         return *this;
     }
 
-    constexpr NumericFacade& operator-=(const numeric auto& other) noexcept
+    constexpr NumericFacade& operator-=(const floating_point auto& other) noexcept
     {
         value -= static_cast<value_type>(other);
         return *this;
@@ -104,7 +93,7 @@ struct NumericFacade
         return *this;
     }
 
-    constexpr NumericFacade& operator*=(const numeric auto& other) noexcept
+    constexpr NumericFacade& operator*=(const floating_point auto& other) noexcept
     {
         value *= static_cast<value_type>(other);
         return *this;
@@ -116,7 +105,7 @@ struct NumericFacade
         return *this;
     }
 
-    constexpr NumericFacade& operator/=(const numeric auto& other)
+    constexpr NumericFacade& operator/=(const floating_point auto& other)
     {
         value /= static_cast<value_type>(other);
         return *this;
@@ -132,7 +121,7 @@ struct NumericFacade
         return { value + other.value };
     }
 
-    constexpr NumericFacade operator+(const numeric auto& other) const noexcept
+    constexpr NumericFacade operator+(const floating_point auto& other) const noexcept
     {
         return { value + static_cast<value_type>(other) };
     }
@@ -142,7 +131,7 @@ struct NumericFacade
         return { value - other.value };
     }
 
-    constexpr NumericFacade operator-(const numeric auto& other) const noexcept
+    constexpr NumericFacade operator-(const floating_point auto& other) const noexcept
     {
         return { value - static_cast<value_type>(other) };
     }
@@ -152,7 +141,7 @@ struct NumericFacade
         return { value * other.value };
     }
 
-    constexpr NumericFacade operator*(const numeric auto& other) const noexcept
+    constexpr NumericFacade operator*(const floating_point auto& other) const noexcept
     {
         return { value * static_cast<value_type>(other) };
     }
@@ -162,7 +151,7 @@ struct NumericFacade
         return { value / other.value };
     }
 
-    constexpr NumericFacade operator/(const numeric auto& other) const
+    constexpr NumericFacade operator/(const floating_point auto& other) const
     {
         return { value / static_cast<value_type>(other) };
     }
@@ -172,27 +161,6 @@ struct NumericFacade
         return { -value };
     }
 
-    constexpr NumericFacade& operator++() noexcept requires integral<value_type>
-    {
-        ++value;
-        return *this;
-    }
-
-    constexpr NumericFacade operator++(int) noexcept requires integral<value_type>
-    {
-        return { value++ };
-    }
-
-    constexpr NumericFacade& operator--() noexcept requires integral<value_type>
-    {
-        --value;
-        return *this;
-    }
-
-    constexpr NumericFacade operator--(int) noexcept requires integral<value_type>
-    {
-        return { value-- };
-    }
 };
 
 } // namespace cura::utils

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -390,7 +390,7 @@ void ArcusCommunication::sendFinishedSlicing() const
     spdlog::debug("Sent slicing finished message.");
 }
 
-void ArcusCommunication::sendLayerComplete(const LayerIndex& layer_nr, const coord_t& z, const coord_t& thickness)
+void ArcusCommunication::sendLayerComplete(const LayerIndex::value_type& layer_nr, const coord_t& z, const coord_t& thickness)
 {
     std::shared_ptr<proto::LayerOptimized> layer = private_data->getOptimizedLayerById(layer_nr);
     layer->set_height(z);
@@ -491,7 +491,7 @@ void ArcusCommunication::sendProgress(const float& progress) const
     private_data->last_sent_progress = rounded_amount;
 }
 
-void ArcusCommunication::setLayerForSend(const LayerIndex& layer_nr)
+void ArcusCommunication::setLayerForSend(const LayerIndex::value_type& layer_nr)
 {
     path_compiler->setLayer(layer_nr);
 }

--- a/src/communication/ArcusCommunicationPrivate.cpp
+++ b/src/communication/ArcusCommunicationPrivate.cpp
@@ -3,20 +3,26 @@
 
 #ifdef ARCUS
 
-#include <spdlog/spdlog.h>
+#include "communication/ArcusCommunicationPrivate.h"
 
 #include "Application.h"
 #include "ExtruderTrain.h"
 #include "Slice.h"
-#include "communication/ArcusCommunicationPrivate.h"
 #include "settings/types/LayerIndex.h"
 #include "utils/FMatrix4x3.h" //To convert vertices to integer-points.
 #include "utils/floatpoint.h" //To accept vertices (which are provided in floating point).
 
+#include <spdlog/spdlog.h>
+
 namespace cura
 {
 
-ArcusCommunication::Private::Private() : socket(nullptr), object_count(0), last_sent_progress(-1), slice_count(0), millisecUntilNextTry(100)
+ArcusCommunication::Private::Private()
+    : socket(nullptr)
+    , object_count(0)
+    , last_sent_progress(-1)
+    , slice_count(0)
+    , millisecUntilNextTry(100)
 {
 }
 
@@ -67,7 +73,9 @@ void ArcusCommunication::Private::readExtruderSettingsMessage(const google::prot
             spdlog::warn("Received extruder index that is out of range: {}", extruder_nr);
             continue;
         }
-        ExtruderTrain& extruder = slice->scene.extruders[extruder_nr]; // Extruder messages may arrive out of order, so don't iteratively get the next extruder but take the extruder_nr from this message.
+        ExtruderTrain& extruder
+            = slice->scene
+                  .extruders[extruder_nr]; // Extruder messages may arrive out of order, so don't iteratively get the next extruder but take the extruder_nr from this message.
         for (const cura::proto::Setting& setting_message : extruder_message.settings().settings())
         {
             extruder.settings.add(setting_message.name(), setting_message.value());

--- a/src/communication/ArcusCommunicationPrivate.cpp
+++ b/src/communication/ArcusCommunicationPrivate.cpp
@@ -20,7 +20,7 @@ ArcusCommunication::Private::Private() : socket(nullptr), object_count(0), last_
 {
 }
 
-std::shared_ptr<proto::LayerOptimized> ArcusCommunication::Private::getOptimizedLayerById(LayerIndex layer_nr)
+std::shared_ptr<proto::LayerOptimized> ArcusCommunication::Private::getOptimizedLayerById(LayerIndex::value_type layer_nr)
 {
     layer_nr += optimized_layers.current_layer_offset;
     std::unordered_map<int, std::shared_ptr<proto::LayerOptimized>>::iterator find_result = optimized_layers.slice_data.find(layer_nr);

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -40,7 +40,7 @@ void CommandLine::sendCurrentPosition(const Point&)
 void CommandLine::sendFinishedSlicing() const
 {
 }
-void CommandLine::sendLayerComplete(const LayerIndex&, const coord_t&, const coord_t&)
+void CommandLine::sendLayerComplete(const LayerIndex::value_type&, const coord_t&, const coord_t&)
 {
 }
 void CommandLine::sendLineTo(const PrintFeatureType&, const Point&, const coord_t&, const coord_t&, const Velocity&)
@@ -58,7 +58,7 @@ void CommandLine::sendPolygons(const PrintFeatureType&, const Polygons&, const c
 void CommandLine::setExtruderForSend(const ExtruderTrain&)
 {
 }
-void CommandLine::setLayerForSend(const LayerIndex&)
+void CommandLine::setLayerForSend(const LayerIndex::value_type&)
 {
 }
 

--- a/tests/arcus/MockCommunication.h
+++ b/tests/arcus/MockCommunication.h
@@ -8,6 +8,7 @@
 #include "utils/Coord_t.h"
 #include "utils/polygon.h" //In the signature of Communication.
 #include <gmock/gmock.h>
+#include "settings/types/LayerIndex.h"
 
 namespace cura
 {
@@ -21,7 +22,7 @@ public:
     MOCK_CONST_METHOD0(hasSlice, bool());
     MOCK_CONST_METHOD0(isSequential, bool());
     MOCK_CONST_METHOD1(sendProgress, void(const float& progress));
-    MOCK_METHOD3(sendLayerComplete, void(const LayerIndex& layer_nr, const coord_t& z, const coord_t& thickness));
+    MOCK_METHOD3(sendLayerComplete, void(const LayerIndex::value_type& layer_nr, const coord_t& z, const coord_t& thickness));
     MOCK_METHOD5(sendPolygons,
                  void(const PrintFeatureType& type,
                       const Polygons& polygons,
@@ -42,7 +43,7 @@ public:
                       const Velocity& velocity));
     MOCK_METHOD1(sendCurrentPosition, void(const Point& position));
     MOCK_METHOD1(setExtruderForSend, void(const ExtruderTrain& extruder));
-    MOCK_METHOD1(setLayerForSend, void(const LayerIndex& layer_nr));
+    MOCK_METHOD1(setLayerForSend, void(const LayerIndex::value_type& layer_nr));
     MOCK_METHOD0(sendOptimizedLayerData, void());
     MOCK_CONST_METHOD0(sendPrintTimeMaterialEstimates, void());
     MOCK_METHOD0(beginGCode, void());


### PR DESCRIPTION
# Description

Make sure that LayerIndex is it's own integral type and don't inherit from numeric facade, A lot of conversion problems, because `LayerIndex + integral-> NumericFacade`

Als ensured that the Cura Arcus types used int64