### PR TITLE
CURA-8889_fix_one_at_a_time_initial_temperature

### DIFF
--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -461,6 +461,11 @@ private:
      */
     void writeMoveBFB(const int x, const int y, const int z, const Velocity& speed, double extrusion_mm3_per_mm, PrintFeatureType feature);
 
+    /*!
+     * Set bed temperature for the initial layer. Called by 'processInitialLayerTemperatures'.
+     */
+    void processInitialLayerBedTemperature();
+
 public:
     /*!
      * Get ready for extrusion moves:


### PR DESCRIPTION
Bed temperature was not applied after the first model being printed.
Only for Griffin-flavored GCode printers (which includes UltiMaker printers).