### PR TITLE
Cura 8889 fix one at a time initial temperature

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1886,8 +1886,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         mesh_group_settings.get<Ratio>("flow_rate_extrusion_offset_factor")); // Offset is in mm.
 
     static LayerIndex layer_1{ 1 - static_cast<LayerIndex>(Raft::getTotalExtraLayers()) };
-    if (layer_nr == layer_1 && mesh_group_settings.get<bool>("machine_heated_bed")
-        && mesh_group_settings.get<Temperature>("material_bed_temperature") != mesh_group_settings.get<Temperature>("material_bed_temperature_layer_0"))
+    if (layer_nr == layer_1 && mesh_group_settings.get<bool>("machine_heated_bed"))
     {
         constexpr bool wait = false;
         gcode.writeBedTemperatureCommand(mesh_group_settings.get<Temperature>("material_bed_temperature"), wait);

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -111,19 +111,22 @@ void GCodeExport::preSetup(const size_t start_extruder)
 
     estimateCalculator.setFirmwareDefaults(mesh_group->settings);
 
-    if (mesh_group != scene.mesh_groups.begin())
+    if (mesh_group == scene.mesh_groups.begin())
     {
-        // Current bed temperature is the one of the previous group
-        bed_temperature = (scene.current_mesh_group - 1)->settings.get<Temperature>("material_bed_temperature");
-    }
-    else if (! scene.current_mesh_group->settings.get<bool>("material_bed_temp_prepend"))
-    {
-        // Current bed temperature is the one of the first layer (has already been set in header)
-        bed_temperature = scene.current_mesh_group->settings.get<Temperature>("material_bed_temperature_layer_0");
+        if (! scene.current_mesh_group->settings.get<bool>("material_bed_temp_prepend"))
+        {
+            // Current bed temperature is the one of the first layer (has already been set in header)
+            bed_temperature = scene.current_mesh_group->settings.get<Temperature>("material_bed_temperature_layer_0");
+        }
+        else
+        {
+            // Bed temperature has not been set yet
+        }
     }
     else
     {
-        // Current bed temperature has not been set yet
+        // Current bed temperature is the one of the previous group
+        bed_temperature = (scene.current_mesh_group - 1)->settings.get<Temperature>("material_bed_temperature");
     }
 }
 
@@ -1517,10 +1520,10 @@ void GCodeExport::writeBedTemperatureCommand(const Temperature& temperature, con
     { // The UM2 family doesn't support temperature commands (they are fixed in the firmware)
         return;
     }
-    bool wrote_command = false;
-    if (wait)
+
+    if (bed_temperature != temperature) // Not already at the desired temperature.
     {
-        if (bed_temperature != temperature) // Not already at the desired temperature.
+        if (wait)
         {
             if (flavor == EGCodeFlavor::MARLIN)
             {
@@ -1528,20 +1531,17 @@ void GCodeExport::writeBedTemperatureCommand(const Temperature& temperature, con
                 *output_stream << PrecisionedDouble{ 1, temperature } << new_line;
                 *output_stream << "M105" << new_line;
             }
+            *output_stream << "M190 S";
         }
-        *output_stream << "M190 S";
-        wrote_command = true;
-    }
-    else if (bed_temperature != temperature)
-    {
-        *output_stream << "M140 S";
-        wrote_command = true;
-    }
-    if (wrote_command)
-    {
+        else
+        {
+            *output_stream << "M140 S";
+        }
+
         *output_stream << PrecisionedDouble{ 1, temperature } << new_line;
+
+        bed_temperature = temperature;
     }
-    bed_temperature = temperature;
 }
 
 void GCodeExport::writeBuildVolumeTemperatureCommand(const Temperature& temperature, const bool wait)


### PR DESCRIPTION
In order to fix the last bed temperature setting bugs, I changed the way `GCodeExport` handles it. The `writeBedTemperatureCommand` method has a check to ensure that the same temperature is not send twice in a row. So I removed checks done before calling this method, and made sure that the initial temperature is properly initialized in the `preSetup` method. This way, the `writeBedTemperatureCommand` method will be called a bit more often, and it is fully in charge of knowing wheter the given temperature is different from the old one.

An other change on the `writeBedTemperatureCommand` is that we don't send any GCode command in case it is called with the same temperature as before, but with a wait command. Before, we would have set the wait command anyway. This does make sense, but actually the wait case is used only once, in the situation that is being heavily refined and retested, so I **think** changing this behavior does not create an unwanted side-effect.

Maybe we should also cache the `"machine_heated_bed"` setting in `GCodeExport` so that it would take care of it in `writeBedTemperatureCommand`, making calls to this method simpler.