### PR TITLE
Cura 9521 extra skin walls bridging

### DIFF
--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -4,17 +4,17 @@
 #ifndef GCODE_WRITER_H
 #define GCODE_WRITER_H
 
-#include <fstream>
-#include <optional>
-
 #include "FanSpeedLayerTime.h"
-#include "gcodeExport.h"
 #include "LayerPlanBuffer.h"
+#include "gcodeExport.h"
 #include "settings/PathConfigStorage.h" //For the MeshPathConfigs subclass.
 #include "utils/ExtrusionLine.h" //Processing variable-width paths.
 #include "utils/NoCopy.h"
 
-namespace cura 
+#include <fstream>
+#include <optional>
+
+namespace cura
 {
 
 class AngleDegrees;
@@ -28,28 +28,28 @@ class TimeKeeper;
 
 /*!
  * Secondary stage in Fused Filament Fabrication processing: The generated polygons are used in the gcode generation.
- * Some polygons in the SliceDataStorage signify areas which are to be filled with parallel lines, 
+ * Some polygons in the SliceDataStorage signify areas which are to be filled with parallel lines,
  * while other polygons signify the contours which should be printed.
- * 
+ *
  * The main function of this class is FffGcodeWriter::writeGCode().
  */
 class FffGcodeWriter : public NoCopy
 {
-    friend class FffProcessor; //Because FffProcessor exposes finalize (TODO)
+    friend class FffProcessor; // Because FffProcessor exposes finalize (TODO)
 private:
     coord_t max_object_height; //!< The maximal height of all previously sliced meshgroups, used to avoid collision when moving to the next meshgroup to print.
 
     /*
      * Buffer for all layer plans (of type LayerPlan)
-     * 
+     *
      * The layer plans are buffered so that we can start heating up a nozzle several layers before it needs to be used.
      * Another reason is to perform Auto Temperature.
      */
-    LayerPlanBuffer layer_plan_buffer; 
+    LayerPlanBuffer layer_plan_buffer;
 
     /*!
      * The class holding the current state of the gcode being written.
-     * 
+     *
      * It holds information such as the last written position etc.
      */
     GCodeExport gcode;
@@ -104,18 +104,18 @@ public:
 
     /*!
      * Set the target to write gcode to: an output stream.
-     * 
+     *
      * Used when CuraEngine is NOT used as command line tool.
-     * 
+     *
      * \param stream The stream to write gcode to.
      */
     void setTargetStream(std::ostream* stream);
 
     /*!
      * Get the total extruded volume for a specific extruder in mm^3
-     * 
+     *
      * Retractions and unretractions don't contribute to this.
-     * 
+     *
      * \param extruder_nr The extruder number for which to get the total netto extruded volume
      * \return total filament printed in mm^3
      */
@@ -123,7 +123,7 @@ public:
 
     /*!
      * Get the total estimated print time in seconds for each feature
-     * 
+     *
      * \return total print time in seconds for each feature
      */
     std::vector<Duration> getTotalPrintTimePerFeature();
@@ -131,7 +131,7 @@ public:
     /*!
      * Write all the gcode for the current meshgroup.
      * This is the primary function of this class.
-     * 
+     *
      * \param[in] storage The data storage from which to get the polygons to print and the areas to fill.
      * \param timeKeeper The stop watch to see how long it takes for each of the stages in the slicing process.
      */
@@ -146,28 +146,28 @@ private:
 
     /*!
      * Set the retraction and wipe config globally, per extruder and per mesh.
-     * 
+     *
      * \param[out] storage The data storage to which to save the configurations
      */
     void setConfigRetractionAndWipe(SliceDataStorage& storage);
 
     /*!
      * Get the extruder with which to start the print.
-     * 
+     *
      * Generally this is the extruder of the adhesion type in use, but in case
      * the platform adhesion type is none, the support extruder is used. If
      * support is also disabled, the extruder with lowest number which is used
      * on the first layer is used as initial extruder.
-     * 
+     *
      * \param[in] storage where to get settings from.
      */
     size_t getStartExtruder(const SliceDataStorage& storage);
 
     /*!
      * Set the infill angles and skin angles in the SliceDataStorage.
-     * 
+     *
      * These lists of angles are cycled through to get the infill angle of a specific layer.
-     * 
+     *
      * \param mesh The mesh for which to determine the infill and skin angles.
      */
     void setInfillAndSkinAngles(SliceMeshStorage& mesh);
@@ -186,24 +186,24 @@ private:
 
     /*!
      * Move up and over the already printed meshgroups to print the next meshgroup.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      */
     void processNextMeshGroupCode(const SliceDataStorage& storage);
-    
+
     /*!
      * Add raft layer plans onto the FffGcodeWriter::layer_plan_buffer
-     * 
+     *
      * \param[in,out] storage where the slice data is stored.
      */
     void processRaft(const SliceDataStorage& storage);
 
     /*!
      * Convert the polygon data of a layer into a layer plan on the FffGcodeWriter::layer_plan_buffer
-     * 
+     *
      * In case of negative layer numbers, create layers only containing the data from
      * the helper parts (support etc) to fill up the gap between the raft and the model.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param layer_nr The index of the layer to write the gcode of.
      * \param total_layers The total number of layers.
@@ -217,17 +217,17 @@ private:
      *
      * Technically, this function checks whether any extruder needs to be primed (with a prime blob)
      * separately just before they are used.
-     * 
+     *
      * \return whether any extruder need to be primed separately just before they are used
      */
     bool getExtruderNeedPrimeBlobDuringFirstLayer(const SliceDataStorage& storage, const size_t extruder_nr) const;
 
     /*!
      * Add the skirt or the brim to the layer plan \p gcodeLayer if it hasn't already been added yet.
-     * 
+     *
      * This function should be called for only one layer;
      * calling it for multiple layers results in the skirt/brim being printed on multiple layers.
-     * 
+     *
      * \param storage where the slice data is stored.
      * \param gcodeLayer The initial planning of the g-code of the layer.
      * \param extruder_nr The extruder train for which to process the skirt or
@@ -238,15 +238,15 @@ private:
 
     /*!
      * Adds the ooze shield to the layer plan \p gcodeLayer.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param gcodeLayer The initial planning of the gcode of the layer.
      */
     void processOozeShield(const SliceDataStorage& storage, LayerPlan& gcodeLayer) const;
-    
+
     /*!
      * Adds the draft protection screen to the layer plan \p gcodeLayer.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param gcodeLayer The initial planning of the gcode of the layer.
      */
@@ -256,14 +256,14 @@ private:
      * Calculate in which order to plan the extruders for each layer
      * Store the order of extruders for each layer in extruder_order_per_layer for normal layers
      * and the order of extruders for raft/filler layers in extruder_order_per_layer_negative_layers.
-     * 
+     *
      * Only extruders which are (most probably) going to be used are planned
-     * 
+     *
      * \note At the planning stage we only have information on areas, not how those are filled.
      * If an area is too small to be filled with anything it will still get specified as being used with the extruder for that area.
-     * 
+     *
      * Computes \ref FffGcodeWriter::extruder_order_per_layer and \ref FffGcodeWriter::extruder_order_per_layer_negative_layers
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      */
     void calculateExtruderOrderPerLayer(const SliceDataStorage& storage);
@@ -280,10 +280,10 @@ private:
     /*!
      * Gets a list of extruders that are used on the given layer, but excluding the given starting extruder.
      * When it's on the first layer, the prime blob will also be taken into account.
-     * 
+     *
      * \note At the planning stage we only have information on areas, not how those are filled.
      * If an area is too small to be filled with anything it will still get specified as being used with the extruder for that area.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param current_extruder The current extruder with which we last printed
      * \return The order of extruders for a layer beginning with \p current_extruder
@@ -294,7 +294,7 @@ private:
      * Calculate in which order to plan the meshes of a specific extruder
      * Each mesh which has some feature printed with the extruder is included in this order.
      * One mesh can occur in the mesh order of multiple extruders.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param extruder_nr The extruder for which to determine the order
      * \return A vector of mesh indices ordered on print order for that extruder.
@@ -303,41 +303,50 @@ private:
 
     /*!
      * Add a single layer from a single mesh-volume to the layer plan \p gcodeLayer in mesh surface mode.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param mesh The mesh to add to the layer plan \p gcodeLayer.
      * \param mesh_config the line config with which to print a print feature
      * \param gcodeLayer The initial planning of the gcode of the layer.
      */
-    void addMeshLayerToGCode_meshSurfaceMode(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, LayerPlan& gcodeLayer) const;
-    
+    void addMeshLayerToGCode_meshSurfaceMode(
+        const SliceDataStorage& storage,
+        const SliceMeshStorage& mesh,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        LayerPlan& gcodeLayer) const;
+
     /*!
      * Add the open polylines from a single layer from a single mesh-volume to the layer plan \p gcodeLayer for mesh the surface modes.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param mesh The mesh for which to add to the layer plan \p gcodeLayer.
      * \param mesh_config the line config with which to print a print feature
      * \param gcodeLayer The initial planning of the gcode of the layer.
      */
     void addMeshOpenPolyLinesToGCode(const SliceMeshStorage& mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, LayerPlan& gcode_layer) const;
-    
+
     /*!
      * Add all features of a given extruder from a single layer from a single mesh-volume to the layer plan \p gcode_layer.
-     * 
+     *
      * This adds all features (e.g. walls, skin etc.) of this \p mesh to the gcode which are printed using \p extruder_nr
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param mesh The mesh to add to the layer plan \p gcode_layer.
      * \param extruder_nr The extruder for which to print all features of the mesh which should be printed with this extruder
      * \param mesh_config the line config with which to print a print feature
      * \param gcode_layer The initial planning of the gcode of the layer.
      */
-    void addMeshLayerToGCode(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, LayerPlan& gcode_layer) const;
+    void addMeshLayerToGCode(
+        const SliceDataStorage& storage,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        LayerPlan& gcode_layer) const;
 
     /*!
      * Add all features of the given extruder from a single part from a given layer of a mesh-volume to the layer plan \p gcode_layer.
      * This only adds the features which are printed with \p extruder_nr.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param storage Storage to get global settings from.
      * \param mesh The mesh to add to the layer plan \p gcode_layer.
@@ -346,7 +355,13 @@ private:
      * \param part The part to add
      * \param gcode_layer The initial planning of the gcode of the layer.
      */
-    void addMeshPartToGCode(const SliceDataStorage& storage, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, LayerPlan& gcode_layer) const;
+    void addMeshPartToGCode(
+        const SliceDataStorage& storage,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SliceLayerPart& part,
+        LayerPlan& gcode_layer) const;
 
     /*!
      * \brief Add infill for a given part in a layer plan.
@@ -359,12 +374,18 @@ private:
      * \param part The part for which to create gcode.
      * \return Whether this function added anything to the layer plan.
      */
-    bool processInfill(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part) const;
+    bool processInfill(
+        const SliceDataStorage& storage,
+        LayerPlan& gcodeLayer,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SliceLayerPart& part) const;
 
     /*!
      * \brief Add thicker (multiple layers) sparse infill for a given part in a
      * layer plan.
-     * 
+     *
      * \param gcodeLayer The initial planning of the gcode of the layer.
      * \param mesh The mesh for which to add to the layer plan \p gcodeLayer.
      * \param extruder_nr The extruder for which to print all features of the
@@ -373,7 +394,13 @@ private:
      * \param part The part for which to create gcode.
      * \return Whether this function added anything to the layer plan.
      */
-    bool processMultiLayerInfill(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part) const;
+    bool processMultiLayerInfill(
+        const SliceDataStorage& storage,
+        LayerPlan& gcodeLayer,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SliceLayerPart& part) const;
 
     /*!
      * \brief Add normal sparse infill for a given part in a layer.
@@ -385,7 +412,13 @@ private:
      * \param part The part for which to create gcode.
      * \return Whether this function added anything to the layer plan.
      */
-    bool processSingleLayerInfill(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part) const;
+    bool processSingleLayerInfill(
+        const SliceDataStorage& storage,
+        LayerPlan& gcodeLayer,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SliceLayerPart& part) const;
 
     /*!
      * Generate the insets for the walls of a given layer part.
@@ -397,7 +430,13 @@ private:
      * \param part The part for which to create gcode
      * \return Whether this function added anything to the layer plan
      */
-    bool processInsets(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part) const;
+    bool processInsets(
+        const SliceDataStorage& storage,
+        LayerPlan& gcodeLayer,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SliceLayerPart& part) const;
 
     /*!
      * Generate the a spiralized wall for a given layer part.
@@ -407,7 +446,12 @@ private:
      * \param part The part for which to create gcode
      * \param mesh The mesh for which to add to the layer plan \p gcodeLayer.
      */
-    void processSpiralizedWall(const SliceDataStorage& storage, LayerPlan& gcode_layer, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part, const SliceMeshStorage& mesh) const;
+    void processSpiralizedWall(
+        const SliceDataStorage& storage,
+        LayerPlan& gcode_layer,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SliceLayerPart& part,
+        const SliceMeshStorage& mesh) const;
 
     /*!
      * Add the gcode of the top/bottom skin of the given part and of the perimeter gaps.
@@ -420,21 +464,27 @@ private:
      * \param part The part for which to create gcode
      * \return Whether this function added anything to the layer plan
      */
-    bool processSkin(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SliceLayerPart& part) const;
+    bool processSkin(
+        const SliceDataStorage& storage,
+        LayerPlan& gcode_layer,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SliceLayerPart& part) const;
 
     /*!
      * Add the gcode of the top/bottom skin of the given skin part and of the perimeter gaps.
-     * 
+     *
      * Perimeter gaps are handled for the current extruder for the following features if they are printed with this extruder.
      * - skin outlines
      * - roofing (if concentric)
      * - top/bottom (if concentric)
      * They are all printed at the end of printing the skin part features which are printed with this extruder.
-     * 
+     *
      * Note that the normal perimeter gaps are printed with the outer wall extruder,
      * while newly generated perimeter gaps
      * are printed with the extruder with which the feature was printed which generated the gaps.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param gcode_layer The initial planning of the gcode of the layer.
      * \param mesh The mesh for which to add to the layer plan \p gcode_layer.
@@ -443,7 +493,13 @@ private:
      * \param skin_part The skin part for which to create gcode
      * \return Whether this function added anything to the layer plan
      */
-    bool processSkinPart(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SkinPart& skin_part) const;
+    bool processSkinPart(
+        const SliceDataStorage& storage,
+        LayerPlan& gcode_layer,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SkinPart& skin_part) const;
 
     /*!
      * Add the roofing which is the area inside the innermost skin inset which has air 'directly' above
@@ -456,7 +512,14 @@ private:
      * \param skin_part The skin part for which to create gcode
      * \param[out] added_something Whether this function added anything to the layer plan
      */
-    void processRoofing(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SkinPart& skin_part, bool& added_something) const;
+    void processRoofing(
+        const SliceDataStorage& storage,
+        LayerPlan& gcode_layer,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SkinPart& skin_part,
+        bool& added_something) const;
 
     /*!
      * Add the normal skinfill which is the area inside the innermost skin inset
@@ -470,11 +533,18 @@ private:
      * \param skin_part The skin part for which to create gcode
      * \param[out] added_something Whether this function added anything to the layer plan
      */
-    void processTopBottom(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const size_t extruder_nr, const PathConfigStorage::MeshPathConfigs& mesh_config, const SkinPart& skin_part, bool& added_something) const;
+    void processTopBottom(
+        const SliceDataStorage& storage,
+        LayerPlan& gcode_layer,
+        const SliceMeshStorage& mesh,
+        const size_t extruder_nr,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const SkinPart& skin_part,
+        bool& added_something) const;
 
     /*!
      * Process a dense skin feature like roofing or top/bottom
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param gcode_layer The initial planning of the gcode of the layer.
      * \param mesh The mesh for which to add to the layer plan \p gcode_layer.
@@ -491,7 +561,22 @@ private:
      * \param[out] added_something Whether this function added anything to the layer plan
      * \param fan_speed fan speed override for this skin area
      */
-    void processSkinPrintFeature(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const size_t extruder_nr, const Polygons& area, const GCodePathConfig& config, EFillMethod pattern, const AngleDegrees skin_angle, const coord_t skin_overlap, const Ratio skin_density, const bool monotonic, bool& added_something, double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT, const bool is_bridge_skin = false) const;
+    void processSkinPrintFeature(
+        const SliceDataStorage& storage,
+        LayerPlan& gcode_layer,
+        const SliceMeshStorage& mesh,
+        const PathConfigStorage::MeshPathConfigs& mesh_config,
+        const size_t extruder_nr,
+        const Polygons& area,
+        const GCodePathConfig& config,
+        EFillMethod pattern,
+        const AngleDegrees skin_angle,
+        const coord_t skin_overlap,
+        const Ratio skin_density,
+        const bool monotonic,
+        bool& added_something,
+        double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT,
+        const bool is_bridge_skin = false) const;
 
     /*!
      *  see if we can avoid printing a lines or zig zag style skin part in multiple segments by moving to
@@ -510,7 +595,7 @@ private:
      *                +------+               +------+
      *     1, 2 = start locations of skin segments
      *     # = seam
-     * 
+     *
      * \param filling_part The part which we are going to fill with a linear filling type
      * \param filling_angle The angle of the filling lines
      * \param last_position The position the print head is in before going to fill the part
@@ -573,9 +658,9 @@ private:
 
     /*!
      * Change to a new extruder, and add the prime tower instructions if the new extruder is different from the last.
-     * 
+     *
      * On layer 0 this function adds the skirt for the nozzle it switches to, instead of the prime tower.
-     * 
+     *
      * \param[in] storage where the slice data is stored.
      * \param gcode_layer The initial planning of the gcode of the layer.
      * \param extruder_nr The extruder to switch to.
@@ -589,7 +674,7 @@ private:
      * \param prev_extruder The current extruder with which we last printed.
      */
     void addPrimeTower(const SliceDataStorage& storage, LayerPlan& gcodeLayer, const size_t prev_extruder) const;
-    
+
     /*!
      * Add the end gcode and set all temperatures to zero.
      */
@@ -628,9 +713,15 @@ private:
      * \param infill_line_width line width of the infill
      * \return true if there needs to be a skin edge support wall in this layer, otherwise false
      */
-    static bool partitionInfillBySkinAbove(Polygons& infill_below_skin, Polygons& infill_not_below_skin, const LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const SliceLayerPart& part, coord_t infill_line_width) ;
+    static bool partitionInfillBySkinAbove(
+        Polygons& infill_below_skin,
+        Polygons& infill_not_below_skin,
+        const LayerPlan& gcode_layer,
+        const SliceMeshStorage& mesh,
+        const SliceLayerPart& part,
+        coord_t infill_line_width);
 };
 
-}//namespace cura
+} // namespace cura
 
 #endif // GCODE_WRITER_H

--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -491,7 +491,7 @@ private:
      * \param[out] added_something Whether this function added anything to the layer plan
      * \param fan_speed fan speed override for this skin area
      */
-    void processSkinPrintFeature(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const size_t extruder_nr, const Polygons& area, const GCodePathConfig& config, EFillMethod pattern, const AngleDegrees skin_angle, const coord_t skin_overlap, const Ratio skin_density, const bool monotonic, bool& added_something, double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT) const;
+    void processSkinPrintFeature(const SliceDataStorage& storage, LayerPlan& gcode_layer, const SliceMeshStorage& mesh, const PathConfigStorage::MeshPathConfigs& mesh_config, const size_t extruder_nr, const Polygons& area, const GCodePathConfig& config, EFillMethod pattern, const AngleDegrees skin_angle, const coord_t skin_overlap, const Ratio skin_density, const bool monotonic, bool& added_something, double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT, const bool is_bridge_skin = false) const;
 
     /*!
      *  see if we can avoid printing a lines or zig zag style skin part in multiple segments by moving to

--- a/include/LayerPlanBuffer.h
+++ b/include/LayerPlanBuffer.h
@@ -1,16 +1,16 @@
-//Copyright (c) 2018 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2018 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef LAYER_PLAN_BUFFER_H
 #define LAYER_PLAN_BUFFER_H
 
-#include "gcodeExport.h"
 #include "Preheat.h"
+#include "gcodeExport.h"
 #include "settings/types/Duration.h"
 
 #include <list>
 
-namespace cura 
+namespace cura
 {
 
 class ExtruderPlan;
@@ -18,16 +18,16 @@ class LayerPlan;
 
 /*!
  * Class for buffering multiple layer plans (\ref LayerPlan) / extruder plans within those layer plans, so that temperature commands can be inserted in earlier layer plans.
- * 
+ *
  * This class handles where to insert temperature commands for:
  * - initial layer temperature
  * - flow dependent temperature
  * - starting to heat up from the standby temperature
  * - initial printing temperature | printing temperature | final printing temperature
- * 
+ *
  * \image html assets/precool.png "Temperature Regulation" width=10cm
  * \image latex assets/precool.png "Temperature Regulation" width=10cm
- * 
+ *
  */
 class LayerPlanBuffer
 {
@@ -35,25 +35,30 @@ class LayerPlanBuffer
 
     Preheat preheat_config; //!< the nozzle and material temperature settings for each extruder train.
 
-    static constexpr size_t buffer_size = 5; // should be as low as possible while still allowing enough time in the buffer to heat up from standby temp to printing temp // TODO: hardcoded value
+    static constexpr size_t buffer_size
+        = 5; // should be as low as possible while still allowing enough time in the buffer to heat up from standby temp to printing temp // TODO: hardcoded value
     // this value should be higher than 1, cause otherwise each layer is viewed as the first layer and no temp commands are inserted.
 
-    static constexpr Duration extra_preheat_time = 1.0_s; //!< Time to start heating earlier than computed to avoid accummulative discrepancy between actual heating times and computed ones.
+    static constexpr Duration extra_preheat_time
+        = 1.0_s; //!< Time to start heating earlier than computed to avoid accummulative discrepancy between actual heating times and computed ones.
 
-    std::vector<bool> extruder_used_in_meshgroup; //!< For each extruder whether it has already been planned once in this meshgroup. This is used to see whether we should heat to the initial_print_temp or to the extrusion_temperature
+    std::vector<bool> extruder_used_in_meshgroup; //!< For each extruder whether it has already been planned once in this meshgroup. This is used to see whether we should heat to
+                                                  //!< the initial_print_temp or to the extrusion_temperature
 
     /*!
      * The buffer containing several layer plans (LayerPlan) before writing them to gcode.
-     * 
+     *
      * The front is the lowest/oldest layer.
      * The back is the highest/newest layer.
      */
     std::list<LayerPlan*> buffer;
+
 public:
     LayerPlanBuffer(GCodeExport& gcode)
-    : gcode(gcode)
-    , extruder_used_in_meshgroup(MAX_EXTRUDERS, false)
-    { }
+        : gcode(gcode)
+        , extruder_used_in_meshgroup(MAX_EXTRUDERS, false)
+    {
+    }
 
     void setPreheatConfig();
 
@@ -65,7 +70,7 @@ public:
     /*!
      * Push a new layer onto the buffer and handle the buffer.
      * Write a layer to gcode if it is popped out of the buffer.
-     * 
+     *
      * \param layer_plan The layer to handle
      * \param gcode The exporter with which to write a layer to gcode if the buffer is too large after pushing the new layer.
      */
@@ -82,7 +87,7 @@ private:
      * This inserts the temperature commands to start warming for a given layer in earlier layers;
      * the fan speeds and layer time settings of the most recently pushed layer are processed;
      * the correctly combing travel move between the last added layer and the layer before is added.
-     * 
+     *
      * Pop out the earliest layer in the buffer if the buffer size is exceeded
      * \return A nullptr or the popped gcode_layer
      */
@@ -90,7 +95,7 @@ private:
 
     /*!
      * Add the travel move to properly travel from the end location of the previous layer to the starting location of the next
-     * 
+     *
      * \param prev_layer The layer before the just added layer, to which to add the combing travel move.
      * \param newest_layer The newly added layer, with a non-combing travel move as first path.
      */
@@ -103,7 +108,7 @@ private:
 
     /*!
      * Insert a preheat command for @p extruder into @p extruder_plan_before
-     * 
+     *
      * \param extruder_plan_before An extruder plan before the extruder plan for which the temperature is computed, in which to insert the preheat command
      * \param time_before_extruder_plan_end The time before the end of the extruder plan, before which to insert the preheat command
      * \param extruder_nr The extruder for which to set the temperature
@@ -114,9 +119,9 @@ private:
     /*!
      * Compute the time needed to preheat from standby to required (initial) printing temperature at the start of an extruder plan,
      * based on the time the extruder has been on standby.
-     * 
+     *
      * Also computes the temperature to which we cool before starting to heat agian.
-     * 
+     *
      * \param extruder_plans The extruder plans in the buffer, moved to a temporary vector (from lower to upper layers)
      * \param extruder_plan_idx The index of the extruder plan in \p extruder_plans for which to find the preheat time needed
      * \return the time needed to preheat and the temperature from which heating starts
@@ -124,11 +129,11 @@ private:
     Preheat::WarmUpResult computeStandbyTempPlan(std::vector<ExtruderPlan*>& extruder_plans, unsigned int extruder_plan_idx);
 
     /*!
-     * For two consecutive extruder plans of the same extruder (so on different layers), 
+     * For two consecutive extruder plans of the same extruder (so on different layers),
      * preheat the extruder to the temperature corresponding to the average flow of the second extruder plan.
-     * 
+     *
      * The preheat commands are inserted such that the middle of the temperature change coincides with the start of the next layer.
-     * 
+     *
      * \param prev_extruder_plan The former extruder plan (of the former layer)
      * \param extruder_nr The extruder for which too set the temperature
      * \param required_temp The required temperature for the second extruder plan
@@ -140,7 +145,7 @@ private:
      * Find the time window in which this extruder hasn't been used
      * and compute at what time the preheat command needs to be inserted.
      * Then insert the preheat command in the right extruder plan.
-     * 
+     *
      * \param extruder_plans The extruder plans in the buffer, moved to a temporary vector (from lower to upper layers)
      * \param extruder_plan_idx The index of the extruder plan in \p extruder_plans for which to find the preheat time needed
      */
@@ -149,15 +154,15 @@ private:
     /*!
      * Insert temperature commands related to the extruder plan corersponding to @p extruder_plan_idx
      * and the extruder plan before:
-     * 
+     *
      * In case the extruder plan before has the same extruder:
      * - gradually change printing temperature around the layer change (\ref LayerPlanBuffer::insertPreheatCommand_singleExtrusion)
-     * 
+     *
      * In case the previous extruder plan is a different extruder
      * - insert preheat command from standby to initial temp in the extruder plan(s) before (\ref LayerPlanBuffer::insertPreheatCommand_multiExtrusion)
      * - insert the final print temp command of the previous extruder plan (\ref LayerPlanBuffer::insertFinalPrintTempCommand)
      * - insert the normal extrusion temp command for the current extruder plan (\ref LayerPlanBuffer::insertPrintTempCommand)
-     * 
+     *
      * \param extruder_plans The extruder plans in the buffer, moved to a temporary vector (from lower to upper layers)
      * \param extruder_plan_idx The index of the extruder plan in \p extruder_plans for which to generate the preheat command
      */
@@ -165,20 +170,20 @@ private:
 
     /*!
      * Insert the temperature command to heat from the initial print temperature to the printing temperature
-     * 
+     *
      * The temperature command is insert at the start of the very first extrusion move
-     * 
+     *
      * \param extruder_plan The extruder plan in which to insert the heat up command
      */
     void insertPrintTempCommand(ExtruderPlan& extruder_plan);
 
     /*!
      * Insert the temp command to start cooling from the printing temperature to the final print temp
-     * 
+     *
      * The print temp is inserted before the last extrusion move of the extruder plan corresponding to \p last_extruder_plan_idx
-     * 
+     *
      * The command is inserted at a timed offset before the end of the last extrusion move
-     * 
+     *
      * \param extruder_plans The extruder plans in the buffer, moved to a temporary vector (from lower to upper layers)
      * \param last_extruder_plan_idx The index of the last extruder plan in \p extruder_plans with the same extruder as previous extruder plans
      */
@@ -193,14 +198,13 @@ private:
      * Reconfigure the standby temperature during which we didn't print with this extruder.
      * Find the previous extruder plan with the same extruder as layers[layer_plan_idx].extruder_plans[extruder_plan_idx]
      * Set the prev_extruder_standby_temp in the next extruder plan
-     * 
+     *
      * \param extruder_plans The extruder plans in the buffer, moved to a temporary vector (from lower to upper layers)
      * \param extruder_plan_idx The index of the extruder plan in \p extruder_plans before which to reconfigure the standby temperature
      * \param standby_temp The temperature to which to cool down when the extruder is in standby mode.
      */
     void handleStandbyTemp(std::vector<ExtruderPlan*>& extruder_plans, unsigned int extruder_plan_idx, double standby_temp);
 };
-
 
 
 } // namespace cura

--- a/include/LayerPlanBuffer.h
+++ b/include/LayerPlanBuffer.h
@@ -4,10 +4,11 @@
 #ifndef LAYER_PLAN_BUFFER_H
 #define LAYER_PLAN_BUFFER_H
 
-#include <list>
-
+#include "gcodeExport.h"
 #include "Preheat.h"
 #include "settings/types/Duration.h"
+
+#include <list>
 
 namespace cura 
 {

--- a/include/infill.h
+++ b/include/infill.h
@@ -131,7 +131,8 @@ public:
         const SierpinskiFillProvider* cross_fill_provider = nullptr,
         const LightningLayer* lightning_layer = nullptr,
         const SliceMeshStorage* mesh = nullptr,
-        const Polygons& prevent_small_exposed_to_air = Polygons());
+        const Polygons& prevent_small_exposed_to_air = Polygons(),
+        const bool is_bridge_skin = false);
 
     /*!
      * Generate the wall toolpaths of an infill area. It will return the inner contour and set the inner-contour.
@@ -153,7 +154,8 @@ public:
         const coord_t infill_overlap,
         const Settings& settings,
         int layer_idx,
-        SectionType section_type);
+        SectionType section_type,
+        const bool is_bridge_skin = false);
 
 private:
     /*!

--- a/include/infill.h
+++ b/include/infill.h
@@ -144,6 +144,7 @@ public:
      * \param line_width [in] The optimum wall line width of the walls
      * \param infill_overlap [in] The overlap of the infill
      * \param settings [in] A settings storage to use for generating variable-width walls.
+     * \param is_bridge_skin [in] Setting to filter out the extra skin walls while bridging
      * \return The inner contour of the wall toolpaths
      */
     static Polygons generateWallToolPaths(

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2724,7 +2724,8 @@ void FffGcodeWriter::processTopBottom(
         skin_density,
         monotonic,
         added_something,
-        fan_speed);
+        fan_speed,
+        is_bridge_skin);
 }
 
 void FffGcodeWriter::processSkinPrintFeature(
@@ -2741,7 +2742,8 @@ void FffGcodeWriter::processSkinPrintFeature(
     const Ratio skin_density,
     const bool monotonic,
     bool& added_something,
-    double fan_speed) const
+    double fan_speed,
+    const bool is_bridge_skin) const
 {
     Polygons skin_polygons;
     Polygons skin_lines;
@@ -2801,7 +2803,8 @@ void FffGcodeWriter::processSkinPrintFeature(
         nullptr,
         nullptr,
         nullptr,
-        small_areas_on_surface ? Polygons() : exposed_to_air);
+        small_areas_on_surface ? Polygons() : exposed_to_air,
+        is_bridge_skin);
 
     // add paths
     if (! skin_polygons.empty() || ! skin_lines.empty() || ! skin_paths.empty())

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -59,13 +59,14 @@ Polygons Infill::generateWallToolPaths(
     const coord_t infill_overlap,
     const Settings& settings,
     int layer_idx,
-    SectionType section_type)
+    SectionType section_type,
+    const bool is_bridge_skin)
 {
     outer_contour = outer_contour.offset(infill_overlap);
     scripta::log("infill_outer_contour", outer_contour, section_type, layer_idx, scripta::CellVDI{ "infill_overlap", infill_overlap });
 
     Polygons inner_contour;
-    if (wall_line_count > 0)
+    if ((wall_line_count > 0) && (! is_bridge_skin))
     {
         constexpr coord_t wall_0_inset = 0; // Don't apply any outer wall inset for these. That's just for the outer wall.
         WallToolPaths wall_toolpaths(outer_contour, line_width, wall_line_count, wall_0_inset, settings, layer_idx, section_type);
@@ -89,14 +90,15 @@ void Infill::generate(
     const SierpinskiFillProvider* cross_fill_provider,
     const LightningLayer* lightning_trees,
     const SliceMeshStorage* mesh,
-    const Polygons& prevent_small_exposed_to_air)
+    const Polygons& prevent_small_exposed_to_air,
+    const bool is_bridge_skin)
 {
     if (outer_contour.empty())
     {
         return;
     }
 
-    inner_contour = generateWallToolPaths(toolpaths, outer_contour, wall_line_count, infill_line_width, infill_overlap, settings, layer_idx, section_type);
+    inner_contour = generateWallToolPaths(toolpaths, outer_contour, wall_line_count, infill_line_width, infill_overlap, settings, layer_idx, section_type, is_bridge_skin);
     scripta::log("infill_inner_contour_0", inner_contour, section_type, layer_idx);
 
     // It does not make sense to print a pattern in a small region. So the infill region


### PR DESCRIPTION
You can adjust the flow rate and speed during bridging. But you can’t adjust this for the skin walls. These will remain printed with the normal skin settings.

CURA-9521

https://github.com/Ultimaker/Cura/issues/14200