### PR TITLE
[CURA-11019] speed-fix (ugly? raw pointer edition)

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -70,7 +70,7 @@ private:
     std::vector<bool> has_prime_tower_planned_per_extruder; //!< For each extruder, whether the prime tower is planned yet or not.
     std::optional<Point> last_planned_position; //!< The last planned XY position of the print head (if known)
 
-    std::shared_ptr<SliceMeshStorage> current_mesh; //!< The mesh of the last planned move.
+    const SliceMeshStorage* current_mesh; //!< The mesh of the last planned move.
 
     /*!
      * Whether the skirt or brim polygons have been processed into planned paths
@@ -236,9 +236,14 @@ public:
 
     /*!
      * Track the currently printing mesh.
-     * \param mesh_id A unique ID indicating the current mesh.
+     * \param mesh The mesh to track.
      */
-    void setMesh(const std::shared_ptr<SliceMeshStorage>& mesh);
+    void setMesh(const SliceMeshStorage& mesh);
+
+    /*!
+     * Untrack previously tracked mesh.
+     */
+    void resetMesh();
 
     /*!
      * Set bridge_wall_mask.

--- a/include/SkeletalTrapezoidationEdge.h
+++ b/include/SkeletalTrapezoidationEdge.h
@@ -4,11 +4,11 @@
 #ifndef SKELETAL_TRAPEZOIDATION_EDGE_H
 #define SKELETAL_TRAPEZOIDATION_EDGE_H
 
-#include <memory> // smart pointers
-#include <list>
-#include <vector>
-
 #include "utils/ExtrusionJunction.h"
+
+#include <list>
+#include <memory> // smart pointers
+#include <vector>
 
 namespace cura
 {
@@ -16,7 +16,12 @@ namespace cura
 class SkeletalTrapezoidationEdge
 {
 private:
-    enum class Central : int { UNKNOWN = -1, NO = 0, YES = 1};
+    enum class Central : int
+    {
+        UNKNOWN = -1,
+        NO = 0,
+        YES = 1
+    };
 
 public:
     /*!
@@ -28,9 +33,11 @@ public:
         int lower_bead_count;
         coord_t feature_radius; // The feature radius at which this transition is placed
         TransitionMiddle(coord_t pos, int lower_bead_count, coord_t feature_radius)
-            : pos(pos), lower_bead_count(lower_bead_count)
+            : pos(pos)
+            , lower_bead_count(lower_bead_count)
             , feature_radius(feature_radius)
-        {}
+        {
+        }
     };
 
     /*!
@@ -42,8 +49,11 @@ public:
         int lower_bead_count;
         bool is_lower_end; // Whether this is the ed of the transition with lower bead count
         TransitionEnd(coord_t pos, int lower_bead_count, bool is_lower_end)
-            : pos(pos), lower_bead_count(lower_bead_count), is_lower_end(is_lower_end)
-        {}
+            : pos(pos)
+            , lower_bead_count(lower_bead_count)
+            , is_lower_end(is_lower_end)
+        {
+        }
     };
 
     enum class EdgeType : int
@@ -55,12 +65,14 @@ public:
     EdgeType type;
 
     SkeletalTrapezoidationEdge()
-    : SkeletalTrapezoidationEdge(EdgeType::NORMAL)
-    {}
+        : SkeletalTrapezoidationEdge(EdgeType::NORMAL)
+    {
+    }
     SkeletalTrapezoidationEdge(const EdgeType& type)
-    : type(type)
-    , is_central(Central::UNKNOWN)
-    {}
+        : type(type)
+        , is_central(Central::UNKNOWN)
+    {
+    }
 
     bool isCentral() const
     {

--- a/include/SkeletalTrapezoidationEdge.h
+++ b/include/SkeletalTrapezoidationEdge.h
@@ -80,7 +80,7 @@ public:
     {
         return transitions.use_count() > 0 && (ignore_empty || ! transitions.lock()->empty());
     }
-    void setTransitions(std::shared_ptr<std::list<TransitionMiddle>> storage)
+    void setTransitions(std::shared_ptr<std::list<TransitionMiddle>>& storage)
     {
         transitions = storage;
     }
@@ -93,7 +93,7 @@ public:
     {
         return transition_ends.use_count() > 0 && (ignore_empty || ! transition_ends.lock()->empty());
     }
-    void setTransitionEnds(std::shared_ptr<std::list<TransitionEnd>> storage)
+    void setTransitionEnds(std::shared_ptr<std::list<TransitionEnd>>& storage)
     {
         transition_ends = storage;
     }
@@ -106,7 +106,7 @@ public:
     {
         return extrusion_junctions.use_count() > 0 && (ignore_empty || ! extrusion_junctions.lock()->empty());
     }
-    void setExtrusionJunctions(std::shared_ptr<LineJunctions> storage)
+    void setExtrusionJunctions(std::shared_ptr<LineJunctions>& storage)
     {
         extrusion_junctions = storage;
     }

--- a/include/SkeletalTrapezoidationJoint.h
+++ b/include/SkeletalTrapezoidationJoint.h
@@ -1,13 +1,13 @@
-//Copyright (c) 2020 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2020 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef SKELETAL_TRAPEZOIDATION_JOINT_H
 #define SKELETAL_TRAPEZOIDATION_JOINT_H
 
-#include <memory> // smart pointers
-
 #include "BeadingStrategy/BeadingStrategy.h"
 #include "utils/IntPoint.h"
+
+#include <memory> // smart pointers
 
 namespace cura
 {
@@ -15,6 +15,7 @@ namespace cura
 class SkeletalTrapezoidationJoint
 {
     using Beading = BeadingStrategy::Beading;
+
 public:
     struct BeadingPropagation
     {
@@ -27,17 +28,20 @@ public:
             , dist_to_bottom_source(0)
             , dist_from_top_source(0)
             , is_upward_propagated_only(false)
-        {}
+        {
+        }
     };
 
     coord_t distance_to_boundary;
     coord_t bead_count;
-    float transition_ratio; //! The distance near the skeleton to leave free because this joint is in the middle of a transition, as a fraction of the inner bead width of the bead at the higher transition.
+    float transition_ratio; //! The distance near the skeleton to leave free because this joint is in the middle of a transition, as a fraction of the inner bead width of the bead
+                            //! at the higher transition.
     SkeletalTrapezoidationJoint()
-    : distance_to_boundary(-1)
-    , bead_count(-1)
-    , transition_ratio(0)
-    {}
+        : distance_to_boundary(-1)
+        , bead_count(-1)
+        , transition_ratio(0)
+    {
+    }
 
     bool hasBeading() const
     {
@@ -53,7 +57,6 @@ public:
     }
 
 private:
-
     std::weak_ptr<BeadingPropagation> beading;
 };
 

--- a/include/SkeletalTrapezoidationJoint.h
+++ b/include/SkeletalTrapezoidationJoint.h
@@ -43,7 +43,7 @@ public:
     {
         return beading.use_count() > 0;
     }
-    void setBeading(std::shared_ptr<BeadingPropagation> storage)
+    void setBeading(std::shared_ptr<BeadingPropagation>& storage)
     {
         beading = storage;
     }

--- a/include/infill.h
+++ b/include/infill.h
@@ -203,8 +203,8 @@ public:
         const Settings& settings,
         int layer_idx,
         SectionType section_type,
-        const std::shared_ptr<SierpinskiFillProvider> cross_fill_provider = nullptr,
-        const std::shared_ptr<LightningLayer> lightning_layer = nullptr,
+        const std::shared_ptr<SierpinskiFillProvider>& cross_fill_provider = nullptr,
+        const std::shared_ptr<LightningLayer>& lightning_layer = nullptr,
         const SliceMeshStorage* mesh = nullptr,
         const Polygons& prevent_small_exposed_to_air = Polygons(),
         const bool is_bridge_skin = false);
@@ -242,8 +242,8 @@ private:
         Polygons& result_polygons,
         Polygons& result_lines,
         const Settings& settings,
-        const std::shared_ptr<SierpinskiFillProvider> cross_fill_pattern = nullptr,
-        const std::shared_ptr<LightningLayer> lightning_layer = nullptr,
+        const std::shared_ptr<SierpinskiFillProvider>& cross_fill_pattern = nullptr,
+        const std::shared_ptr<LightningLayer>& lightning_layer = nullptr,
         const SliceMeshStorage* mesh = nullptr);
 
     /*!
@@ -402,7 +402,7 @@ private:
      * see https://hal.archives-ouvertes.fr/hal-02155929/document
      * \param result (output) The resulting polygons
      */
-    void generateLightningInfill(const std::shared_ptr<LightningLayer> lightning_layer, Polygons& result_lines);
+    void generateLightningInfill(const std::shared_ptr<LightningLayer>& lightning_layer, Polygons& result_lines);
 
     /*!
      * Generate sparse concentric infill

--- a/include/pathPlanning/GCodePath.h
+++ b/include/pathPlanning/GCodePath.h
@@ -30,7 +30,7 @@ namespace cura
 struct GCodePath
 {
     GCodePathConfig config{}; //!< The configuration settings of the path.
-    std::shared_ptr<SliceMeshStorage> mesh; //!< Which mesh this path belongs to, if any. If it's not part of any mesh, the mesh should be nullptr;
+    const SliceMeshStorage* mesh; //!< Which mesh this path belongs to, if any. If it's not part of any mesh, the mesh should be nullptr;
     SpaceFillType space_fill_type{}; //!< The type of space filling of which this path is a part
     Ratio flow{}; //!< A type-independent flow configuration
     Ratio width_factor{}; //!< Adjustment to the line width. Similar to flow, but causes the speed_back_pressure_factor to be adjusted.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1471,7 +1471,7 @@ void FffGcodeWriter::addMeshLayerToGCode(
         return;
     }
 
-    gcode_layer.setMesh(std::make_shared<SliceMeshStorage>(mesh));
+    gcode_layer.setMesh(mesh);
 
     ZSeamConfig z_seam_config;
     if (mesh.isPrinted()) //"normal" meshes with walls, skin, infill, etc. get the traditional part ordering based on the z-seam settings.
@@ -1502,7 +1502,7 @@ void FffGcodeWriter::addMeshLayerToGCode(
     {
         addMeshOpenPolyLinesToGCode(mesh, mesh_config, gcode_layer);
     }
-    gcode_layer.setMesh(nullptr);
+    gcode_layer.resetMesh();
 }
 
 void FffGcodeWriter::addMeshPartToGCode(

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -282,9 +282,15 @@ bool LayerPlan::setExtruder(const size_t extruder_nr)
     }
     return true;
 }
-void LayerPlan::setMesh(const std::shared_ptr<SliceMeshStorage>& mesh)
+
+void LayerPlan::setMesh(const SliceMeshStorage& mesh)
 {
-    current_mesh = mesh;
+    current_mesh = &mesh;
+}
+
+void LayerPlan::resetMesh()
+{
+    current_mesh = nullptr;
 }
 
 void LayerPlan::moveInsideCombBoundary(const coord_t distance, const std::optional<SliceLayerPart>& part)
@@ -1846,7 +1852,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
     const bool acceleration_travel_enabled = mesh_group_settings.get<bool>("acceleration_travel_enabled");
     const bool jerk_enabled = mesh_group_settings.get<bool>("jerk_enabled");
     const bool jerk_travel_enabled = mesh_group_settings.get<bool>("jerk_travel_enabled");
-    std::shared_ptr<SliceMeshStorage> current_mesh;
+    const SliceMeshStorage* current_mesh = nullptr;
 
     for (size_t extruder_plan_idx = 0; extruder_plan_idx < extruder_plans.size(); extruder_plan_idx++)
     {

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -420,7 +420,7 @@ void ArcusCommunication::sendOptimizedLayerData()
     }
     spdlog::info("Sending {} layers.", data.current_layer_count);
 
-    for (std::pair<const int, std::shared_ptr<proto::LayerOptimized>> entry : data.slice_data) // Note: This is in no particular order!
+    for (const auto& entry : data.slice_data) // Note: This is in no particular order!
     {
         spdlog::debug("Sending layer data for layer {} of {}.", entry.first, data.slice_data.size());
         private_data->socket->sendMessage(entry.second); // Send the actual layers.

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -88,8 +88,8 @@ void Infill::generate(
     const Settings& settings,
     int layer_idx,
     SectionType section_type,
-    const std::shared_ptr<SierpinskiFillProvider> cross_fill_provider,
-    const std::shared_ptr<LightningLayer> lightning_trees,
+    const std::shared_ptr<SierpinskiFillProvider>& cross_fill_provider,
+    const std::shared_ptr<LightningLayer>& lightning_trees,
     const SliceMeshStorage* mesh,
     const Polygons& prevent_small_exposed_to_air,
     const bool is_bridge_skin)
@@ -255,8 +255,8 @@ void Infill::_generate(
     Polygons& result_polygons,
     Polygons& result_lines,
     const Settings& settings,
-    const std::shared_ptr<SierpinskiFillProvider> cross_fill_provider,
-    const std::shared_ptr<LightningLayer> lightning_trees,
+    const std::shared_ptr<SierpinskiFillProvider>& cross_fill_provider,
+    const std::shared_ptr<LightningLayer>& lightning_trees,
     const SliceMeshStorage* mesh)
 {
     if (inner_contour.empty())
@@ -432,7 +432,7 @@ void Infill::generateGyroidInfill(Polygons& result_lines, Polygons& result_polyg
     PolylineStitcher<Polygons, Polygon, Point>::stitch(line_segments, result_lines, result_polygons, infill_line_width);
 }
 
-void Infill::generateLightningInfill(const std::shared_ptr<LightningLayer> trees, Polygons& result_lines)
+void Infill::generateLightningInfill(const std::shared_ptr<LightningLayer>& trees, Polygons& result_lines)
 {
     // Don't need to support areas smaller than line width, as they are always within radius:
     if (std::abs(inner_contour.area()) < infill_line_width || ! trees)

--- a/src/plugins/converters.cpp
+++ b/src/plugins/converters.cpp
@@ -430,7 +430,7 @@ gcode_paths_modify_response::native_value_type
     gcode_paths_modify_response::operator()(gcode_paths_modify_response::native_value_type& original_value, const gcode_paths_modify_response::value_type& message) const
 {
     std::vector<GCodePath> paths;
-    using map_t = std::unordered_map<std::string, std::shared_ptr<SliceMeshStorage>>;
+    using map_t = std::unordered_map<std::string, const SliceMeshStorage*>;
     auto meshes = original_value
                 | ranges::views::filter(
                       [](const auto& path)

--- a/tests/ExtruderPlanTest.cpp
+++ b/tests/ExtruderPlanTest.cpp
@@ -74,7 +74,7 @@ public:
         : extrusion_config(GCodePathConfig{ .type = PrintFeatureType::OuterWall, .line_width = 400, .layer_thickness = 100, .flow = 1.0_r, .speed_derivatives = SpeedDerivatives { .speed = 50.0, .acceleration = 1000.0, .jerk = 10.0 } })
         , travel_config(GCodePathConfig{ .type = PrintFeatureType::MoveCombing, .line_width = 0, .layer_thickness = 100, .flow = 0.0_r, .speed_derivatives = SpeedDerivatives { .speed = 120.0, .acceleration = 5000.0, .jerk = 30.0 } })
     {
-        std::shared_ptr<SliceMeshStorage> mesh = nullptr;
+        constexpr SliceMeshStorage* mesh = nullptr;
         constexpr Ratio flow_1 = 1.0_r;
         constexpr Ratio width_1 = 1.0_r;
         constexpr bool no_spiralize = false;


### PR DESCRIPTION
The `make_shared` function copies the entire object, since it's in essence a sort of `emplace` for a smart-pointer version of the constructor of an object. Which means basically that the copy-constructor is called in the case where an object is inserted into `make_shared`. This is normally not so bad, but this is an object representing an entire layer, with non-pointer member-variables. It didn't happen that often, but each operation was quite expensive.

The solution presented here is _maybe_ a bit ugly, but we should either accept raw pointers (because the original object is on the stack and manages itself -- a lot less risk of dangling pointers or whatever), _or_ we go all the way and start constructing it as a smart-pointer in the first place.

(I also made some pass-by-copy into pass-by-reference changes, since smart pointers are still objects, so probably slightly bigger than a reference.)