### PR TITLE
[CURA-11035] Plugins specify a verion-range, slots just a version.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -85,7 +85,7 @@ class CuraEngineConan(ConanFile):
             self.requires("arcus/5.3.0")
         self.requires("asio-grpc/2.6.0")
         self.requires("grpc/1.50.1")
-        self.requires("curaengine_grpc_definitions/(latest)@ultimaker/cura_11035")  # FIXME!: Put back to .../testing after merge!
+        self.requires("curaengine_grpc_definitions/(latest)@ultimaker/testing")
         self.requires("clipper/6.4.2")
         self.requires("boost/1.82.0")
         self.requires("rapidjson/1.1.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -85,7 +85,7 @@ class CuraEngineConan(ConanFile):
             self.requires("arcus/5.3.0")
         self.requires("asio-grpc/2.6.0")
         self.requires("grpc/1.50.1")
-        self.requires("curaengine_grpc_definitions/(latest)@ultimaker/testing")
+        self.requires("curaengine_grpc_definitions/(latest)@ultimaker/cura_11035")  # FIXME!: Put back to .../testing after merge!
         self.requires("clipper/6.4.2")
         self.requires("boost/1.82.0")
         self.requires("rapidjson/1.1.0")

--- a/include/plugins/exception.h
+++ b/include/plugins/exception.h
@@ -28,13 +28,13 @@ public:
 
     ValidatorException(const auto& validator, const slot_metadata& slot_info, const plugin_metadata& plugin_info) noexcept
         : msg_(fmt::format(
-            "Failed to validate plugin '{}-{}' running at [{}] for slot '{}', slot range '{}' incompatible with plugin slot version '{}'",
+            "Failed to validate plugin '{}-{}' running at [{}] for slot '{}', version '{}' incompatible with plugin specified slot-version-range '{}'.",
             plugin_info.plugin_name,
             plugin_info.plugin_version,
             plugin_info.peer,
             slot_info.slot_id,
-            slot_info.version_range,
-            plugin_info.slot_version))
+            slot_info.version,
+            plugin_info.slot_version_range))
     {
     }
 

--- a/include/plugins/metadata.h
+++ b/include/plugins/metadata.h
@@ -18,7 +18,7 @@ namespace cura::plugins
 
 struct plugin_metadata
 {
-    std::string slot_version;
+    std::string slot_version_range;
     std::string plugin_name;
     std::string plugin_version;
     std::string peer;
@@ -28,7 +28,7 @@ struct plugin_metadata
 struct slot_metadata
 {
     plugins::v0::SlotID slot_id;
-    std::string_view version_range;
+    std::string_view version;
     std::string_view engine_uuid;
 };
 

--- a/include/plugins/pluginproxy.h
+++ b/include/plugins/pluginproxy.h
@@ -50,7 +50,7 @@ namespace cura::plugins
  *
  * Template arguments are:
  * SlotID - plugin slot ID
- * SlotVersionRng - plugin version range
+ * SlotVersion - slot version used -- will be the only version available in the engine for that slot, since there is just the latest version of the slot a.t.m.
  * Stub - process stub type
  * ValidatorTp - validator type
  * RequestTp - gRPC convertible request type, or dummy -- if stub is a proper invoke-stub, this is enforced by the specialization of the invoke component
@@ -58,7 +58,7 @@ namespace cura::plugins
  *
  * Class provides methods for validating the plugin, making requests and processing responses.
  */
-template<plugins::v0::SlotID SlotID, utils::CharRangeLiteral SlotVersionRng, class Stub, class ValidatorTp, typename RequestTp, typename ResponseTp>
+template<plugins::v0::SlotID SlotID, utils::CharRangeLiteral SlotVersion, class Stub, class ValidatorTp, typename RequestTp, typename ResponseTp>
 class PluginProxy
 {
     // type aliases for easy use
@@ -131,7 +131,7 @@ public:
             spdlog::error(status.error_message());
             throw exceptions::RemoteException(slot_info_, status.error_message());
         }
-        if (! plugin_info.plugin_name.empty() && ! plugin_info.slot_version.empty())
+        if (! plugin_info.plugin_name.empty() && ! plugin_info.slot_version_range.empty())
         {
             plugin_info_.emplace(plugin_info);
         }
@@ -340,7 +340,7 @@ private:
     req_converter_type req_{}; ///< The Invoke request converter object.
     rsp_converter_type rsp_{}; ///< The Invoke response converter object.
     slot_metadata slot_info_{ .slot_id = SlotID,
-                              .version_range = SlotVersionRng.value,
+                              .version = SlotVersion.value,
                               .engine_uuid = Application::getInstance().instance_uuid }; ///< Holds information about the plugin slot.
     std::optional<plugin_metadata> plugin_info_{ std::optional<plugin_metadata>(std::nullopt) }; ///< Optional object that holds the plugin metadata, set after handshake
 };

--- a/include/plugins/slotproxy.h
+++ b/include/plugins/slotproxy.h
@@ -28,19 +28,19 @@ namespace cura::plugins
  * for communication with plugins assigned to the slot. It delegates plugin requests to the
  * corresponding PluginProxy object and provides a default behavior when no plugin is available.
  *
- * @tparam Slot The plugin slot ID.
- * @tparam Validator The type used for validating the plugin.
+ * @tparam SlotID The plugin slot ID.
+ * @tparam SlotVersion The version of the indicated slot.
  * @tparam Stub The process stub type.
- * @tparam Prepare The prepare type.
- * @tparam Request The gRPC convertible request type.
- * @tparam Response The gRPC convertible response type.
+ * @tparam ValidatorTp The type used for validating the plugin.
+ * @tparam RequestTp The gRPC convertible request type.
+ * @tparam ResponseTp The gRPC convertible response type.
  * @tparam Default The default behavior when no plugin is available.
  */
-template<plugins::v0::SlotID SlotID, utils::CharRangeLiteral SlotVersionRng, class Stub, class ValidatorTp, class RequestTp, class ResponseTp, class Default>
+template<plugins::v0::SlotID SlotID, utils::CharRangeLiteral SlotVersion, class Stub, class ValidatorTp, class RequestTp, class ResponseTp, class Default>
 class SlotProxy
 {
     Default default_process{};
-    using value_type = PluginProxy<SlotID, SlotVersionRng, Stub, ValidatorTp, RequestTp, ResponseTp>;
+    using value_type = PluginProxy<SlotID, SlotVersion, Stub, ValidatorTp, RequestTp, ResponseTp>;
     std::optional<value_type> plugin_{ std::nullopt };
 
 public:

--- a/include/plugins/slots.h
+++ b/include/plugins/slots.h
@@ -69,12 +69,12 @@ struct infill_generate_default
  */
 template<class Default = default_process>
 using slot_simplify_
-    = SlotProxy<v0::SlotID::SIMPLIFY_MODIFY, "<=1.0.0", slots::simplify::v0::modify::SimplifyModifyService::Stub, Validator, simplify_request, simplify_response, Default>;
+    = SlotProxy<v0::SlotID::SIMPLIFY_MODIFY, "0.1.0-alpha", slots::simplify::v0::modify::SimplifyModifyService::Stub, Validator, simplify_request, simplify_response, Default>;
 
 template<class Default = default_process>
 using slot_infill_generate_ = SlotProxy<
     v0::SlotID::INFILL_GENERATE,
-    "<=1.0.0",
+    "0.1.0-alpha",
     slots::infill::v0::generate::InfillGenerateService::Stub,
     Validator,
     infill_generate_request,
@@ -91,7 +91,7 @@ using slot_infill_generate_ = SlotProxy<
 template<class Default = default_process>
 using slot_postprocess_ = SlotProxy<
     v0::SlotID::POSTPROCESS_MODIFY,
-    "<=1.0.0",
+    "0.1.0-alpha",
     slots::postprocess::v0::modify::PostprocessModifyService::Stub,
     Validator,
     postprocess_request,
@@ -100,12 +100,12 @@ using slot_postprocess_ = SlotProxy<
 
 template<class Default = default_process>
 using slot_settings_broadcast_
-    = SlotProxy<v0::SlotID::SETTINGS_BROADCAST, "<=1.0.0", slots::broadcast::v0::BroadcastService::Stub, Validator, broadcast_settings_request, empty, Default>;
+    = SlotProxy<v0::SlotID::SETTINGS_BROADCAST, "0.1.0-alpha", slots::broadcast::v0::BroadcastService::Stub, Validator, broadcast_settings_request, empty, Default>;
 
 template<class Default = default_process>
 using slot_gcode_paths_modify_ = SlotProxy<
     v0::SlotID::GCODE_PATHS_MODIFY,
-    "<=1.0.0",
+    "0.1.0-alpha",
     slots::gcode_paths::v0::modify::GCodePathsModifyService::Stub,
     Validator,
     gcode_paths_modify_request,

--- a/include/plugins/validator.h
+++ b/include/plugins/validator.h
@@ -33,8 +33,8 @@ public:
      */
     Validator(const slot_metadata& slot_info, const plugin_metadata& plugin_info)
     {
-        auto slot_range = semver::range::detail::range(slot_info.version_range);
-        auto slot_version = semver::from_string(plugin_info.slot_version);
+        auto slot_range = semver::range::detail::range(plugin_info.slot_version_range);
+        auto slot_version = semver::from_string(slot_info.version);
         valid_ = slot_range.satisfies(slot_version, include_prerelease_);
     };
 

--- a/src/plugins/converters.cpp
+++ b/src/plugins/converters.cpp
@@ -70,7 +70,7 @@ handshake_request::value_type handshake_request::operator()(const std::string& n
 {
     value_type message{};
     message.set_slot_id(slot_info.slot_id);
-    message.set_version_range(slot_info.version_range.data());
+    message.set_version(slot_info.version.data());
     message.set_plugin_name(name);
     message.set_plugin_version(version);
     return message;
@@ -78,7 +78,7 @@ handshake_request::value_type handshake_request::operator()(const std::string& n
 
 handshake_response::native_value_type handshake_response::operator()(const handshake_response::value_type& message, std::string_view peer) const
 {
-    return { .slot_version = message.slot_version(),
+    return { .slot_version_range = message.slot_version_range(),
              .plugin_name = message.plugin_name(),
              .plugin_version = message.plugin_version(),
              .peer = std::string{ peer },


### PR DESCRIPTION
Not the other way around as we have now. This also adheres closer to the way we handle front-end plugins. Ideally you'd maybe want both of them to be ranges, but that's for the future.