### PR TITLE
[CURA-11084] Add missing 'perform_prime' member-variable.

### DIFF
--- a/src/plugins/converters.cpp
+++ b/src/plugins/converters.cpp
@@ -345,6 +345,7 @@ gcode_paths_modify_request::value_type
         gcode_path->set_retract(path.retract);
         gcode_path->set_unretract_before_last_travel_move(path.unretract_before_last_travel_move);
         gcode_path->set_perform_z_hop(path.perform_z_hop);
+        gcode_path->set_perform_prime(path.perform_prime);
         gcode_path->set_skip_agressive_merge_hint(path.skip_agressive_merge_hint);
         gcode_path->set_done(path.done);
         gcode_path->set_fan_speed(path.getFanSpeed());
@@ -458,6 +459,7 @@ gcode_paths_modify_response::native_value_type
             .retract = gcode_path_msg.retract(),
             .unretract_before_last_travel_move = gcode_path_msg.unretract_before_last_travel_move(),
             .perform_z_hop = gcode_path_msg.perform_z_hop(),
+            .perform_prime = gcode_path_msg.perform_prime(),
             .skip_agressive_merge_hint = gcode_path_msg.skip_agressive_merge_hint(),
             .done = gcode_path_msg.done(),
             .fan_speed = gcode_path_msg.fan_speed(),


### PR DESCRIPTION
Note that this needs the updated GRPC definitions as well! -- This caused that variable to always be (re)set to false, even when no plugin was present, due to the 'identity' conversion taking place. (Maybe we should stop that in general, since that implies that we copy the data even when no plugin is present.) In any case, even if it wouldn't have caused this particular bug, it's an oversight that should be fixed anyway.

See also: https://github.com/Ultimaker/CuraEngine_grpc_definitions/pull/13