### PR TITLE
the length of brim is correctly calculated in case of no adhesion

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3050,7 +3050,6 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
     }
     island_order_optimizer.optimize();
 
-    const auto support_brim_line_count = infill_extruder.settings.get<coord_t>("support_brim_line_count");
     const auto support_connect_zigzags = infill_extruder.settings.get<bool>("support_connect_zigzags");
     const auto support_structure = infill_extruder.settings.get<ESupportStructure>("support_structure");
     const Point infill_origin;

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -667,8 +667,8 @@ void SkirtBrim::generateSupportBrim()
         }
 
         storage.support_brim.add(brim_line);
-
-        const coord_t length = (adhesion_type == EPlatformAdhesion::NONE) ? skirt_brim_length : skirt_brim_length + storage.support_brim.polygonLength();
+        // In case of adhesion::NONE length of support brim is only the length of the brims formed for the support
+        const coord_t length = (adhesion_type == EPlatformAdhesion::NONE) ? skirt_brim_length: skirt_brim_length + storage.support_brim.polygonLength();
         if (skirt_brim_number + 1 >= line_count && length > 0 && length < minimal_length) // Make brim or skirt have more lines when total length is too small.
         {
             line_count++;

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -668,7 +668,7 @@ void SkirtBrim::generateSupportBrim()
 
         storage.support_brim.add(brim_line);
 
-        const coord_t length = skirt_brim_length + storage.support_brim.polygonLength();
+        const coord_t length = (adhesion_type == EPlatformAdhesion::NONE)? skirt_brim_length: skirt_brim_length + storage.support_brim.polygonLength();
         if (skirt_brim_number + 1 >= line_count && length > 0 && length < minimal_length) // Make brim or skirt have more lines when total length is too small.
         {
             line_count++;

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -668,7 +668,7 @@ void SkirtBrim::generateSupportBrim()
 
         storage.support_brim.add(brim_line);
 
-        const coord_t length = (adhesion_type == EPlatformAdhesion::NONE)? skirt_brim_length: skirt_brim_length + storage.support_brim.polygonLength();
+        const coord_t length = (adhesion_type == EPlatformAdhesion::NONE) ? skirt_brim_length : skirt_brim_length + storage.support_brim.polygonLength();
         if (skirt_brim_number + 1 >= line_count && length > 0 && length < minimal_length) // Make brim or skirt have more lines when total length is too small.
         {
             line_count++;

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -668,7 +668,7 @@ void SkirtBrim::generateSupportBrim()
 
         storage.support_brim.add(brim_line);
         // In case of adhesion::NONE length of support brim is only the length of the brims formed for the support
-        const coord_t length = (adhesion_type == EPlatformAdhesion::NONE) ? skirt_brim_length: skirt_brim_length + storage.support_brim.polygonLength();
+        const coord_t length = (adhesion_type == EPlatformAdhesion::NONE) ? skirt_brim_length : skirt_brim_length + storage.support_brim.polygonLength();
         if (skirt_brim_number + 1 >= line_count && length > 0 && length < minimal_length) // Make brim or skirt have more lines when total length is too small.
         {
             line_count++;


### PR DESCRIPTION
CURA-11097

Issue: This happens when Build-plate adhesion is set to None, but you still have the support brim enabled for Normal support.
![still_happens_in_other_model (1)](https://github.com/Ultimaker/CuraEngine/assets/70144862/78dfb7d4-919d-49c3-9c07-01279859e3aa)
