### PR TITLE
Fix prime tower when only raft has multi-material 

### DIFF
--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -103,7 +103,7 @@ void PrimeTower::generateGroundpoly()
 void PrimeTower::generatePaths(const SliceDataStorage& storage)
 {
     would_have_actual_tower
-        = storage.max_print_height_second_to_last_extruder >= 0; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
+        = storage.max_print_height_second_to_last_extruder >= -Raft::getTotalExtraLayers() + 1; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
     if (would_have_actual_tower && enabled)
     {
         generatePaths_denseInfill();

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -102,8 +102,9 @@ void PrimeTower::generateGroundpoly()
 
 void PrimeTower::generatePaths(const SliceDataStorage& storage)
 {
-    would_have_actual_tower = storage.max_print_height_second_to_last_extruder
-                           >= -Raft::getTotalExtraLayers() + 1; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
+    const int raft_total_extra_layers = Raft::getTotalExtraLayers();
+    would_have_actual_tower
+        = storage.max_print_height_second_to_last_extruder >= -raft_total_extra_layers + 1; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
     if (would_have_actual_tower && enabled)
     {
         generatePaths_denseInfill();

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -104,7 +104,7 @@ void PrimeTower::generatePaths(const SliceDataStorage& storage)
 {
     const int raft_total_extra_layers = Raft::getTotalExtraLayers();
     would_have_actual_tower = storage.max_print_height_second_to_last_extruder
-                           >= -raft_total_extra_layers + 1; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
+                           >= -raft_total_extra_layers; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
     if (would_have_actual_tower && enabled)
     {
         generatePaths_denseInfill();

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -103,8 +103,8 @@ void PrimeTower::generateGroundpoly()
 void PrimeTower::generatePaths(const SliceDataStorage& storage)
 {
     const int raft_total_extra_layers = Raft::getTotalExtraLayers();
-    would_have_actual_tower
-        = storage.max_print_height_second_to_last_extruder >= -raft_total_extra_layers + 1; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
+    would_have_actual_tower = storage.max_print_height_second_to_last_extruder
+                           >= -raft_total_extra_layers + 1; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
     if (would_have_actual_tower && enabled)
     {
         generatePaths_denseInfill();

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -102,8 +102,8 @@ void PrimeTower::generateGroundpoly()
 
 void PrimeTower::generatePaths(const SliceDataStorage& storage)
 {
-    would_have_actual_tower
-        = storage.max_print_height_second_to_last_extruder >= -Raft::getTotalExtraLayers() + 1; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
+    would_have_actual_tower = storage.max_print_height_second_to_last_extruder
+                           >= -Raft::getTotalExtraLayers() + 1; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.
     if (would_have_actual_tower && enabled)
     {
         generatePaths_denseInfill();


### PR DESCRIPTION
# Description

We didn't take into account that raft layers are negative

CURA-11291

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

🏃🏼‍♀️ running from sause

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change