### PR TITLE
Plugin gcode modify patches

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2415,9 +2415,9 @@ void LayerPlan::applyModifyPlugin()
                     if (path.points.front() != first_travel_destination)
                     {
                         first_travel_destination = path.points.front();
-                        first_travel_destination_is_inside = current_mesh->layers[layer_nr].getOutlines().inside(path.points.front());
                     }
                     handled_initial_travel = true;
+                    break;
                 }
             }
         }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1949,7 +1949,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
             // Fans need time to reach the new setting. Adjust fan speed as early as possible. If travel paths have a non default fan speed for some reason set it as fan speed.
             // As such modification could be made by a plugin.
-            if(!path.isTravelPath() || path.fan_speed < 0)
+            if(!path.isTravelPath() || path.fan_speed >= 0)
             {
                 const double path_fan_speed = path.getFanSpeed();
                 gcode.writeFanCommand(path_fan_speed != GCodePathConfig::FAN_SPEED_DEFAULT ? path_fan_speed : extruder_plan.getFanSpeed());

--- a/src/plugins/converters.cpp
+++ b/src/plugins/converters.cpp
@@ -49,12 +49,28 @@ broadcast_settings_request::value_type broadcast_settings_request::operator()(co
     }
 
     auto* object_settings = message.mutable_object_settings();
-    for (const auto& object : slice_message.object_lists())
+    for (const auto& mesh_group : slice_message.object_lists())
     {
-        auto* settings = object_settings->Add()->mutable_settings();
-        for (const auto& setting : object.settings())
+        std::unordered_map<std::string, std::string> mesh_group_settings;
+        for (const auto& setting : mesh_group.settings())
         {
-            settings->emplace(setting.name(), setting.value());
+            mesh_group_settings[setting.name()] = setting.value();
+        }
+        for (const auto& object : mesh_group.objects())
+        {
+            std::unordered_map<std::string, std::string> per_object_settings = mesh_group_settings;
+            for (const auto& setting : object.settings())
+            {
+                per_object_settings[setting.name()] = setting.value();
+            }
+
+            per_object_settings["mesh_name"] = object.name();
+
+            auto* settings = object_settings->Add()->mutable_settings();
+            for (const auto& key_value_pair : per_object_settings)
+            {
+                settings->emplace(key_value_pair.first, key_value_pair.second);
+            }
         }
     }
 


### PR DESCRIPTION
# Description

CuraEngine currently does not set per model settings to a the GcodePathModify slot. 
Also if fan speed is changed for travel paths, the changed fan speed will not be applied. 
This fixes both of these issues. 
Also it adds the a "mesh_name" setting to the per-model settings, so that the mesh can later be identified using its name.
To my knowledge the mesh name is unique as if the same model is added multiple times a counter is appended by the frontend (e.g. Example.stl and Example.stl(1) and so forth).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change