### PR TITLE
[CURA-11293] fix disallowed areas

### DIFF
--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -561,7 +561,8 @@ Polygons SliceDataStorage::getMachineBorder(int checking_extruder_nr) const
     Polygons disallowed_areas = mesh_group_settings.get<Polygons>("machine_disallowed_areas");
     disallowed_areas = disallowed_areas.unionPolygons(); // union overlapping disallowed areas
 
-    // The disallowed areas are always expressed in buildplate-centered coordinates
+    // The disallowed areas are expressed in buildplate-centered coordinates, but the models
+    // may be expressed in front-left-centered coordinantes, so in this case we need to translate them
     if (! mesh_group_settings.get<bool>("machine_center_is_zero"))
     {
         for (PolygonRef poly : disallowed_areas)

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -565,8 +565,12 @@ Polygons SliceDataStorage::getMachineBorder(int checking_extruder_nr) const
     if (! mesh_group_settings.get<bool>("machine_center_is_zero"))
     {
         for (PolygonRef poly : disallowed_areas)
+        {
             for (Point& p : poly)
+            {
                 p = Point(machine_size.max.x / 2 + p.X, machine_size.max.y / 2 - p.Y);
+            }
+        }
     }
 
     std::vector<bool> extruder_is_used = getExtrudersUsed();

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -560,9 +560,14 @@ Polygons SliceDataStorage::getMachineBorder(int checking_extruder_nr) const
 
     Polygons disallowed_areas = mesh_group_settings.get<Polygons>("machine_disallowed_areas");
     disallowed_areas = disallowed_areas.unionPolygons(); // union overlapping disallowed areas
-    for (PolygonRef poly : disallowed_areas)
-        for (Point& p : poly)
-            p = Point(machine_size.max.x / 2 + p.X, machine_size.max.y / 2 - p.Y); // apparently the frontend stores the disallowed areas in a different coordinate system
+
+    // The disallowed areas are always expressed in buildplate-centered coordinates
+    if (! mesh_group_settings.get<bool>("machine_center_is_zero"))
+    {
+        for (PolygonRef poly : disallowed_areas)
+            for (Point& p : poly)
+                p = Point(machine_size.max.x / 2 + p.X, machine_size.max.y / 2 - p.Y);
+    }
 
     std::vector<bool> extruder_is_used = getExtrudersUsed();
 


### PR DESCRIPTION
Machine disallowed areas dimensions are always expressed in zero-centered coordinates. However, the engine always converted them back to front-left-centered coordinates. But in cases where all the coordinates are expressed in zero-centered, is it not required to convert them, which leads to disallowed ared being shifted over the build plate.

CURA-11293