### PR TITLE
Cura 11099 nozzle switch duration

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -3,6 +3,13 @@
 
 #include "gcodeExport.h"
 
+#include <assert.h>
+#include <cmath>
+#include <iomanip>
+#include <stdarg.h>
+
+#include <spdlog/spdlog.h>
+
 #include "Application.h" //To send layer view data.
 #include "ExtruderTrain.h"
 #include "PrintFeature.h"
@@ -13,13 +20,6 @@
 #include "settings/types/LayerIndex.h"
 #include "utils/Date.h"
 #include "utils/string.h" // MMtoStream, PrecisionedDouble
-
-#include <spdlog/spdlog.h>
-
-#include <assert.h>
-#include <cmath>
-#include <iomanip>
-#include <stdarg.h>
 
 namespace cura
 {

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1254,8 +1254,8 @@ void GCodeExport::startExtruder(const size_t new_extruder)
     assert(getCurrentExtrudedVolume() == 0.0 && "Just after an extruder switch we haven't extruded anything yet!");
     resetExtrusionValue(); // zero the E value on the new extruder, just to be sure
 
-    const std::string start_code = Application::getInstance().current_slice->scene.extruders[new_extruder].settings.get<std::string>("machine_extruder_start_code");
-
+    const auto extruder_settings = Application::getInstance().current_slice->scene.extruders[new_extruder].settings;
+    const auto start_code = extruder_settings.get<std::string>("machine_extruder_start_code");
     if (! start_code.empty())
     {
         if (relative_extrusion)
@@ -1270,6 +1270,9 @@ void GCodeExport::startExtruder(const size_t new_extruder)
             writeExtrusionMode(true); // restore relative extrusion mode
         }
     }
+
+    const auto start_code_duration = extruder_settings.get<Duration>("machine_extruder_start_code_duration");
+    estimateCalculator.addTime(start_code_duration);
 
     Application::getInstance().communication->setExtruderForSend(Application::getInstance().current_slice->scene.extruders[new_extruder]);
     Application::getInstance().communication->sendCurrentPosition(getPositionXY());
@@ -1302,7 +1305,7 @@ void GCodeExport::switchExtruder(size_t new_extruder, const RetractionConfig& re
 
     resetExtrusionValue(); // zero the E value on the old extruder, so that the current_e_value is registered on the old extruder
 
-    const std::string end_code = old_extruder_settings.get<std::string>("machine_extruder_end_code");
+    const auto end_code = old_extruder_settings.get<std::string>("machine_extruder_end_code");
 
     if (! end_code.empty())
     {
@@ -1318,6 +1321,9 @@ void GCodeExport::switchExtruder(size_t new_extruder, const RetractionConfig& re
             writeExtrusionMode(true); // restore relative extrusion mode
         }
     }
+
+    const auto end_code_duration = old_extruder_settings.get<Duration>("machine_extruder_end_code_duration");
+    estimateCalculator.addTime(end_code_duration);
 
     startExtruder(new_extruder);
 }

--- a/tests/GCodeExportTest.cpp
+++ b/tests/GCodeExportTest.cpp
@@ -459,14 +459,21 @@ TEST_F(GCodeExportTest, SwitchExtruderSimple)
 
     scene.extruders.emplace_back(0, nullptr);
     ExtruderTrain& train1 = scene.extruders.back();
+
     train1.settings.add("machine_extruder_start_code", ";FIRST EXTRUDER START G-CODE!");
     train1.settings.add("machine_extruder_end_code", ";FIRST EXTRUDER END G-CODE!");
+    train1.settings.add("machine_extruder_start_code_duration", "0.0");
+    train1.settings.add("machine_extruder_end_code_duration", "0.0");
     train1.settings.add("machine_firmware_retract", "True");
     train1.settings.add("retraction_enable", "True");
+
     scene.extruders.emplace_back(1, nullptr);
     ExtruderTrain& train2 = scene.extruders.back();
+
     train2.settings.add("machine_extruder_start_code", ";SECOND EXTRUDER START G-CODE!");
     train2.settings.add("machine_extruder_end_code", ";SECOND EXTRUDER END G-CODE!");
+    train2.settings.add("machine_extruder_start_code_duration", "0.0");
+    train2.settings.add("machine_extruder_end_code_duration", "0.0");
     train2.settings.add("machine_firmware_retract", "True");
     train2.settings.add("retraction_enable", "True");
 


### PR DESCRIPTION
# Description

This PR adds the following settings
- Extruder start gcode duration
- Extruder end gcode duration
By entering a duration (expressed in seconds) for this setting the amount of time is added to the time estimation for a nozzle switch. This makes it possible to more accurately tune print time estimations, especially for printers that have longer nozzle switching sequences. Both these settings default to 0; if no value is entered no amount of time is added to the print time estimations.

![Screenshot 2023-11-13 at 10 49 49](https://github.com/Ultimaker/Cura/assets/6638028/6fe6206a-2573-4edc-add9-87712dc2a105)

Also see Cura PR: https://github.com/Ultimaker/Cura/pull/17301

CURA-11099

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Yas

**Test Configuration**:
* Operating System: MacOS 13

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
