### PR TITLE
Fix issue where part of raft was missing

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -929,9 +929,37 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             skip_some_zags,
             zag_skip_count,
             pocket_size);
+
         std::vector<VariableWidthLines> raft_paths; // Should remain empty, since we have no walls.
         infill_comp.generate(raft_paths, raft_polygons, raft_lines, surface_settings, layer_nr, SectionType::ADHESION);
-        gcode_layer.addLinesByOptimizer(raft_lines, gcode_layer.configs_storage.raft_surface_config, SpaceFillType::Lines, false, 0, 1.0, last_planned_position);
+
+        const auto wipe_dist = 0;
+        const auto spiralize = false;
+        const auto flow_ratio = 1.0_r;
+        const auto enable_travel_optimization = false;
+        const auto always_retract = false;
+        const auto reverse_order = false;
+
+        gcode_layer.addLinesByOptimizer(
+            raft_lines,
+            gcode_layer.configs_storage.raft_surface_config,
+            SpaceFillType::Lines,
+            enable_travel_optimization,
+            wipe_dist,
+            flow_ratio,
+            last_planned_position
+        );
+        gcode_layer.addPolygonsByOptimizer(
+            raft_polygons,
+            gcode_layer.configs_storage.raft_surface_config,
+            ZSeamConfig(),
+            wipe_dist,
+            spiralize,
+            flow_ratio,
+            always_retract,
+            reverse_order,
+            gcode_layer.getLastPlannedPositionOrStartingPosition()
+        );
 
         raft_polygons.clear();
         raft_lines.clear();

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -947,8 +947,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             enable_travel_optimization,
             wipe_dist,
             flow_ratio,
-            last_planned_position
-        );
+            last_planned_position);
         gcode_layer.addPolygonsByOptimizer(
             raft_polygons,
             gcode_layer.configs_storage.raft_surface_config,
@@ -958,8 +957,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             flow_ratio,
             always_retract,
             reverse_order,
-            gcode_layer.getLastPlannedPositionOrStartingPosition()
-        );
+            gcode_layer.getLastPlannedPositionOrStartingPosition());
 
         raft_polygons.clear();
         raft_lines.clear();


### PR DESCRIPTION
# Description

Due to the special shape of the polygon it is possible to “stitch” the polylines into a closed polygon loop. See svg’s below, first image is the input to the stitching algorithm and the second is the output of the stitching algorithm. The blue color denotes open polylines, and the red color denotes closed polygons.

![6after_simplify](https://github.com/Ultimaker/CuraEngine/assets/6638028/5cfa262a-a0f9-435b-988f-292a163155ba)
![6after_stitching](https://github.com/Ultimaker/CuraEngine/assets/6638028/83f57ee6-707f-408c-9d62-89ec383f1576)

As you can see in the output put polygon a closed loop was indeed found. However, in the code we always assumed that the output of “ZigZagged” infill never contained any closed polygon loops https://github.com/Ultimaker/CuraEngine/blob/main/src/FffGcodeWriter.cpp#L576, and thus these were never added.

CURA-11355

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

yassss

**Test Configuration**:
* Operating System: macOS

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change