### PR TITLE
CURA-11482 additional sentry info

### DIFF
--- a/Cura.proto
+++ b/Cura.proto
@@ -37,6 +37,8 @@ message Slice
     repeated Extruder extruders = 3; // The settings sent to each extruder object
     repeated SettingExtruder limit_to_extruder = 4; // From which stack the setting would inherit if not defined per object
     repeated EnginePlugin engine_plugins = 5;
+    string sentry_id = 6; // The anonymized Sentry user id that requested the slice
+    string cura_version = 7; // The version of Cura that requested the slice
 }
 
 message Extruder

--- a/include/communication/ArcusCommunication.h
+++ b/include/communication/ArcusCommunication.h
@@ -1,9 +1,13 @@
-//  Copyright (c) 2022 Ultimaker B.V.
-//  CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef ARCUSCOMMUNICATION_H
 #define ARCUSCOMMUNICATION_H
 #ifdef ARCUS
+
+#ifdef SENTRY_URL
+#include <sentry.h>
+#endif
 
 #ifdef BUILD_TESTS
 #include <gtest/gtest_prod.h>

--- a/include/communication/ArcusCommunication.h
+++ b/include/communication/ArcusCommunication.h
@@ -5,10 +5,6 @@
 #define ARCUSCOMMUNICATION_H
 #ifdef ARCUS
 
-#ifdef SENTRY_URL
-#include <sentry.h>
-#endif
-
 #ifdef BUILD_TESTS
 #include <gtest/gtest_prod.h>
 #endif

--- a/include/utils/sentry_sink.h
+++ b/include/utils/sentry_sink.h
@@ -17,7 +17,7 @@ protected:
     {
         sentry_value_t crumb = sentry_value_new_breadcrumb("debug", msg.payload.data());
         sentry_value_set_by_key(crumb, "category", sentry_value_new_string(msg.logger_name.data()));
-        sentry_value_set_by_key(crumb, "level", sentry_value_new_string(spdlog::level::to_short_c_str(msg.level)));
+        sentry_value_set_by_key(crumb, "level", sentry_value_new_string(spdlog::level::to_string_view(msg.level).data()));
 
         auto duration = msg.time.time_since_epoch();
         auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(duration).count();

--- a/include/utils/sentry_sink.h
+++ b/include/utils/sentry_sink.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
+
+#ifndef CURAENGINE_INCLUDE_UTILS_SENTRY_SINK_H
+#define CURAENGINE_INCLUDE_UTILS_SENTRY_SINK_H
+
+#include <sentry.h>
+
+#include <fmt/format.h>
+#include <spdlog/sinks/base_sink.h>
+
+template<typename Mutex>
+class SentryBreadcrumbSink : public spdlog::sinks::base_sink<Mutex>
+{
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        sentry_value_t crumb = sentry_value_new_breadcrumb("debug", msg.payload.data());
+        sentry_value_set_by_key(crumb, "category", sentry_value_new_string(msg.logger_name.data()));
+        sentry_value_set_by_key(crumb, "level", sentry_value_new_string(spdlog::level::to_short_c_str(msg.level)));
+
+        auto duration = msg.time.time_since_epoch();
+        auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(duration).count();
+        sentry_value_set_by_key(crumb, "timestamp", sentry_value_new_int32(timestamp));
+
+        sentry_add_breadcrumb(crumb);
+    }
+    void flush_() override
+    {
+        // The sink doesn't buffer or cache anything, so there's nothing to flush
+    }
+};
+
+// Convenience typedefs
+using SentryBreadcrumbSink_mt = SentryBreadcrumbSink<std::mutex>;
+using SentryBreadcrumbSink_st = SentryBreadcrumbSink<spdlog::details::null_mutex>;
+
+#endif // CURAENGINE_INCLUDE_UTILS_SENTRY_SINK_H

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -24,6 +24,9 @@
 #include "plugins/slots.h"
 #include "progress/Progress.h"
 #include "utils/ThreadPool.h"
+#ifdef SENTRY_URL
+#include "utils/sentry_sink.h"
+#endif
 #include "utils/string.h" //For stringcasecompare.
 
 namespace cura
@@ -35,6 +38,11 @@ Application::Application()
     auto dup_sink = std::make_shared<spdlog::sinks::dup_filter_sink_mt>(std::chrono::seconds{ 10 });
     auto base_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
     dup_sink->add_sink(base_sink);
+
+#ifdef SENTRY_URL
+    auto sentry_sink = std::make_shared<SentryBreadcrumbSink_mt>();
+    dup_sink->add_sink(sentry_sink);
+#endif
 
     spdlog::default_logger()->sinks()
         = std::vector<std::shared_ptr<spdlog::sinks::sink>>{ dup_sink }; // replace default_logger sinks with the duplicating filtering sink to avoid spamming

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -10,8 +10,8 @@
 
 #include <Arcus/Socket.h> //The socket to communicate to.
 #include <fmt/format.h>
-#include <spdlog/spdlog.h>
 #include <spdlog/details/os.h>
+#include <spdlog/spdlog.h>
 
 #include "Application.h" //To get and set the current slice command.
 #include "ExtruderTrain.h"

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -5,6 +5,18 @@
 
 #include "communication/ArcusCommunication.h"
 
+#ifdef SENTRY_URL
+#ifdef _WIN32
+#if ! defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#if ! defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#endif
+#include <sentry.h>
+#endif
+
 #include <thread> //To sleep while waiting for the connection.
 #include <unordered_map> //To map settings to their extruder numbers for limit_to_extruder.
 

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -548,7 +548,7 @@ void ArcusCommunication::sliceNext()
         const auto slot_id = static_cast<plugins::v0::SlotID>(plugin.id());
         slots::instance().connect(slot_id, plugin.plugin_name(), plugin.plugin_version(), utils::createChannel({ plugin.address(), plugin.port() }));
 #ifdef SENTRY_URL
-        sentry_set_tag(fmt::format("engine_plugin.{}", plugin.plugin_name()).c_str(), plugin.plugin_version().c_str());
+      sentry_set_tag(fmt::format("plugin_{}.version", plugin.plugin_name()).c_str(), plugin.plugin_version().c_str());
 #endif
     }
 #endif // ENABLE_PLUGINS

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -548,7 +548,7 @@ void ArcusCommunication::sliceNext()
         const auto slot_id = static_cast<plugins::v0::SlotID>(plugin.id());
         slots::instance().connect(slot_id, plugin.plugin_name(), plugin.plugin_version(), utils::createChannel({ plugin.address(), plugin.port() }));
 #ifdef SENTRY_URL
-      sentry_set_tag(fmt::format("plugin_{}.version", plugin.plugin_name()).c_str(), plugin.plugin_version().c_str());
+        sentry_set_tag(fmt::format("plugin_{}.version", plugin.plugin_name()).c_str(), plugin.plugin_version().c_str());
 #endif
     }
 #endif // ENABLE_PLUGINS

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -547,6 +547,9 @@ void ArcusCommunication::sliceNext()
     {
         const auto slot_id = static_cast<plugins::v0::SlotID>(plugin.id());
         slots::instance().connect(slot_id, plugin.plugin_name(), plugin.plugin_version(), utils::createChannel({ plugin.address(), plugin.port() }));
+#ifdef SENTRY_URL
+      sentry_set_tag(fmt::format("engine_plugin.{}", plugin.plugin_name()).c_str(), plugin.plugin_version().c_str());
+#endif
     }
 #endif // ENABLE_PLUGINS
 

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -548,7 +548,7 @@ void ArcusCommunication::sliceNext()
         const auto slot_id = static_cast<plugins::v0::SlotID>(plugin.id());
         slots::instance().connect(slot_id, plugin.plugin_name(), plugin.plugin_version(), utils::createChannel({ plugin.address(), plugin.port() }));
 #ifdef SENTRY_URL
-      sentry_set_tag(fmt::format("engine_plugin.{}", plugin.plugin_name()).c_str(), plugin.plugin_version().c_str());
+        sentry_set_tag(fmt::format("engine_plugin.{}", plugin.plugin_name()).c_str(), plugin.plugin_version().c_str());
 #endif
     }
 #endif // ENABLE_PLUGINS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,18 +87,6 @@ int main(int argc, char** argv)
         sentry_options_set_release(options, fmt::format("curaengine@{}", cura_engine_version).c_str());
         sentry_init(options);
 
-        // Set the presumed Cura version as a Sentry tag (this is unknown at the time of compiling
-        auto prerelease = version.prerelease_type == semver::prerelease::none
-                            ? ""
-                            : fmt::format("-{}.{}", version.prerelease_type == semver::prerelease::alpha ? "alpha" : "beta", version.prerelease_number);
-        sentry_set_tag("cura.version", fmt::format("{}.{}.{}{}", version.major, version.minor, version.patch, prerelease).c_str());
-
-        if (const auto sentry_user = spdlog::details::os::getenv("CURAENGINE_SENTRY_USER"); ! sentry_user.empty())
-        {
-            sentry_value_t user = sentry_value_new_object();
-            sentry_value_set_by_key(user, "email", sentry_value_new_string(sentry_user.c_str()));
-            sentry_set_user(user);
-        }
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,11 +11,11 @@
 #include <filesystem>
 #include <semver.hpp>
 #include <sentry.h>
-#include <spdlog/details/os.h>
 #include <string>
 
 #include <range/v3/algorithm/contains.hpp>
 #include <range/v3/range/conversion.hpp>
+#include <spdlog/details/os.h>
 
 #include "utils/format/filesystem_path.h"
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,6 @@ int main(int argc, char** argv)
         // Set the actual CuraEngine version
         sentry_options_set_release(options, fmt::format("curaengine@{}", cura_engine_version).c_str());
         sentry_init(options);
-
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,14 @@
 #endif
 
 #ifdef SENTRY_URL
+#ifdef _WIN32
+#if ! defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#if ! defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#endif
 #include <filesystem>
 #include <semver.hpp>
 #include <sentry.h>


### PR DESCRIPTION
# Description

Coupled the anonymized Cura id with the same id in CuraEngine Sentry, allowing us to determine the general health of the engine.

Allow for tracking of internal QA users by settings the environmental variable `CURAENGINE_SENTRY_USER=pietje.puk@ultimaker.com`

You can then filter issues in Sentry using the `user.email:pietje.puk@ultimaker.com` this allows you to quickly identify the crash that occurred during QA. It is recommended to make this environmental variable persistent, since all crashes from builds are after all logged.

Send over additional log info as breadcrumbs.
![Screenshot_20231215_164651](https://github.com/Ultimaker/CuraEngine/assets/8535734/c843c53f-6982-4aee-978b-a1204aa787f2)

Add the tag `plugin_<specific_engine_plugin_name>.version` such that we can also track if an engine plugin is being used and which version might give us trouble

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] from source
- [X] from build

**Test Configuration**:
* Operating System: Linux

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change