### PR TITLE
Improve slice performance of wall ordering

### DIFF
--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -72,7 +72,7 @@ public:
      *
      * \param outer_to_inner Whether the wall polygons with a lower inset_idx should go before those with a higher one.
      */
-    static value_type getRegionOrder(const auto& input, const bool outer_to_inner);
+    static value_type getRegionOrder(const std::vector<ExtrusionLine>& input, const bool outer_to_inner);
 
     /*!
      * Get the order constraints of the insets when printing walls per inset.

--- a/include/utils/ExtrusionLine.h
+++ b/include/utils/ExtrusionLine.h
@@ -7,10 +7,6 @@
 
 #include <range/v3/view/sliding.hpp>
 #include <range/v3/view/reverse.hpp>
-//#include <range/v3/view/take.hpp>
-//#include <range/v3/view/take_last.hpp>
-//#include <range/v3/view/drop.hpp>
-//#include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/enumerate.hpp>
 
 #include "ExtrusionJunction.h"

--- a/include/utils/ExtrusionLine.h
+++ b/include/utils/ExtrusionLine.h
@@ -7,10 +7,6 @@
 
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/sliding.hpp>
-//#include <range/v3/view/take.hpp>
-//#include <range/v3/view/take_last.hpp>
-//#include <range/v3/view/drop.hpp>
-//#include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/enumerate.hpp>
 
 #include "ExtrusionJunction.h"

--- a/include/utils/ExtrusionLine.h
+++ b/include/utils/ExtrusionLine.h
@@ -239,8 +239,6 @@ struct ExtrusionLine
 
         const auto add_line_direction = [&poly](const auto iterator)
         {
-            const auto window = iterator | ranges::views::sliding(2);
-
             for (const auto& element : iterator | ranges::views::sliding(2))
             {
                 const ExtrusionJunction& j1 = element[0];

--- a/include/utils/ExtrusionLine.h
+++ b/include/utils/ExtrusionLine.h
@@ -5,9 +5,9 @@
 #ifndef UTILS_EXTRUSION_LINE_H
 #define UTILS_EXTRUSION_LINE_H
 
+#include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/sliding.hpp>
-#include <range/v3/view/enumerate.hpp>
 
 #include "ExtrusionJunction.h"
 #include "polygon.h"

--- a/include/utils/ExtrusionLine.h
+++ b/include/utils/ExtrusionLine.h
@@ -230,9 +230,8 @@ struct ExtrusionLine
     }
 
     /*!
-     * Create a true-extrosion area polygo
-     *
-     * When this path is not closed the returned Polygon should be handled as a polyline, rather than a polygon.
+     * Create a true-extrusion area shape for the path; this means that each junction follows the bead-width
+     * set for that junction.
      */
     Polygons toExtrusionPolygons() const
     {

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -187,7 +187,7 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const auto& 
         std::vector<LineLoc*> erase;
         for (const auto& root : roots)
         {
-            if (root->poly.inside(locator->poly))
+            if (root->poly.inside(locator->poly[0], false))
             {
                 // The root polygon is inside the location polygon. It is no longer a root in the graph we are building.
                 // Add this relationship (locator <-> root) to the graph, and remove root from roots.

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -171,7 +171,7 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const std::v
                    {
                        return std::get<0>(pair);
                    })
-                | ranges::to_vector;
+             | ranges::to_vector;
     }();
 
     // graph will contain the parent-child relationships between the extrusion lines

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -170,7 +170,8 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const std::v
                    [](const auto& pair)
                    {
                        return std::get<0>(pair);
-                   });
+                   })
+                | ranges::to_vector;
     }();
 
     // graph will contain the parent-child relationships between the extrusion lines

--- a/tests/WallsComputationTest.cpp
+++ b/tests/WallsComputationTest.cpp
@@ -212,13 +212,6 @@ TEST_F(WallsComputationTest, WallToolPathsGetWeakOrder)
         }
     }
     EXPECT_GT(order.size(), 0) << "There should be ordered pairs!";
-    std::unordered_set<const ExtrusionLine*> has_order_info(part.wall_toolpaths.size());
-    for (auto [from, to] : order)
-    {
-        has_order_info.emplace(from);
-        has_order_info.emplace(to);
-    }
-    EXPECT_EQ(has_order_info.size(), n_paths) << "Every path should have order information.";
 }
 
 } // namespace cura


### PR DESCRIPTION
Main performance improvement was done here: https://github.com/Ultimaker/CuraEngine/pull/2001/commits/afab09646ac0f97d8cb4542e4bb6c4e15c30d6e4. From commit message why this improves tihngs:
> Quick optimization we could make; we were checking if one polygon was the child of another polygon. We were doing this for contour parallel tool paths. These tool paths have one property we can exploit, the polygons are never intersecting. A logical consequence from this property is that if one point of the child polygon is inside the parent polygon then all points are inside.
> 
> The child-parent check is simplified by chekcing a single point.

Other commit(s) simplified the code and resolved some remaining bugs

CURA-11352