### PR TITLE
Fix hole expansion

### DIFF
--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -145,7 +145,7 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const std::v
     }
 
     // view on the extrusion lines, sorted by area
-    const auto sorted_extrusion_lines = [&extrusion_lines]()
+    const std::vector<const ExtrusionLine*> sorted_extrusion_lines = [&extrusion_lines]()
     {
         auto extrusion_lines_area = extrusion_lines | ranges::views::addressof
                                   | ranges::views::transform(
@@ -195,7 +195,7 @@ InsetOrderOptimizer::value_type InsetOrderOptimizer::getRegionOrder(const std::v
             }
         }
         // increase the size of the hole polygons by 10um to make sure we don't miss any invariant parents
-        hole_polygons.offset(10);
+        hole_polygons = hole_polygons.offset(10);
 
         // go through all the invariant parents and see if they are inside the hole polygon
         // if they are, then that means we have found a child for this extrusion line


### PR DESCRIPTION
As we were only taking the very inner contour of the true extrusion polygon. There was code that would increase this area a bit, but it wasn't properly implemented, so for certain cases we would miss parent child relationships.

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change