### PR TITLE
Fix some convex hull related issues

### DIFF
--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -134,8 +134,8 @@ void Polygons::makeConvex()
 
                 if (LinearAlg2D::pointIsLeftOfLine(current, convexified.path->back(), after) < 0)
                 {
-                    //Track backwards to make sure we haven't been in a concave pocket for multiple vertices already.
-                    while(convexified.size() >= 2 && LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], current) > 0)
+                    // Track backwards to make sure we haven't been in a concave pocket for multiple vertices already.
+                    while (convexified.size() >= 2 && LinearAlg2D::pointIsLeftOfLine(convexified.path->back(), (*convexified.path)[convexified.size() - 2], current) > 0)
                     {
                         convexified.path->pop_back();
                     }
@@ -144,7 +144,13 @@ void Polygons::makeConvex()
             }
         };
 
-        std::sort(poly.begin(), poly.end(), [](Point2LL a, Point2LL b) { return a.X == b.X ? a.Y < b.Y : a.X < b.X; });
+        std::sort(
+            poly.begin(),
+            poly.end(),
+            [](Point2LL a, Point2LL b)
+            {
+                return a.X == b.X ? a.Y < b.Y : a.X < b.X;
+            });
         makeSortedPolyConvex(poly);
         std::reverse(poly.begin(), poly.end());
         makeSortedPolyConvex(poly);


### PR DESCRIPTION
# Description

Previously we tried to be cheeky and cut some corners by implementing “Andrew’s Monotone Chain Convex Hull Algorithm” without sorting points. However, turns out we need to sort as we did run into some edge cases where this wouldn't work.

CURA-11395

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

yes

**Test Configuration**:
* Operating System: MacOS 13.3

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change