### PR TITLE
Re implement wall roofing

### DIFF
--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Ultimaker B.V.
+// Copyright (c) 2024 Ultimaker B.V.
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef INSET_ORDER_OPTIMIZER_H
@@ -45,6 +45,8 @@ public:
         const int extruder_nr,
         const GCodePathConfig& inset_0_non_bridge_config,
         const GCodePathConfig& inset_X_non_bridge_config,
+        const GCodePathConfig& inset_0_roofing_config,
+        const GCodePathConfig& inset_X_roofing_config,
         const GCodePathConfig& inset_0_bridge_config,
         const GCodePathConfig& inset_X_bridge_config,
         const bool retract_before_outer_wall,
@@ -92,6 +94,8 @@ private:
     const size_t extruder_nr_;
     const GCodePathConfig& inset_0_non_bridge_config_;
     const GCodePathConfig& inset_X_non_bridge_config_;
+    const GCodePathConfig& inset_0_roofing_config_;
+    const GCodePathConfig& inset_X_roofing_config_;
     const GCodePathConfig& inset_0_bridge_config_;
     const GCodePathConfig& inset_X_bridge_config_;
     const bool retract_before_outer_wall_;

--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -43,8 +43,8 @@ public:
         LayerPlan& gcode_layer,
         const Settings& settings,
         const int extruder_nr,
-        const GCodePathConfig& inset_0_non_bridge_config,
-        const GCodePathConfig& inset_X_non_bridge_config,
+        const GCodePathConfig& inset_0_default_config,
+        const GCodePathConfig& inset_X_default_config,
         const GCodePathConfig& inset_0_roofing_config,
         const GCodePathConfig& inset_X_roofing_config,
         const GCodePathConfig& inset_0_bridge_config,
@@ -92,8 +92,8 @@ private:
     LayerPlan& gcode_layer_;
     const Settings& settings_;
     const size_t extruder_nr_;
-    const GCodePathConfig& inset_0_non_bridge_config_;
-    const GCodePathConfig& inset_X_non_bridge_config_;
+    const GCodePathConfig& inset_0_default_config_;
+    const GCodePathConfig& inset_X_default_config_;
     const GCodePathConfig& inset_0_roofing_config_;
     const GCodePathConfig& inset_X_roofing_config_;
     const GCodePathConfig& inset_0_bridge_config_;

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -403,7 +403,7 @@ public:
      * \param p1 The end vertex of the line.
      * \param settings The settings which should apply to this line added to the
      * layer plan.
-     * \param non_bridge_config The config with which to print the wall lines
+     * \param default_config The config with which to print the wall lines
      * that are not spanning a bridge.
      * \param bridge_config The config with which to print the wall lines that
      * are spanning a bridge.
@@ -421,7 +421,7 @@ public:
         const Point2LL& p0,
         const Point2LL& p1,
         const Settings& settings,
-        const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& default_config,
         const GCodePathConfig& roofing_config,
         const GCodePathConfig& bridge_config,
         double flow,
@@ -435,7 +435,7 @@ public:
      * \param wall The vertices of the wall to add.
      * \param start_idx The index of the starting vertex to start at.
      * \param settings The settings which should apply to this wall added to the layer plan.
-     * \param non_bridge_config The config with which to print the wall lines
+     * \param default_config The config with which to print the wall lines
      * that are not spanning a bridge.
      * \param bridge_config The config with which to print the wall lines that
      * are spanning a bridge.
@@ -449,7 +449,7 @@ public:
         ConstPolygonRef wall,
         int start_idx,
         const Settings& settings,
-        const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& default_config,
         const GCodePathConfig& roofing_config,
         const GCodePathConfig& bridge_config,
         coord_t wall_0_wipe_dist,
@@ -461,7 +461,7 @@ public:
      * \param wall The wall of type ExtrusionJunctions
      * \param start_idx The index of the starting vertex to start at.
      * \param mesh The current mesh being added to the layer plan.
-     * \param non_bridge_config The config with which to print the wall lines
+     * \param default_config The config with which to print the wall lines
      * that are not spanning a bridge.
      * \param bridge_config The config with which to print the wall lines that
      * are spanning a bridge
@@ -479,7 +479,7 @@ public:
         const ExtrusionLine& wall,
         int start_idx,
         const Settings& settings,
-        const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& default_config,
         const GCodePathConfig& roofing_config,
         const GCodePathConfig& bridge_config,
         coord_t wall_0_wipe_dist,
@@ -501,7 +501,7 @@ public:
      * Add walls (polygons) to the gcode with optimized order.
      * \param walls The walls
      * \param settings The settings which should apply to these walls added to the layer plan.
-     * \param non_bridge_config The config with which to print the wall lines that are not spanning a bridge
+     * \param default_config The config with which to print the wall lines that are not spanning a bridge
      * \param bridge_config The config with which to print the wall lines that are spanning a bridge
      * \param z_seam_config Optional configuration for z-seam
      * \param wall_0_wipe_dist The distance to travel along each wall after it has been laid down, in order to wipe the start and end of the wall together
@@ -512,7 +512,7 @@ public:
     void addWalls(
         const Polygons& walls,
         const Settings& settings,
-        const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& default_config,
         const GCodePathConfig& roofing_config,
         const GCodePathConfig& bridge_config,
         const ZSeamConfig& z_seam_config = ZSeamConfig(),

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 UltiMaker
+// Copyright (c) 2024 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #ifndef LAYER_PLAN_H
@@ -96,6 +96,7 @@ private:
     coord_t comb_move_inside_distance_; //!< Whenever using the minimum boundary for combing it tries to move the coordinates inside by this distance after calculating the combing.
     Polygons bridge_wall_mask_; //!< The regions of a layer part that are not supported, used for bridging
     Polygons overhang_mask_; //!< The regions of a layer part where the walls overhang
+    Polygons roofing_mask_; //!< The regions of a layer part where the walls are exposed to the air
 
     const std::vector<FanSpeedLayerTimeSettings> fan_speed_layer_time_settings_per_extruder_;
 
@@ -258,6 +259,13 @@ public:
     void setOverhangMask(const Polygons& polys);
 
     /*!
+     * Set roofing_mask.
+     *
+     * \param polys The areas of the part currently being processed that will require roofing.
+     */
+    void setRoofingMask(const Polygons& polys);
+
+    /*!
      * Travel to a certain point, with all of the procedures necessary to do so.
      *
      * Additional procedures here are:
@@ -414,6 +422,7 @@ public:
         const Point2LL& p1,
         const Settings& settings,
         const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& roofing_config,
         const GCodePathConfig& bridge_config,
         double flow,
         const Ratio width_factor,
@@ -441,6 +450,7 @@ public:
         int start_idx,
         const Settings& settings,
         const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& roofing_config,
         const GCodePathConfig& bridge_config,
         coord_t wall_0_wipe_dist,
         double flow_ratio,
@@ -470,6 +480,7 @@ public:
         int start_idx,
         const Settings& settings,
         const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& roofing_config,
         const GCodePathConfig& bridge_config,
         coord_t wall_0_wipe_dist,
         double flow_ratio,
@@ -502,6 +513,7 @@ public:
         const Polygons& walls,
         const Settings& settings,
         const GCodePathConfig& non_bridge_config,
+        const GCodePathConfig& roofing_config,
         const GCodePathConfig& bridge_config,
         const ZSeamConfig& z_seam_config = ZSeamConfig(),
         coord_t wall_0_wipe_dist = 0,
@@ -625,7 +637,7 @@ public:
             return start_idx;
         }
 
-        Polygons air_below(bridge_wall_mask_.unionPolygons(overhang_mask_));
+        const auto air_below = bridge_wall_mask_.unionPolygons(overhang_mask_);
 
         unsigned curr_idx = start_idx;
 

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -404,7 +404,9 @@ public:
      * \param settings The settings which should apply to this line added to the
      * layer plan.
      * \param default_config The config with which to print the wall lines
-     * that are not spanning a bridge.
+     * that are not spanning a bridge or are exposed to air.
+     * \param roofing_config The config with which to print the wall lines
+     * that are exposed to air.
      * \param bridge_config The config with which to print the wall lines that
      * are spanning a bridge.
      * \param flow The ratio with which to multiply the extrusion amount.
@@ -436,9 +438,9 @@ public:
      * \param start_idx The index of the starting vertex to start at.
      * \param settings The settings which should apply to this wall added to the layer plan.
      * \param default_config The config with which to print the wall lines
-     * that are not spanning a bridge.
-     * \param bridge_config The config with which to print the wall lines that
-     * are spanning a bridge.
+     * that are not spanning a bridge or are exposed to air.
+     * \param roofing_config The config with which to print the wall lines
+     * that are exposed to air.
      * \param wall_0_wipe_dist The distance to travel along the wall after it
      * has been laid down, in order to wipe the start and end of the wall
      * \param flow_ratio The ratio with which to multiply the extrusion amount.
@@ -462,7 +464,9 @@ public:
      * \param start_idx The index of the starting vertex to start at.
      * \param mesh The current mesh being added to the layer plan.
      * \param default_config The config with which to print the wall lines
-     * that are not spanning a bridge.
+     * that are not spanning a bridge or are exposed to air.
+     * \param roofing_config The config with which to print the wall lines
+     * that are exposed to air.
      * \param bridge_config The config with which to print the wall lines that
      * are spanning a bridge
      * \param wall_0_wipe_dist The distance to travel along the wall after it
@@ -501,7 +505,10 @@ public:
      * Add walls (polygons) to the gcode with optimized order.
      * \param walls The walls
      * \param settings The settings which should apply to these walls added to the layer plan.
-     * \param default_config The config with which to print the wall lines that are not spanning a bridge
+     * \param default_config The config with which to print the wall lines
+     * that are not spanning a bridge or are exposed to air.
+     * \param roofing_config The config with which to print the wall lines
+     * that are exposed to air.
      * \param bridge_config The config with which to print the wall lines that are spanning a bridge
      * \param z_seam_config Optional configuration for z-seam
      * \param wall_0_wipe_dist The distance to travel along each wall after it has been laid down, in order to wipe the start and end of the wall together

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2613,7 +2613,7 @@ bool FffGcodeWriter::processInsets(
                     roofing_mask.add(layer_part.outline);
                 }
             }
-            return roofing_mask.offset(100);
+            return roofing_mask;
         }();
 
         gcode_layer.setRoofingMask(roofing_mask);

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -38,8 +38,8 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     LayerPlan& gcode_layer,
     const Settings& settings,
     const int extruder_nr,
-    const GCodePathConfig& inset_0_non_bridge_config,
-    const GCodePathConfig& inset_X_non_bridge_config,
+    const GCodePathConfig& inset_0_default_config,
+    const GCodePathConfig& inset_X_default_config,
     const GCodePathConfig& inset_0_roofing_config,
     const GCodePathConfig& inset_X_roofing_config,
     const GCodePathConfig& inset_0_bridge_config,
@@ -56,8 +56,8 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     , gcode_layer_(gcode_layer)
     , settings_(settings)
     , extruder_nr_(extruder_nr)
-    , inset_0_non_bridge_config_(inset_0_non_bridge_config)
-    , inset_X_non_bridge_config_(inset_X_non_bridge_config)
+    , inset_0_default_config_(inset_0_default_config)
+    , inset_X_default_config_(inset_X_default_config)
     , inset_0_roofing_config_(inset_0_roofing_config)
     , inset_X_roofing_config_(inset_X_roofing_config)
     , inset_0_bridge_config_(inset_0_bridge_config)
@@ -124,7 +124,7 @@ bool InsetOrderOptimizer::addToLayer()
 
         const bool is_outer_wall = path.vertices_->inset_idx_ == 0; // or thin wall 'gap filler'
         const bool is_gap_filler = path.vertices_->is_odd_;
-        const GCodePathConfig& non_bridge_config = is_outer_wall ? inset_0_non_bridge_config_ : inset_X_non_bridge_config_;
+        const GCodePathConfig& default_config = is_outer_wall ? inset_0_default_config_ : inset_X_default_config_;
         const GCodePathConfig& roofing_config = is_outer_wall ? inset_0_roofing_config_ : inset_X_roofing_config_;
         const GCodePathConfig& bridge_config = is_outer_wall ? inset_0_bridge_config_ : inset_X_bridge_config_;
         const coord_t wipe_dist = is_outer_wall && ! is_gap_filler ? wall_0_wipe_dist_ : wall_x_wipe_dist_;
@@ -137,7 +137,7 @@ bool InsetOrderOptimizer::addToLayer()
         const bool linked_path = ! path.is_closed_;
 
         gcode_layer_.setIsInside(true); // Going to print walls, which are always inside.
-        gcode_layer_.addWall(*path.vertices_, start_index, settings_, non_bridge_config, roofing_config, bridge_config, wipe_dist, flow, retract_before, path.is_closed_, backwards, linked_path);
+        gcode_layer_.addWall(*path.vertices_, start_index, settings_, default_config, roofing_config, bridge_config, wipe_dist, flow, retract_before, path.is_closed_, backwards, linked_path);
         added_something = true;
     }
     return added_something;

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 UltiMaker
+// Copyright (c) 2024 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "InsetOrderOptimizer.h"
@@ -40,6 +40,8 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     const int extruder_nr,
     const GCodePathConfig& inset_0_non_bridge_config,
     const GCodePathConfig& inset_X_non_bridge_config,
+    const GCodePathConfig& inset_0_roofing_config,
+    const GCodePathConfig& inset_X_roofing_config,
     const GCodePathConfig& inset_0_bridge_config,
     const GCodePathConfig& inset_X_bridge_config,
     const bool retract_before_outer_wall,
@@ -56,6 +58,8 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     , extruder_nr_(extruder_nr)
     , inset_0_non_bridge_config_(inset_0_non_bridge_config)
     , inset_X_non_bridge_config_(inset_X_non_bridge_config)
+    , inset_0_roofing_config_(inset_0_roofing_config)
+    , inset_X_roofing_config_(inset_X_roofing_config)
     , inset_0_bridge_config_(inset_0_bridge_config)
     , inset_X_bridge_config_(inset_X_bridge_config)
     , retract_before_outer_wall_(retract_before_outer_wall)
@@ -114,23 +118,26 @@ bool InsetOrderOptimizer::addToLayer()
     for (const PathOrdering<const ExtrusionLine*>& path : order_optimizer.paths_)
     {
         if (path.vertices_->empty())
+        {
             continue;
+        }
 
         const bool is_outer_wall = path.vertices_->inset_idx_ == 0; // or thin wall 'gap filler'
         const bool is_gap_filler = path.vertices_->is_odd_;
         const GCodePathConfig& non_bridge_config = is_outer_wall ? inset_0_non_bridge_config_ : inset_X_non_bridge_config_;
+        const GCodePathConfig& roofing_config = is_outer_wall ? inset_0_roofing_config_ : inset_X_roofing_config_;
         const GCodePathConfig& bridge_config = is_outer_wall ? inset_0_bridge_config_ : inset_X_bridge_config_;
         const coord_t wipe_dist = is_outer_wall && ! is_gap_filler ? wall_0_wipe_dist_ : wall_x_wipe_dist_;
         const bool retract_before = is_outer_wall ? retract_before_outer_wall_ : false;
 
-        const bool revert_inset = alternate_walls && (path.vertices_->inset_idx_ % 2);
-        const bool revert_layer = alternate_walls && (layer_nr_ % 2);
+        const bool revert_inset = alternate_walls && (path.vertices_->inset_idx_ % 2 != 0);
+        const bool revert_layer = alternate_walls && (layer_nr_ % 2 != 0);
         const bool backwards = path.backwards_ != (revert_inset != revert_layer);
         const size_t start_index = (backwards != path.backwards_) ? path.vertices_->size() - (path.start_vertex_ + 1) : path.start_vertex_;
         const bool linked_path = ! path.is_closed_;
 
         gcode_layer_.setIsInside(true); // Going to print walls, which are always inside.
-        gcode_layer_.addWall(*path.vertices_, start_index, settings_, non_bridge_config, bridge_config, wipe_dist, flow, retract_before, path.is_closed_, backwards, linked_path);
+        gcode_layer_.addWall(*path.vertices_, start_index, settings_, non_bridge_config, roofing_config, bridge_config, wipe_dist, flow, retract_before, path.is_closed_, backwards, linked_path);
         added_something = true;
     }
     return added_something;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -767,7 +767,7 @@ void LayerPlan::addWallLine(
     {
         if (roofing_config == default_config)
         {
-            // if the roofing config and normal config are the same any way there is no need to check 
+            // if the roofing config and normal config are the same any way there is no need to check
             // what part of the line segment will be printed with what config.
             return false;
         }

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -642,6 +642,8 @@ void LayerPlan::addPolygonsByOptimizer(
 
 static constexpr double max_non_bridge_line_volume = MM2INT(100); // limit to accumulated "volume" of non-bridge lines which is proportional to distance x extrusion rate
 
+static int i = 0;
+
 void LayerPlan::addWallLine(
     const Point2LL& p0,
     const Point2LL& p1,
@@ -773,14 +775,54 @@ void LayerPlan::addWallLine(
 
     if (use_roofing_config)
     {
-        addExtrusionMove(
-            p1,
-            roofing_config,
-            SpaceFillType::Polygons,
-            flow,
-            width_factor,
-            spiralize,
-            1.0_r);
+        // The line segment is wholly or partially in the roofing area. The line is intersected
+        // with the roofing area into line segments. Each line segment left in this intersection
+        // will be printed using the roofing config, all removed segments will be printed using
+        // the non_bridge_config. Since the original line segment was straight we can simply print
+        // to the first and last point of the intersected line segments alternating between
+        // roofing and non_bridge_config's.
+        Polygons line_polys;
+        line_polys.addLine(p0, p1);
+        constexpr bool restitch = false; // only a single line doesn't need stitching
+        auto has_area_above_poly_lines = roofing_mask_.intersectionPolyLines(line_polys, restitch);
+
+        if (has_area_above_poly_lines.empty())
+        {
+            addExtrusionMove(p1, roofing_config, SpaceFillType::Polygons, flow, width_factor, spiralize, 1.0_r);
+        }
+        else
+        {
+            // reorder all the line segments so all lines start at p0 and end at p1
+            for (auto& line_poly : has_area_above_poly_lines)
+            {
+                const Point2LL& line_p0 = line_poly.front();
+                const Point2LL& line_p1 = line_poly.back();
+                if (vSize2(line_p1 - p0) < vSize2(line_p0 - p0))
+                {
+                    std::reverse(line_poly.begin(), line_poly.end());
+                }
+            }
+            std::sort(has_area_above_poly_lines.begin(), has_area_above_poly_lines.end(), [&](auto& a, auto& b) { return vSize2(a.front() - p0) < vSize2(b.front() - p0); });
+
+            // add intersected line segments, alternating between roofing and non_bridge_config
+            for (const auto& line_poly : has_area_above_poly_lines)
+            {
+                // This is only relevant for the very fist iteration of the loop
+                // if the start of the line segment is already the same as p0 then no move is required
+                if (line_poly.front() != p0)
+                {
+                    addExtrusionMove(line_poly.front(), roofing_config, SpaceFillType::Polygons, flow, width_factor, spiralize, 1.0_r);
+                }
+
+                addExtrusionMove(line_poly.back(), non_bridge_config, SpaceFillType::Polygons, flow, width_factor, spiralize, 1.0_r);
+            }
+
+            // if the last point is not yet at p1 then add a move to p1
+            if (has_area_above_poly_lines.back().back() != p1)
+            {
+                addExtrusionMove(p1, roofing_config, SpaceFillType::Polygons, flow, width_factor, spiralize, 1.0_r);
+            }
+        }
     }
     else if (bridge_wall_mask_.empty())
     {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -768,6 +768,7 @@ void LayerPlan::addWallLine(
         if (roofing_config == default_config)
         {
             // if the roofing config and normal config are the same any way there is no need to check what part of the line segment
+            // what part of the line segment will be printed with what config.
             return false;
         }
         return roofing_mask_.empty() || PolygonUtils::polygonCollidesWithLineSegment(roofing_mask_, p0, p1) || !roofing_mask_.inside(p1, true);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -767,7 +767,7 @@ void LayerPlan::addWallLine(
     {
         if (roofing_config == default_config)
         {
-            // if the roofing config and normal config are the same any way there is no need to check what part of the line segment
+            // if the roofing config and normal config are the same any way there is no need to check 
             // what part of the line segment will be printed with what config.
             return false;
         }

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 UltiMaker
+// Copyright (c) 2024 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "TopSurface.h"
@@ -172,6 +172,8 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
             layer,
             mesh.settings,
             extruder_nr,
+            line_config,
+            line_config,
             line_config,
             line_config,
             line_config,


### PR DESCRIPTION
# Description

This "feature" allows users to set a different print configuration (speed, acceleration, jerk) for those outer walls that in the "top surface layers". This gives users more control over printed part quality, especially when tuning profiles for speed.

Previously this feature was implemented but it had some downsides. There was a lot of code duplication, and the code was running into performance issues.

This new implementation solves both this issues, and adds a better interpretation of the feature. Previously if a line segment was partially within and partially outside a top layer then the whole line segment would be printed with the top surface layer outer wall config. With the new implementation only those area's within a line segment that are within the area are printed with this config.

![Screenshot 2024-01-26 at 15 19 26](https://github.com/Ultimaker/CuraEngine/assets/6638028/37e9d765-f8e6-4a7f-998d-e888f426b2db)

CURA-11129 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Yes

**Test Configuration**:
* Operating System: MacOS 13.3

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change