### PR TITLE
Fix printing rafts-holes in monotonic order

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -983,24 +983,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             raft_outline_path = raft_outline_path.difference(storage.primeTower.getOuterPoly(layer_nr));
         }
 
-        std::vector<Polygons> raft_islands;
-        if (monotonic)
-        {
-            // When using monotonic infill, process islands separately otherwise multiple rafts
-            // will be printed in parallel in a global monotonic order, which doesn't look good
-            for (const PolygonRef raft_island : raft_outline_path)
-            {
-                Polygons island;
-                island.add(raft_island);
-                raft_islands.emplace_back(island);
-            }
-        }
-        else
-        {
-            raft_islands.emplace_back(raft_outline_path);
-        }
-
-        for (const Polygons raft_island : raft_islands)
+        for (const Polygons raft_island : raft_outline_path.splitIntoParts())
         {
             Infill infill_comp(
                 EFillMethod::ZIG_ZAG,


### PR DESCRIPTION
# Description

Previous implementation contains a bug where raft holes would be printed doubly.

CURA-11438

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Yes

**Test Configuration**:
* Operating System: MacOS 13.3

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change