### PR TITLE
Fix travel length regression

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1775,12 +1775,15 @@ void FffGcodeWriter::addMeshLayerToGCode(
     PathOrderOptimizer<const SliceLayerPart*> part_order_optimizer(gcode_layer.getLastPlannedPositionOrStartingPosition(), z_seam_config);
     for (const SliceLayerPart& part : layer.parts)
     {
+        if (part.outline.empty())
+        {
+            continue;
+        }
         part_order_optimizer.addPolygon(&part);
     }
-    if (part_order_optimizer.vertices_to_paths_.size() > 1)
-    {
-        part_order_optimizer.optimize(false);
-    }
+
+    part_order_optimizer.optimize(false);
+
     for (const PathOrdering<const SliceLayerPart*>& path : part_order_optimizer.paths_)
     {
         addMeshPartToGCode(storage, mesh, extruder_nr, mesh_config, *path.vertices_, gcode_layer);


### PR DESCRIPTION
# Description

We found a regression regarding travel-lengths in the gcode analyzer. The regression was caused by this commit: https://github.com/Ultimaker/CuraEngine/commit/8be88c26a10476832ccccebd8d0d1234d6fbc8d1. This PR resolves the regression while still implementing the engine crash fix in the a fore mentioned commit.

CURA-11653

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Yes

**Test Configuration**:
* Operating System: macOS 13.3

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change