### PR TITLE
condition to start position while in case of prime-blob enabled

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -141,8 +141,8 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
         }
     }
     const auto extruder_settings = Application::getInstance().current_slice_->scene.extruders[gcode.getExtruderNr()].settings_;
-    //in case the prime blob is enabled the brim already starts from the closest start position which is blob location
-    if (!extruder_settings.get<bool>("prime_blob_enable"))
+    // in case the prime blob is enabled the brim already starts from the closest start position which is blob location
+    if (! extruder_settings.get<bool>("prime_blob_enable"))
     {
         // Setting first travel move of the first extruder to the machine start position
         Point3LL p(extruder_settings.get<coord_t>("machine_extruder_start_pos_x"), extruder_settings.get<coord_t>("machine_extruder_start_pos_y"), gcode.getPositionZ());

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -140,11 +140,15 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
             mesh_order_per_extruder.push_back(calculateMeshOrder(storage, extruder_nr));
         }
     }
-
-    // Setting first travel move of the first extruder to the machine start position
     const auto extruder_settings = Application::getInstance().current_slice_->scene.extruders[gcode.getExtruderNr()].settings_;
-    Point3LL p(extruder_settings.get<coord_t>("machine_extruder_start_pos_x"), extruder_settings.get<coord_t>("machine_extruder_start_pos_y"), gcode.getPositionZ());
-    gcode.writeTravel(p, extruder_settings.get<Velocity>("speed_travel"));
+    //in case the prime blob is enabled the brim already starts from the closest start position which is blob location
+    if (!extruder_settings.get<bool>("prime_blob_enable"))
+    {
+        // Setting first travel move of the first extruder to the machine start position
+        Point3LL p(extruder_settings.get<coord_t>("machine_extruder_start_pos_x"), extruder_settings.get<coord_t>("machine_extruder_start_pos_y"), gcode.getPositionZ());
+        gcode.writeTravel(p, extruder_settings.get<Velocity>("speed_travel"));
+    }
+
 
     calculateExtruderOrderPerLayer(storage);
     calculatePrimeLayerPerExtruder(storage);


### PR DESCRIPTION
CURA-11553

It seems like the purpose of prime blob was to handle scarring in the print as well. I recommend that initial travel move not to be applied when prime blob is enabled. This solves our problem of scarring that might happed wile prime-blob.(Also during prime blob the start position of brim starts close to the blob rather than the “machine_extruder_start_pos_x, machine_extruder_start_pos_y”)