### PR TITLE
Cura 9838 brim location

### DIFF
--- a/include/SkirtBrim.h
+++ b/include/SkirtBrim.h
@@ -198,6 +198,14 @@ private:
      */
     void generateSecondarySkirtBrim(Polygons& covered_area, std::vector<Polygons>& allowed_areas_per_extruder, std::vector<coord_t>& total_length);
 
+    /*!
+     * Generate the allowed areas for each extruder. Allowed areas represent where the brim/skirt is allowed to grow
+     * while adding new outset lines. This is basically the whole build plate, removing the areas where models are
+     * located, offsetted with some specific margins.
+     *
+     * \param[in] starting_outlines The previously generated starting outlines for each extruder
+     * \return The list of allowed areas for each extruder
+     */
     std::vector<Polygons> generateAllowedAreas(const std::vector<Polygons>& starting_outlines) const;
 
 public:

--- a/include/SkirtBrim.h
+++ b/include/SkirtBrim.h
@@ -65,7 +65,7 @@ private:
         bool extruder_is_used_; //!< Whether the extruder is actually used in this print
         bool outside_polys_; //!< Whether to generate brim on the outside
         bool inside_polys_; //!< Whether to generate brim on the inside
-        coord_t line_widths_; //!< The skirt/brim line width
+        coord_t line_width_; //!< The skirt/brim line width
         coord_t skirt_brim_minimal_length_; //!< The minimal brim length
         int line_count_; //!< The (minimal) number of brim lines to generate
         coord_t gap_; //!< The gap between the part and the first brim/skirt line
@@ -197,6 +197,8 @@ private:
      * \param[in,out] total_length The total length of the brim lines for each extruder.
      */
     void generateSecondarySkirtBrim(Polygons& covered_area, std::vector<Polygons>& allowed_areas_per_extruder, std::vector<coord_t>& total_length);
+
+    std::vector<Polygons> generateAllowedAreas() const;
 
 public:
     /*!

--- a/include/SkirtBrim.h
+++ b/include/SkirtBrim.h
@@ -29,14 +29,16 @@ private:
     {
         Offset(
             const std::variant<Polygons*, int>& reference_outline_or_index,
-            const bool external_only,
+            const bool outside,
+            const bool inside,
             const coord_t offset_value,
             const coord_t total_offset,
             const size_t inset_idx,
-            const int extruder_nr,
+            const size_t extruder_nr,
             const bool is_last)
             : reference_outline_or_index_(reference_outline_or_index)
-            , external_only_(external_only)
+            , outside_(outside)
+            , inside_(inside)
             , offset_value_(offset_value)
             , total_offset_(total_offset)
             , inset_idx_(inset_idx)
@@ -46,12 +48,27 @@ private:
         }
 
         std::variant<Polygons*, int> reference_outline_or_index_;
-        bool external_only_; //!< Wether to only offset outward from the reference polygons
+        bool outside_; //!< Wether to offset outward from the reference polygons
+        bool inside_; //!< Wether to offset inward from the reference polygons
         coord_t offset_value_; //!< Distance by which to offset from the reference
         coord_t total_offset_; //!< Total distance from the model
         int inset_idx_; //!< The outset index of this brimline
-        int extruder_nr_; //!< The extruder by which to print this brim line
+        size_t extruder_nr_; //!< The extruder by which to print this brim line
         bool is_last_; //!< Whether this is the last planned offset for this extruder.
+    };
+
+    /*!
+     * Container to store the pre-extracted settings of an extruder
+     */
+    struct ExtruderConfig
+    {
+        bool extruder_is_used_; //!< Whether the extruder is actually used in this print
+        bool outside_polys_; //!< Whether to generate brim on the outside
+        bool inside_polys_; //!< Whether to generate brim on the inside
+        coord_t line_widths_; //!< The skirt/brim line width
+        coord_t skirt_brim_minimal_length_; //!< The minimal brim length
+        int line_count_; //!< The (minimal) number of brim lines to generate
+        coord_t gap_; //!< The gap between the part and the first brim/skirt line
     };
 
     /*!
@@ -68,15 +85,10 @@ private:
     const bool has_ooze_shield_; //!< Whether the meshgroup has an ooze shield
     const bool has_draft_shield_; //!< Whether the meshgroup has a draft shield
     const std::vector<ExtruderTrain>& extruders_; //!< The extruders of the current slice
-    const int extruder_count_; //!< The total number of extruders
-    const std::vector<bool> extruder_is_used_; //!< For each extruder whether it is actually used in this print
-    int first_used_extruder_nr_; //!< The first extruder which is used
+    size_t extruder_count_; //!< The total number of extruders
+    size_t first_used_extruder_nr_; //!< The first extruder which is used
     int skirt_brim_extruder_nr_; //!< The extruder with which the skirt/brim is printed or -1 if printed with both
-    std::vector<bool> external_polys_only_; //!< For each extruder whether to only generate brim on the outside
-    std::vector<coord_t> line_widths_; //!< For each extruder the skirt/brim line width
-    std::vector<coord_t> skirt_brim_minimal_length_; //!< For each extruder the minimal brim length
-    std::vector<int> line_count_; //!< For each extruder the (minimal) number of brim lines to generate
-    std::vector<coord_t> gap_; //!< For each extruder the gap between the part and the first brim/skirt line
+    std::vector<ExtruderConfig> extruders_configs_; //!< The brim setup for each extruder
 
 public:
     /*!
@@ -158,7 +170,7 @@ private:
      * \param extruder_nr The extruder for which to compute disallowed areas
      * \return The disallowed areas
      */
-    Polygons getInternalHoleExclusionArea(const Polygons& outline, const int extruder_nr);
+    Polygons getInternalHoleExclusionArea(const Polygons& outline, const int extruder_nr) const;
 
     /*!
      * Generate a brim line with offset parameters given by \p offset from the \p starting_outlines and store it in the \ref storage.

--- a/include/SkirtBrim.h
+++ b/include/SkirtBrim.h
@@ -198,7 +198,7 @@ private:
      */
     void generateSecondarySkirtBrim(Polygons& covered_area, std::vector<Polygons>& allowed_areas_per_extruder, std::vector<coord_t>& total_length);
 
-    std::vector<Polygons> generateAllowedAreas() const;
+    std::vector<Polygons> generateAllowedAreas(const std::vector<Polygons>& starting_outlines) const;
 
 public:
     /*!

--- a/include/settings/EnumSettings.h
+++ b/include/settings/EnumSettings.h
@@ -267,6 +267,24 @@ enum class PrimeTowerMethod
     NORMAL,
 };
 
+/*!
+ * Brim location, inside, outside or both
+ */
+enum class BrimLocation
+{
+    OUTSIDE = 0x01, // Brim only on the outside of the model
+    INSIDE = 0x02, // Brim only on the inside of the model
+    EVERYWHERE = 0x03, // Brim on both the outside and inside of the model
+};
+
+/*!
+ * Convenience binary operator to allow testing brim location easily, like (actual_location & BrimLocation::OUTSIDE)
+ */
+static int operator&(BrimLocation location1, BrimLocation location2)
+{
+    return static_cast<int>(location1) & static_cast<int>(location2);
+}
+
 } // namespace cura
 
 #endif // ENUMSETTINGS_H

--- a/include/sliceDataStorage.h
+++ b/include/sliceDataStorage.h
@@ -186,19 +186,21 @@ public:
     /*!
      * Get the all outlines of all layer parts in this layer.
      *
-     * \param external_polys_only Whether to only include the outermost outline of each layer part
+     * \param outer_polys Whether to include the outermost outline of each layer part
+     * \param inner_polys Whether to include the inner outlines (holes) of each layer part
      * \return A collection of all the outline polygons
      */
-    Polygons getOutlines(bool external_polys_only = false) const;
+    Polygons getOutlines(bool outer_polys = true, bool inner_polys = true) const;
 
     /*!
      * Get the all outlines of all layer parts in this layer.
      * Add those polygons to @p result.
      *
-     * \param external_polys_only Whether to only include the outermost outline of each layer part
+     * \param outer_polys Whether to include the outermost outline of each layer part
+     * \param inner_polys Whether to include the inner outlines (holes) of each layer part
      * \param result The result: a collection of all the outline polygons
      */
-    void getOutlines(Polygons& result, bool external_polys_only = false) const;
+    void getOutlines(Polygons& result, bool outer_polys = true, bool inner_polys = true) const;
 
     ~SliceLayer();
 };
@@ -391,12 +393,17 @@ public:
      * \param include_support Whether to include support in the outline.
      * \param include_prime_tower Whether to include the prime tower in the
      * outline.
-     * \param external_polys_only Whether to disregard all hole polygons.
+     * \param outer_polys Whether to include the outline polygons.
+     * \param inner_polys Whether to include all hole polygons.
      * \param extruder_nr (optional) only give back outlines for this extruder (where the walls are printed with this extruder)
      */
-    Polygons
-        getLayerOutlines(const LayerIndex layer_nr, const bool include_support, const bool include_prime_tower, const bool external_polys_only = false, const int extruder_nr = -1)
-            const;
+    Polygons getLayerOutlines(
+        const LayerIndex layer_nr,
+        const bool include_support,
+        const bool include_prime_tower,
+        const bool outer_polys = true,
+        const bool inner_polys = true,
+        const int extruder_nr = -1) const;
 
     /*!
      * Get the extruders used.

--- a/include/sliceDataStorage.h
+++ b/include/sliceDataStorage.h
@@ -389,14 +389,18 @@ public:
      * \param layer_nr The index of the layer for which to get the outlines
      * (negative layer numbers indicate the raft).
      * \param include_support Whether to include support in the outline.
-     * \param include_prime_tower Whether to include the prime tower in the
-     * outline.
+     * \param include_prime_tower Whether to include the prime tower in the outline.
+     * \param include_models Whether to include the models in the outline
      * \param external_polys_only Whether to disregard all hole polygons.
      * \param extruder_nr (optional) only give back outlines for this extruder (where the walls are printed with this extruder)
      */
-    Polygons
-        getLayerOutlines(const LayerIndex layer_nr, const bool include_support, const bool include_prime_tower, const bool external_polys_only = false, const int extruder_nr = -1)
-            const;
+    Polygons getLayerOutlines(
+        const LayerIndex layer_nr,
+        const bool include_support,
+        const bool include_prime_tower,
+        const bool external_polys_only = false,
+        const int extruder_nr = -1,
+        const bool include_models = true) const;
 
     /*!
      * Get the extruders used.

--- a/include/sliceDataStorage.h
+++ b/include/sliceDataStorage.h
@@ -186,21 +186,19 @@ public:
     /*!
      * Get the all outlines of all layer parts in this layer.
      *
-     * \param outer_polys Whether to include the outermost outline of each layer part
-     * \param inner_polys Whether to include the inner outlines (holes) of each layer part
+     * \param external_polys_only Whether to only include the outermost outline of each layer part
      * \return A collection of all the outline polygons
      */
-    Polygons getOutlines(bool outer_polys = true, bool inner_polys = true) const;
+    Polygons getOutlines(bool external_polys_only = false) const;
 
     /*!
      * Get the all outlines of all layer parts in this layer.
      * Add those polygons to @p result.
      *
-     * \param outer_polys Whether to include the outermost outline of each layer part
-     * \param inner_polys Whether to include the inner outlines (holes) of each layer part
+     * \param external_polys_only Whether to only include the outermost outline of each layer part
      * \param result The result: a collection of all the outline polygons
      */
-    void getOutlines(Polygons& result, bool outer_polys = true, bool inner_polys = true) const;
+    void getOutlines(Polygons& result, bool external_polys_only = false) const;
 
     ~SliceLayer();
 };
@@ -393,17 +391,12 @@ public:
      * \param include_support Whether to include support in the outline.
      * \param include_prime_tower Whether to include the prime tower in the
      * outline.
-     * \param outer_polys Whether to include the outline polygons.
-     * \param inner_polys Whether to include all hole polygons.
+     * \param external_polys_only Whether to disregard all hole polygons.
      * \param extruder_nr (optional) only give back outlines for this extruder (where the walls are printed with this extruder)
      */
-    Polygons getLayerOutlines(
-        const LayerIndex layer_nr,
-        const bool include_support,
-        const bool include_prime_tower,
-        const bool outer_polys = true,
-        const bool inner_polys = true,
-        const int extruder_nr = -1) const;
+    Polygons
+        getLayerOutlines(const LayerIndex layer_nr, const bool include_support, const bool include_prime_tower, const bool external_polys_only = false, const int extruder_nr = -1)
+            const;
 
     /*!
      * Get the extruders used.

--- a/include/utils/SVG.h
+++ b/include/utils/SVG.h
@@ -144,9 +144,9 @@ public:
 
     void writeText(const Point2LL& p, const std::string& txt, const ColorObject color = Color::BLACK, const double font_size = 10.0) const;
 
-    void writePolygons(const Polygons& polys, const ColorObject color = Color::BLACK, const double stroke_width = 1.0) const;
+    void writePolygons(const Polygons& polys, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;
 
-    void writePolygon(ConstPolygonRef poly, const ColorObject color = Color::BLACK, const double stroke_width = 1.0) const;
+    void writePolygon(ConstPolygonRef poly, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;
 
     void writePolylines(const Polygons& polys, const ColorObject color = Color::BLACK, const double stroke_width = 1.0) const;
 

--- a/include/utils/polygon.h
+++ b/include/utils/polygon.h
@@ -1194,11 +1194,6 @@ public:
      */
     double area() const;
 
-    void reverse()
-    {
-        ClipperLib::ReversePaths(paths);
-    }
-
     /*!
      * Smooth out small perpendicular segments
      * Smoothing is performed by removing the inner most vertex of a line segment smaller than \p remove_length
@@ -1557,16 +1552,6 @@ public:
     ConstPolygonRef outerPolygon() const
     {
         return paths[0];
-    }
-
-    Polygons innerPolygons() const
-    {
-        Polygons ret;
-        if (size() > 1)
-        {
-            ret.paths = ClipperLib::Paths(std::next(paths.begin()), paths.end());
-        }
-        return ret;
     }
 
     /*!

--- a/include/utils/polygon.h
+++ b/include/utils/polygon.h
@@ -1194,6 +1194,11 @@ public:
      */
     double area() const;
 
+    void reverse()
+    {
+        ClipperLib::ReversePaths(paths);
+    }
+
     /*!
      * Smooth out small perpendicular segments
      * Smoothing is performed by removing the inner most vertex of a line segment smaller than \p remove_length
@@ -1564,6 +1569,16 @@ public:
     ConstPolygonRef outerPolygon() const
     {
         return paths[0];
+    }
+
+    Polygons innerPolygons() const
+    {
+        Polygons ret;
+        if (size() > 1)
+        {
+            ret.paths = ClipperLib::Paths(std::next(paths.begin()), paths.end());
+        }
+        return ret;
     }
 
     /*!

--- a/include/utils/polygon.h
+++ b/include/utils/polygon.h
@@ -1286,6 +1286,8 @@ public:
      */
     Polygons getEmptyHoles() const;
 
+    Polygons getHoles() const;
+
     /*!
      * Split up the polygons into groups according to the even-odd rule.
      * Each PolygonsPart in the result has an outline as first polygon, whereas the rest are holes.

--- a/include/utils/polygon.h
+++ b/include/utils/polygon.h
@@ -1275,20 +1275,6 @@ public:
     Polygons getOutsidePolygons() const;
 
     /*!
-     * Exclude holes which have no parts inside of them.
-     * \return the resulting polygons.
-     */
-    Polygons removeEmptyHoles() const;
-
-    /*!
-     * Return hole polygons which have no parts inside of them.
-     * \return the resulting polygons.
-     */
-    Polygons getEmptyHoles() const;
-
-    Polygons getHoles() const;
-
-    /*!
      * Split up the polygons into groups according to the even-odd rule.
      * Each PolygonsPart in the result has an outline as first polygon, whereas the rest are holes.
      */

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -108,6 +108,8 @@ void PrimeTower::generateGroundpoly()
 
 void PrimeTower::generatePaths(const SliceDataStorage& storage)
 {
+    checkUsed(storage);
+
     const int raft_total_extra_layers = Raft::getTotalExtraLayers();
     would_have_actual_tower_ = storage.max_print_height_second_to_last_extruder
                             >= -raft_total_extra_layers; // Maybe it turns out that we don't need a prime tower after all because there are no layer switches.

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -92,6 +92,7 @@ std::vector<SkirtBrim::Offset> SkirtBrim::generateBrimOffsetPlan(std::vector<Pol
     for (int extruder_nr = 0; extruder_nr < extruder_count_; extruder_nr++)
     {
         const ExtruderConfig& extruder_config = extruders_configs_[extruder_nr];
+        const coord_t semi_line_width = extruder_config.line_width_ / 2;
 
         if (! extruder_config.extruder_is_used_ || (skirt_brim_extruder_nr_ >= 0 && extruder_nr != skirt_brim_extruder_nr_) || starting_outlines[extruder_nr].empty())
         {
@@ -101,7 +102,7 @@ std::vector<SkirtBrim::Offset> SkirtBrim::generateBrimOffsetPlan(std::vector<Pol
         for (int line_idx = 0; line_idx < extruder_config.line_count_; line_idx++)
         {
             const bool is_last = line_idx == extruder_config.line_count_ - 1;
-            coord_t offset = extruder_config.gap_ + extruder_config.line_width_ / 2 + extruder_config.line_width_ * line_idx;
+            coord_t offset = extruder_config.gap_ + semi_line_width + extruder_config.line_width_ * line_idx;
             if (line_idx == 0)
             {
                 all_brim_offsets

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -222,13 +222,17 @@ coord_t SkirtBrim::generateOffset(const Offset& offset, Polygons& covered_area, 
     if (std::holds_alternative<Polygons*>(offset.reference_outline_or_index_))
     {
         Polygons* reference_outline = std::get<Polygons*>(offset.reference_outline_or_index_);
+        const coord_t offset_value = offset.offset_value_;
         for (ConstPolygonRef polygon : *reference_outline)
         {
-            const coord_t offset_value = offset.offset_value_;
             const double area = polygon.area();
-            if ((area > 0 && offset.outside_) || (area < 0 && offset.inside_))
+            if (area > 0 && offset.outside_)
             {
-                brim.add(polygon.offset(area < 0 ? -offset_value : offset_value, ClipperLib::jtRound));
+                brim.add(polygon.offset(offset_value, ClipperLib::jtRound));
+            }
+            else if (area < 0 && offset.inside_)
+            {
+                brim.add(polygon.offset(-offset_value, ClipperLib::jtRound));
             }
         }
     }

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -634,7 +634,7 @@ std::vector<Polygons> SkirtBrim::generateAllowedAreas(const std::vector<Polygons
                 }
 
                 // Remove areas covered by support, with a low margin because we don't care if the brim touches it
-                allowed_areas = allowed_areas.difference(extruder_outlines.supports_outlines.offset(base_offset));
+                allowed_areas = allowed_areas.difference(extruder_outlines.supports_outlines.offset(base_offset - 50));
             }
         }
 

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -315,11 +315,9 @@ Polygons SkirtBrim::getFirstLayerOutline(const int extruder_nr /* = -1 */)
 
         for (int i_layer = layer_nr; i_layer < skirt_height; ++i_layer)
         {
-            first_layer_outline = first_layer_outline.unionPolygons(storage_.getLayerOutlines(
-                i_layer,
-                /*include_support*/ true,
-                /*include_prime_tower*/ true,
-                true));
+            constexpr bool include_support = true;
+            constexpr bool include_prime_tower = true;
+            first_layer_outline = first_layer_outline.unionPolygons(storage_.getLayerOutlines(i_layer, include_support, include_prime_tower, true));
         }
 
         Polygons shields;
@@ -563,20 +561,19 @@ std::vector<Polygons> SkirtBrim::generateAllowedAreas(const std::vector<Polygons
             {
                 // Gather models/support/prime tower areas separately to apply different margins
                 ExtruderOutlines& extruder_outlines = covered_area_by_extruder[extruder_nr];
-                extruder_outlines.models_outlines = storage_.getLayerOutlines(
-                    layer_nr,
-                    /*include_support*/ false,
-                    /*include_prime_tower*/ false,
-                    /*external_polys_only*/ false,
-                    extruder_nr,
-                    /*include_model*/ true);
-                extruder_outlines.supports_outlines = storage_.getLayerOutlines(
-                    layer_nr,
-                    /*include_support*/ true,
-                    /*include_prime_tower*/ true,
-                    /*external_polys_only*/ false,
-                    extruder_nr,
-                    /*include_model*/ false);
+                constexpr bool external_polys_only = false;
+                {
+                    constexpr bool include_support = false;
+                    constexpr bool include_prime_tower = false;
+                    constexpr bool include_model = true;
+                    extruder_outlines.models_outlines = storage_.getLayerOutlines(layer_nr, include_support, include_prime_tower, external_polys_only, extruder_nr, include_model);
+                }
+                {
+                    constexpr bool include_support = true;
+                    constexpr bool include_prime_tower = true;
+                    constexpr bool include_model = false;
+                    extruder_outlines.models_outlines = storage_.getLayerOutlines(layer_nr, include_support, include_prime_tower, external_polys_only, extruder_nr, include_model);
+                }
             }
         }
     }

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -437,13 +437,7 @@ Polygons SkirtBrim::getFirstLayerOutline(const int extruder_nr /* = -1 */)
         {
             for (const ExtruderTrain& extruder : Application::getInstance().current_slice_->scene.extruders)
             {
-                first_layer_outline = first_layer_outline.unionPolygons(storage_.getLayerOutlines(
-                    i_layer,
-                    include_support,
-                    include_prime_tower,
-                    reference_extruder_config.outside_polys_,
-                    reference_extruder_config.inside_polys_,
-                    extruder.extruder_nr_));
+                first_layer_outline = first_layer_outline.unionPolygons(storage_.getLayerOutlines(i_layer, include_support, include_prime_tower, true, extruder.extruder_nr_));
             }
         }
 
@@ -474,9 +468,8 @@ Polygons SkirtBrim::getFirstLayerOutline(const int extruder_nr /* = -1 */)
     { // add brim underneath support by removing support where there's brim around the model
         constexpr bool include_support = false; // Include manually below.
         constexpr bool include_prime_tower = false; // Not included.
-        constexpr bool outer_polys = true; // Remove manually below.
-        constexpr bool inner_polys = true; // Remove manually below.
-        first_layer_outline = storage_.getLayerOutlines(layer_nr, include_support, include_prime_tower, outer_polys, inner_polys, extruder_nr);
+        constexpr bool external_polys_only = false; // Remove manually below.
+        first_layer_outline = storage_.getLayerOutlines(layer_nr, include_support, include_prime_tower, external_polys_only, extruder_nr);
         first_layer_outline = first_layer_outline.unionPolygons(); // To guard against overlapping outlines, which would produce holes according to the even-odd rule.
         Polygons first_layer_empty_holes;
         if (! reference_extruder_config.inside_polys_)

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -620,7 +620,8 @@ std::vector<Polygons> SkirtBrim::generateAllowedAreas(const std::vector<Polygons
                     coord_t offset = extruder_config.line_width_ / 2;
                     double covered_area = covered_surface.area();
 
-                    if (other_extruder_nr == extruder_nr && ((covered_area > 0 && extruder_config.outside_polys_) || (covered_area < 0 && extruder_config.inside_polys_)))
+                    if ((other_extruder_nr == extruder_nr || extruder_nr == skirt_brim_extruder_nr_)
+                        && ((covered_area > 0 && extruder_config.outside_polys_) || (covered_area < 0 && extruder_config.inside_polys_)))
                     {
                         // This is an area we are gonna generate brim on with the same extruder, use the actual gap
                         offset += extruder_config.gap_ - 50; // Lower margin a bit to avoid discarding legitimate lines

--- a/src/SkirtBrim.cpp
+++ b/src/SkirtBrim.cpp
@@ -576,7 +576,8 @@ std::vector<Polygons> SkirtBrim::generateAllowedAreas(const std::vector<Polygons
                     constexpr bool include_support = true;
                     constexpr bool include_prime_tower = true;
                     constexpr bool include_model = false;
-                    extruder_outlines.models_outlines = storage_.getLayerOutlines(layer_nr, include_support, include_prime_tower, external_polys_only, extruder_nr, include_model);
+                    extruder_outlines.supports_outlines
+                        = storage_.getLayerOutlines(layer_nr, include_support, include_prime_tower, external_polys_only, extruder_nr, include_model);
                 }
             }
         }

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -572,6 +572,7 @@ Polygons TreeModelVolumes::extractOutlineFromMesh(const SliceMeshStorage& mesh, 
 {
     // Similar to SliceDataStorage.getLayerOutlines but only for one mesh instead of for all of them.
 
+    constexpr bool external_polys_only = false;
     Polygons total;
 
     if (mesh.settings.get<bool>("infill_mesh") || mesh.settings.get<bool>("anti_overhang_mesh"))
@@ -580,7 +581,7 @@ Polygons TreeModelVolumes::extractOutlineFromMesh(const SliceMeshStorage& mesh, 
     }
     const SliceLayer& layer = mesh.layers[layer_idx];
 
-    layer.getOutlines(total);
+    layer.getOutlines(total, external_polys_only);
     if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
     {
         total = total.unionPolygons(layer.openPolyLines.offsetPolyLine(FUDGE_LENGTH * 2));

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -572,7 +572,6 @@ Polygons TreeModelVolumes::extractOutlineFromMesh(const SliceMeshStorage& mesh, 
 {
     // Similar to SliceDataStorage.getLayerOutlines but only for one mesh instead of for all of them.
 
-    constexpr bool external_polys_only = false;
     Polygons total;
 
     if (mesh.settings.get<bool>("infill_mesh") || mesh.settings.get<bool>("anti_overhang_mesh"))
@@ -581,7 +580,7 @@ Polygons TreeModelVolumes::extractOutlineFromMesh(const SliceMeshStorage& mesh, 
     }
     const SliceLayer& layer = mesh.layers[layer_idx];
 
-    layer.getOutlines(total, external_polys_only);
+    layer.getOutlines(total);
     if (mesh.settings.get<ESurfaceMode>("magic_mesh_surface_mode") != ESurfaceMode::NORMAL)
     {
         total = total.unionPolygons(layer.openPolyLines.offsetPolyLine(FUDGE_LENGTH * 2));

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -697,6 +697,24 @@ PrimeTowerMethod Settings::get<PrimeTowerMethod>(const std::string& key) const
 }
 
 template<>
+BrimLocation Settings::get<BrimLocation>(const std::string& key) const
+{
+    const std::string& value = get<std::string>(key);
+    if (value == "everywhere")
+    {
+        return BrimLocation::EVERYWHERE;
+    }
+    else if (value == "inside")
+    {
+        return BrimLocation::INSIDE;
+    }
+    else // Default.
+    {
+        return BrimLocation::OUTSIDE;
+    }
+}
+
+template<>
 std::vector<double> Settings::get<std::vector<double>>(const std::string& key) const
 {
     const std::string& value_string = get<std::string>(key);

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -266,9 +266,13 @@ SliceDataStorage::SliceDataStorage()
     machine_size.include(machine_max);
 }
 
-Polygons
-    SliceDataStorage::getLayerOutlines(const LayerIndex layer_nr, const bool include_support, const bool include_prime_tower, const bool external_polys_only, const int extruder_nr)
-        const
+Polygons SliceDataStorage::getLayerOutlines(
+    const LayerIndex layer_nr,
+    const bool include_support,
+    const bool include_prime_tower,
+    const bool external_polys_only,
+    const int extruder_nr,
+    const bool include_models) const
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
 
@@ -328,7 +332,7 @@ Polygons
     case Raft::LayerType::Model:
     {
         Polygons total;
-        if (layer_nr >= 0)
+        if (include_models && layer_nr >= 0)
         {
             for (const std::shared_ptr<SliceMeshStorage>& mesh : meshes)
             {

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -334,16 +334,20 @@ void SVG::writeText(const Point2LL& p, const std::string& txt, const ColorObject
         txt.c_str());
 }
 
-void SVG::writePolygons(const Polygons& polys, const ColorObject color, const double stroke_width) const
+void SVG::writePolygons(const Polygons& polys, const ColorObject color, const double stroke_width, const bool flush) const
 {
     for (ConstPolygonRef poly : polys)
     {
-        writePolygon(poly, color, stroke_width);
+        writePolygon(poly, color, stroke_width, false);
     }
-    fflush(out_);
+
+    if (flush)
+    {
+        fflush(out_);
+    }
 }
 
-void SVG::writePolygon(ConstPolygonRef poly, const ColorObject color, const double stroke_width) const
+void SVG::writePolygon(ConstPolygonRef poly, const ColorObject color, const double stroke_width, const bool flush) const
 {
     if (poly.size() == 0)
     {
@@ -375,7 +379,11 @@ void SVG::writePolygon(ConstPolygonRef poly, const ColorObject color, const doub
         p0 = p1;
         i++;
     }
-    fflush(out_);
+
+    if (flush)
+    {
+        fflush(out_);
+    }
 }
 
 

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -340,6 +340,7 @@ void SVG::writePolygons(const Polygons& polys, const ColorObject color, const do
     {
         writePolygon(poly, color, stroke_width);
     }
+    fflush(out_);
 }
 
 void SVG::writePolygon(ConstPolygonRef poly, const ColorObject color, const double stroke_width) const
@@ -374,6 +375,7 @@ void SVG::writePolygon(ConstPolygonRef poly, const ColorObject color, const doub
         p0 = p1;
         i++;
     }
+    fflush(out_);
 }
 
 

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -599,6 +599,19 @@ Polygons Polygons::getEmptyHoles() const
     return ret;
 }
 
+Polygons Polygons::getHoles() const
+{
+    Polygons ret;
+    for (ConstPolygonRef polygon : *this)
+    {
+        if (polygon.area() < 0)
+        {
+            ret.add(polygon);
+        }
+    }
+    return ret;
+}
+
 void Polygons::removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, const bool remove_holes, Polygons& ret) const
 {
     for (int outer_poly_idx = 0; outer_poly_idx < node.ChildCount(); outer_poly_idx++)

--- a/src/utils/polygon.cpp
+++ b/src/utils/polygon.cpp
@@ -571,47 +571,6 @@ Polygons Polygons::getOutsidePolygons() const
     return ret;
 }
 
-Polygons Polygons::removeEmptyHoles() const
-{
-    Polygons ret;
-    ClipperLib::Clipper clipper(clipper_init);
-    ClipperLib::PolyTree poly_tree;
-    constexpr bool paths_are_closed_polys = true;
-    clipper.AddPaths(paths, ClipperLib::ptSubject, paths_are_closed_polys);
-    clipper.Execute(ClipperLib::ctUnion, poly_tree);
-
-    bool remove_holes = true;
-    removeEmptyHoles_processPolyTreeNode(poly_tree, remove_holes, ret);
-    return ret;
-}
-
-Polygons Polygons::getEmptyHoles() const
-{
-    Polygons ret;
-    ClipperLib::Clipper clipper(clipper_init);
-    ClipperLib::PolyTree poly_tree;
-    constexpr bool paths_are_closed_polys = true;
-    clipper.AddPaths(paths, ClipperLib::ptSubject, paths_are_closed_polys);
-    clipper.Execute(ClipperLib::ctUnion, poly_tree);
-
-    bool remove_holes = false;
-    removeEmptyHoles_processPolyTreeNode(poly_tree, remove_holes, ret);
-    return ret;
-}
-
-Polygons Polygons::getHoles() const
-{
-    Polygons ret;
-    for (ConstPolygonRef polygon : *this)
-    {
-        if (polygon.area() < 0)
-        {
-            ret.add(polygon);
-        }
-    }
-    return ret;
-}
-
 void Polygons::removeEmptyHoles_processPolyTreeNode(const ClipperLib::PolyNode& node, const bool remove_holes, Polygons& ret) const
 {
     for (int outer_poly_idx = 0; outer_poly_idx < node.ChildCount(); outer_poly_idx++)

--- a/tests/LayerPlanTest.cpp
+++ b/tests/LayerPlanTest.cpp
@@ -2,6 +2,9 @@
 // CuraEngine is released under the terms of the AGPLv3 or higher
 
 #include "LayerPlan.h" //The code under test.
+
+#include <gtest/gtest.h>
+
 #include "Application.h" //To provide settings for the layer plan.
 #include "RetractionConfig.h" //To provide retraction settings.
 #include "Slice.h" //To provide settings for the layer plan.
@@ -9,7 +12,6 @@
 #include "pathPlanning/NozzleTempInsert.h" //To provide nozzle temperature commands.
 #include "sliceDataStorage.h" //To provide slice data as input for the planning stage.
 #include "utils/Coord_t.h"
-#include <gtest/gtest.h>
 
 // NOLINTBEGIN(*-magic-numbers)
 namespace cura
@@ -59,7 +61,9 @@ public:
      */
     Mesh mesh;
 
-    LayerPlanTest() : storage(setUpStorage()), layer_plan(*storage, 100, 10000, 100, 0, fan_speed_layer_time_settings, 20, 10, 5000)
+    LayerPlanTest()
+        : storage(setUpStorage())
+        , layer_plan(*storage, 100, 10000, 100, 0, fan_speed_layer_time_settings, 20, 10, 5000)
     {
     }
 
@@ -119,7 +123,8 @@ public:
         settings->add("machine_width", "1000");
         settings->add("material_flow_layer_0", "100");
         settings->add("meshfix_maximum_travel_resolution", "0");
-        settings->add("prime_tower_mode", "default");
+        settings->add("prime_tower_enable", "false");
+        settings->add("prime_tower_mode", "normal");
         settings->add("prime_tower_flow", "108");
         settings->add("prime_tower_line_width", "0.48");
         settings->add("prime_tower_min_volume", "10");
@@ -312,7 +317,8 @@ public:
     Polygon between; // Between the start and end position.
     Polygon between_hole; // Negative polygon between the start and end position (a hole).
 
-    AddTravelTest() : parameters(std::make_tuple<std::string, std::string, std::string, bool, bool, AddTravelTestScene>("false", "false", "off", false, false, AddTravelTestScene::OPEN))
+    AddTravelTest()
+        : parameters(std::make_tuple<std::string, std::string, std::string, bool, bool, AddTravelTestScene>("false", "false", "off", false, false, AddTravelTestScene::OPEN))
     {
         around_start_end.add(Point2LL(-100, -100));
         around_start_end.add(Point2LL(500100, -100));
@@ -353,7 +359,8 @@ public:
         settings->add("retraction_hop_enabled", parameters.hop_enable);
         settings->add("retraction_combing", parameters.combing);
         settings->add("retraction_min_travel", parameters.is_long ? "1" : "10000"); // If disabled, give it a high minimum travel so we're sure that our travel move is shorter.
-        storage->retraction_wipe_config_per_extruder[0].retraction_config.retraction_min_travel_distance = settings->get<coord_t>("retraction_min_travel"); // Update the copy that the storage has of this.
+        storage->retraction_wipe_config_per_extruder[0].retraction_config.retraction_min_travel_distance
+            = settings->get<coord_t>("retraction_min_travel"); // Update the copy that the storage has of this.
         settings->add("retraction_combing_max_distance", parameters.is_long_combing ? "1" : "10000");
 
         Polygons slice_data;
@@ -411,9 +418,16 @@ public:
 };
 // NOLINTEND(misc-non-private-member-variables-in-classes)
 
-INSTANTIATE_TEST_SUITE_P(AllCombinations,
-                         AddTravelTest,
-                         testing::Combine(testing::ValuesIn(retraction_enable), testing::ValuesIn(hop_enable), testing::ValuesIn(combing), testing::ValuesIn(is_long), testing::ValuesIn(is_long_combing), testing::ValuesIn(scene)));
+INSTANTIATE_TEST_SUITE_P(
+    AllCombinations,
+    AddTravelTest,
+    testing::Combine(
+        testing::ValuesIn(retraction_enable),
+        testing::ValuesIn(hop_enable),
+        testing::ValuesIn(combing),
+        testing::ValuesIn(is_long),
+        testing::ValuesIn(is_long_combing),
+        testing::ValuesIn(scene)));
 
 /*!
  * Test if there are indeed no retractions if retractions are disabled.

--- a/tests/utils/PolygonTest.cpp
+++ b/tests/utils/PolygonTest.cpp
@@ -2,10 +2,12 @@
 // CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "utils/polygon.h" // The class under test.
+
+#include <gtest/gtest.h>
+
 #include "utils/Coord_t.h"
 #include "utils/SVG.h" // helper functions
 #include "utils/polygonUtils.h" // helper functions
-#include <gtest/gtest.h>
 
 // NOLINTBEGIN(*-magic-numbers)
 namespace cura
@@ -79,7 +81,18 @@ public:
     }
     void twoPolygonsAreEqual(Polygons& polygon1, Polygons& polygon2) const
     {
-        auto poly_cmp = [](const ClipperLib::Path& a, const ClipperLib::Path& b) { return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), [](const Point2LL& p1, const Point2LL& p2) { return p1 < p2; }); };
+        auto poly_cmp = [](const ClipperLib::Path& a, const ClipperLib::Path& b)
+        {
+            return std::lexicographical_compare(
+                a.begin(),
+                a.end(),
+                b.begin(),
+                b.end(),
+                [](const Point2LL& p1, const Point2LL& p2)
+                {
+                    return p1 < p2;
+                });
+        };
         std::sort(polygon1.begin(), polygon1.end(), poly_cmp);
         std::sort(polygon2.begin(), polygon2.end(), poly_cmp);
 
@@ -223,18 +236,6 @@ TEST_F(PolygonTest, differenceClockwiseTest)
         area += (next.X - point.X) * (point.Y + next.Y);
     }
     EXPECT_GT(area, 0) << "Inner polygon should be clockwise.";
-}
-
-TEST_F(PolygonTest, getEmptyHolesTest)
-{
-    const Polygons holes = clockwise_donut.getEmptyHoles();
-
-    ASSERT_EQ(holes.size(), 1);
-    ASSERT_EQ(holes[0].size(), clockwise_small.size()) << "Empty hole should have the same amount of vertices as the original polygon.";
-    for (size_t point_index = 0; point_index < holes[0].size(); point_index++)
-    {
-        EXPECT_EQ(holes[0][point_index], clockwise_small[point_index]) << "Coordinates of the empty hole must be the same as the original polygon.";
-    }
 }
 
 /*


### PR DESCRIPTION
This PR adds the ability to generate a brim outside a model, inside or both.
For this to work, I had to partially rewrite the brim generation because we cannot treat single holes when they are not part of an outer shape.
The brim has interactions with the draft/ooze shields, and also with supports, so those parts were also impacted.
And finally, this opened new edge-case that were previously impossible, so more fixes were required.
In the end, this is a pretty big PR with a lot of geometric logic. I added documentation where I felt it was required, but feel free to ask for more.

Comes along with https://github.com/Ultimaker/Cura/pull/18466