### PR TITLE
Cura 11724 disable initial travel for one at a time

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -143,7 +143,7 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
     const auto extruder_settings = Application::getInstance().current_slice_->scene.extruders[gcode.getExtruderNr()].settings_;
     // in case the prime blob is enabled the brim already starts from the closest start position which is blob location
     // also in case of one at a time printing the first move of every object shouldn't be start position of machine
-    if (! extruder_settings.get<bool>("prime_blob_enable") and ! (extruder_settings.get<std::string>("print_sequence")=="one_at_a_time") )
+    if (! extruder_settings.get<bool>("prime_blob_enable") and ! (extruder_settings.get<std::string>("print_sequence") == "one_at_a_time"))
     {
         // Setting first travel move of the first extruder to the machine start position
         Point3LL p(extruder_settings.get<coord_t>("machine_extruder_start_pos_x"), extruder_settings.get<coord_t>("machine_extruder_start_pos_y"), gcode.getPositionZ());

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -142,7 +142,8 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
     }
     const auto extruder_settings = Application::getInstance().current_slice_->scene.extruders[gcode.getExtruderNr()].settings_;
     // in case the prime blob is enabled the brim already starts from the closest start position which is blob location
-    if (! extruder_settings.get<bool>("prime_blob_enable"))
+    // also in case of one at a time printing the first move of every object shouldn't be start position of machine
+    if (! extruder_settings.get<bool>("prime_blob_enable") and ! (extruder_settings.get<std::string>("print_sequence")=="one_at_a_time") )
     {
         // Setting first travel move of the first extruder to the machine start position
         Point3LL p(extruder_settings.get<coord_t>("machine_extruder_start_pos_x"), extruder_settings.get<coord_t>("machine_extruder_start_pos_y"), gcode.getPositionZ());


### PR DESCRIPTION
# Description
Travel is not considered in the logic for collision detection. While printing one at a time, because of scarring ticket the initial travel of extruder goes to start position before printing every object, this doesn't comply in case of "One at a time" printing where the nozzle shouldn't go to the start position as it might collide with the objects that are already printed in the buildplate. 
Added a condition here to not do the initial travel in case of one at a time.