### PR TITLE
[CURA-11424] Fix fractional support-layers applied to often.

### DIFF
--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -634,8 +634,8 @@ private:
      * layer.
      *
      * \param[in] storage Where the slice data is stored.
-     * \param[in] support_roof_outlines which polygons to generate roofs for -- originally split-up because of fractional (layer-height) layers
-     * \param[in] current_roof_config config to be used -- most importantly, support has slightly different configs for fractional (layer-height) layers
+     * \param[in] support_roof_outlines which polygons to generate roofs for.
+     * \param[in] current_roof_config config to be used.
      * \param gcodeLayer The initial planning of the g-code of the layer.
      * \return Whether any support skin was added to the layer plan.
      */

--- a/include/sliceDataStorage.h
+++ b/include/sliceDataStorage.h
@@ -230,8 +230,10 @@ public:
     /* Fill up the infill parts for the support with the given support polygons. The support polygons will be split into parts. This also takes into account fractional-height
      * support layers.
      *
-     * \param layer_nr Current layer index.
-     * \param support_fill_per_layer All of the (infill) support (since the layer above might be needed).
+     * \param layer_nr The layer-index of the support layer to be filled.
+     * \param support_fill_per_layer The support polygons to fill up with infill parts.
+     * \param infill_layer_height The layer height of the support-fill.
+     * \param meshes The model meshes to be supported, needed here to handle fractional support layer height.
      * \param support_line_width Line width of the support extrusions.
      * \param wall_line_count Wall-line count around the fill.
      * \param grow_layer_above (optional, default to 0) In cases where support shrinks per layer up, an appropriate offset may be nescesary.
@@ -241,6 +243,8 @@ public:
     void fillInfillParts(
         const LayerIndex layer_nr,
         const std::vector<Polygons>& support_fill_per_layer,
+        const coord_t infill_layer_height,
+        const std::vector<std::shared_ptr<SliceMeshStorage>>& meshes,
         const coord_t support_line_width,
         const coord_t wall_line_count,
         const coord_t grow_layer_above = 0,

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2237,9 +2237,16 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(std::vector<Polygons>& suppor
         [&](const LayerIndex layer_idx)
         {
             constexpr bool convert_every_part = true; // Convert every part into a PolygonsPart for the support.
-            storage.support.supportLayers[layer_idx]
-                .fillInfillParts(layer_idx, support_layer_storage, config.support_line_width, config.support_wall_count, config.maximum_move_distance, convert_every_part);
 
+            storage.support.supportLayers[layer_idx].fillInfillParts(
+                layer_idx,
+                support_layer_storage,
+                config.layer_height,
+                storage.meshes,
+                config.support_line_width,
+                config.support_wall_count,
+                config.maximum_move_distance,
+                convert_every_part);
             {
                 std::lock_guard<std::mutex> critical_section_progress(critical_sections);
                 progress_total += TREE_PROGRESS_FINALIZE_BRANCH_AREAS / support_layer_storage.size();

--- a/src/TreeSupportTipGenerator.cpp
+++ b/src/TreeSupportTipGenerator.cpp
@@ -1163,8 +1163,16 @@ void TreeSupportTipGenerator::generateTips(
             {
                 if (use_fake_roof_)
                 {
-                    storage.support.supportLayers[layer_idx]
-                        .fillInfillParts(layer_idx, support_roof_drawn_, config_.support_line_width, 0, config_.maximum_move_distance, false, support_roof_line_distance_);
+                    storage.support.supportLayers[layer_idx].fillInfillParts(
+                        layer_idx,
+                        support_roof_drawn_,
+                        config_.layer_height,
+                        storage.meshes,
+                        config_.support_line_width,
+                        0,
+                        config_.maximum_move_distance,
+                        false,
+                        support_roof_line_distance_);
                     placed_support_lines_support_areas[layer_idx].add(TreeSupportUtils::generateSupportInfillLines(
                                                                           support_roof_drawn_[layer_idx],
                                                                           config_,

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -781,7 +781,8 @@ void SupportLayer::fillInfillParts(
     overhang_z_dist_above = overhang_z_dist_above.unionPolygons();
 
     // Split the support outline into areas that are directly under the overhang and areas that are not.
-    const auto all_support_areas_in_layer = { support_fill_per_layer[layer_nr].intersection(overhang_z_dist_above), support_fill_per_layer[layer_nr].difference(overhang_z_dist_above) };
+    const auto all_support_areas_in_layer
+        = { support_fill_per_layer[layer_nr].intersection(overhang_z_dist_above), support_fill_per_layer[layer_nr].difference(overhang_z_dist_above) };
     bool use_fractional_config = true;
     for (auto& support_areas : all_support_areas_in_layer)
     {

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -759,16 +759,29 @@ void SupportLayer::excludeAreasFromSupportInfillAreas(const Polygons& exclude_po
 void SupportLayer::fillInfillParts(
     const LayerIndex layer_nr,
     const std::vector<Polygons>& support_fill_per_layer,
+    const coord_t infill_layer_height,
+    const std::vector<std::shared_ptr<SliceMeshStorage>>& meshes,
     const coord_t support_line_width,
     const coord_t wall_line_count,
     const coord_t grow_layer_above /*has default 0*/,
     const bool unionAll /*has default false*/,
     const coord_t custom_line_distance /*has default 0*/)
 {
-    const Polygons& support_this_layer = support_fill_per_layer[layer_nr];
-    const Polygons& support_layer_above
-        = (layer_nr + 1) >= support_fill_per_layer.size() || layer_nr <= 0 ? Polygons() : support_fill_per_layer[layer_nr + 1].offset(grow_layer_above);
-    const auto all_support_areas_in_layer = { support_this_layer.difference(support_layer_above), support_this_layer.intersection(support_layer_above) };
+    // Find the model exactly z-distance above the support layer.
+    Polygons overhang_z_dist_above;
+    for (const auto& mesh : meshes)
+    {
+        const coord_t mesh_z_distance_top = mesh->settings.get<coord_t>("support_top_distance");
+        const size_t overhang_layer_nr = layer_nr + (mesh_z_distance_top / infill_layer_height) + 1;
+        if (overhang_layer_nr < mesh->overhang_areas.size())
+        {
+            overhang_z_dist_above.add(mesh->overhang_areas[overhang_layer_nr]);
+        }
+    }
+    overhang_z_dist_above = overhang_z_dist_above.unionPolygons();
+
+    // Split the support outline into areas that are directly under the overhang and areas that are not.
+    const auto all_support_areas_in_layer = { support_fill_per_layer[layer_nr].intersection(overhang_z_dist_above), support_fill_per_layer[layer_nr].difference(overhang_z_dist_above) };
     bool use_fractional_config = true;
     for (auto& support_areas : all_support_areas_in_layer)
     {

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -121,13 +121,8 @@ void AreaSupport::splitGlobalSupportAreasIntoSupportInfillParts(
         // We don't generate insets and infill area for the parts yet because later the skirt/brim and prime
         // tower will remove themselves from the support, so the outlines of the parts can be changed.
         const coord_t layer_height = infill_extruder.settings_.get<coord_t>("layer_height");
-        storage.support.supportLayers[layer_nr].fillInfillParts(
-            layer_nr,
-            global_support_areas_per_layer,
-            layer_height,
-            storage.meshes,
-            support_line_width_here,
-            wall_line_count_this_layer);
+        storage.support.supportLayers[layer_nr]
+            .fillInfillParts(layer_nr, global_support_areas_per_layer, layer_height, storage.meshes, support_line_width_here, wall_line_count_this_layer);
     }
 }
 

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -120,7 +120,14 @@ void AreaSupport::splitGlobalSupportAreasIntoSupportInfillParts(
         }
         // We don't generate insets and infill area for the parts yet because later the skirt/brim and prime
         // tower will remove themselves from the support, so the outlines of the parts can be changed.
-        storage.support.supportLayers[layer_nr].fillInfillParts(layer_nr, global_support_areas_per_layer, support_line_width_here, wall_line_count_this_layer);
+        const coord_t layer_height = infill_extruder.settings_.get<coord_t>("layer_height");
+        storage.support.supportLayers[layer_nr].fillInfillParts(
+            layer_nr,
+            global_support_areas_per_layer,
+            layer_height,
+            storage.meshes,
+            support_line_width_here,
+            wall_line_count_this_layer);
     }
 }
 


### PR DESCRIPTION
Get fractional support from model-overhang instead of layer above.

The detection of where fractional support layers (where the z-distance between model and support was a fractional value compared to support-layer-height) where supposed to be was handled by looking at the internal structure of the support layers itself, rather than where it's actually needed. This fix replaces the previous method, which looked at if the layer above this one had support, and if not, assumed that the gap with the model must be directly above it (this was originally done both for performance reasons, and making it less dependent on the model and thus more encapsulated) -- but this has proven to be a mistake, given how many problems it introduces.`

The new method instead queries the meshes directly for the overhang. Otherwise, any gap between two layers of support would introduce new 'fractional support layers', which aren't supposed to be in those places.