### PR TITLE
Fix support on top of interface

### DIFF
--- a/include/settings/PathConfigStorage.h
+++ b/include/settings/PathConfigStorage.h
@@ -53,7 +53,7 @@ public:
     GCodePathConfig support_fractional_roof_config; //!< The config used to print the dense roofs of support on fractional layer-height parts.
     GCodePathConfig support_bottom_config; //!< The config to use to print the dense bottoms of support
 
-    std::vector<MeshPathConfigs> mesh_configs; //!< For each meash the config for all its feature types
+    std::vector<MeshPathConfigs> mesh_configs; //!< For each mesh the config for all its feature types
 
     /*!
      * \warning Note that the layer_nr might be below zero for raft (filler) layers

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1680,10 +1680,6 @@ void AreaSupport::generateSupportBottom(SliceDataStorage& storage, const SliceMe
     const coord_t bottom_line_width = mesh_group_settings.get<ExtruderTrain&>("support_bottom_extruder_nr").settings_.get<coord_t>("support_bottom_line_width");
     const coord_t bottom_outline_offset = mesh_group_settings.get<ExtruderTrain&>("support_bottom_extruder_nr").settings_.get<coord_t>("support_bottom_offset");
 
-    const size_t scan_count = std::max(size_t(1), (bottom_layer_count - 1)); // How many measurements to take to generate bottom areas.
-    const double z_skip = std::max(
-        1.0,
-        double(bottom_layer_count - 1) / double(scan_count)); // How many layers to skip between measurements. Using float for better spread, but this is later rounded.
     const double minimum_bottom_area = mesh.settings.get<double>("minimum_bottom_area");
 
     std::vector<SupportLayer>& support_layers = storage.support.supportLayers;
@@ -1691,9 +1687,9 @@ void AreaSupport::generateSupportBottom(SliceDataStorage& storage, const SliceMe
     {
         const unsigned int bottom_layer_idx_below = std::max(0, int(layer_idx) - int(bottom_layer_count) - int(z_distance_bottom));
         Polygons mesh_outlines;
-        for (double layer_idx_below = bottom_layer_idx_below; std::round(layer_idx_below) < (int)(layer_idx - z_distance_bottom); layer_idx_below += z_skip)
+        for (auto layer_idx_below = bottom_layer_idx_below; layer_idx_below < layer_idx - z_distance_bottom + 1; layer_idx_below += 1)
         {
-            mesh_outlines.add(mesh.layers[std::round(layer_idx_below)].getOutlines());
+            mesh_outlines.add(mesh.layers[layer_idx_below].getOutlines());
         }
         Polygons bottoms;
         generateSupportInterfaceLayer(global_support_areas_per_layer[layer_idx], mesh_outlines, bottom_line_width, bottom_outline_offset, minimum_bottom_area, bottoms);
@@ -1715,10 +1711,6 @@ void AreaSupport::generateSupportRoof(SliceDataStorage& storage, const SliceMesh
     const coord_t roof_line_width = mesh_group_settings.get<ExtruderTrain&>("support_roof_extruder_nr").settings_.get<coord_t>("support_roof_line_width");
     const coord_t roof_outline_offset = mesh_group_settings.get<ExtruderTrain&>("support_roof_extruder_nr").settings_.get<coord_t>("support_roof_offset");
 
-    const size_t scan_count = std::max(size_t(1), (roof_layer_count - 1)); // How many measurements to take to generate roof areas.
-    const double z_skip = std::max(
-        1.0,
-        double(roof_layer_count - 1) / double(scan_count)); // How many layers to skip between measurements. Using float for better spread, but this is later rounded.
     const double minimum_roof_area = mesh.settings.get<double>("minimum_roof_area");
 
     std::vector<SupportLayer>& support_layers = storage.support.supportLayers;
@@ -1728,9 +1720,9 @@ void AreaSupport::generateSupportRoof(SliceDataStorage& storage, const SliceMesh
             std::min(LayerIndex{ support_layers.size() - 1 }, LayerIndex{ layer_idx + roof_layer_count + z_distance_top })
         }; // Maximum layer of the model that generates support roof.
         Polygons mesh_outlines;
-        for (double layer_idx_above = top_layer_idx_above; layer_idx_above > layer_idx + z_distance_top; layer_idx_above -= z_skip)
+        for (auto layer_idx_above = top_layer_idx_above; layer_idx_above > layer_idx + z_distance_top - 1; layer_idx_above -= 1)
         {
-            mesh_outlines.add(mesh.layers[std::round(layer_idx_above)].getOutlines());
+            mesh_outlines.add(mesh.layers[layer_idx_above].getOutlines());
         }
         Polygons roofs;
         generateSupportInterfaceLayer(global_support_areas_per_layer[layer_idx], mesh_outlines, roof_line_width, roof_outline_offset, minimum_roof_area, roofs);


### PR DESCRIPTION
# Description

Due to newly added fractional layer height, in combination with the extremely small model height (1 layer) the model was completely missed in the logic that added the roof logic. Added one additional layer in the for loop that checks for model area's in the interface logic to take into account fractional layers. Also removed the "skip layers" logic as this was just a performance optimization that was adding a lot of unneeded complexity in my opinion.

**Before**
![Screenshot 2024-03-18 at 17 19 24](https://github.com/Ultimaker/CuraEngine/assets/6638028/284cb639-8873-4614-bc10-72a3baf84de8)

**After**
![Screenshot 2024-03-18 at 17 18 29](https://github.com/Ultimaker/CuraEngine/assets/6638028/a234b740-1014-4b4e-95ec-c8bef8c7d17b)



CURA-11423


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

yes

**Test Configuration**:
* Operating System: macos 13.3

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change