### PR TITLE
Fix double support on first layer

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3673,7 +3673,7 @@ bool FffGcodeWriter::addSupportRoofsToGCode(
     // make sure there is a wall if this is on the first layer
     if (gcode_layer.getLayerNr() == 0)
     {
-        wall = support_layer.support_roof.offset(-support_roof_line_width / 2);
+        wall = support_roof_outlines.offset(-support_roof_line_width / 2);
         infill_outline = wall.offset(-support_roof_line_width / 2);
     }
     infill_outline = Simplify(roof_extruder.settings_).polygon(infill_outline);


### PR DESCRIPTION
When adding a fractional layer support, it could be replaced by the non-fractional support layer, for the first layer only. Now we use the actual fractional support layer instead.