### PR TITLE
CURA-11757 fix crash with empty layers

### DIFF
--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -170,7 +170,7 @@ private:
      *
      * \param[in] storage where to get settings from.
      */
-    size_t getStartExtruder(const SliceDataStorage& storage);
+    size_t getStartExtruder(const SliceDataStorage& storage) const;
 
     /*!
      * Set the infill angles and skin angles in the SliceDataStorage.
@@ -287,7 +287,7 @@ private:
     void calculatePrimeLayerPerExtruder(const SliceDataStorage& storage);
 
     /*!
-     * Gets a list of extruders that are used on the given layer, but excluding the given starting extruder.
+     * Gets a list of extruders that are used on the given layer.
      * When it's on the first layer, the prime blob will also be taken into account.
      *
      * \note At the planning stage we only have information on areas, not how those are filled.
@@ -297,7 +297,7 @@ private:
      * \param current_extruder The current extruder with which we last printed
      * \return The order of extruders for a layer beginning with \p current_extruder
      */
-    std::vector<ExtruderUse> getUsedExtrudersOnLayerExcludingStartingExtruder(const SliceDataStorage& storage, const size_t start_extruder, const LayerIndex& layer_nr) const;
+    std::vector<ExtruderUse> getUsedExtrudersOnLayer(const SliceDataStorage& storage, const size_t start_extruder, const LayerIndex& layer_nr) const;
 
     /*!
      * Calculate in which order to plan the meshes of a specific extruder
@@ -715,6 +715,10 @@ private:
         const SliceMeshStorage& mesh,
         const SliceLayerPart& part,
         coord_t infill_line_width);
+
+    size_t findUsedExtruderIndex(const SliceDataStorage& storage, const LayerIndex& layer_nr, bool last) const;
+
+    std::vector<ExtruderUse> getExtruderUse(const LayerIndex& layer_nr) const;
 };
 
 } // namespace cura

--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -716,8 +716,24 @@ private:
         const SliceLayerPart& part,
         coord_t infill_line_width);
 
+    /*!
+     * Find the first or last extruder used at the given layer. This may loop to lower layers if
+     * there is no extryder on the one that has been asked. If no extruder can be found at all, the
+     * very first used extruder will be returned.
+     *
+     * \param storage where the slice data is stored
+     * \param layer_nr The layer for which we want the extruder index
+     * \param last Indicates whether we want to retrieve the last or the first extruder being used
+     * \return The first or last exruder used at the given index
+     */
     size_t findUsedExtruderIndex(const SliceDataStorage& storage, const LayerIndex& layer_nr, bool last) const;
 
+    /*!
+     * Get the extruders use at the given layer
+     *
+     * \param layer_nr The index of the layer at which we want the extruders uses
+     * \return The extruders use at the given layer, which may be empty in some cases
+     */
     std::vector<ExtruderUse> getExtruderUse(const LayerIndex& layer_nr) const;
 };
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -278,7 +278,7 @@ void FffGcodeWriter::findLayerSeamsForSpiralize(SliceDataStorage& storage, size_
         bool done_this_layer = false;
 
         // iterate through extruders until we find a mesh that has a part with insets
-        const std::vector<ExtruderUse>& extruder_order = extruder_order_per_layer[layer_nr];
+        const std::vector<ExtruderUse> extruder_order = getExtruderUse(layer_nr);
         for (unsigned int extruder_idx = 0; ! done_this_layer && extruder_idx < extruder_order.size(); ++extruder_idx)
         {
             const size_t extruder_nr = extruder_order[extruder_idx].extruder_nr;
@@ -394,7 +394,7 @@ void FffGcodeWriter::setConfigRetractionAndWipe(SliceDataStorage& storage)
     }
 }
 
-size_t FffGcodeWriter::getStartExtruder(const SliceDataStorage& storage)
+size_t FffGcodeWriter::getStartExtruder(const SliceDataStorage& storage) const
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
     const EPlatformAdhesion adhesion_type = mesh_group_settings.get<EPlatformAdhesion>("adhesion_type");
@@ -1181,24 +1181,10 @@ FffGcodeWriter::ProcessLayerResult FffGcodeWriter::processLayer(const SliceDataS
 
     assert(
         static_cast<LayerIndex>(extruder_order_per_layer_negative_layers.size()) + layer_nr >= 0 && "Layer numbers shouldn't get more negative than there are raft/filler layers");
-    const std::vector<ExtruderUse>& extruder_order
-        = (layer_nr < 0) ? extruder_order_per_layer_negative_layers[extruder_order_per_layer_negative_layers.size() + layer_nr] : extruder_order_per_layer[layer_nr];
 
-    size_t first_extruder;
-    if (extruder_order.size() > 0)
-    {
-        first_extruder = extruder_order.front().extruder_nr;
-    }
-    else
-    {
-        // find the last extruder used in the previous layer
-        size_t last_extruder_nr_layer = layer_nr - 1;
-        while (extruder_order_per_layer[last_extruder_nr_layer].size() == 0 && last_extruder_nr_layer >= 0)
-        {
-            last_extruder_nr_layer--;
-        }
-        first_extruder = extruder_order_per_layer[last_extruder_nr_layer].back().extruder_nr;
-    }
+    const size_t first_extruder = findUsedExtruderIndex(storage, layer_nr, false);
+
+    const std::vector<ExtruderUse> extruder_order = getExtruderUse(layer_nr);
 
     const coord_t first_outer_wall_line_width = scene.extruders[first_extruder].settings_.get<coord_t>("wall_line_width_0");
     LayerPlan& gcode_layer = *new LayerPlan(
@@ -1562,7 +1548,7 @@ void FffGcodeWriter::calculateExtruderOrderPerLayer(const SliceDataStorage& stor
     for (LayerIndex layer_nr = -Raft::getTotalExtraLayers(); layer_nr < static_cast<LayerIndex>(storage.print_layer_count); layer_nr++)
     {
         std::vector<std::vector<ExtruderUse>>& extruder_order_per_layer_here = (layer_nr < 0) ? extruder_order_per_layer_negative_layers : extruder_order_per_layer;
-        std::vector<ExtruderUse> extruder_order = getUsedExtrudersOnLayerExcludingStartingExtruder(storage, last_extruder, layer_nr);
+        std::vector<ExtruderUse> extruder_order = getUsedExtrudersOnLayer(storage, last_extruder, layer_nr);
         extruder_order_per_layer_here.push_back(extruder_order);
 
         if (! extruder_order.empty())
@@ -1587,8 +1573,7 @@ void FffGcodeWriter::calculatePrimeLayerPerExtruder(const SliceDataStorage& stor
     }
 }
 
-std::vector<ExtruderUse>
-    FffGcodeWriter::getUsedExtrudersOnLayerExcludingStartingExtruder(const SliceDataStorage& storage, const size_t start_extruder, const LayerIndex& layer_nr) const
+std::vector<ExtruderUse> FffGcodeWriter::getUsedExtrudersOnLayer(const SliceDataStorage& storage, const size_t start_extruder, const LayerIndex& layer_nr) const
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
     size_t extruder_count = Application::getInstance().current_slice_->scene.extruders.size();
@@ -2469,6 +2454,53 @@ bool FffGcodeWriter::partitionInfillBySkinAbove(
     return ! infill_below_skin_overlap.empty() && ! infill_not_below_skin.empty();
 }
 
+size_t FffGcodeWriter::findUsedExtruderIndex(const SliceDataStorage& storage, const LayerIndex& layer_nr, bool last) const
+{
+    const std::vector<ExtruderUse> extruder_use = getExtruderUse(layer_nr);
+
+    if (! extruder_use.empty())
+    {
+        return last ? extruder_use.back().extruder_nr : extruder_use.front().extruder_nr;
+    }
+    else if (layer_nr <= -extruder_order_per_layer_negative_layers.size())
+    {
+        // Asking for extruder use below first layer, give first extruder
+        return getStartExtruder(storage);
+    }
+    else
+    {
+        // Asking for extruder on an empty layer, get the one from layer below
+        return findUsedExtruderIndex(storage, layer_nr - 1, true);
+    }
+}
+
+std::vector<ExtruderUse> FffGcodeWriter::getExtruderUse(const LayerIndex& layer_nr) const
+{
+    int layer_index;
+    const std::vector<std::vector<ExtruderUse>>* extruder_order;
+
+    if (layer_nr >= 0)
+    {
+        layer_index = layer_nr;
+        extruder_order = &extruder_order_per_layer;
+    }
+    else
+    {
+        layer_index = extruder_order_per_layer_negative_layers.size() + layer_nr;
+        extruder_order = &extruder_order_per_layer_negative_layers;
+    }
+
+    if (layer_index >= 0 && layer_index < extruder_order->size())
+    {
+        return (*extruder_order)[layer_index];
+    }
+    else
+    {
+        // No extruder use registered for this layer, which may happen in some edge-cases
+        return {};
+    }
+}
+
 void FffGcodeWriter::processSpiralizedWall(
     const SliceDataStorage& storage,
     LayerPlan& gcode_layer,
@@ -3289,6 +3321,10 @@ bool FffGcodeWriter::addSupportToGCode(const SliceDataStorage& storage, LayerPla
     if (extruder_nr == support_roof_extruder_nr)
     {
         support_added |= addSupportRoofsToGCode(storage, support_layer.support_fractional_roof, gcode_layer.configs_storage_.support_fractional_roof_config, gcode_layer);
+        /*SVG svg(fmt::format("/tmp/support_{}.svg", gcode_layer.getLayerNr().value), AABB(storage.getMachineBorder()), 0.001);
+        svg.writePolygons(support_layer.support_roof, SVG::Color::BLACK, 0.15);
+        svg.writePolygons(support_layer.support_fractional_roof, SVG::Color::MAGENTA, 0.1);
+        svg.writePolygons(support_layer.support_roof.difference(support_layer.support_fractional_roof), SVG::Color::ORANGE, 0.05);*/
     }
     if (extruder_nr == support_infill_extruder_nr)
     {
@@ -3913,8 +3949,7 @@ void FffGcodeWriter::addPrimeTower(const SliceDataStorage& storage, LayerPlan& g
     }
 
     LayerIndex layer_nr = gcode_layer.getLayerNr();
-    const std::vector<ExtruderUse>& extruder_order
-        = (layer_nr < 0) ? extruder_order_per_layer_negative_layers[extruder_order_per_layer_negative_layers.size() + layer_nr] : extruder_order_per_layer[layer_nr];
+    const std::vector<ExtruderUse> extruder_order = getExtruderUse(layer_nr);
     storage.primeTower.addToGcode(storage, gcode_layer, extruder_order, prev_extruder, gcode_layer.getExtruder());
 }
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3321,10 +3321,6 @@ bool FffGcodeWriter::addSupportToGCode(const SliceDataStorage& storage, LayerPla
     if (extruder_nr == support_roof_extruder_nr)
     {
         support_added |= addSupportRoofsToGCode(storage, support_layer.support_fractional_roof, gcode_layer.configs_storage_.support_fractional_roof_config, gcode_layer);
-        /*SVG svg(fmt::format("/tmp/support_{}.svg", gcode_layer.getLayerNr().value), AABB(storage.getMachineBorder()), 0.001);
-        svg.writePolygons(support_layer.support_roof, SVG::Color::BLACK, 0.15);
-        svg.writePolygons(support_layer.support_fractional_roof, SVG::Color::MAGENTA, 0.1);
-        svg.writePolygons(support_layer.support_roof.difference(support_layer.support_fractional_roof), SVG::Color::ORANGE, 0.05);*/
     }
     if (extruder_nr == support_infill_extruder_nr)
     {


### PR DESCRIPTION
Apparently in some conditions it is possible to ask for the extruders use list at a layer that don't have one. It is also possible to get an empty list for an existing layer. In both cases this cas lead to crashes because somes consumers of this list assume it is not empty.
These changes add protections for those cases, while not changing the "normal" situations.

CURA-11757