### PR TITLE
Improved fractional tree support

### DIFF
--- a/include/TreeSupport.h
+++ b/include/TreeSupport.h
@@ -45,6 +45,32 @@ constexpr coord_t SUPPORT_TREE_COLLISION_RESOLUTION = 500; // Only has an effect
 using PropertyAreasUnordered = std::unordered_map<TreeSupportElement, Polygons>;
 using PropertyAreas = std::map<TreeSupportElement, Polygons>;
 
+struct FakeRoofArea
+{
+    FakeRoofArea(Polygons area, coord_t line_distance, bool fractional):
+        area_(area)
+        , line_distance_(line_distance)
+        , fractional_(fractional)
+    {
+
+    }
+    /*!
+     * \brief Area that should be a fake roof.
+     */
+    Polygons area_;
+
+    /*!
+     * \brief Distance between support lines
+     */
+    coord_t line_distance_;
+
+    /*!
+     * \brief If the area should be added as a fractional support area.
+     */
+    bool fractional_;
+};
+
+
 /*!
  * \brief Generates a tree structure to support your models.
  */
@@ -271,7 +297,10 @@ private:
      * \param support_roof_storage[in] Areas where support was replaced with roof.
      * \param storage[in,out] The storage where the support should be stored.
      */
-    void finalizeInterfaceAndSupportAreas(std::vector<Polygons>& support_layer_storage, std::vector<Polygons>& support_roof_storage, SliceDataStorage& storage);
+    void finalizeInterfaceAndSupportAreas(std::vector<Polygons>& support_layer_storage,
+                                          std::vector<Polygons>& support_roof_storage,
+                                          std::vector<Polygons>& support_layer_storage_fractional,
+                                          SliceDataStorage& storage);
 
     /*!
      * \brief Draws circles around result_on_layer points of the influence areas and applies some post processing.
@@ -292,9 +321,9 @@ private:
     std::vector<Polygons> additional_required_support_area;
 
     /*!
-     * \brief A representation of already placed lines. Required for subtracting from new support areas.
+     * \brief Areas that use a higher density pattern of regular support to support the model (fake_roof).
      */
-    std::vector<Polygons> placed_support_lines_support_areas;
+    std::vector<std::vector<FakeRoofArea>> fake_roof_areas;
 
     /*!
      * \brief Generator for model collision, avoidance and internal guide volumes.

--- a/include/TreeSupportSettings.h
+++ b/include/TreeSupportSettings.h
@@ -54,7 +54,8 @@ struct TreeSupportSettings
         , // Either 40° or as much as possible so that 2 lines will overlap by at least 50%, whichever is smaller.
         support_overrides(mesh_group_settings.get<SupportDistPriority>("support_xy_overrides_z"))
         , xy_min_distance(support_overrides == SupportDistPriority::Z_OVERRIDES_XY ? mesh_group_settings.get<coord_t>("support_xy_distance_overhang") : xy_distance)
-        , z_distance_top_layers(round_up_divide(mesh_group_settings.get<coord_t>("support_top_distance"), layer_height))
+        , z_distance_top(mesh_group_settings.get<coord_t>("support_top_distance"))
+        , z_distance_top_layers(round_up_divide(z_distance_top, layer_height))
         , z_distance_bottom_layers(round_up_divide(mesh_group_settings.get<coord_t>("support_bottom_distance"), layer_height))
         , support_infill_angles(mesh_group_settings.get<std::vector<AngleDegrees>>("support_infill_angles"))
         , support_roof_angles(mesh_group_settings.get<std::vector<AngleDegrees>>("support_roof_angles"))
@@ -258,6 +259,11 @@ public:
     coord_t xy_min_distance;
 
     /*!
+     * \brief Distance required the top of the support to the model
+     */
+    coord_t z_distance_top;
+
+    /*!
      * \brief Amount of layers distance required the top of the support to the model
      */
     size_t z_distance_top_layers;
@@ -397,7 +403,7 @@ public:
             && // can not be set on a per-mesh basis currently, so code to enable processing different roof patterns in the same iteration seems useless.
                support_roof_angles == other.support_roof_angles && support_infill_angles == other.support_infill_angles
             && increase_radius_until_radius == other.increase_radius_until_radius && support_bottom_layers == other.support_bottom_layers && layer_height == other.layer_height
-            && z_distance_top_layers == other.z_distance_top_layers && maximum_deviation == other.maximum_deviation && // Infill generation depends on deviation and resolution.
+            && z_distance_top == other.z_distance_top && maximum_deviation == other.maximum_deviation && // Infill generation depends on deviation and resolution.
                maximum_resolution == other.maximum_resolution && support_roof_line_distance == other.support_roof_line_distance && skip_some_zags == other.skip_some_zags
             && zag_skip_count == other.zag_skip_count && connect_zigzags == other.connect_zigzags && interface_preference == other.interface_preference
             && min_feature_size == other.min_feature_size && // interface_preference should be identical to ensure the tree will correctly interact with the roof.

--- a/include/TreeSupportTipGenerator.h
+++ b/include/TreeSupportTipGenerator.h
@@ -299,7 +299,7 @@ private:
     std::vector<Polygons> support_roof_drawn_;
 
     /*!
-     * \brief Areas that will be saved as fractional support roof
+     * \brief Areas that require fractional roof above it.
      */
     std::vector<Polygons> support_roof_drawn_fractional_;
 

--- a/include/TreeSupportTipGenerator.h
+++ b/include/TreeSupportTipGenerator.h
@@ -33,7 +33,7 @@ public:
      * \param mesh[in] The mesh that is currently processed. Contains the overhangs.
      * \param move_bounds[out] The storage for the tips.
      * \param additional_support_areas[out] Areas that should have been roofs, but are now support, as they would not generate any lines as roof. Should already be initialised.
-
+     * \param placed_fake_roof_areas[out] Areas where fake roof has to be placed.
      * \return All lines of the \p polylines object, with information for each point regarding in which avoidance it is currently valid in.
      */
     void generateTips(
@@ -41,7 +41,7 @@ public:
         const SliceMeshStorage& mesh,
         std::vector<std::set<TreeSupportElement*>>& move_bounds,
         std::vector<Polygons>& additional_support_areas,
-        std::vector<Polygons>& placed_support_lines_support_areas);
+        std::vector<std::vector<FakeRoofArea>>& placed_fake_roof_areas);
 
 private:
     enum class LineStatus
@@ -297,6 +297,11 @@ private:
      * \brief Areas that will be saved as support roof
      */
     std::vector<Polygons> support_roof_drawn_;
+
+    /*!
+     * \brief Areas that will be saved as fractional support roof
+     */
+    std::vector<Polygons> support_roof_drawn_fractional_;
 
     /*!
      * \brief Areas that will be saved as support roof, originating from tips being replaced with roof areas.

--- a/include/sliceDataStorage.h
+++ b/include/sliceDataStorage.h
@@ -227,6 +227,29 @@ public:
      */
     void excludeAreasFromSupportInfillAreas(const Polygons& exclude_polygons, const AABB& exclude_polygons_boundary_box);
 
+    /* Fill up the infill parts for the support with the given support polygons. The support polygons will be split into parts.
+     *
+     * \param area The support polygon to fill up with infill parts.
+     * \param support_fill_per_layer The support polygons to fill up with infill parts.
+     * \param support_line_width Line width of the support extrusions.
+     * \param wall_line_count Wall-line count around the fill.
+     * \param use_fractional_config (optional, default to false) If the area should be added as fractional support.
+     * \param unionAll (optional, default to false) Wether to 'union all' for the split into parts bit.
+     * \param custom_line_distance (optional, default to 0) Distance between lines of the infill pattern. custom_line_distance of 0 means use the default instead.
+     */
+    void fillInfillParts(const Polygons& area,
+                         const coord_t support_line_width,
+                         const coord_t wall_line_count,
+                         const bool use_fractional_config = false,
+                         const bool unionAll = false,
+                         const coord_t custom_line_distance = 0)
+    {
+        for (const PolygonsPart& island_outline : area.splitIntoParts(unionAll))
+        {
+            support_infill_parts.emplace_back(island_outline, support_line_width, use_fractional_config, wall_line_count, custom_line_distance);
+        }
+    }
+
     /* Fill up the infill parts for the support with the given support polygons. The support polygons will be split into parts. This also takes into account fractional-height
      * support layers.
      *

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -94,7 +94,7 @@ TreeSupport::TreeSupport(const SliceDataStorage& storage)
         mesh.first.setActualZ(known_z);
     }
 
-    placed_support_lines_support_areas = std::vector<Polygons>(storage.support.supportLayers.size(), Polygons());
+    fake_roof_areas = std::vector<std::vector<FakeRoofArea>>(storage.support.supportLayers.size(),std::vector<FakeRoofArea>());
 }
 
 void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
@@ -256,7 +256,7 @@ LayerIndex TreeSupport::precalculate(const SliceDataStorage& storage, std::vecto
 void TreeSupport::generateInitialAreas(const SliceMeshStorage& mesh, std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage)
 {
     TreeSupportTipGenerator tip_gen(mesh, volumes_);
-    tip_gen.generateTips(storage, mesh, move_bounds, additional_required_support_area, placed_support_lines_support_areas);
+    tip_gen.generateTips(storage, mesh, move_bounds, additional_required_support_area, fake_roof_areas);
 }
 
 void TreeSupport::mergeHelper(
@@ -2135,7 +2135,10 @@ void TreeSupport::filterFloatingLines(std::vector<Polygons>& support_layer_stora
         dur_hole_removal);
 }
 
-void TreeSupport::finalizeInterfaceAndSupportAreas(std::vector<Polygons>& support_layer_storage, std::vector<Polygons>& support_roof_storage, SliceDataStorage& storage)
+void TreeSupport::finalizeInterfaceAndSupportAreas(std::vector<Polygons>& support_layer_storage,
+                                                   std::vector<Polygons>& support_roof_storage,
+                                                   std::vector<Polygons>& support_layer_storage_fractional,
+                                                   SliceDataStorage& storage)
 {
     InterfacePreference interface_pref = config.interface_preference; // InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE;
     double progress_total = TREE_PROGRESS_PRECALC_AVO + TREE_PROGRESS_PRECALC_COLL + TREE_PROGRESS_GENERATE_NODES + TREE_PROGRESS_AREA_CALC + TREE_PROGRESS_GENERATE_BRANCH_AREAS
@@ -2148,7 +2151,22 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(std::vector<Polygons>& suppor
         support_layer_storage.size(),
         [&](const LayerIndex layer_idx)
         {
-            support_layer_storage[layer_idx] = support_layer_storage[layer_idx].difference(placed_support_lines_support_areas[layer_idx]);
+
+            Polygons fake_roof_lines;
+
+            for(FakeRoofArea& f_roof:fake_roof_areas[layer_idx])
+            {
+                fake_roof_lines.add(TreeSupportUtils::generateSupportInfillLines(f_roof.area_,
+                                                                           config,
+                                                                           false,
+                                                                           layer_idx,
+                                                                           f_roof.line_distance_,
+                                                                           storage.support.cross_fill_provider,
+                                                                           false).offsetPolyLine(config.support_line_width / 2));
+            }
+            fake_roof_lines = fake_roof_lines.unionPolygons();
+
+            support_layer_storage[layer_idx] = support_layer_storage[layer_idx].difference(fake_roof_lines);
 
             // Subtract support lines of the branches from the roof
             storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.unionPolygons(support_roof_storage[layer_idx]);
@@ -2238,15 +2256,48 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(std::vector<Polygons>& suppor
         {
             constexpr bool convert_every_part = true; // Convert every part into a PolygonsPart for the support.
 
+
             storage.support.supportLayers[layer_idx].fillInfillParts(
-                layer_idx,
-                support_layer_storage,
-                config.layer_height,
-                storage.meshes,
+                support_layer_storage[layer_idx],
                 config.support_line_width,
                 config.support_wall_count,
-                config.maximum_move_distance,
+                false,
                 convert_every_part);
+
+
+            // This only works because fractional support is always just projected upwards regular support or skin.
+            // Also technically violates skin height, but there is no good way to prevent that.
+            Polygons fractional_support;
+
+            if(layer_idx > 0)
+            {
+                fractional_support = support_layer_storage_fractional[layer_idx].intersection(support_layer_storage[layer_idx - 1]);
+            }
+            else
+            {
+                fractional_support = support_layer_storage_fractional[layer_idx];
+            }
+
+            storage.support.supportLayers[layer_idx].fillInfillParts(
+                fractional_support,
+                config.support_line_width,
+                config.support_wall_count,
+                true,
+                convert_every_part);
+
+
+            for(FakeRoofArea& fake_roof : fake_roof_areas[layer_idx])
+            {
+                storage.support.supportLayers[layer_idx].fillInfillParts(
+                    fake_roof.area_,
+                    config.support_line_width,
+                    0,
+                    fake_roof.fractional_,
+                    convert_every_part,
+                    fake_roof.line_distance_);
+            }
+
+
             {
                 std::lock_guard<std::mutex> critical_section_progress(critical_sections);
                 progress_total += TREE_PROGRESS_FINALIZE_BRANCH_AREAS / support_layer_storage.size();
@@ -2266,6 +2317,8 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(std::vector<Polygons>& suppor
 void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage)
 {
     std::vector<Polygons> support_layer_storage(move_bounds.size());
+    std::vector<Polygons> support_layer_storage_fractional(move_bounds.size());
+    std::vector<Polygons> support_roof_storage_fractional(move_bounds.size());
     std::vector<Polygons> support_roof_storage(move_bounds.size());
     std::map<TreeSupportElement*, TreeSupportElement*>
         inverse_tree_order; // In the tree structure only the parents can be accessed. Inverse this to be able to access the children.
@@ -2360,7 +2413,25 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
     {
         for (std::pair<TreeSupportElement*, Polygons> data_pair : layer_tree_polygons[layer_idx])
         {
+            if(data_pair.first->parents_.empty() && !data_pair.first->supports_roof_ && layer_idx + 1 < support_roof_storage_fractional.size())
+            {
+                if(data_pair.first->missing_roof_layers_ > data_pair.first->distance_to_top_)
+                {
+                    support_roof_storage_fractional[layer_idx+1].add(data_pair.second);
+                }
+                else
+                {
+                    support_layer_storage_fractional[layer_idx+1].add(data_pair.second);
+                }
+
+            }
+
             ((data_pair.first->missing_roof_layers_ > data_pair.first->distance_to_top_) ? support_roof_storage : support_layer_storage)[layer_idx].add(data_pair.second);
+        }
+        if(layer_idx + 1< support_roof_storage_fractional.size())
+        {
+            support_roof_storage_fractional[layer_idx+1] = support_roof_storage_fractional[layer_idx+1].unionPolygons();
+            support_layer_storage_fractional[layer_idx+1] = support_layer_storage_fractional[layer_idx+1].unionPolygons();
         }
     }
 
@@ -2376,7 +2447,7 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
     filterFloatingLines(support_layer_storage);
     const auto t_filter = std::chrono::high_resolution_clock::now();
 
-    finalizeInterfaceAndSupportAreas(support_layer_storage, support_roof_storage, storage);
+    finalizeInterfaceAndSupportAreas(support_layer_storage, support_roof_storage, support_layer_storage_fractional, storage);
     const auto t_end = std::chrono::high_resolution_clock::now();
 
     const auto dur_gen_tips = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_generate - t_start).count();

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2414,7 +2414,10 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
         {
             for (std::pair<TreeSupportElement*, Polygons> data_pair : layer_tree_polygons[layer_idx])
             {
-                if (data_pair.first->parents_.empty() && ! data_pair.first->supports_roof_ && layer_idx + 1 < support_roof_storage_fractional.size())
+                if (data_pair.first->parents_.empty() &&
+                    ! data_pair.first->supports_roof_ &&
+                    layer_idx + 1 < support_roof_storage_fractional.size() &&
+                    config.z_distance_top % config.layer_height > 0)
                 {
                     if (data_pair.first->missing_roof_layers_ > data_pair.first->distance_to_top_)
                     {

--- a/src/TreeSupportTipGenerator.cpp
+++ b/src/TreeSupportTipGenerator.cpp
@@ -748,8 +748,12 @@ void TreeSupportTipGenerator::addLinesAsInfluenceAreas(
             added_roofs = added_roofs.unionPolygons();
             {
                 std::lock_guard<std::mutex> critical_section_roof(critical_roof_tips_);
-
                 roof_tips_drawn_[insert_layer_idx - dtt_roof_tip].add(added_roofs);
+
+                if(dtt_roof_tip == 0)
+                {
+                    support_roof_drawn_fractional_[insert_layer_idx].add(added_roofs);
+                }
             }
         }
     }

--- a/src/TreeSupportTipGenerator.cpp
+++ b/src/TreeSupportTipGenerator.cpp
@@ -54,7 +54,7 @@ TreeSupportTipGenerator::TreeSupportTipGenerator(const SliceMeshStorage& mesh, T
     , support_tree_branch_reach_limit_(support_tree_limit_branch_reach_ ? mesh.settings.get<coord_t>("support_tree_branch_reach_limit") : 0)
     , z_distance_delta_(std::min(config_.z_distance_top_layers + 1, mesh.overhang_areas.size()))
     , xy_overrides_(config_.support_overrides == SupportDistPriority::XY_OVERRIDES_Z)
-    , tip_roof_size_(force_tip_to_roof_ ? config_.min_radius * config_.min_radius * std::numbers::pi : 0)
+    , tip_roof_size_(force_tip_to_roof_ ? INT2MM2(config_.min_radius * config_.min_radius) * std::numbers::pi : 0)
     , force_minimum_roof_area_(use_fake_roof_ || SUPPORT_TREE_MINIMUM_ROOF_AREA_HARD_LIMIT)
     , already_inserted_(mesh.overhang_areas.size())
     , support_roof_drawn_(mesh.overhang_areas.size(), Polygons())
@@ -663,7 +663,7 @@ void TreeSupportTipGenerator::addPointAsInfluenceArea(
                 dont_move_until,
                 roof,
                 safe_radius,
-                force_tip_to_roof_,
+                !roof && force_tip_to_roof_,
                 skip_ovalisation,
                 support_tree_limit_branch_reach_,
                 support_tree_branch_reach_limit_);


### PR DESCRIPTION
# Description

Improving how fractional support and fractional support roof is generated. Areas that need fractional support are no longer extrapolated from finished support calculations, but the information about which area need fractional support is stored to be later added as such. Should be more resilient.
Intended to be an alternative to https://github.com/Ultimaker/CuraEngine/pull/2052

It also contains a fix for a bug found while testing this: Missing conversion from square microns to square mm causing roof to sometimes not being generated correctly (Commit 9cfea95a4ce3cd9942228c9990a8b1ee696ef02d)

# Possible Improvements

- If the fractional support layer is very thin (e.g. _Support Top Distance_ of 0.19mm at a layer height of 0.1mm) reducing the top-most support layer by 0.01mm would be better than printing a fractional support layer of 0.01mm height. This would require more changes to the way fractional support is handled though.

- Fractional roof/support at layer 0 is not supported as of now.

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change