### PR TITLE
added same path for extra combing move introduced

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -746,7 +746,7 @@ public:
      * it.
      * \param part If given, stay within the boundary of this part.
      */
-    void moveInsideCombBoundary(const coord_t distance, const std::optional<SliceLayerPart>& part = std::nullopt);
+    void moveInsideCombBoundary(const coord_t distance, const std::optional<SliceLayerPart>& part = std::nullopt, GCodePath* path = nullptr);
 
     /*!
      * If enabled, apply the modify plugin to the layer-plan.

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -310,7 +310,7 @@ void LayerPlan::setMesh(const std::shared_ptr<const SliceMeshStorage>& mesh)
     current_mesh_ = mesh;
 }
 
-void LayerPlan::moveInsideCombBoundary(const coord_t distance, const std::optional<SliceLayerPart>& part)
+void LayerPlan::moveInsideCombBoundary(const coord_t distance, const std::optional<SliceLayerPart>& part, GCodePath* path)
 {
     constexpr coord_t max_dist2 = MM2INT(2.0) * MM2INT(2.0); // if we are further than this distance, we conclude we are not inside even though we thought we were.
     // this function is to be used to move from the boundary of a part to inside the part
@@ -321,7 +321,7 @@ void LayerPlan::moveInsideCombBoundary(const coord_t distance, const std::option
         PolygonUtils::moveInside(comb_boundary_preferred_, p, distance, max_dist2);
         if (comb_boundary_preferred_.inside(p) && (part == std::nullopt || part->outline.inside(p)))
         {
-            addTravel_simple(p);
+            addTravel_simple(p, path);
             // Make sure the that any retraction happens after this move, not before it by starting a new move path.
             forceNewPathStart();
         }
@@ -507,7 +507,7 @@ GCodePath& LayerPlan::addTravel(const Point2LL& p, const bool force_retract, con
             {
                 innermost_wall_line_width *= mesh_or_extruder_settings.get<Ratio>("initial_layer_line_width_factor");
             }
-            moveInsideCombBoundary(innermost_wall_line_width);
+            moveInsideCombBoundary(innermost_wall_line_width, std::nullopt, path);
         }
         path->retract = retraction_enable;
         path->perform_z_hop = retraction_enable && mesh_or_extruder_settings.get<bool>("retraction_hop_enabled");


### PR DESCRIPTION
CURA-11735

# Description
The moveInsideCombBoundary method in LayerPlan class has been updated to take an extra GCodePath parameter. This update improves the combing process by ensuring a consistent path is followed. Previously a new gcodepath was getting created for this combing move, however last_position was somehow not properly updated .

In the picture it could be seen what it changes in gcode

![Capture](https://github.com/Ultimaker/CuraEngine/assets/70144862/23695887-fede-4d60-a5da-c779a5025456)
