### PR TITLE
CURA-11249 travel up with fractional layer

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -56,7 +56,7 @@ class LayerPlan : public NoCopy
 
 public:
     const PathConfigStorage configs_storage_; //!< The line configs for this layer for each feature type
-    coord_t z_;
+    const coord_t z_;
     coord_t final_travel_z_;
     bool mode_skip_agressive_merge_; //!< Whether to give every new path the 'skip_agressive_merge_hint' property (see GCodePath); default is false.
 

--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -266,7 +266,7 @@ public:
      */
     void addExtraPrimeAmount(double extra_prime_volume);
 
-    Point3LL getPosition() const;
+    const Point3LL& getPosition() const;
 
     Point2LL getPositionXY() const;
 

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2185,6 +2185,13 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 ss << "MESH:" << (current_mesh ? current_mesh->mesh_name : "NONMESH");
                 gcode.writeComment(ss.str());
             }
+
+            if (! path.spiralize && (! path.retract || ! path.perform_z_hop) && (z_ + path.z_offset != gcode.getPositionZ()) && (path_idx > 0 || layer_nr_ > 0))
+            {
+                // First move to desired height to then make a plain horizontal move
+                gcode.writeTravel(Point3LL(gcode.getPosition().x_, gcode.getPosition().y_, z_ + path.z_offset), speed);
+            }
+
             if (path.config.isTravelPath())
             { // early comp for travel paths, which are handled more simply
                 if (! path.perform_z_hop && final_travel_z_ != z_ && extruder_plan_idx == (extruder_plans_.size() - 1) && path_idx == (paths.size() - 1))

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -411,7 +411,7 @@ void GCodeExport::setFlowRateExtrusionSettings(double max_extrusion_offset, doub
     this->extrusion_offset_factor_ = extrusion_offset_factor;
 }
 
-Point3LL GCodeExport::getPosition() const
+const Point3LL& GCodeExport::getPosition() const
 {
     return current_position_;
 }


### PR DESCRIPTION
Add a small vertical travel move when starting to print/travel along some lines that have a different Z that the previous. This allows performing those lines fully horizontally instead of moving along Z axis while moving.

This fixes a case where it was possible that the nozzle would go through printed material from the model when also printing supports with fractional layer height. It also improves the first printed segment of a fractional layer line which was previous starting at full layer height and moving down while extruding.

CURA-11249