### PR TITLE
CURA-11717 prime tower has unused material

### DIFF
--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -295,9 +295,11 @@ private:
      *
      * \param[in] storage where the slice data is stored.
      * \param current_extruder The current extruder with which we last printed
+     * \param global_extruders_used The extruders that are at some point used for the print job
      * \return The order of extruders for a layer beginning with \p current_extruder
      */
-    std::vector<ExtruderUse> getUsedExtrudersOnLayer(const SliceDataStorage& storage, const size_t start_extruder, const LayerIndex& layer_nr) const;
+    std::vector<ExtruderUse>
+        getUsedExtrudersOnLayer(const SliceDataStorage& storage, const size_t start_extruder, const LayerIndex& layer_nr, const std::vector<bool>& global_extruders_used) const;
 
     /*!
      * Calculate in which order to plan the meshes of a specific extruder

--- a/include/PrimeTower.h
+++ b/include/PrimeTower.h
@@ -28,8 +28,8 @@ class LayerPlan;
 class PrimeTower
 {
 private:
-    using MovesByExtruder = std::vector<Polygons>;
-    using MovesByLayer = std::vector<MovesByExtruder>;
+    using MovesByExtruder = std::map<size_t, Polygons>;
+    using MovesByLayer = std::map<size_t, std::vector<Polygons>>;
 
     size_t extruder_count_; //!< Number of extruders
 
@@ -79,10 +79,12 @@ public:
      */
     PrimeTower();
 
+    void initializeExtruders(const std::vector<bool>& used_extruders);
+
     /*!
      * Check whether we actually use the prime tower.
      */
-    void checkUsed(const SliceDataStorage& storage);
+    void checkUsed();
 
     /*!
      * Generate the prime tower area to be used on each layer

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1543,12 +1543,13 @@ void FffGcodeWriter::calculateExtruderOrderPerLayer(const SliceDataStorage& stor
     }
 
     size_t extruder_count = Application::getInstance().current_slice_->scene.extruders.size();
+    const std::vector<bool> extruders_used = storage.getExtrudersUsed();
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
     PrimeTowerMethod prime_tower_mode = mesh_group_settings.get<PrimeTowerMethod>("prime_tower_mode");
     for (LayerIndex layer_nr = -Raft::getTotalExtraLayers(); layer_nr < static_cast<LayerIndex>(storage.print_layer_count); layer_nr++)
     {
         std::vector<std::vector<ExtruderUse>>& extruder_order_per_layer_here = (layer_nr < 0) ? extruder_order_per_layer_negative_layers : extruder_order_per_layer;
-        std::vector<ExtruderUse> extruder_order = getUsedExtrudersOnLayer(storage, last_extruder, layer_nr);
+        std::vector<ExtruderUse> extruder_order = getUsedExtrudersOnLayer(storage, last_extruder, layer_nr, extruders_used);
         extruder_order_per_layer_here.push_back(extruder_order);
 
         if (! extruder_order.empty())
@@ -1573,10 +1574,14 @@ void FffGcodeWriter::calculatePrimeLayerPerExtruder(const SliceDataStorage& stor
     }
 }
 
-std::vector<ExtruderUse> FffGcodeWriter::getUsedExtrudersOnLayer(const SliceDataStorage& storage, const size_t start_extruder, const LayerIndex& layer_nr) const
+std::vector<ExtruderUse> FffGcodeWriter::getUsedExtrudersOnLayer(
+    const SliceDataStorage& storage,
+    const size_t start_extruder,
+    const LayerIndex& layer_nr,
+    const std::vector<bool>& global_extruders_used) const
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
-    size_t extruder_count = Application::getInstance().current_slice_->scene.extruders.size();
+    size_t extruder_count = global_extruders_used.size();
     assert(static_cast<int>(extruder_count) > 0);
     std::vector<ExtruderUse> ret;
     std::vector<bool> extruder_is_used_on_this_layer = storage.getExtrudersUsed(layer_nr);
@@ -1601,7 +1606,7 @@ std::vector<ExtruderUse> FffGcodeWriter::getUsedExtrudersOnLayer(const SliceData
     ordered_extruders.push_back(start_extruder);
     for (size_t extruder_nr = 0; extruder_nr < extruder_count; extruder_nr++)
     {
-        if (extruder_nr != start_extruder)
+        if (extruder_nr != start_extruder && global_extruders_used[extruder_nr])
         {
             ordered_extruders.push_back(extruder_nr);
         }

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -404,6 +404,8 @@ void FffPolygonGenerator::slices2polygons(SliceDataStorage& storage, TimeKeeper&
 
     Progress::messageProgressStage(Progress::Stage::SUPPORT, &time_keeper);
 
+    storage.primeTower.initializeExtruders(storage.getExtrudersUsed());
+
     AreaSupport::generateOverhangAreas(storage);
     AreaSupport::generateSupportAreas(storage);
     TreeSupport tree_support_generator(storage);

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -362,13 +362,9 @@ Polygons SliceDataStorage::getLayerOutlines(
                 total.add(support_layer.support_roof);
             }
         }
-        int prime_tower_outer_extruder_nr = primeTower.extruder_order_[0];
-        if (include_prime_tower && (extruder_nr == -1 || extruder_nr == prime_tower_outer_extruder_nr))
+        if (include_prime_tower && primeTower.enabled_ && (extruder_nr == -1 || (! primeTower.extruder_order_.empty() && extruder_nr == primeTower.extruder_order_[0])))
         {
-            if (primeTower.enabled_)
-            {
-                total.add(primeTower.getOuterPoly(layer_nr));
-            }
+            total.add(primeTower.getOuterPoly(layer_nr));
         }
         return total;
     }


### PR DESCRIPTION
Until now, the prime tower used all the extruders of the printers even if they were not used nor enabled.

We now check whether an extruder is actually used during the print, and completely remove it from the prime tower generation if it's not. This way, the rings for each extruder adapt to the global extruders use.

CURA-11717