### PR TITLE
Cura 11821 crash due to permission

### DIFF
--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -87,7 +87,7 @@ SVG::SVG(std::string filename, AABB aabb, double scale, Point2LL canvas_size, Co
     out_ = fopen(filename.c_str(), "w");
     if (! out_)
     {
-        spdlog::error("The file %s could not be opened for writing.", filename);
+        spdlog::error("The file {} could not be opened for writing.", filename);
     }
     if (output_is_html_)
     {

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -16,6 +16,7 @@
 
 #ifdef DEBUG
 #include <spdlog/spdlog.h>
+
 #include "utils/AABB.h"
 #endif
 

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -16,6 +16,7 @@
 
 #ifdef DEBUG
 #include <filesystem>
+
 #include <spdlog/spdlog.h>
 
 #include "utils/AABB.h"

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -15,15 +15,9 @@
 #include "utils/linearAlg2D.h"
 
 #ifdef DEBUG
-#include <filesystem>
-
 #include <spdlog/spdlog.h>
-
 #include "utils/AABB.h"
-#include "utils/SVG.h"
 #endif
-
-namespace fs = std::filesystem;
 
 namespace cura
 {
@@ -693,51 +687,6 @@ ClosestPolygonPoint PolygonUtils::ensureInsideOrOutside(
                 bool overall_is_inside = polygons.inside(overall_inside.location_);
                 if (overall_is_inside != (preferred_dist_inside > 0))
                 {
-#ifdef DEBUG
-                    static bool has_run = false;
-                    if (! has_run)
-                    {
-                        fs::path const debug_file_name = fs::temp_directory_path() / "debug.html";
-                        try
-                        {
-                            int offset_performed = offset / 2;
-                            AABB aabb(polygons);
-                            aabb.expand(std::abs(preferred_dist_inside) * 2);
-                            SVG svg(debug_file_name.string(), aabb);
-                            svg.writeComment("Original polygon in black");
-                            svg.writePolygons(polygons, SVG::Color::BLACK);
-                            for (auto poly : polygons)
-                            {
-                                for (auto point : poly)
-                                {
-                                    svg.writePoint(point, true, 2);
-                                }
-                            }
-                            std::stringstream ss;
-                            svg.writeComment("Reference polygon in yellow");
-                            svg.writePolygon(closest_poly, SVG::Color::YELLOW);
-                            ss << "Offsetted polygon in blue with offset " << offset_performed;
-                            svg.writeComment(ss.str());
-                            svg.writePolygons(insetted, SVG::Color::BLUE);
-                            for (auto poly : insetted)
-                            {
-                                for (auto point : poly)
-                                {
-                                    svg.writePoint(point, true, 2);
-                                }
-                            }
-                            svg.writeComment("From location");
-                            svg.writePoint(from, true, 5, SVG::Color::GREEN);
-                            svg.writeComment("Location computed to be inside the black polygon");
-                            svg.writePoint(inside.location_, true, 5, SVG::Color::RED);
-                        }
-                        catch (...)
-                        {
-                        }
-                        spdlog::error("Clipper::offset failed. See generated {}! Black is original Blue is offsetted polygon", debug_file_name.string());
-                        has_run = true;
-                    }
-#endif
                     return ClosestPolygonPoint();
                 }
                 inside = overall_inside;

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -15,11 +15,14 @@
 #include "utils/linearAlg2D.h"
 
 #ifdef DEBUG
+#include <filesystem>
 #include <spdlog/spdlog.h>
 
 #include "utils/AABB.h"
 #include "utils/SVG.h"
 #endif
+
+namespace fs = std::filesystem;
 
 namespace cura
 {
@@ -693,12 +696,13 @@ ClosestPolygonPoint PolygonUtils::ensureInsideOrOutside(
                     static bool has_run = false;
                     if (! has_run)
                     {
+                        fs::path const debug_file_name = fs::temp_directory_path() / "debug.html";
                         try
                         {
                             int offset_performed = offset / 2;
                             AABB aabb(polygons);
                             aabb.expand(std::abs(preferred_dist_inside) * 2);
-                            SVG svg("debug.html", aabb);
+                            SVG svg(debug_file_name.string(), aabb);
                             svg.writeComment("Original polygon in black");
                             svg.writePolygons(polygons, SVG::Color::BLACK);
                             for (auto poly : polygons)
@@ -729,7 +733,7 @@ ClosestPolygonPoint PolygonUtils::ensureInsideOrOutside(
                         catch (...)
                         {
                         }
-                        spdlog::error("Clipper::offset failed. See generated debug.html! Black is original Blue is offsetted polygon");
+                        spdlog::error("Clipper::offset failed. See generated {}! Black is original Blue is offsetted polygon", debug_file_name.string());
                         has_run = true;
                     }
 #endif


### PR DESCRIPTION
# Description

writing debug.html in temp folder

writing debug.html in the current folder (in case of build the program data) makes it read only and no write modifications are allowed, hence crash. Now it is written in temp folder of the computer where writing the file is also allowed.
should solve : https://github.com/Ultimaker/Cura/issues/18835

CURA-11821