### PR TITLE
Add cura resources as optional Conan dependency

### DIFF
--- a/.github/workflows/gcodeanalyzer.yml
+++ b/.github/workflows/gcodeanalyzer.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           for file in `ls ../NightlyTestModels/*.stl`;
           do
-              ( time ./build/Release/CuraEngine slice --force-read-parent --force-read-nondefault -v -p -j ../Cura/resources/definitions/ultimaker_s3.def.json -l $file -o ../`basename $file .stl`.gcode ) 2> ../`basename $file .stl`.time
+              ( time ./build/Release/CuraEngine slice --force-read-parent --force-read-nondefault -v -p -j $CURA_RESOURCES/definitions/ultimaker_s3.def.json -l $file -o ../`basename $file .stl`.gcode ) 2> ../`basename $file .stl`.time
           done
         working-directory: CuraEngine
 

--- a/.github/workflows/gcodeanalyzer.yml
+++ b/.github/workflows/gcodeanalyzer.yml
@@ -81,28 +81,6 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine the corresponding Cura branch
-        id: curabranch
-        run: |
-          status_code=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/ultimaker/cura/branches/${{ github.head_ref }}")
-          if [ "$status_code" -eq 200 ]; then
-            echo "The branch exists in Cura"
-            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-          else
-            echo "branch=main" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout Cura
-        uses: actions/checkout@v3
-        with:
-          repository: 'Ultimaker/Cura'
-          ref: ${{ steps.curabranch.outputs.branch}}
-          path: 'Cura'
-          fetch-depth: 1
-          sparse-checkout: |
-            resources/definitions
-            resources/extruders
-
       - name: Sync pip requirements
         run: curl -O https://raw.githubusercontent.com/Ultimaker/cura-workflows/main/.github/workflows/requirements-runner.txt
         working-directory: CuraEngine/.github/workflows
@@ -159,7 +137,7 @@ jobs:
             ${{ runner.os }}-conan-downloads-
 
       - name: Install dependencies
-        run: conan install . ${{ needs.conan-recipe-version.outputs.recipe_id_full }} -s build_type=Release --build=missing --update -g GitHubActionsRunEnv -g GitHubActionsBuildEnv -c tools.build:skip_test=True
+        run: conan install . ${{ needs.conan-recipe-version.outputs.recipe_id_full }} -s build_type=Release --build=missing --update -g GitHubActionsRunEnv -g GitHubActionsBuildEnv -c tools.build:skip_test=True -o with_cura_resources=True
         working-directory: CuraEngine
 
       - name: Set Environment variables from Conan install (bash)
@@ -167,7 +145,6 @@ jobs:
         run: |
           . ./activate_github_actions_runenv.sh
           . ./activate_github_actions_buildenv.sh
-          echo "CURA_ENGINE_SEARCH_PATH=$GITHUB_WORKSPACE/Cura/resources/definitions:$GITHUB_WORKSPACE/Cura/resources/extruders" >> $GITHUB_ENV
         working-directory: CuraEngine/build/Release/generators
 
       - name: Build CuraEngine and tests

--- a/conandata.yml
+++ b/conandata.yml
@@ -6,4 +6,4 @@ requirements_arcus:
 requirements_plugins:
   - "curaengine_grpc_definitions/(latest)@ultimaker/testing"
 requirements_cura_resources:
-  - "cura_resources/(latest)@ultimaker/np_186"
+  - "cura_resources/(latest)@ultimaker/testing"

--- a/conandata.yml
+++ b/conandata.yml
@@ -6,4 +6,4 @@ requirements_arcus:
 requirements_plugins:
   - "curaengine_grpc_definitions/(latest)@ultimaker/testing"
 requirements_cura_resources:
-  - "cura_resources/(latest)@ultimaker/testing"
+  - "cura_resources/(latest)@ultimaker/np_186"

--- a/conandata.yml
+++ b/conandata.yml
@@ -5,3 +5,5 @@ requirements_arcus:
   - "arcus/5.3.1"
 requirements_plugins:
   - "curaengine_grpc_definitions/(latest)@ultimaker/testing"
+requirements_cura_resources:
+  - "cura_resources/(latest)@ultimaker/testing"

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,6 +32,7 @@ class CuraEngineConan(ConanFile):
         "enable_plugins": [True, False],
         "enable_sentry": [True, False],
         "enable_remote_plugins": [True, False],
+        "with_cura_resources": [True, False],
     }
     default_options = {
         "enable_arcus": True,
@@ -40,6 +41,7 @@ class CuraEngineConan(ConanFile):
         "enable_plugins": True,
         "enable_sentry": False,
         "enable_remote_plugins": False,
+        "with_cura_resources": False,
     }
 
     def set_version(self):
@@ -115,6 +117,9 @@ class CuraEngineConan(ConanFile):
             self.requires("asio-grpc/2.6.0")
             self.requires("grpc/1.50.1")
             for req in self.conan_data["requirements_plugins"]:
+                self.requires(req)
+        if self.options.with_cura_resources:
+            for req in self.conan_data["requirements_cura_resources"]:
                 self.requires(req)
         if self.options.enable_arcus or self.options.enable_plugins:
             self.requires("protobuf/3.21.12")


### PR DESCRIPTION
This update adds an optional dependency to 'cura_resources' in the 'conandata.yml' and 'conanfile.py'. Another significant change is in the 'gcodeanalyzer.yml' where the steps to checkout Cura and the associated environment variables have been removed in favor of adding the Cura resources directly to the Conan install command.

Contribute to NP-186

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change