### PR TITLE
CURA-11873 interleaved prime tower bad raft

### DIFF
--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -207,6 +207,10 @@ private:
      */
     void processRaft(const SliceDataStorage& storage);
 
+    void startRaftLayer(const SliceDataStorage& storage, LayerPlan& gcode_layer, const LayerIndex layer_nr, size_t layer_extruder, size_t& current_extruder);
+
+    void endRaftLayer(const SliceDataStorage& storage, LayerPlan& gcode_layer, const LayerIndex layer_nr, size_t& current_extruder);
+
     /*!
      * Convert the polygon data of a layer into a layer plan on the FffGcodeWriter::layer_plan_buffer
      *

--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -209,7 +209,7 @@ private:
 
     void startRaftLayer(const SliceDataStorage& storage, LayerPlan& gcode_layer, const LayerIndex layer_nr, size_t layer_extruder, size_t& current_extruder);
 
-    void endRaftLayer(const SliceDataStorage& storage, LayerPlan& gcode_layer, const LayerIndex layer_nr, size_t& current_extruder);
+    void endRaftLayer(const SliceDataStorage& storage, LayerPlan& gcode_layer, const LayerIndex layer_nr, size_t& current_extruder, const bool append_to_prime_tower = true);
 
     /*!
      * Convert the polygon data of a layer into a layer plan on the FffGcodeWriter::layer_plan_buffer
@@ -665,8 +665,11 @@ private:
      * \param[in] storage where the slice data is stored.
      * \param gcode_layer The initial planning of the gcode of the layer.
      * \param extruder_nr The extruder to switch to.
+     * \param append_to_prime_tower Indicates whether we should actually prime the extruder on the prime tower (normal
+     *                              case before actually using the extruder) or just do the basic priming (i.e. on first
+     *                              layer before starting the print
      */
-    void setExtruder_addPrime(const SliceDataStorage& storage, LayerPlan& gcode_layer, const size_t extruder_nr) const;
+    void setExtruder_addPrime(const SliceDataStorage& storage, LayerPlan& gcode_layer, const size_t extruder_nr, const bool append_to_prime_tower = true) const;
 
     /*!
      * Add the prime tower gcode for the current layer.

--- a/include/PrimeTower.h
+++ b/include/PrimeTower.h
@@ -59,7 +59,6 @@ private:
 
 public:
     bool enabled_; //!< Whether the prime tower is enabled.
-    bool would_have_actual_tower_; //!< Whether there is an actual tower.
 
     /*
      * In which order, from outside to inside, will we be printing the prime

--- a/include/PrimeTower.h
+++ b/include/PrimeTower.h
@@ -60,7 +60,6 @@ private:
 public:
     bool enabled_; //!< Whether the prime tower is enabled.
     bool would_have_actual_tower_; //!< Whether there is an actual tower.
-    bool multiple_extruders_on_first_layer_; //!< Whether multiple extruders are allowed on the first layer of the prime tower (e.g. when a raft is there)
 
     /*
      * In which order, from outside to inside, will we be printing the prime

--- a/include/raft.h
+++ b/include/raft.h
@@ -55,6 +55,18 @@ public:
      */
     static size_t getTotalExtraLayers();
 
+    /*!
+     *  \brief Get the amount of bottom for the raft interface.
+     *  \note This is currently hard-coded to 1 because we have yet no setting for the bottom
+     */
+    static size_t getBottomLayers();
+
+    /*! \brief Get the amount of layers for the raft interface. */
+    static size_t getInterfaceLayers();
+
+    /*! \brief Get the amount of layers for the raft top. */
+    static size_t getSurfaceLayers();
+
     enum LayerType
     {
         RaftBase,
@@ -70,6 +82,9 @@ public:
      * \return The type of layer at the given layer index.
      */
     static LayerType getLayerType(LayerIndex layer_index);
+
+private:
+    static size_t getLayersAmount(const std::string& extruder_nr, const std::string& layers_nr);
 };
 
 } // namespace cura

--- a/include/raft.h
+++ b/include/raft.h
@@ -84,7 +84,13 @@ public:
     static LayerType getLayerType(LayerIndex layer_index);
 
 private:
-    static size_t getLayersAmount(const std::string& extruder_nr, const std::string& layers_nr);
+    /*!
+     * \brief Get the amount of layers to be printed for the given raft section
+     * \param extruder_nr_setting_name The name of the setting to be fetched to get the proper extruder number
+     * \param target_raft_section The name of the setting to be fetched to get the number of layers
+     * \return The number of layers for the given raft section, or 0 if raft is disabled
+     */
+    static size_t getLayersAmount(const std::string& extruder_nr_setting_name, const std::string& target_raft_section);
 };
 
 } // namespace cura

--- a/include/raft.h
+++ b/include/raft.h
@@ -56,10 +56,10 @@ public:
     static size_t getTotalExtraLayers();
 
     /*!
-     *  \brief Get the amount of bottom for the raft interface.
-     *  \note This is currently hard-coded to 1 because we have yet no setting for the bottom
+     *  \brief Get the amount of layers for the raft base.
+     *  \note This is currently hard-coded to 1 because we have yet no setting for the base
      */
-    static size_t getBottomLayers();
+    static size_t getBaseLayers();
 
     /*! \brief Get the amount of layers for the raft interface. */
     static size_t getInterfaceLayers();

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -570,7 +570,6 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
     const size_t base_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr_;
     const size_t interface_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr_;
     const size_t surface_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").extruder_nr_;
-    const size_t prime_tower_extruder_nr = storage.primeTower.extruder_order_.front();
 
     coord_t z = 0;
     const LayerIndex initial_raft_layer_nr = -Raft::getTotalExtraLayers();
@@ -782,12 +781,6 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             interface_line_width,
             interface_avoid_distance);
 
-        if (! prime_tower_added_on_this_layer && current_extruder_nr == prime_tower_extruder_nr)
-        {
-            addPrimeTower(storage, gcode_layer, current_extruder_nr);
-            prime_tower_added_on_this_layer = true;
-        }
-
         gcode_layer.setIsInside(true);
         if (interface_extruder_nr != current_extruder_nr)
         {
@@ -908,8 +901,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
         if (! prime_tower_added_on_this_layer)
         {
-            setExtruder_addPrime(storage, gcode_layer, prime_tower_extruder_nr);
-            current_extruder_nr = prime_tower_extruder_nr;
+            addPrimeTower(storage, gcode_layer, current_extruder_nr);
         }
 
         layer_plan_buffer.handle(gcode_layer, gcode);
@@ -951,12 +943,6 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             comb_offset,
             surface_line_width,
             surface_avoid_distance);
-
-        if (! prime_tower_added_on_this_layer && current_extruder_nr == prime_tower_extruder_nr)
-        {
-            addPrimeTower(storage, gcode_layer, current_extruder_nr);
-            prime_tower_added_on_this_layer = true;
-        }
 
         gcode_layer.setIsInside(true);
 
@@ -1098,8 +1084,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
 
         if (! prime_tower_added_on_this_layer)
         {
-            setExtruder_addPrime(storage, gcode_layer, prime_tower_extruder_nr);
-            current_extruder_nr = prime_tower_extruder_nr;
+            addPrimeTower(storage, gcode_layer, current_extruder_nr);
         }
 
         layer_plan_buffer.handle(gcode_layer, gcode);
@@ -1620,7 +1605,7 @@ std::vector<ExtruderUse> FffGcodeWriter::getUsedExtrudersOnLayer(
         }
     }
 
-    // Now check whether extuders should really used, and how
+    // Now check whether extuders should really be used, and how
     size_t last_extruder = start_extruder;
     for (size_t extruder_nr : ordered_extruders)
     {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -1580,8 +1580,9 @@ std::vector<ExtruderUse> FffGcodeWriter::getUsedExtrudersOnLayer(
     const auto method = mesh_group_settings.get<PrimeTowerMethod>("prime_tower_mode");
     const auto prime_tower_enable = mesh_group_settings.get<bool>("prime_tower_enable");
     const LayerIndex raft_base_layer_nr = -Raft::getTotalExtraLayers();
+    Raft::LayerType layer_type = Raft::getLayerType(layer_nr);
 
-    if (layer_nr < 0 && layer_nr < raft_base_layer_nr + Raft::getBottomLayers())
+    if (layer_type == Raft::RaftBase)
     {
         // Raft base layers area treated apart because they don't have a proper prime tower
         const size_t raft_base_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr_;

--- a/src/PrimeTower.cpp
+++ b/src/PrimeTower.cpp
@@ -32,22 +32,6 @@ PrimeTower::PrimeTower()
     const Scene& scene = Application::getInstance().current_slice_->scene;
     PrimeTowerMethod method = scene.current_mesh_group->settings.get<PrimeTowerMethod>("prime_tower_mode");
 
-    {
-        EPlatformAdhesion adhesion_type = scene.current_mesh_group->settings.get<EPlatformAdhesion>("adhesion_type");
-
-        // When we have multiple extruders sharing the same heater/nozzle, we expect that all the extruders have been
-        //'primed' by the print-start gcode script, but we don't know which one has been left at the tip of the nozzle
-        // and whether it needs 'purging' (before extruding a pure material) or not, so we need to prime (actually purge)
-        // each extruder before it is used for the model. This can done by the (per-extruder) brim lines or (per-extruder)
-        // skirt lines when they are used, but we need to do that inside the first prime-tower layer when they are not
-        // used (sacrifying for this purpose the usual single-extruder first layer, that would be better for prime-tower
-        // adhesion).
-
-        multiple_extruders_on_first_layer_ = (method == PrimeTowerMethod::INTERLEAVED) || (method == PrimeTowerMethod::NORMAL)
-                                          || (scene.current_mesh_group->settings.get<bool>("machine_extruders_share_nozzle")
-                                              && ((adhesion_type != EPlatformAdhesion::SKIRT) && (adhesion_type != EPlatformAdhesion::BRIM)));
-    }
-
     enabled_ = scene.current_mesh_group->settings.get<bool>("prime_tower_enable") && scene.current_mesh_group->settings.get<coord_t>("prime_tower_min_volume") > 10
             && scene.current_mesh_group->settings.get<coord_t>("prime_tower_size") > 10;
 

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -168,18 +168,29 @@ coord_t Raft::getFillerLayerHeight()
     return round_divide(getZdiffBetweenRaftAndLayer0(), getFillerLayerCount());
 }
 
-
 size_t Raft::getTotalExtraLayers()
 {
+    return getBottomLayers() + getInterfaceLayers() + getSurfaceLayers() + getFillerLayerCount();
+}
+
+size_t Raft::getBottomLayers()
+{
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
-    const ExtruderTrain& base_train = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr");
-    const ExtruderTrain& interface_train = mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr");
-    const ExtruderTrain& surface_train = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr");
-    if (base_train.settings_.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::RAFT)
+    if (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::RAFT)
     {
         return 0;
     }
-    return 1 + interface_train.settings_.get<size_t>("raft_interface_layers") + surface_train.settings_.get<size_t>("raft_surface_layers") + getFillerLayerCount();
+    return 1;
+}
+
+size_t Raft::getInterfaceLayers()
+{
+    return getLayersAmount("raft_interface_extruder_nr", "raft_interface_layers");
+}
+
+size_t Raft::getSurfaceLayers()
+{
+    return getLayersAmount("raft_surface_extruder_nr", "raft_surface_layers");
 }
 
 Raft::LayerType Raft::getLayerType(LayerIndex layer_index)
@@ -212,6 +223,18 @@ Raft::LayerType Raft::getLayerType(LayerIndex layer_index)
     {
         return LayerType::Model;
     }
+}
+
+size_t Raft::getLayersAmount(const std::string& extruder_nr, const std::string& layers_nr)
+{
+    const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
+    if (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::RAFT)
+    {
+        return 0;
+    }
+
+    const ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>(extruder_nr);
+    return train.settings_.get<size_t>(layers_nr);
 }
 
 

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -195,23 +195,19 @@ size_t Raft::getSurfaceLayers()
 
 Raft::LayerType Raft::getLayerType(LayerIndex layer_index)
 {
-    const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
-    const ExtruderTrain& base_train = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr");
-    const ExtruderTrain& interface_train = mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr");
-    const ExtruderTrain& surface_train = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr");
     const auto airgap = Raft::getFillerLayerCount();
-    const auto interface_layers = interface_train.settings_.get<size_t>("raft_interface_layers");
-    const auto surface_layers = surface_train.settings_.get<size_t>("raft_surface_layers");
+    const auto interface_layers = Raft::getInterfaceLayers();
+    const auto surface_layers = Raft::getSurfaceLayers();
 
     if (layer_index < -airgap - surface_layers - interface_layers)
     {
         return LayerType::RaftBase;
     }
-    if (layer_index < -airgap - surface_layers)
+    else if (layer_index < -airgap - surface_layers)
     {
         return LayerType::RaftInterface;
     }
-    if (layer_index < -airgap)
+    else if (layer_index < -airgap)
     {
         return LayerType::RaftSurface;
     }

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -170,10 +170,10 @@ coord_t Raft::getFillerLayerHeight()
 
 size_t Raft::getTotalExtraLayers()
 {
-    return getBottomLayers() + getInterfaceLayers() + getSurfaceLayers() + getFillerLayerCount();
+    return getBaseLayers() + getInterfaceLayers() + getSurfaceLayers() + getFillerLayerCount();
 }
 
-size_t Raft::getBottomLayers()
+size_t Raft::getBaseLayers()
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
     if (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::RAFT)

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -125,20 +125,6 @@ void Raft::generate(SliceDataStorage& storage)
         settings.get<bool>("raft_surface_remove_inside_corners"),
         settings.get<coord_t>("raft_surface_smoothing"),
         nominal_raft_line_width);
-
-    if (storage.primeTower.enabled_ && ! storage.primeTower.would_have_actual_tower_)
-    {
-        // Find out if the prime-tower part of the raft still needs to be printed, even if there is no actual tower.
-        // This will only happen if the different raft layers are printed by different extruders.
-        const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
-        const size_t base_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr_;
-        const size_t interface_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr_;
-        const size_t surface_extruder_nr = mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").extruder_nr_;
-        if (base_extruder_nr == interface_extruder_nr && base_extruder_nr == surface_extruder_nr)
-        {
-            return;
-        }
-    }
 }
 
 coord_t Raft::getTotalThickness()

--- a/src/raft.cpp
+++ b/src/raft.cpp
@@ -221,7 +221,7 @@ Raft::LayerType Raft::getLayerType(LayerIndex layer_index)
     }
 }
 
-size_t Raft::getLayersAmount(const std::string& extruder_nr, const std::string& layers_nr)
+size_t Raft::getLayersAmount(const std::string& extruder_nr_setting_name, const std::string& target_raft_section)
 {
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
     if (mesh_group_settings.get<EPlatformAdhesion>("adhesion_type") != EPlatformAdhesion::RAFT)
@@ -229,8 +229,8 @@ size_t Raft::getLayersAmount(const std::string& extruder_nr, const std::string& 
         return 0;
     }
 
-    const ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>(extruder_nr);
-    return train.settings_.get<size_t>(layers_nr);
+    const ExtruderTrain& train = mesh_group_settings.get<ExtruderTrain&>(extruder_nr_setting_name);
+    return train.settings_.get<size_t>(target_raft_section);
 }
 
 

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -482,8 +482,8 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed(const LayerIndex layer_nr) 
         }
         if (adhesion_type == EPlatformAdhesion::RAFT)
         {
-            const LayerIndex raft_base_layer_index = -Raft::getTotalExtraLayers();
-            if (layer_nr < raft_base_layer_index + Raft::getBottomLayers()) // Base layer.
+            const Raft::LayerType layer_type = Raft::getLayerType(layer_nr);
+            if (layer_type == Raft::RaftBase)
             {
                 ret[mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr_] = true;
                 // When using a raft, all prime blobs need to be on the lowest layer (the build plate).
@@ -495,11 +495,11 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed(const LayerIndex layer_nr) 
                     }
                 }
             }
-            else if (layer_nr < raft_base_layer_index + Raft::getBottomLayers() + Raft::getInterfaceLayers()) // Interface layer.
+            else if (layer_type == Raft::RaftInterface)
             {
                 ret[mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr_] = true;
             }
-            else if (layer_nr < -static_cast<LayerIndex>(Raft::getFillerLayerCount())) // Any of the surface layers.
+            else if (layer_type == Raft::RaftSurface)
             {
                 ret[mesh_group_settings.get<ExtruderTrain&>("raft_surface_extruder_nr").extruder_nr_] = true;
             }

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -482,8 +482,8 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed(const LayerIndex layer_nr) 
         }
         if (adhesion_type == EPlatformAdhesion::RAFT)
         {
-            const LayerIndex raft_layers = Raft::getTotalExtraLayers();
-            if (layer_nr == -raft_layers) // Base layer.
+            const LayerIndex raft_base_layer_index = -Raft::getTotalExtraLayers();
+            if (layer_nr < raft_base_layer_index + Raft::getBottomLayers()) // Base layer.
             {
                 ret[mesh_group_settings.get<ExtruderTrain&>("raft_base_extruder_nr").extruder_nr_] = true;
                 // When using a raft, all prime blobs need to be on the lowest layer (the build plate).
@@ -495,7 +495,7 @@ std::vector<bool> SliceDataStorage::getExtrudersUsed(const LayerIndex layer_nr) 
                     }
                 }
             }
-            else if (layer_nr == -raft_layers + 1) // Interface layer.
+            else if (layer_nr < raft_base_layer_index + Raft::getBottomLayers() + Raft::getInterfaceLayers()) // Interface layer.
             {
                 ret[mesh_group_settings.get<ExtruderTrain&>("raft_interface_extruder_nr").extruder_nr_] = true;
             }


### PR DESCRIPTION
The recent addition of the "interleaved" prime tower didn't really consider the use of the raft, which can use various extruders combinations. This PR fixes cases were some prime tower layers were completely missing while printing the raft, resulting in unusable interleaved prime tower.

The first 2 commits do some code simplification that is now possible due to the changed prime tower raft a few months ago. Before that, the prime tower had a regular raft below it, which is not the case anymore.
The last 2 commits actually handle the prime tower generation, properly taking care of the raft.

CURA-11873