### PR TITLE
CURA-11930 set start temperature but dont wait

### DIFF
--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -541,7 +541,14 @@ public:
 
     void writeFanCommand(double speed);
 
-    void writeTemperatureCommand(const size_t extruder, const Temperature& temperature, const bool wait = false);
+    /*!
+     * \brief Write a GCode temperature command
+     * \param extruder The extruder number
+     * \param temperature The temperature to bo set
+     * \param wait Indicates whether we should just set the temperature and keep going, or wait for the temperature to be reach before going further
+     * \param force_same_temperature When true, we should set the temperature command even if the actual set temperature is the same
+     */
+    void writeTemperatureCommand(const size_t extruder, const Temperature& temperature, const bool wait = false, const bool force_same_temperature = false);
     void writeBedTemperatureCommand(const Temperature& temperature, const bool wait = false);
     void writeBuildVolumeTemperatureCommand(const Temperature& temperature, const bool wait = false);
 

--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -546,9 +546,9 @@ public:
      * \param extruder The extruder number
      * \param temperature The temperature to bo set
      * \param wait Indicates whether we should just set the temperature and keep going, or wait for the temperature to be reach before going further
-     * \param force_same_temperature When true, we should set the temperature command even if the actual set temperature is the same
+     * \param force_write_on_equal When true, we should write the temperature command even if the actual set temperature is the same
      */
-    void writeTemperatureCommand(const size_t extruder, const Temperature& temperature, const bool wait = false, const bool force_same_temperature = false);
+    void writeTemperatureCommand(const size_t extruder, const Temperature& temperature, const bool wait = false, const bool force_write_on_equal = false);
     void writeBedTemperatureCommand(const Temperature& temperature, const bool wait = false);
     void writeBuildVolumeTemperatureCommand(const Temperature& temperature, const bool wait = false);
 

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1479,7 +1479,7 @@ void GCodeExport::writeFanCommand(double speed)
     current_fan_speed_ = speed;
 }
 
-void GCodeExport::writeTemperatureCommand(const size_t extruder, const Temperature& temperature, const bool wait, const bool force_same_temperature)
+void GCodeExport::writeTemperatureCommand(const size_t extruder, const Temperature& temperature, const bool wait, const bool force_write_on_equal)
 {
     const ExtruderTrain& extruder_train = Application::getInstance().current_slice_->scene.extruders[extruder];
 
@@ -1515,7 +1515,7 @@ void GCodeExport::writeTemperatureCommand(const size_t extruder, const Temperatu
         }
     }
 
-    if ((! wait || extruder_attr_[extruder].waited_for_temperature_) && ! force_same_temperature && extruder_attr_[extruder].current_temperature_ == temperature)
+    if ((! wait || extruder_attr_[extruder].waited_for_temperature_) && ! force_write_on_equal && extruder_attr_[extruder].current_temperature_ == temperature)
     {
         return;
     }


### PR DESCRIPTION
Previously, the initial temperatures commands were ignored if the temperatures were already set in the header. This causes issues because we don't actually know in what state the printer will let the nozzles after its init sequence. So we now write non-wait and wait temperatures commands based only on the settings, so that one can set them properly according to the printer init sequence.

CURA-11930