### PR TITLE
Fix Tree-support lines overlapping with the model

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2023,6 +2023,7 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
                 return;
             }
 
+            Shape relevant_forbidden = volumes_.getCollision(0, layer_idx, true);
             Shape outer_walls = TreeSupportUtils::toPolylines(support_layer_storage[layer_idx - 1].getOutsidePolygons())
                                     .createTubeShape(
                                         closing_dist,
@@ -2041,6 +2042,11 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
                 hole_aabb.expand(EPSILON);
                 if (! hole.intersection(PolygonUtils::clipPolygonWithAABB(outer_walls, hole_aabb)).empty())
                 {
+                    holes_resting_outside[layer_idx].emplace(idx);
+                }
+                else if (! hole.intersection(PolygonUtils::clipPolygonWithAABB(relevant_forbidden, hole_aabb)).offset(-config.xy_min_distance / 2).empty())
+                {
+                    // technically not resting outside, also not valid, but the alternative is potentially having lines go through the model
                     holes_resting_outside[layer_idx].emplace(idx);
                 }
                 else


### PR DESCRIPTION
# Description

Fixes https://github.com/Ultimaker/Cura/issues/18970 by keeping holes if they overlap with the model.
Technically this does cause floating lines, but that is in my opinion better than the alternative.
There could be an argument made to only apply this if the `support density` is > 0%, but I do not know if there could be other issues caused by model areas being inside of a support area.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] [Project file in issue 18970](https://github.com/Ultimaker/Cura/issues/18970#issuecomment-2081523866)

**Test Configuration**:
* Operating System: Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas