### PR TITLE
Improve handling of small areas

### DIFF
--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -281,6 +281,10 @@ void WallToolPaths::removeSmallLines(std::vector<VariableWidthLines>& toolpaths)
         for (size_t line_idx = 0; line_idx < inset.size(); line_idx++)
         {
             ExtrusionLine& line = inset[line_idx];
+            if(line.is_outer_wall())
+            {
+                continue;
+            }
             coord_t min_width = std::numeric_limits<coord_t>::max();
             for (const ExtrusionJunction& j : line)
             {


### PR DESCRIPTION
# Description

I looked into the issue https://github.com/Ultimaker/Cura/issues/18397 and would be interested in feedback regarding the following opinions:

1. WallToolPaths::removeSmallLines should not remove outer walls. By my understanding it was added to prevent very small lines filling holes. An outer wall will never fill a hole.
2. In SkeletalTrapezoidation there is no functional difference between a single local maxima or multiple very close to each other. If the resulting outer wall path is so short that it not even reaches its own width, maybe it would be better to combine all these local maxima into a single one and handle it accordingly. 


I am not convinced that this is the correct way to fix it, as I think arachne should not even generate such to small paths, even if the graph consists of multiple local maxima close to each other. I just want to highlight one possible solution to avoid completely missing areas.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] Project file linked in https://github.com/Ultimaker/Cura/issues/18397

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change