### PR TITLE
Remove the debug defines when building with RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,9 +191,6 @@ target_compile_definitions(_CuraEngine
         $<$<CONFIG:Debug>:ASSERT_INSANE_OUTPUT>
         $<$<CONFIG:Debug>:USE_CPU_TIME>
         $<$<CONFIG:Debug>:DEBUG>
-        $<$<CONFIG:RelWithDebInfo>:ASSERT_INSANE_OUTPUT>
-        $<$<CONFIG:RelWithDebInfo>:USE_CPU_TIME>
-        $<$<CONFIG:RelWithDebInfo>:DEBUG>
 )
 
 enable_sanitizers(_CuraEngine)

--- a/include/Application.h
+++ b/include/Application.h
@@ -105,9 +105,17 @@ protected:
 #endif // ARCUS
 
     /*!
-     * \brief Print the header and license to the stderr channel.
+     * \brief Print the header to the stderr channel.
+     */
+    void printHeader() const;
+
+    /*!
+     * \brief Print the license to the stderr channel.
      */
     void printLicense() const;
+
+    /*! Print a big warning when the code has been build in debug mode, otherwise just issue a small nice message. */
+    void printDebugWarning() const;
 
     /*!
      * \brief Start slicing.

--- a/include/Application.h
+++ b/include/Application.h
@@ -114,9 +114,6 @@ protected:
      */
     void printLicense() const;
 
-    /*! Print a big warning when the code has been build in debug mode, otherwise just issue a small nice message. */
-    void printDebugWarning() const;
-
     /*!
      * \brief Start slicing.
      * \param argc The number of arguments provided to the application.

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -148,10 +148,49 @@ void Application::printHelp() const
     fmt::print("\n");
 }
 
-void Application::printLicense() const
+void Application::printHeader() const
 {
     fmt::print("\n");
     fmt::print("Cura_SteamEngine version {}\n", CURA_ENGINE_VERSION);
+
+#ifdef DEBUG
+    fmt::print("\n");
+    fmt::print(" _______   ________  _______   __    __   ______\n");
+    fmt::print("/       \\ /        |/       \\ /  |  /  | /      \\\n");
+    fmt::print("███████  |████████/ ███████  |██ |  ██ |/██████  |\n");
+    fmt::print("██ |  ██ |██ |__    ██ |__██ |██ |  ██ |██ | _██/\n");
+    fmt::print("██ |  ██ |██    |   ██    ██< ██ |  ██ |██ |/    |\n");
+    fmt::print("██ |  ██ |█████/    ███████  |██ |  ██ |██ |████ |\n");
+    fmt::print("██ |__██ |██ |_____ ██ |__██ |██ \\__██ |██ \\__██ |\n");
+    fmt::print("██    ██/ ██       |██    ██/ ██    ██/ ██    ██/\n");
+    fmt::print("███████/  ████████/ ███████/   ██████/   ██████/\n");
+    fmt::print("\n");
+    fmt::print(" __       __   ______   _______   ________\n");
+    fmt::print("/  \\     /  | /      \\ /       \\ /        |\n");
+    fmt::print("██  \\   /██ |/██████  |███████  |████████/\n");
+    fmt::print("███  \\ /███ |██ |  ██ |██ |  ██ |██ |__\n");
+    fmt::print("████  /████ |██ |  ██ |██ |  ██ |██    |\n");
+    fmt::print("██ ██ ██/██ |██ |  ██ |██ |  ██ |█████/\n");
+    fmt::print("██ |███/ ██ |██ \\__██ |██ |__██ |██ |_____\n");
+    fmt::print("██ | █/  ██ |██    ██/ ██    ██/ ██       |\n");
+    fmt::print("██/      ██/  ██████/  ███████/  ████████/\n");
+    fmt::print("\n");
+
+    fmt::print("#########################################################\n");
+    fmt::print("#########################################################\n");
+    fmt::print("## WARNING: This version of CuraEngine has been built  ##\n");
+    fmt::print("## in developper mode. This may impact performances,   ##\n");
+    fmt::print("## provoke unexpected results or crashes.              ##\n");
+    fmt::print("## If you downloaded an official version of CuraEngine ##\n");
+    fmt::print("## and see this message, please report the issue.      ##\n");
+    fmt::print("#########################################################\n");
+    fmt::print("#########################################################\n");
+#endif
+}
+
+void Application::printLicense() const
+{
+    fmt::print("\n");
     fmt::print("Copyright (C) 2024 Ultimaker\n");
     fmt::print("\n");
     fmt::print("This program is free software: you can redistribute it and/or modify\n");
@@ -184,6 +223,7 @@ void Application::run(const size_t argc, char** argv)
     argc_ = argc;
     argv_ = argv;
 
+    printHeader();
     printLicense();
     Progress::init();
 


### PR DESCRIPTION
The variables `DEBUG`, `USE_CPU_TIME` and `ASSERT_INSANE_OUTPUT` were defined also when building in mode RelWithDebInfo, which is used when building the production installers. This leads to some debug code being executed by customers, with potential crashes and decreased performances.

Contributes to CURA-11821