### PR TITLE
CURA-11796 Combine the long and short unretracts at nozzle switch

### DIFF
--- a/include/pathPlanning/GCodePath.h
+++ b/include/pathPlanning/GCodePath.h
@@ -40,6 +40,7 @@ struct GCodePath
     Ratio speed_factor{ 1.0 }; //!< A speed factor that is multiplied with the travel speed. This factor can be used to change the travel speed.
     Ratio speed_back_pressure_factor{ 1.0 }; // <! The factor the (non-travel) speed should be multiplied with as a consequence of back pressure compensation.
     bool retract{ false }; //!< Whether the path is a move path preceded by a retraction move; whether the path is a retracted move path.
+    bool retract_for_nozzle_switch{ false }; //! Also retract to prepare for a nozzle switch
     bool unretract_before_last_travel_move{ false }; //!< Whether the last move of the path should be preceded by an unretraction. Used to unretract in the last travel move before
                                                      //!< an outer wall
     bool perform_z_hop{ false }; //!< Whether to perform a z_hop in this path, which is assumed to be a travel path.

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -267,7 +267,8 @@ bool LayerPlan::setExtruder(const size_t extruder_nr)
         }
         if (end_pos_absolute || last_planned_position_)
         {
-            addTravel(end_pos); //  + extruder_offset cause it
+            GCodePath& path = addTravel(end_pos); //  + extruder_offset cause it
+            path.retract_for_nozzle_switch = true;
         }
     }
     if (extruder_plans_.back().paths_.empty() && extruder_plans_.back().inserts_.empty())
@@ -2227,6 +2228,12 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
             {
                 retraction_config = path.mesh ? &path.mesh->retraction_wipe_config : retraction_config;
                 gcode.writeRetraction(retraction_config->retraction_config);
+                if (path.retract_for_nozzle_switch)
+                {
+                    constexpr bool force = true;
+                    constexpr bool extruder_switch = true;
+                    gcode.writeRetraction(retraction_config->extruder_switch_retraction_config, force, extruder_switch);
+                }
                 insertTempOnTime(extruder_plan.getRetractTime(path), path_idx);
                 if (path.perform_z_hop)
                 {

--- a/src/plugins/converters.cpp
+++ b/src/plugins/converters.cpp
@@ -347,6 +347,7 @@ gcode_paths_modify_request::value_type
         gcode_path->set_speed_factor(path.speed_factor);
         gcode_path->set_speed_back_pressure_factor(path.speed_back_pressure_factor);
         gcode_path->set_retract(path.retract);
+        gcode_path->set_retract_for_nozzle_switch(path.retract_for_nozzle_switch);
         gcode_path->set_unretract_before_last_travel_move(path.unretract_before_last_travel_move);
         gcode_path->set_perform_z_hop(path.perform_z_hop);
         gcode_path->set_perform_prime(path.perform_prime);
@@ -464,6 +465,7 @@ gcode_paths_modify_response::native_value_type
             .speed_factor = gcode_path_msg.speed_factor(),
             .speed_back_pressure_factor = gcode_path_msg.speed_back_pressure_factor(),
             .retract = gcode_path_msg.retract(),
+            .retract_for_nozzle_switch = gcode_path_msg.retract_for_nozzle_switch(),
             .unretract_before_last_travel_move = gcode_path_msg.unretract_before_last_travel_move(),
             .perform_z_hop = gcode_path_msg.perform_z_hop(),
             .perform_prime = gcode_path_msg.perform_prime(),


### PR DESCRIPTION
We now try to insert the nozzle switch retract at the same time as the travel move to the nozzle switch position, to avoid oozing during this (long) move. If there is no such move, it will fallback to the old behavior, but this should quite never happen.

CURA-11796

Requires https://github.com/Ultimaker/CuraEngine_grpc_definitions/pull/16