### PR TITLE
Prevent negative (= raft) layers from messing up z-seam calculation.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3469,7 +3469,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
             ZSeamConfig z_seam_config
                 = ZSeamConfig(EZSeamType::SHORTEST, gcode_layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE, false);
             Shape disallowed_area_for_seams{};
-            if (infill_extruder.settings_.get<bool>("support_z_seam_away_from_model"))
+            if (infill_extruder.settings_.get<bool>("support_z_seam_away_from_model") && (gcode_layer.getLayerNr() >= 0))
             {
                 for (std::shared_ptr<SliceMeshStorage> mesh_ptr : storage.meshes)
                 {


### PR DESCRIPTION
Not part of a ticket (yet?), done as a quick-fix.