### PR TITLE
Freeze grpc_definitions version

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -4,6 +4,6 @@ requirements:
 requirements_arcus:
   - "arcus/5.3.1"
 requirements_plugins:
-  - "curaengine_grpc_definitions/(latest)@ultimaker/testing"
+  - "curaengine_grpc_definitions/0.2.1"
 requirements_cura_resources:
   - "cura_resources/(latest)@ultimaker/testing"


### PR DESCRIPTION
Use a fixed version of CuraEngine_grpc_definitions because we actually need to use a specific interface.

CURA-12001