### PR TITLE
Mac fixes prime tower

### DIFF
--- a/src/PrimeTower/PrimeTower.cpp
+++ b/src/PrimeTower/PrimeTower.cpp
@@ -53,7 +53,7 @@ PrimeTower::PrimeTower()
             const double brim_radius_factor = std::pow((1.0 - static_cast<double>(z) / static_cast<double>(base_height)), base_curve_magnitude);
             const coord_t extra_radius = std::llrint(static_cast<double>(base_extra_radius) * brim_radius_factor);
             const coord_t total_radius = tower_radius + extra_radius;
-            base_occupied_outline_.emplace_back(OccupiedOutline{ PolygonUtils::makeDisc(middle_, total_radius, circle_definition_), total_radius });
+            base_occupied_outline_.push_back(OccupiedOutline{ PolygonUtils::makeDisc(middle_, total_radius, circle_definition_), total_radius });
         }
     }
 }

--- a/src/PrimeTower/PrimeTower.cpp
+++ b/src/PrimeTower/PrimeTower.cpp
@@ -53,7 +53,7 @@ PrimeTower::PrimeTower()
             const double brim_radius_factor = std::pow((1.0 - static_cast<double>(z) / static_cast<double>(base_height)), base_curve_magnitude);
             const coord_t extra_radius = std::llrint(static_cast<double>(base_extra_radius) * brim_radius_factor);
             const coord_t total_radius = tower_radius + extra_radius;
-            base_occupied_outline_.emplace_back(OccupiedOutline { PolygonUtils::makeDisc(middle_, total_radius, circle_definition_), total_radius });
+            base_occupied_outline_.emplace_back(OccupiedOutline{ PolygonUtils::makeDisc(middle_, total_radius, circle_definition_), total_radius });
         }
     }
 }

--- a/src/PrimeTower/PrimeTower.cpp
+++ b/src/PrimeTower/PrimeTower.cpp
@@ -53,7 +53,7 @@ PrimeTower::PrimeTower()
             const double brim_radius_factor = std::pow((1.0 - static_cast<double>(z) / static_cast<double>(base_height)), base_curve_magnitude);
             const coord_t extra_radius = std::llrint(static_cast<double>(base_extra_radius) * brim_radius_factor);
             const coord_t total_radius = tower_radius + extra_radius;
-            base_occupied_outline_.emplace_back(PolygonUtils::makeDisc(middle_, total_radius, circle_definition_), total_radius);
+            base_occupied_outline_.emplace_back(OccupiedOutline { PolygonUtils::makeDisc(middle_, total_radius, circle_definition_), total_radius });
         }
     }
 }

--- a/src/PrimeTower/PrimeTowerInterleaved.cpp
+++ b/src/PrimeTower/PrimeTowerInterleaved.cpp
@@ -88,7 +88,7 @@ std::map<LayerIndex, std::vector<PrimeTower::ExtruderToolPaths>> PrimeTowerInter
             {
                 if (toolpaths_at_layer.empty())
                 {
-                    toolpaths_at_layer.emplace_back(ExtruderToolPaths { last_extruder_support, ClosedLinesSet(), prime_next_outer_radius, inner_support_radius });
+                    toolpaths_at_layer.emplace_back(ExtruderToolPaths{ last_extruder_support, ClosedLinesSet(), prime_next_outer_radius, inner_support_radius });
                 }
 
                 ExtruderToolPaths& last_extruder_toolpaths = toolpaths_at_layer.back();
@@ -117,7 +117,7 @@ void PrimeTowerInterleaved::polishExtrudersUses(LayerVector<std::vector<Extruder
         // Make sure we always have something to print
         if (extruders_use_at_layer.empty())
         {
-            extruders_use_at_layer.emplace_back(ExtruderUse { last_used_extruder, ExtruderPrime::Support });
+            extruders_use_at_layer.emplace_back(ExtruderUse{ last_used_extruder, ExtruderPrime::Support });
         }
         else if (std::all_of(
                      extruders_use_at_layer.begin(),

--- a/src/PrimeTower/PrimeTowerInterleaved.cpp
+++ b/src/PrimeTower/PrimeTowerInterleaved.cpp
@@ -88,7 +88,7 @@ std::map<LayerIndex, std::vector<PrimeTower::ExtruderToolPaths>> PrimeTowerInter
             {
                 if (toolpaths_at_layer.empty())
                 {
-                    toolpaths_at_layer.emplace_back(last_extruder_support, ClosedLinesSet(), prime_next_outer_radius, inner_support_radius);
+                    toolpaths_at_layer.emplace_back(ExtruderToolPaths { last_extruder_support, ClosedLinesSet(), prime_next_outer_radius, inner_support_radius });
                 }
 
                 ExtruderToolPaths& last_extruder_toolpaths = toolpaths_at_layer.back();
@@ -117,7 +117,7 @@ void PrimeTowerInterleaved::polishExtrudersUses(LayerVector<std::vector<Extruder
         // Make sure we always have something to print
         if (extruders_use_at_layer.empty())
         {
-            extruders_use_at_layer.emplace_back(last_used_extruder, ExtruderPrime::Support);
+            extruders_use_at_layer.emplace_back(ExtruderUse { last_used_extruder, ExtruderPrime::Support });
         }
         else if (std::all_of(
                      extruders_use_at_layer.begin(),

--- a/src/PrimeTower/PrimeTowerInterleaved.cpp
+++ b/src/PrimeTower/PrimeTowerInterleaved.cpp
@@ -88,7 +88,7 @@ std::map<LayerIndex, std::vector<PrimeTower::ExtruderToolPaths>> PrimeTowerInter
             {
                 if (toolpaths_at_layer.empty())
                 {
-                    toolpaths_at_layer.emplace_back(ExtruderToolPaths{ last_extruder_support, ClosedLinesSet(), prime_next_outer_radius, inner_support_radius });
+                    toolpaths_at_layer.push_back(ExtruderToolPaths{ last_extruder_support, ClosedLinesSet(), prime_next_outer_radius, inner_support_radius });
                 }
 
                 ExtruderToolPaths& last_extruder_toolpaths = toolpaths_at_layer.back();
@@ -117,7 +117,7 @@ void PrimeTowerInterleaved::polishExtrudersUses(LayerVector<std::vector<Extruder
         // Make sure we always have something to print
         if (extruders_use_at_layer.empty())
         {
-            extruders_use_at_layer.emplace_back(ExtruderUse{ last_used_extruder, ExtruderPrime::Support });
+            extruders_use_at_layer.push_back(ExtruderUse{ last_used_extruder, ExtruderPrime::Support });
         }
         else if (std::all_of(
                      extruders_use_at_layer.begin(),


### PR DESCRIPTION
Fix build issue on MAC when using the `emplace_back` method

The XCode compiler seems to be stricter about structs default constructors, so we can't use `emplace_back` and the construct-in-place mechanism without manually declaring the constructors, which would be overkill in this case. We don't really need the provided performance improvement because those operations are not done thousands of times. Just use `push_back` with the explicit struct default constructor.