### PR TITLE
[CURA-11887] Fuzzy Skin Outside Only: Make definition of 'inside' user-settable

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1081,6 +1081,7 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
         return;
     }
 
+    constexpr coord_t epsilon = 5; // the distance between two points that are considered to be the same
     const coord_t line_width = mesh.settings.get<coord_t>("line_width");
     const bool apply_outside_only = mesh.settings.get<bool>("magic_fuzzy_skin_outside_only");
     const coord_t fuzziness = mesh.settings.get<coord_t>("magic_fuzzy_skin_thickness");
@@ -1115,20 +1116,30 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
 
                 if (apply_outside_only)
                 {
-                    hole_area = part.print_outline.getOutsidePolygons().offset(-line_width);
-                    accumulate_is_in_hole = [&hole_area](const bool& prev_result, const ExtrusionJunction& junction)
+                    hole_area.clear();
+                    const auto initial_hole_area = part.print_outline.approxConvexHull().difference(part.print_outline.offset(epsilon)).offset(line_width - epsilon);
+                    const auto near_shape_area = part.print_outline.offset(line_width / 2 + epsilon);
+
+                    for (const auto& hole_part : initial_hole_area.splitIntoParts())
                     {
-                        return prev_result || hole_area.inside(junction.p_);
-                    };
+                        const auto thick_outline = hole_part.createTubeShape(line_width / 2, 0);
+                        const auto total_area_size = thick_outline.area();
+                        const auto open_area_size = thick_outline.difference(near_shape_area).area();
+
+                        constexpr double max_ratio = 0.45;  // TODO: make this a setting
+                        constexpr coord_t min_part_area = 1000000;  // TODO: make this a setting
+                        if ((open_area_size == 0 || hole_part.area() >= min_part_area) && (open_area_size / total_area_size) < max_ratio)
+                        {
+                            hole_area.push_back(hole_part);
+                        }
+                    }
+                }
+                else
+                {
+                    hole_area = Shape();
                 }
                 for (auto& line : toolpath)
                 {
-                    if (apply_outside_only && std::accumulate(line.begin(), line.end(), false, accumulate_is_in_hole))
-                    {
-                        result_lines.push_back(line);
-                        continue;
-                    }
-
                     auto& result = result_lines.emplace_back(line.inset_idx_, line.is_odd_, line.is_closed_);
 
                     // generate points in between p0 and p1
@@ -1140,6 +1151,17 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
                         if (p0->p_ == p1.p_) // avoid seams
                         {
                             result.emplace_back(p1.p_, p1.w_, p1.perimeter_index_);
+                            continue;
+                        }
+                        if (apply_outside_only && hole_area.inside(p1.p_) && hole_area.inside(p0->p_)) // avoid 'inside'
+                        {
+                            if (result.size() > 0 && result.back().p_ != p0->p_)
+                            {
+                                // Ensure the wall starts on the previous vertex.
+                                result.emplace_back(p0->p_, p0->w_, p0->perimeter_index_);
+                            }
+                            result.emplace_back(p1.p_, p1.w_, p1.perimeter_index_);
+                            p0 = &p1;
                             continue;
                         }
 

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1084,6 +1084,8 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
     constexpr coord_t epsilon = 5; // the distance between two points that are considered to be the same
     const coord_t line_width = mesh.settings.get<coord_t>("line_width");
     const bool apply_outside_only = mesh.settings.get<bool>("magic_fuzzy_skin_outside_only");
+    const Ratio inside_max_part_ratio = mesh.settings.get<Ratio>("magic_fuzzy_skin_outside_convex_ratio");
+    const double inside_min_part_area = MM2_2INT(mesh.settings.get<double>("magic_fuzzy_skin_outside_min_area"));
     const coord_t fuzziness = mesh.settings.get<coord_t>("magic_fuzzy_skin_thickness");
     const coord_t avg_dist_between_points = mesh.settings.get<coord_t>("magic_fuzzy_skin_point_dist");
     const coord_t min_dist_between_points = avg_dist_between_points * 3 / 4; // hardcoded: the point distance may vary between 3/4 and 5/4 the supplied value
@@ -1125,10 +1127,7 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
                         const auto thick_outline = hole_part.createTubeShape(line_width / 2, 0);
                         const auto total_area_size = thick_outline.area();
                         const auto open_area_size = thick_outline.difference(near_shape_area).area();
-
-                        constexpr double max_ratio = 0.45; // TODO: make this a setting
-                        constexpr coord_t min_part_area = 1000000; // TODO: make this a setting
-                        if ((open_area_size == 0 || hole_part.area() >= min_part_area) && (open_area_size / total_area_size) < max_ratio)
+                        if ((open_area_size == 0 || hole_part.area() >= inside_min_part_area) && (open_area_size / total_area_size) <= inside_max_part_ratio)
                         {
                             hole_area.push_back(hole_part);
                         }

--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1126,8 +1126,8 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
                         const auto total_area_size = thick_outline.area();
                         const auto open_area_size = thick_outline.difference(near_shape_area).area();
 
-                        constexpr double max_ratio = 0.45;  // TODO: make this a setting
-                        constexpr coord_t min_part_area = 1000000;  // TODO: make this a setting
+                        constexpr double max_ratio = 0.45; // TODO: make this a setting
+                        constexpr coord_t min_part_area = 1000000; // TODO: make this a setting
                         if ((open_area_size == 0 || hole_part.area() >= min_part_area) && (open_area_size / total_area_size) < max_ratio)
                         {
                             hole_area.push_back(hole_part);


### PR DESCRIPTION
Previously, for the Fuzzy Skin Outside Only setting, the definition of 'inside' was only areas that are fully enclosed within a layer.

With these changes (see also [the necessary added settings in the front-end](https://github.com/Ultimaker/Cura/pull/19324)), it is now possible to define 'sufficiently convex' areas as 'inside' as well -- skipping these areas when jittering the outer-wall.

The new settings are:

- A measure of the 'convexity' of a near-hole in an area; the ratio of the circumference of that hole 'exposed' to the outside versus the total circumference of that hole.
- A limit on how small such a hole area considered for exclusion needs to be at minimum (_given_ that the hole is exposed to the outside, fully enclosed holes will never be considered outside, no matter how small).

![fuzzy_skin_8_1073](https://github.com/Ultimaker/CuraEngine/assets/41987080/9f2712d5-c607-4c80-828e-632d1349f738)

![fuzzy_skin_8_117](https://github.com/Ultimaker/CuraEngine/assets/41987080/0782ce2f-c928-4e7d-8b90-4b8bab687e18)