### PR TITLE
CURA-12023 Fix ghost prime tower

### DIFF
--- a/include/PrimeTower/PrimeTowerNormal.h
+++ b/include/PrimeTower/PrimeTowerNormal.h
@@ -18,8 +18,11 @@ namespace cura
  */
 class PrimeTowerNormal : public PrimeTower
 {
+private:
+    const std::vector<size_t> used_extruders_;
+
 public:
-    PrimeTowerNormal();
+    PrimeTowerNormal(const std::vector<size_t>& used_extruders);
 
     virtual ExtruderPrime getExtruderPrime(
         const std::vector<bool>& extruder_is_used_on_this_layer,

--- a/src/PrimeTower/PrimeTowerNormal.cpp
+++ b/src/PrimeTower/PrimeTowerNormal.cpp
@@ -12,8 +12,9 @@
 namespace cura
 {
 
-PrimeTowerNormal::PrimeTowerNormal()
+PrimeTowerNormal::PrimeTowerNormal(const std::vector<size_t>& used_extruders)
     : PrimeTower()
+    , used_extruders_(used_extruders)
 {
 }
 
@@ -45,13 +46,8 @@ std::map<LayerIndex, std::vector<PrimeTower::ExtruderToolPaths>> PrimeTowerNorma
     const coord_t tower_radius = mesh_group_settings.get<coord_t>("prime_tower_size") / 2;
     std::map<LayerIndex, std::vector<ExtruderToolPaths>> toolpaths;
 
-    // First make a basic list of used extruders numbers
-    std::vector<size_t> extruder_order;
-    extruder_order.reserve(scene.extruders.size());
-    for (const ExtruderTrain& extruder : scene.extruders)
-    {
-        extruder_order.push_back(extruder.extruder_nr_);
-    }
+    // First take all the used extruders numbers, unsorted
+    std::vector<size_t> extruder_order = used_extruders_;
 
     // Then sort from high adhesion to low adhesion. This will give us the outside to inside extruder processing order.
     std::sort(


### PR DESCRIPTION
Restore the check to used extruders to create prime tower: this check was removed while working on the smaller prime tower, to rely only on the `max_print_height_second_to_last_extruder` variable. However, this one can be miscalculated in some conditions because it is done very early. We then use `storage.getExtrudersUsed()` again to check the actual extruders use.
This may leave some edge cases where a ghost prime tower could appear, but they should now be very limited.

CURA-12026