### PR TITLE
CURA-11967 fix material print temp prepend not being disabled

### DIFF
--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -471,6 +471,8 @@ private:
      */
     void processInitialLayerBedTemperature();
 
+    void processInitialLayerExtrudersTemperatures(const SliceDataStorage& storage, const bool wait_start_extruder, const size_t start_extruder_nr);
+
 public:
     /*!
      * Get ready for extrusion moves:

--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -471,6 +471,13 @@ private:
      */
     void processInitialLayerBedTemperature();
 
+    /*!
+     * Set extruders temperatures for the initial layer. Called by 'processInitialLayerTemperatures'.
+     *
+     * \param storage The slice data storage
+     * \param wait_start_extruder Indicates whether we should always wait for the start extruder temperature to be reached
+     * \param start_extruder_nr The index of the start extruder
+     */
     void processInitialLayerExtrudersTemperatures(const SliceDataStorage& storage, const bool wait_start_extruder, const size_t start_extruder_nr);
 
 public:


### PR DESCRIPTION
We would previously still append the temperatures within some conditions. Now we completely skip it if the setting is disabled, considering that it means the temperatures are handled in the start G-Code and not te be treated here at all.

CURA-11967

Fixes https://github.com/Ultimaker/Cura/issues/19204