### PR TITLE
CURA-12038 Coasting affected by z seam not on vertex

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1151,7 +1151,7 @@ void LayerPlan::addWall(
         for (size_t piece = 0; piece < pieces; ++piece)
         {
             const double average_progress = (double(piece) + 0.5) / pieces; // How far along this line to sample the line width in the middle of this piece.
-            const coord_t line_width = p0.w_ + average_progress * delta_line_width;
+            const coord_t line_width = std::lrint(p0.w_ + average_progress * delta_line_width);
             const Point2LL destination = p0.p_ + normal(line_vector, piece_length * (piece + 1));
             if (is_small_feature)
             {


### PR DESCRIPTION
The calculated line width is quite important here, because `GCodePath` objects may be merged (or not) depending on it, and sometimes the value would be rounded to a very close value, but not equal. We now use `llrint` to make sure we round to the neareset value.