### PR TITLE
Fix possible crash

### DIFF
--- a/src/geometry/MixedLinesSet.cpp
+++ b/src/geometry/MixedLinesSet.cpp
@@ -42,16 +42,17 @@ Shape MixedLinesSet::offset(coord_t distance, ClipperLib::JoinType join_type, do
         }
         else
         {
-            static auto end_type_fn = [&line, &join_type]()
-            {
-                if (line->hasClosingSegment())
-                {
-                    return ClipperLib::etClosedLine;
-                }
-                return join_type == ClipperLib::jtMiter ? ClipperLib::etOpenSquare : ClipperLib::etOpenRound;
-            };
+            ClipperLib::EndType end_type;
 
-            const ClipperLib::EndType end_type{ end_type_fn() };
+            if (line->hasClosingSegment())
+            {
+                end_type = ClipperLib::etClosedLine;
+            }
+            else
+            {
+                end_type = (join_type == ClipperLib::jtMiter) ? ClipperLib::etOpenSquare : ClipperLib::etOpenRound;
+            }
+
             clipper.AddPath(line->getPoints(), join_type, end_type);
         }
     }


### PR DESCRIPTION
To compute the end type, we previously used a lambda function, that was declared static. Thus, the arguments were apparently captured when calling it the first time, and didn't change for subsequent calls. As one of them is a pointer, this could crash if the pointed object had been destroyed in the meantime.

Although the minimum fix is just to remove the static for the function, I removed the function itself because it really doesn't make sense anymore in this context.

CURA-12042