### PR TITLE
[CURA-10914] Add ability to register multiple modify plugins

### DIFF
--- a/include/plugins/slots.h
+++ b/include/plugins/slots.h
@@ -160,8 +160,7 @@ public:
     {
         if (slot_id == T::slot_id)
         {
-            using Tp = typename Unit<T>::value_type;
-            value_.proxy = Tp{ name, version, std::forward<decltype(channel)>(channel) };
+            value_.proxy.addPlugin(name, version, std::forward<decltype(channel)>(channel));
             return;
         }
         Base::connect(slot_id, name, version, std::forward<decltype(channel)>(channel));


### PR DESCRIPTION
The plugins will be called one after the other, in the order they were registered.

This version basically reverts the changes I wanted when reviewing https://github.com/Ultimaker/CuraEngine/pull/2121 since that screws up the benchmark (for non benchmark related reasons but it still shows that the API is different which scares a little).

It's safer to do it without the requested optimization.