### PR TITLE
[CURA-12043] When the mesh is known, use its center-point, instead of that of the scene.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2309,7 +2309,7 @@ bool FffGcodeWriter::processSingleLayerInfill(
                     extruder_nr,
                     z_seam_config,
                     tool_paths,
-                    storage.getModelBoundingBox().flatten().getMiddle());
+                    mesh.bounding_box.flatten().getMiddle());
                 added_something |= wall_orderer.addToLayer();
             }
         }
@@ -2752,7 +2752,7 @@ bool FffGcodeWriter::processInsets(
             mesh.settings.get<ExtruderTrain&>("wall_x_extruder_nr").extruder_nr_,
             z_seam_config,
             part.wall_toolpaths,
-            storage.getModelBoundingBox().flatten().getMiddle());
+            mesh.bounding_box.flatten().getMiddle());
         added_something |= wall_orderer.addToLayer();
     }
     return added_something;
@@ -3178,7 +3178,7 @@ void FffGcodeWriter::processSkinPrintFeature(
                     skin_extruder_nr,
                     z_seam_config,
                     skin_paths,
-                    storage.getModelBoundingBox().flatten().getMiddle());
+                    mesh.bounding_box.flatten().getMiddle());
                 added_something |= wall_orderer.addToLayer();
             }
         }


### PR DESCRIPTION
This could get increasingly inaccurate results with more objects on the buildplate, since the center could be outside of the objects.