### PR TITLE
Run CuraEngine wasm with pthread support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,34 @@ endif ()
 
 if (CMAKE_CXX_PLATFORM_ID STREQUAL "emscripten")
     message(STATUS "Building for Emscripten")
-    target_link_options(_CuraEngine PUBLIC -Wno-unused-command-line-argument -sINVOKE_RUN=0 -sEXPORT_NAME=CuraEngine -sEXPORTED_RUNTIME_METHODS=[callMain,FS] -sFORCE_FILESYSTEM=1 -sALLOW_MEMORY_GROWTH=1 -sEXPORT_ES6=1 -sMODULARIZE=1 -sSINGLE_FILE=1 -sENVIRONMENT=worker -sERROR_ON_UNDEFINED_SYMBOLS=0 -lembind --embind-emit-tsd CuraEngine.d.ts)
+    target_link_options(_CuraEngine
+            PUBLIC
+            "SHELL:-sINVOKE_RUN=0"
+            "SHELL:-sEXPORT_NAME=CuraEngine"
+            "SHELL:-sEXPORTED_RUNTIME_METHODS=[callMain,FS]"
+            "SHELL:-sFORCE_FILESYSTEM=1"
+            "SHELL:-sALLOW_MEMORY_GROWTH=1" # TODO: Figure out what to do with this ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271
+            "SHELL:-sEXPORT_ES6=1"
+            "SHELL:-sMODULARIZE=1"
+            "SHELL:-sSINGLE_FILE=1"
+            "SHELL:-sENVIRONMENT=worker"
+            "SHELL:-sERROR_ON_UNDEFINED_SYMBOLS=0"
+            "SHELL:-sWASM_BIGINT=1"
+            "SHELL:-sUSE_PTHREADS=1"
+            "SHELL:-sPTHREAD_POOL_SIZE_STRICT=0"
+            "SHELL:-sWASM_MEM_MAX=2GB"
+            "SHELL:-sSHARED_MEMORY=1"
+            "SHELL:-sSUPPORT_LONGJMP=1"
+            "SHELL:-sALLOW_MEMORY_GROWTH=1"
+            "SHELL:-sSTACK_SIZE=196608" # three times the default stack size https://emscripten.org/docs/tools_reference/settings_reference.html?highlight=environment#stack-size
+            $<$<CONFIG:Debug>:SHELL:-sASSERTIONS=2>
+            $<$<CONFIG:Debug>:SHELL:-sSAFE_HEAP=1>
+            $<$<CONFIG:Debug>:SHELL:-sSTACK_OVERFLOW_CHECK=2>
+            $<$<CONFIG:Debug>:SHELL:-g3>
+            $<$<CONFIG:Debug>:SHELL:-gsource-map>
+            "SHELL:-lembind"
+            "SHELL:--embind-emit-tsd CuraEngine.d.ts"
+    )
 endif ()
 
 target_link_libraries(CuraEngine PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,6 @@ if (CMAKE_CXX_PLATFORM_ID STREQUAL "emscripten")
             "SHELL:-sWASM_MEM_MAX=2GB"
             "SHELL:-sSHARED_MEMORY=1"
             "SHELL:-sSUPPORT_LONGJMP=1"
-            "SHELL:-sALLOW_MEMORY_GROWTH=1"
             "SHELL:-sSTACK_SIZE=196608" # three times the default stack size https://emscripten.org/docs/tools_reference/settings_reference.html?highlight=environment#stack-size
             $<$<CONFIG:Debug>:SHELL:-sASSERTIONS=2>
             $<$<CONFIG:Debug>:SHELL:-sSAFE_HEAP=1>

--- a/conanfile.py
+++ b/conanfile.py
@@ -145,7 +145,6 @@ class CuraEngineConan(ConanFile):
         tc.variables["ENABLE_BENCHMARKS"] = self.options.enable_benchmarks
         tc.variables["EXTENSIVE_WARNINGS"] = self.options.enable_extensive_warnings
         tc.variables["OLDER_APPLE_CLANG"] = self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "14"
-        tc.variables["ENABLE_THREADING"] = not (self.settings.arch == "wasm" and self.settings.os == "Emscripten")
         if self.options.get_safe("enable_sentry", False):
             tc.variables["ENABLE_SENTRY"] = True
             tc.variables["SENTRY_URL"] = self.conf.get("user.curaengine:sentry_url", "", check_type=str)

--- a/conanfile.py
+++ b/conanfile.py
@@ -231,6 +231,7 @@ class CuraEngineConan(ConanFile):
                 ext = ""
         copy(self, f"CuraEngine{ext}", src=self.build_folder, dst=path.join(self.package_folder, "bin"))
         copy(self, f"*.d.ts", src=self.build_folder, dst=path.join(self.package_folder, "bin"))
+        copy(self, f"*.worker.js", src=self.build_folder, dst=path.join(self.package_folder, "bin"))
         copy(self, f"_CuraEngine.*", src=self.build_folder, dst=path.join(self.package_folder, "lib"))
         copy(self, "LICENSE*", src=self.source_folder, dst=path.join(self.package_folder, "license"))
 


### PR DESCRIPTION
Revised target_link_options for better readability and maintainability by using the "SHELL:" prefix for each option. Additionally, removed the ENABLE_THREADING variable from conanfile.py as threading support is now handled directly in the build options.

Contribute to NP-334

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change