### PR TITLE
Add z height to CuraEngine Infill Plugin Call

### DIFF
--- a/include/plugins/converters.h
+++ b/include/plugins/converters.h
@@ -105,7 +105,7 @@ struct postprocess_response : public details::converter<postprocess_response, sl
 
 struct infill_generate_request : public details::converter<infill_generate_request, slots::infill::v0::generate::CallRequest, Shape>
 {
-    value_type operator()(const native_value_type& inner_contour, const std::string& pattern, const Settings& settings) const;
+    value_type operator()(const native_value_type& inner_contour, const std::string& pattern, const Settings& settings, const coord_t z) const;
 };
 
 struct infill_generate_response

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -322,7 +322,8 @@ void Infill::_generate(
         auto [toolpaths_, generated_result_polygons_, generated_result_lines_] = slots::instance().generate<plugins::v0::SlotID::INFILL_GENERATE>(
             inner_contour_,
             mesh ? mesh->settings.get<std::string>("infill_pattern") : settings.get<std::string>("infill_pattern"),
-            mesh ? mesh->settings : settings);
+            mesh ? mesh->settings : settings,
+            z_);
         toolpaths.insert(toolpaths.end(), toolpaths_.begin(), toolpaths_.end());
         result_polygons.push_back(generated_result_polygons_);
         result_lines.push_back(generated_result_lines_);

--- a/src/plugins/converters.cpp
+++ b/src/plugins/converters.cpp
@@ -168,7 +168,7 @@ postprocess_response::native_value_type
 }
 
 infill_generate_request::value_type
-    infill_generate_request::operator()(const infill_generate_request::native_value_type& inner_contour, const std::string& pattern, const Settings& settings) const
+    infill_generate_request::operator()(const infill_generate_request::native_value_type& inner_contour, const std::string& pattern, const Settings& settings, const coord_t z) const
 {
     value_type message{};
     message.set_pattern(pattern);
@@ -177,6 +177,11 @@ infill_generate_request::value_type
     {
         msg_settings->insert({ key, value });
     }
+
+    // ------------------------------------------------------------
+    // Add current z height to settings message
+    // ------------------------------------------------------------
+    msg_settings->insert({ "z" , std::to_string(z) });
 
     if (inner_contour.empty())
     {


### PR DESCRIPTION
# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

This adds the z-height of the current layer to the settings of the CureEngine Infill plugins.
This does NOT break compatibility with existing plugins.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

Added z-height to the settings dict passed to the CureEngine Infill Plugin.
This was needed to ensure compatability with existing Plugins.

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Tested with existing Infill Plugin to ensure compatability ( https://github.com/Ultimaker/CuraEngine_plugin_infill_generate )
- [X] Tested with my own Infill Plugin currently in development with an infill variing per layer height. The Plugin is not fully finished yet, therefore not publicly available (yet).

**Test Configuration**:
* Operating System: Windows 10

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change