### PR TITLE
refactor/improve-math-functions

### DIFF
--- a/include/utils/math.h
+++ b/include/utils/math.h
@@ -13,38 +13,125 @@
 namespace cura
 {
 
+/**
+ * @brief Returns the square of a value.
+ *
+ * @tparam T A multipliable type (arithmetic types such as int, float, double, etc.)
+ * @param a The value to be squared.
+ * @return T The square of the input value.
+ */
 template<utils::multipliable T>
 [[nodiscard]] T square(const T& a)
 {
     return a * a;
 }
 
-[[nodiscard]] inline int64_t round_divide_signed(const int64_t dividend, const int64_t divisor) //!< Return dividend divided by divisor rounded to the nearest integer
+/**
+ * @brief Returns the quotient of the division of two signed integers, rounded to the nearest integer.
+ *
+ * @param dividend The numerator.
+ * @param divisor The denominator (must not be zero).
+ * @return int64_t The result of the division rounded to the nearest integer.
+ * @throws std::invalid_argument If the divisor is zero.
+ */
+[[nodiscard]] inline int64_t round_divide_signed(const int64_t dividend, const int64_t divisor)
 {
-    if ((dividend < 0) ^ (divisor < 0)) // Either the numerator or the denominator is negative, so the result must be negative.
+    if (divisor == 0)
     {
-        return (dividend - divisor / 2) / divisor; // Flip the .5 offset to do proper rounding in the negatives too.
+        throw std::invalid_argument("Divisor cannot be zero");
+    }
+
+    if ((dividend < 0) ^ (divisor < 0))
+    {
+        return (dividend - divisor / 2) / divisor;
     }
     return (dividend + divisor / 2) / divisor;
 }
 
-[[nodiscard]] inline uint64_t ceil_divide_signed(const int64_t dividend, const int64_t divisor) //!< Return dividend divided by divisor rounded up towards positive infinity.
+/**
+ * @brief Returns the quotient of the division of two signed integers, rounded up towards positive infinity.
+ *
+ * @param dividend The numerator.
+ * @param divisor The denominator (must not be zero).
+ * @return int64_t The result of the division rounded up.
+ * @throws std::invalid_argument If the divisor is zero.
+ */
+[[nodiscard]] inline int64_t ceil_divide_signed(const int64_t dividend, const int64_t divisor)
 {
-    return static_cast<uint64_t>((dividend / divisor) + (dividend * divisor > 0 ? 1 : 0));
+    if (divisor == 0)
+    {
+        throw std::invalid_argument("Divisor cannot be zero");
+    }
+
+    int64_t quotient = dividend / divisor;
+    int64_t remainder = dividend % divisor;
+
+    // Round up if there's a remainder and the signs of dividend and divisor are the same
+    if (remainder != 0 && ((dividend > 0 && divisor > 0) || (dividend < 0 && divisor < 0)))
+    {
+        quotient += 1;
+    }
+
+    return quotient;
 }
 
-[[nodiscard]] inline uint64_t floor_divide_signed(const int64_t dividend, const int64_t divisor) //!< Return dividend divided by divisor rounded down towards negative infinity.
+/**
+ * @brief Returns the quotient of the division of two signed integers, rounded down towards negative infinity.
+ *
+ * @param dividend The numerator.
+ * @param divisor The denominator (must not be zero).
+ * @return int64_t The result of the division rounded down.
+ * @throws std::invalid_argument If the divisor is zero.
+ */
+[[nodiscard]] inline int64_t floor_divide_signed(const int64_t dividend, const int64_t divisor)
 {
-    return static_cast<uint64_t>((dividend / divisor) + (dividend * divisor > 0 ? 0 : -1));
+    if (divisor == 0)
+    {
+        throw std::invalid_argument("Divisor cannot be zero");
+    }
+
+    int64_t quotient = dividend / divisor;
+    int64_t remainder = dividend % divisor;
+
+    if (remainder != 0 && ((dividend > 0 && divisor < 0) || (dividend < 0 && divisor > 0)))
+    {
+        quotient -= 1;
+    }
+
+    return quotient;
 }
 
-[[nodiscard]] inline uint64_t round_divide(const uint64_t dividend, const uint64_t divisor) //!< Return dividend divided by divisor rounded to the nearest integer
+/**
+ * @brief Returns the quotient of the division of two unsigned integers, rounded to the nearest integer.
+ *
+ * @param dividend The numerator.
+ * @param divisor The denominator (must not be zero).
+ * @return uint64_t The result of the division rounded to the nearest integer.
+ */
+[[nodiscard]] inline uint64_t round_divide(const uint64_t dividend, const uint64_t divisor)
 {
+    if (divisor == 0)
+    {
+        throw std::invalid_argument("Divisor cannot be zero");
+    }
+
     return (dividend + divisor / 2) / divisor;
 }
 
-[[nodiscard]] inline uint64_t round_up_divide(const uint64_t dividend, const uint64_t divisor) //!< Return dividend divided by divisor rounded to the nearest integer
+/**
+ * @brief Returns the quotient of the division of two unsigned integers, rounded up towards positive infinity.
+ *
+ * @param dividend The numerator.
+ * @param divisor The denominator (must not be zero).
+ * @return uint64_t The result of the division rounded up.
+ */
+[[nodiscard]] inline uint64_t round_up_divide(const uint64_t dividend, const uint64_t divisor)
 {
+    if (divisor == 0)
+    {
+        throw std::invalid_argument("Divisor cannot be zero");
+    }
+
     return (dividend + divisor - 1) / divisor;
 }
 

--- a/tests/utils/MathTest.cpp
+++ b/tests/utils/MathTest.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2022 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#include "utils/math.h"
+
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+namespace cura
+{
+// NOLINTBEGIN(*-magic-numbers)
+
+// Test cases for the square function
+TEST(MathTest, TestSquare)
+{
+    EXPECT_EQ(square(2), 4) << "Square of 2 should be 4.";
+    EXPECT_EQ(square(-3), 9) << "Square of -3 should be 9.";
+    EXPECT_EQ(square(0), 0) << "Square of 0 should be 0.";
+    EXPECT_EQ(square(1.5), 2.25) << "Square of 1.5 should be 2.25.";
+}
+
+// Test cases for the round_divide_signed function
+TEST(MathTest, TestRoundDivideSigned)
+{
+    EXPECT_EQ(round_divide_signed(10, 3), 3) << "10 / 3 rounded should be 3.";
+    EXPECT_EQ(round_divide_signed(10, -3), -3) << "10 / -3 rounded should be -3.";
+    EXPECT_EQ(round_divide_signed(-10, 3), -3) << "-10 / 3 rounded should be -3.";
+    EXPECT_EQ(round_divide_signed(-10, -3), 3) << "-10 / -3 rounded should be 3.";
+
+    EXPECT_THROW(round_divide_signed(10, 0), std::invalid_argument) << "Division by zero should throw an exception.";
+}
+
+// Test cases for the ceil_divide_signed function
+TEST(MathTest, TestCeilDivideSigned)
+{
+    EXPECT_EQ(ceil_divide_signed(10, 3), 4) << "10 / 3 rounded up should be 4.";
+    EXPECT_EQ(ceil_divide_signed(10, -3), -3) << "10 / -3 rounded up should be -3.";
+    EXPECT_EQ(ceil_divide_signed(-10, 3), -3) << "-10 / 3 rounded up should be -3.";
+    EXPECT_EQ(ceil_divide_signed(-10, -3), 4) << "-10 / -3 rounded up should be 4.";
+
+    EXPECT_THROW(ceil_divide_signed(10, 0), std::invalid_argument) << "Division by zero should throw an exception.";
+}
+
+// Test cases for the floor_divide_signed function
+TEST(MathTest, TestFloorDivideSigned)
+{
+    EXPECT_EQ(floor_divide_signed(10, 3), 3) << "10 / 3 rounded down should be 3.";
+    EXPECT_EQ(floor_divide_signed(10, -3), -4) << "10 / -3 rounded down should be -4.";
+    EXPECT_EQ(floor_divide_signed(-10, 3), -4) << "-10 / 3 rounded down should be -4.";
+    EXPECT_EQ(floor_divide_signed(-10, -3), 3) << "-10 / -3 rounded down should be 3.";
+
+    EXPECT_THROW(floor_divide_signed(10, 0), std::invalid_argument) << "Division by zero should throw an exception.";
+}
+
+// Test cases for the round_divide function
+TEST(MathTest, TestRoundDivide)
+{
+    EXPECT_EQ(round_divide(10, 3), 3) << "10 / 3 rounded should be 3.";
+    EXPECT_EQ(round_divide(11, 3), 4) << "11 / 3 rounded should be 4.";
+    EXPECT_EQ(round_divide(9, 3), 3) << "9 / 3 rounded should be 3.";
+
+    EXPECT_THROW(round_divide(10, 0), std::invalid_argument) << "Division by zero should throw an exception.";
+}
+
+// Test cases for the round_up_divide function
+TEST(MathTest, TestRoundUpDivide)
+{
+    EXPECT_EQ(round_up_divide(10, 3), 4) << "10 / 3 rounded up should be 4.";
+    EXPECT_EQ(round_up_divide(9, 3), 3) << "9 / 3 rounded up should be 3.";
+    EXPECT_EQ(round_up_divide(1, 1), 1) << "1 / 1 rounded up should be 1.";
+
+    EXPECT_THROW(round_up_divide(10, 0), std::invalid_argument) << "Division by zero should throw an exception.";
+}
+
+// NOLINTEND(*-magic-numbers)
+
+} // namespace cura


### PR DESCRIPTION
# Description

This pull request addresses a critical issue in the `math.h` utility functions related to incorrect rounding behavior in the `ceil_divide_signed` function. Specifically, it fixes a bug where the function would incorrectly round up even when the division was exact, such as returning `31` instead of `30` for `ceil_divide_signed(90, 3)` -> (https://github.com/Ultimaker/CuraEngine/issues/2005)

Additionally, the PR includes the following improvements:

- Error Handling: Added exception handling to ensure division by zero is appropriately managed across all relevant functions.
- Refactoring: Refactored functions like `round_divide_signed` and `floor_divide_signed` to clarify logic, improve readability, and maintain consistency.
- Documentation: Enhanced inline documentation for better clarity and maintainability.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit Testing: Updated and ran unit tests for all modified functions.
- [x] Code Review.

**Test Configuration**:
* Operating System: Ubuntu 22.04 LTS

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change