### PR TITLE
PartsView.h Included cstddef for size_t

### DIFF
--- a/include/geometry/PartsView.h
+++ b/include/geometry/PartsView.h
@@ -5,6 +5,7 @@
 #define GEOMETRY_PARTS_VIEW_H
 
 #include <vector>
+#include <cstddef> //For size_t.
 
 namespace cura
 {


### PR DESCRIPTION
g++ (Debian 12.2.0-14) 12.2.0
Did not have the definition of size_t which was failing the compile.

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] CuraEngine now compiles with g++ (Debian 12.2.0-14) 12.2.0

**Test Configuration**:
* Operating System: Linux Debian bookworm 12.0

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change