### PR TITLE
Fix contributing.md which is now CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,8 +23,9 @@ This fixes... OR This improves... -->
 * Operating System:
 
 # Checklist:
+<!-- Check if relevant -->
 
 - [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
-- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
+- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md)
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have uploaded any files required to test this change


### PR DESCRIPTION
The link is out of date since the Cura repository renamed the file.
"I have read the [Contribution guide]"(https://github.com/Ultimaker/Cura/blob/main/contributing.md)
Should be CONTRIBUTING.md

Added &lt;!-- Check if relevant --&gt; from the Cura version.

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Copy/paste with web browser now works.

**Test Configuration**:
* Operating System:

# Checklist:

- [X] I have read the [Contribution guide] (https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md)