### PR TITLE
Change segment overhanging calculation formula

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -820,6 +820,13 @@ private:
         const coord_t wipe_dist,
         const Ratio flow_ratio,
         const double fan_speed);
+
+    /*!
+     * \brief Calculates whether the given segment is to be treated as overhanging
+     * \param p0 The start point of the segment
+     * \param p1 The end point of the segment
+     */
+    bool segmentIsOnOverhang(const Point2LL& p0, const Point2LL& p1) const;
 };
 
 } // namespace cura


### PR DESCRIPTION
CURA-12078

Instead of naively checking whether the start and end point of the segment are in the overhang area, calculate the intersection of the segment with the overhang area, and see if the length of the intersection is a significant enough part of the origin segment. This filters out some segments that partially overhang and are not really expected to be treated as overhanging.

The behavior is technically a bit less correct than the former one, but tends to more homogeneity in the speeds so it may be preferable overall.

This is quite experimental, but did perform very well on all the models I tested. Please test it more extensively, there may be edge cases that I overlooked.