### PR TITLE
[CURA-12153] Fix 'encompassing hole' issue (tree support).

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2093,6 +2093,17 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
             if (! found)
             {
                 next_removed_holes_by_idx.emplace(idx);
+
+                // Individual pieces of the hole could still be valid (if the 'hole' is made by branches surrounding others' for instance).
+                for (const auto& poly : hole)
+                {
+                    if (poly.area() < 0)
+                    {
+                        auto poly_copy = poly;
+                        poly_copy.reverse();
+                        valid_holes[layer_idx].push_back(poly_copy);
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
When a hole is large enough to wholly contain (sometimes many) other branches, those also get cut. This prevents that. The solution isn't ideal, as there is an offset happening somewhere, but it's better than just missing the top of trees.
