### PR TITLE
CURA-12164 Fix innerwall seam position

### DIFF
--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -59,7 +59,8 @@ public:
         const Point2LL& model_center_point,
         const Shape& disallowed_areas_for_seams = {},
         const bool scarf_seam = false,
-        const bool smooth_speed = false);
+        const bool smooth_speed = false,
+        const Shape& overhang_areas = Shape());
 
     /*!
      * Adds the insets to the given layer plan.
@@ -114,6 +115,7 @@ private:
     Shape disallowed_areas_for_seams_;
     const bool scarf_seam_;
     const bool smooth_speed_;
+    Shape overhang_areas_;
 
     std::vector<std::vector<const Polygon*>> inset_polys_; // vector of vectors holding the inset polygons
     Shape retraction_region_; // After printing an outer wall, move into this region so that retractions do not leave visible blobs. Calculated lazily if needed (see

--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -130,7 +130,7 @@ private:
      *
      * \param closed_line The polygon to insert the seam point in. (It's assumed to be closed at least.)
      *
-     * \return The index of the inserted seam point, or std::nullopt if no seam point was inserted.
+     * \return The index of the inserted seam point, or the index of the closest point if an existing one can be used.
      */
     std::optional<size_t> insertSeamPoint(ExtrusionLine& closed_line);
 

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -299,6 +299,11 @@ public:
     void setSeamOverhangMask(const Shape& polys);
 
     /*!
+     * Get the areas that are considered having air below, which is a unite between bridge and overhang masks
+     */
+    Shape getAirBelowMask() const;
+
+    /*!
      * Set roofing_mask.
      *
      * \param polys The areas of the part currently being processed that will require roofing.
@@ -676,50 +681,6 @@ public:
         int last_seam_vertex_idx,
         const bool is_top_layer,
         const bool is_bottom_layer);
-
-
-    /*!
-     * Given a wall polygon and a start vertex index, return the index of the first vertex that is supported (is not above air)
-     *
-     * Uses bridge_wall_mask and overhang_mask to determine where there is air below
-     *
-     * \param wall The wall polygon
-     * \param start_idx The index of the starting vertex of \p wall
-     * \return The index of the first supported vertex - if no vertices are supported, start_idx is returned
-     */
-    template<typename T>
-    size_t locateFirstSupportedVertex(const T& wall, const size_t start_idx) const
-    {
-        if (bridge_wall_mask_.empty() && seam_overhang_mask_.empty())
-        {
-            return start_idx;
-        }
-
-        const auto air_below = bridge_wall_mask_.unionPolygons(seam_overhang_mask_);
-
-        size_t curr_idx = start_idx;
-
-        while (true)
-        {
-            const Point2LL& vertex = cura::make_point(wall[curr_idx]);
-            if (! air_below.inside(vertex, true))
-            {
-                // vertex isn't above air so it's OK to use
-                return curr_idx;
-            }
-
-            if (++curr_idx >= wall.size())
-            {
-                curr_idx = 0;
-            }
-
-            if (curr_idx == start_idx)
-            {
-                // no vertices are supported so just return the original index
-                return start_idx;
-            }
-        }
-    }
 
     /*!
      * Write the planned paths to gcode

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -299,9 +299,9 @@ public:
     void setSeamOverhangMask(const Shape& polys);
 
     /*!
-     * Get the areas that are considered having air below, which is a union between bridge and overhang masks
+     * Get the seam overhang mask, which contains the areas where we don't want to place the seam because they are overhanding
      */
-    Shape getAirBelowMask() const;
+    const Shape& getSeamOverhangMask() const;
 
     /*!
      * Set roofing_mask.

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -299,7 +299,7 @@ public:
     void setSeamOverhangMask(const Shape& polys);
 
     /*!
-     * Get the areas that are considered having air below, which is a unite between bridge and overhang masks
+     * Get the areas that are considered having air below, which is a union between bridge and overhang masks
      */
     Shape getAirBelowMask() const;
 

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -743,17 +743,20 @@ protected:
         // ########## Step 2: define which criteria should be taken into account in the total score
         const bool calculate_forced_pos_score = path.force_start_index_.has_value();
 
-        // For most seam types, the shortest distance matters. Not for SHARPEST_CORNER though.
-        const bool calculate_distance_score
-            = ! calculate_forced_pos_score
-           && (path.seam_config_.type_ != EZSeamType::SHARPEST_CORNER || path.seam_config_.corner_pref_ == EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE);
+        bool calculate_distance_score = false;
+        bool calculate_corner_score = false;
+        bool calculate_random_score = false;
+        if (! calculate_forced_pos_score)
+        {
+            // For most seam types, the shortest distance matters. Not for SHARPEST_CORNER though.
+            calculate_distance_score = path.seam_config_.type_ != EZSeamType::SHARPEST_CORNER || path.seam_config_.corner_pref_ == EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE;
 
-        const bool calculate_corner_score
-            = ! calculate_forced_pos_score
-           && (path.seam_config_.type_ == EZSeamType::SHARPEST_CORNER
-               && (path.seam_config_.corner_pref_ != EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE && path.seam_config_.corner_pref_ != EZSeamCornerPrefType::PLUGIN));
+            calculate_corner_score
+                = path.seam_config_.type_ == EZSeamType::SHARPEST_CORNER
+               && (path.seam_config_.corner_pref_ != EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE && path.seam_config_.corner_pref_ != EZSeamCornerPrefType::PLUGIN);
 
-        const bool calculate_random_score = ! calculate_forced_pos_score && (path.seam_config_.type_ == EZSeamType::RANDOM);
+            calculate_random_score = path.seam_config_.type_ == EZSeamType::RANDOM;
+        }
 
         const bool calculate_consistency_score = calculate_distance_score || calculate_corner_score;
 

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -759,8 +759,8 @@ protected:
         constexpr double weight_consistency_x = 0.05;
         constexpr double weight_consistency_y = weight_consistency_x / 2.0; // Less weight on Y to avoid symmetry effects
 
-        // Fixed divider for shortests distances computation. The divider should be set so that the minimum encountered
-        // distance gives a score very close to 1.0
+        // Fixed divider for shortest distances computation. The divider should be set so that the minimum encountered
+        // distance gives a score very close to 1.0, and a medium-far distance gives a score close to 0.5
         constexpr double distance_divider = 20.0;
 
         const AABB path_bounding_box(*path.converted_);
@@ -787,7 +787,6 @@ protected:
             else
             {
                 // For most seam types, the shortest distance matters. Not for SHARPEST_CORNER though.
-                // For SHARPEST_CORNER, use a fixed score of 0.
                 if (path.seam_config_.type_ != EZSeamType::SHARPEST_CORNER || path.seam_config_.corner_pref_ == EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE)
                 {
                     vertex_score += CriterionScore{ .score = scoreFromDistance(here, target_pos), .weight = weight_distance };

--- a/include/path_ordering.h
+++ b/include/path_ordering.h
@@ -83,6 +83,16 @@ struct PathOrdering
     std::optional<size_t> force_start_index_;
 
     /*!
+     * The start point calculation strategy to be used for this path
+     */
+    ZSeamConfig seam_config_;
+
+    /*!
+     * Indicates whether this path is an outer (or inner) wall
+     */
+    bool is_outer_wall{ false };
+
+    /*!
      * Get vertex data from the custom path type.
      *
      * This is a function that allows the reordering algorithm to work with any

--- a/include/utils/AABB.h
+++ b/include/utils/AABB.h
@@ -9,6 +9,7 @@
 namespace cura
 {
 
+class PointsSet;
 class Polygon;
 class Shape;
 
@@ -21,10 +22,10 @@ public:
     AABB(); //!< initializes with invalid min and max
     AABB(const Point2LL& min, const Point2LL& max); //!< initializes with given min and max
     AABB(const Shape& shape); //!< Computes the boundary box for the given shape
-    AABB(const Polygon& poly); //!< Computes the boundary box for the given polygons
+    AABB(const PointsSet& poly); //!< Computes the boundary box for the given polygons
 
     void calculate(const Shape& shape); //!< Calculates the aabb for the given shape (throws away old min and max data of this aabb)
-    void calculate(const Polygon& poly); //!< Calculates the aabb for the given polygon (throws away old min and max data of this aabb)
+    void calculate(const PointsSet& poly); //!< Calculates the aabb for the given polygon (throws away old min and max data of this aabb)
 
     /*!
      * Whether the bounding box contains the specified point.
@@ -80,7 +81,7 @@ public:
      */
     void include(const Point2LL& point);
 
-    void include(const Polygon& polygon);
+    void include(const PointsSet& polygon);
 
     /*!
      * \brief Includes the specified bounding box in the bounding box.

--- a/include/utils/CriterionScore.h
+++ b/include/utils/CriterionScore.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef UTILS_CRITERION_SCORE_H
+#define UTILS_CRITERION_SCORE_H
+
+#include <cassert>
+
+#include "SparsePointGrid.h"
+
+namespace cura
+{
+
+struct CriterionScore
+{
+    double score{ 0.0 };
+    double weight{ 0.0 };
+};
+
+} // namespace cura
+#endif // UTILS_CRITERION_SCORE_H

--- a/include/utils/CriterionScore.h
+++ b/include/utils/CriterionScore.h
@@ -4,10 +4,6 @@
 #ifndef UTILS_CRITERION_SCORE_H
 #define UTILS_CRITERION_SCORE_H
 
-#include <cassert>
-
-#include "SparsePointGrid.h"
-
 namespace cura
 {
 

--- a/include/utils/CriterionScore.h
+++ b/include/utils/CriterionScore.h
@@ -11,9 +11,23 @@
 namespace cura
 {
 
+/*!
+ * This structure represents a score given by a single crtierion when calculating a global score to select a best
+ * candidate among a list with multiple criteria.
+ */
 struct CriterionScore
 {
+    /*!
+     * The score given by the criterion. To ensure a proper selection, this value must be contained in [0.0, 1.0] and
+     * the different given scores must be evenly distributed in this range.
+     */
     double score{ 0.0 };
+
+    /*!
+     * The weight to be given when taking this score into the global score. A score that contributes "normally" to the
+     * global score should have a weight of 1.0, and others should be adjusted around this value, to give them more or
+     * less influence.
+     */
     double weight{ 0.0 };
 };
 

--- a/include/utils/Score.h
+++ b/include/utils/Score.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2024 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef UTILS_SCORE_H
+#define UTILS_SCORE_H
+
+#include <fmt/format.h>
+
+#include "CriterionScore.h"
+
+namespace cura
+{
+
+class Score
+{
+private:
+    double value_{ 0.0 };
+
+public:
+    double getValue() const
+    {
+        return value_;
+    }
+
+    void operator+=(const CriterionScore& criterion_score)
+    {
+        value_ += criterion_score.score * criterion_score.weight;
+    }
+
+    auto operator<=>(const Score&) const = default;
+
+    double operator-(const Score& other) const
+    {
+        return value_ - other.value_;
+    }
+};
+
+} // namespace cura
+
+namespace fmt
+{
+
+template<>
+struct formatter<cura::Score> : formatter<std::string>
+{
+    auto format(const cura::Score& score, format_context& ctx)
+    {
+        return fmt::format_to(ctx.out(), "Score{{{}}}", score.getValue());
+    }
+};
+
+} // namespace fmt
+
+#endif // UTILS_SCORE_H

--- a/include/utils/Score.h
+++ b/include/utils/Score.h
@@ -11,28 +11,35 @@
 namespace cura
 {
 
+/*!
+ * This class represents a score to be calculated over different criteria, to select the best candidate among a list.
+ */
 class Score
 {
 private:
     double value_{ 0.0 };
 
 public:
+    /*!
+     * Get the actual score value, should be used for debug purposes only
+     */
     double getValue() const
     {
         return value_;
     }
 
+    /*!
+     * Add the calculated score of an inidividual criterion to the global score, taking care of its weight
+     */
     void operator+=(const CriterionScore& criterion_score)
     {
         value_ += criterion_score.score * criterion_score.weight;
     }
 
+    /*!
+     * Comparison operators to allow selecting the best global score
+     */
     auto operator<=>(const Score&) const = default;
-
-    double operator-(const Score& other) const
-    {
-        return value_ - other.value_;
-    }
 };
 
 } // namespace cura

--- a/include/utils/math.h
+++ b/include/utils/math.h
@@ -25,6 +25,7 @@ template<utils::multipliable T>
 {
     return a * a;
 }
+
 /**
  * @brief Returns the quotient of the division of two signed integers, rounded to the nearest integer.
  *

--- a/include/utils/math.h
+++ b/include/utils/math.h
@@ -107,16 +107,23 @@ template<utils::multipliable T>
     return (dividend + divisor - 1) / divisor;
 }
 
-[[nodiscard]] inline double inverse_lerp(double a, double b, double v)
+/*!
+ * \brief Calculates the "inverse linear interpolation" of a value over a range, i.e. given a range [min, max] the
+ *        value "min" would give a result of 0.0 and the value "max" would give a result of 1.0, values in between will
+ *        be interpolated linearly.
+ * \note The returned value may be out of the [0.0, 1.0] range if the given value is outside the [min, max] range, it is
+ *       up to the caller to clamp the result if required
+ * \note The range_min value may be greater than the range_max, inverting the interpolation logic
+ */
+template<utils::numeric T>
+[[nodiscard]] inline double inverse_lerp(T range_min, T range_max, T value)
 {
-    if (a == b)
+    if (range_min == range_max)
     {
         return 0.0;
     }
-    else
-    {
-        return (v - a) / (b - a);
-    }
+
+    return static_cast<double>(value - range_min) / (range_max - range_min);
 }
 
 } // namespace cura

--- a/include/utils/math.h
+++ b/include/utils/math.h
@@ -127,5 +127,14 @@ template<utils::numeric T>
     return static_cast<double>(value - range_min) / (range_max - range_min);
 }
 
+/*!
+ * \brief Get a random floating point number in the range [0.0, 1.0]
+ */
+template<std::floating_point T>
+[[nodiscard]] inline T randf()
+{
+    return static_cast<T>(std::rand()) / static_cast<T>(RAND_MAX);
+}
+
 } // namespace cura
 #endif // UTILS_MATH_H

--- a/include/utils/math.h
+++ b/include/utils/math.h
@@ -25,7 +25,6 @@ template<utils::multipliable T>
 {
     return a * a;
 }
-
 /**
  * @brief Returns the quotient of the division of two signed integers, rounded to the nearest integer.
  *
@@ -106,6 +105,18 @@ template<utils::multipliable T>
 [[nodiscard]] inline uint64_t round_up_divide(const uint64_t dividend, const uint64_t divisor)
 {
     return (dividend + divisor - 1) / divisor;
+}
+
+[[nodiscard]] inline double inverse_lerp(double a, double b, double v)
+{
+    if (a == b)
+    {
+        return 0.0;
+    }
+    else
+    {
+        return (v - a) / (b - a);
+    }
 }
 
 } // namespace cura

--- a/include/utils/math.h
+++ b/include/utils/math.h
@@ -130,7 +130,7 @@ template<utils::numeric T>
 /*!
  * \brief Get a random floating point number in the range [0.0, 1.0]
  */
-template<std::floating_point T>
+template<utils::floating_point T>
 [[nodiscard]] inline T randf()
 {
     return static_cast<T>(std::rand()) / static_cast<T>(RAND_MAX);

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3149,7 +3149,7 @@ bool FffGcodeWriter::processInsets(
             disallowed_areas_for_seams,
             scarf_seam,
             smooth_speed,
-            gcode_layer.getAirBelowMask());
+            gcode_layer.getSeamOverhangMask());
         added_something |= wall_orderer.addToLayer();
     }
     return added_something;

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3148,7 +3148,8 @@ bool FffGcodeWriter::processInsets(
             mesh.bounding_box.flatten().getMiddle(),
             disallowed_areas_for_seams,
             scarf_seam,
-            smooth_speed);
+            smooth_speed,
+            gcode_layer.getAirBelowMask());
         added_something |= wall_orderer.addToLayer();
     }
     return added_something;

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -93,6 +93,7 @@ bool InsetOrderOptimizer::addToLayer()
     const bool current_extruder_is_wall_x = wall_x_extruder_nr_ == extruder_nr_;
 
     const bool reverse = shouldReversePath(use_one_extruder, current_extruder_is_wall_x, outer_to_inner);
+    const bool use_shortest_for_inner_walls = ! pack_by_inset && outer_to_inner;
     auto walls_to_be_added = getWallsToBeAdded(reverse, use_one_extruder);
 
     const auto order = pack_by_inset ? getInsetOrder(walls_to_be_added, outer_to_inner) : getRegionOrder(walls_to_be_added, outer_to_inner);
@@ -114,7 +115,8 @@ bool InsetOrderOptimizer::addToLayer()
         reverse,
         order,
         group_outer_walls,
-        disallowed_areas_for_seams_);
+        disallowed_areas_for_seams_,
+        use_shortest_for_inner_walls);
 
     for (auto& line : walls_to_be_added)
     {
@@ -126,7 +128,7 @@ bool InsetOrderOptimizer::addToLayer()
                 // If the user indicated that we may deviate from the vertices for the seam, we can insert a seam point, if needed.
                 force_start = insertSeamPoint(line);
             }
-            order_optimizer.addPolygon(&line, force_start);
+            order_optimizer.addPolygon(&line, force_start, line.is_outer_wall());
         }
         else
         {

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -95,7 +95,7 @@ bool InsetOrderOptimizer::addToLayer()
     const bool current_extruder_is_wall_x = wall_x_extruder_nr_ == extruder_nr_;
 
     const bool reverse = shouldReversePath(use_one_extruder, current_extruder_is_wall_x, outer_to_inner);
-    const bool use_shortest_for_inner_walls = ! pack_by_inset && outer_to_inner;
+    const bool use_shortest_for_inner_walls = outer_to_inner;
     auto walls_to_be_added = getWallsToBeAdded(reverse, use_one_extruder);
 
     const auto order = pack_by_inset ? getInsetOrder(walls_to_be_added, outer_to_inner) : getRegionOrder(walls_to_be_added, outer_to_inner);

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -54,7 +54,8 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     const Point2LL& model_center_point,
     const Shape& disallowed_areas_for_seams,
     const bool scarf_seam,
-    const bool smooth_speed)
+    const bool smooth_speed,
+    const Shape& overhang_areas)
     : gcode_writer_(gcode_writer)
     , storage_(storage)
     , gcode_layer_(gcode_layer)
@@ -78,6 +79,7 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     , disallowed_areas_for_seams_{ disallowed_areas_for_seams }
     , scarf_seam_(scarf_seam)
     , smooth_speed_(smooth_speed)
+    , overhang_areas_(overhang_areas)
 {
 }
 
@@ -116,7 +118,8 @@ bool InsetOrderOptimizer::addToLayer()
         order,
         group_outer_walls,
         disallowed_areas_for_seams_,
-        use_shortest_for_inner_walls);
+        use_shortest_for_inner_walls,
+        overhang_areas_);
 
     for (auto& line : walls_to_be_added)
     {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1328,11 +1328,6 @@ void LayerPlan::addWall(
     {
         return;
     }
-    if (is_closed)
-    {
-        // make sure wall start point is not above air!
-        start_idx = locateFirstSupportedVertex(wall, start_idx);
-    }
     const bool actual_scarf_seam = scarf_seam && is_closed;
 
     double non_bridge_line_volume = max_non_bridge_line_volume; // assume extruder is fully pressurised before first non-bridge line is output
@@ -3048,6 +3043,11 @@ void LayerPlan::setOverhangMask(const Shape& polys)
 void LayerPlan::setSeamOverhangMask(const Shape& polys)
 {
     seam_overhang_mask_ = polys;
+}
+
+Shape LayerPlan::getAirBelowMask() const
+{
+    return bridge_wall_mask_.unionPolygons(seam_overhang_mask_);
 }
 
 void LayerPlan::setRoofingMask(const Shape& polys)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2381,7 +2381,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
             for (const auto& reversed_chunk : paths | ranges::views::enumerate | ranges::views::reverse
                                                   | ranges::views::chunk_by(
-                                                      [](const auto&path_a, const auto&path_b)
+                                                      [](const auto& path_a, const auto& path_b)
                                                       {
                                                           return (! std::get<1>(path_a).isTravelPath()) || std::get<1>(path_b).isTravelPath();
                                                       }))
@@ -3044,9 +3044,9 @@ void LayerPlan::setSeamOverhangMask(const Shape& polys)
     seam_overhang_mask_ = polys;
 }
 
-Shape LayerPlan::getAirBelowMask() const
+const Shape& LayerPlan::getSeamOverhangMask() const
 {
-    return bridge_wall_mask_.unionPolygons(seam_overhang_mask_);
+    return seam_overhang_mask_;
 }
 
 void LayerPlan::setRoofingMask(const Shape& polys)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2387,7 +2387,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
             for (const auto& reversed_chunk : paths | ranges::views::enumerate | ranges::views::reverse
                                                   | ranges::views::chunk_by(
-                                                      [](const auto&path_a, const auto&path_b)
+                                                      [](const auto& path_a, const auto& path_b)
                                                       {
                                                           return (! std::get<1>(path_a).isTravelPath()) || std::get<1>(path_b).isTravelPath();
                                                       }))

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2382,7 +2382,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
             for (const auto& reversed_chunk : paths | ranges::views::enumerate | ranges::views::reverse
                                                   | ranges::views::chunk_by(
-                                                      [](const auto& path_a, const auto& path_b)
+                                                      [](const auto&path_a, const auto&path_b)
                                                       {
                                                           return (! std::get<1>(path_a).isTravelPath()) || std::get<1>(path_b).isTravelPath();
                                                       }))

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2381,7 +2381,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
             for (const auto& reversed_chunk : paths | ranges::views::enumerate | ranges::views::reverse
                                                   | ranges::views::chunk_by(
-                                                      [](const auto& path_a, const auto& path_b)
+                                                      [](const auto&path_a, const auto&path_b)
                                                       {
                                                           return (! std::get<1>(path_a).isTravelPath()) || std::get<1>(path_b).isTravelPath();
                                                       }))

--- a/src/utils/AABB.cpp
+++ b/src/utils/AABB.cpp
@@ -33,7 +33,7 @@ AABB::AABB(const Shape& shape)
     calculate(shape);
 }
 
-AABB::AABB(const PointsSet &poly)
+AABB::AABB(const PointsSet& poly)
     : min_(POINT_MAX, POINT_MAX)
     , max_(POINT_MIN, POINT_MIN)
 {
@@ -83,7 +83,7 @@ void AABB::calculate(const Shape& shape)
     }
 }
 
-void AABB::calculate(const PointsSet &poly)
+void AABB::calculate(const PointsSet& poly)
 {
     min_ = Point2LL(POINT_MAX, POINT_MAX);
     max_ = Point2LL(POINT_MIN, POINT_MIN);
@@ -141,7 +141,7 @@ void AABB::include(const Point2LL& point)
     max_.Y = std::max(max_.Y, point.Y);
 }
 
-void AABB::include(const PointsSet &polygon)
+void AABB::include(const PointsSet& polygon)
 {
     for (const Point2LL& point : polygon)
     {

--- a/src/utils/AABB.cpp
+++ b/src/utils/AABB.cpp
@@ -33,7 +33,7 @@ AABB::AABB(const Shape& shape)
     calculate(shape);
 }
 
-AABB::AABB(const Polygon& poly)
+AABB::AABB(const PointsSet &poly)
     : min_(POINT_MAX, POINT_MAX)
     , max_(POINT_MIN, POINT_MIN)
 {
@@ -83,7 +83,7 @@ void AABB::calculate(const Shape& shape)
     }
 }
 
-void AABB::calculate(const Polygon& poly)
+void AABB::calculate(const PointsSet &poly)
 {
     min_ = Point2LL(POINT_MAX, POINT_MAX);
     max_ = Point2LL(POINT_MIN, POINT_MIN);
@@ -141,7 +141,7 @@ void AABB::include(const Point2LL& point)
     max_.Y = std::max(max_.Y, point.Y);
 }
 
-void AABB::include(const Polygon& polygon)
+void AABB::include(const PointsSet &polygon)
 {
     for (const Point2LL& point : polygon)
     {

--- a/tests/PathOrderOptimizerTest.cpp
+++ b/tests/PathOrderOptimizerTest.cpp
@@ -13,24 +13,16 @@ class PathOrderOptimizerTest : public testing::Test
 {
 public:
     /*!
-     * A blank optimizer with no polygons added yet. Fresh and virgin.
-     */
-    PathOrderOptimizer<const Polygon*> optimizer;
-
-    /*!
      * A simple isosceles triangle. Base length and height 50.
      */
     Polygon triangle;
 
     PathOrderOptimizerTest()
-        : optimizer(Point2LL(0, 0))
     {
     }
 
     void SetUp() override
     {
-        optimizer = PathOrderOptimizer<const Polygon*>(Point2LL(0, 0));
-
         triangle.clear();
         triangle.push_back(Point2LL(0, 0));
         triangle.push_back(Point2LL(50, 0));
@@ -44,6 +36,7 @@ public:
  */
 TEST_F(PathOrderOptimizerTest, OptimizeWhileEmpty)
 {
+    PathOrderOptimizer<const Polygon*> optimizer(Point2LL(0, 0));
     optimizer.optimize(); // Don't crash.
     EXPECT_EQ(optimizer.paths_.size(), 0) << "Still empty!";
 }
@@ -54,6 +47,8 @@ TEST_F(PathOrderOptimizerTest, OptimizeWhileEmpty)
  */
 TEST_F(PathOrderOptimizerTest, ThreeTrianglesShortestOrder)
 {
+    PathOrderOptimizer<const Polygon*> optimizer(Point2LL(0, 0));
+
     Polygon near = triangle; // Copy, then translate.
     near.translate(Point2LL(100, 100));
     Polygon middle = triangle;


### PR DESCRIPTION
This PR actually contains a few different works:
* Rework of the score calculation for the seam point selection. Previously, the calculated scores were inconsistent and depending on each other when they should not, making it very difficult to add new scoring criteria. The scoring is now more consistent, hopefully easier to read, and much easier to tweak.
* The overhang avoidance for the seam placement was previously done after the actual seam placement, making it impossible to calculated the seam for inner walls related to the correct outer wall seam position. The overhang avoidance is now integrated in the global score calculation for the seam placement.
* The seam calculation strategy for inner walls is now forcibly set to "shortest" when outer walls are printed first, so that the starting point of the inner wall will be located as close as possible to the starting point of the outer wall.
* Rework of the user-set position for the seam, which is now treated as other strategies so that we can find a proper fallback point when the original one is on overhang.

:warning: This introduces some behavior changes of the existing seam selection strategy. Although they are more logical (no more depending on hidden settings) and more explainable, they do change the results of situations people probably got used to.