### PR TITLE
Alternative fix for 'encompassing hole' tree support issue

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2023,8 +2023,10 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
                 return;
             }
 
-            const Shape& relevant_forbidden = volumes_.getCollision(0, layer_idx, true);
-            Shape outer_walls = TreeSupportUtils::toPolylines(support_layer_storage[layer_idx - 1].getOutsidePolygons()).createTubeShape(closing_dist, 0);
+            Shape outer_walls = TreeSupportUtils::toPolylines(support_layer_storage[layer_idx - 1].getOutsidePolygons())
+                                    .createTubeShape(
+                                        closing_dist,
+                                        0); //.unionPolygons(volumes_.getCollision(0, layer_idx - 1, true).offset(-(config.support_line_width+config.xy_min_distance)));
 
             Shape holes_below;
 
@@ -2040,11 +2042,6 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
                 if (! hole.intersection(PolygonUtils::clipPolygonWithAABB(outer_walls, hole_aabb)).empty())
                 {
                     holes_resting_outside[layer_idx].emplace(idx);
-                }
-                else if (hole.intersection(PolygonUtils::clipPolygonWithAABB(relevant_forbidden, hole_aabb)).area() > hole.length() * EPSILON)
-                {
-                    holes_resting_outside[layer_idx].emplace(
-                        idx); // technically not resting outside, also not valid, but the alternative is potentially having lines go though the model
                 }
                 else
                 {

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2023,6 +2023,7 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
                 return;
             }
 
+            Shape relevant_forbidden = volumes_.getCollision(0, layer_idx, true);
             Shape outer_walls = TreeSupportUtils::toPolylines(support_layer_storage[layer_idx - 1].getOutsidePolygons())
                                     .createTubeShape(
                                         closing_dist,
@@ -2041,6 +2042,11 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
                 hole_aabb.expand(EPSILON);
                 if (! hole.intersection(PolygonUtils::clipPolygonWithAABB(outer_walls, hole_aabb)).empty())
                 {
+                    holes_resting_outside[layer_idx].emplace(idx);
+                }
+                else if (! hole.intersection(PolygonUtils::clipPolygonWithAABB(relevant_forbidden, hole_aabb)).offset(-config.xy_min_distance / 2).empty())
+                {
+                    // technically not resting outside, also not valid, but the alternative is potentially having lines go through the model
                     holes_resting_outside[layer_idx].emplace(idx);
                 }
                 else

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2093,17 +2093,6 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
             if (! found)
             {
                 next_removed_holes_by_idx.emplace(idx);
-
-                // Individual pieces of the hole could still be valid (if the 'hole' is made by branches surrounding others' for instance).
-                for (const auto& poly : hole)
-                {
-                    if (poly.area() < 0)
-                    {
-                        auto poly_copy = poly;
-                        poly_copy.reverse();
-                        valid_holes[layer_idx].push_back(poly_copy);
-                    }
-                }
             }
             else
             {


### PR DESCRIPTION
# Description

This pull request does 3 things:
1. It reverts https://github.com/Ultimaker/CuraEngine/pull/2145 and adds an alternative solution for what it intended.
I think explicitly excluding holes with branches inside them from being removes is better than re-adding the branches later.
In the best case if the branches are added back, there is no difference between the hole being removed or not. Worst case something breaks:
If I understood the change there correctly it adds all branches in a hole aka negative-holes in a positive-hole, as a positive-hole, which later is then reversed and added back to the support area as a negative-hole. This should mean that if support density is larger than 0 this fix will cause confused people wondering why suddenly the area around the branches is filled with support infill, but the branch itself is not:

![grafik](https://github.com/user-attachments/assets/2d0621c7-5f54-42c3-a534-70ce63e108ae)


This is what it looks with this pull request:

![grafik](https://github.com/user-attachments/assets/cfcecbc8-305d-46ff-93c8-3d1dd2407c1f)


(Why the branch paths are different between these two screenshots is an investigation for another day)

2. It correctly adds the change from https://github.com/Ultimaker/CuraEngine/pull/2088
How the other solution, where I tried to solve it without an offset found its way back I do not understand. As seen by the example file given in the pull request https://github.com/Ultimaker/CuraEngine/pull/2145 it sadly does not work and can cause inconsistent hole removal.

3. While debugging I noticed that this function takes longer than I would have expected. I found a small change that drastically increases the performance in this test-case. While it is not related to the things above, I don't see any reason to not include it.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] File from https://github.com/Ultimaker/CuraEngine/pull/2145 its changes back-ported to a 5.8 branch, as I currently have issues compiling 5.9.

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
