### PR TITLE
[CURA-12173] Only perform 'tiny loops' fix if there's space to do so.

### DIFF
--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -931,12 +931,16 @@ void Infill::connectLines(OpenLinesSet& result_lines)
                     }
                     else
                     {
+                        constexpr coord_t epsilon_sqd = 25;
+
                         // Resolve any intersections of the fill lines close to the boundary, by inserting extra points so the lines don't create a tiny 'loop'.
                         Point2LL intersect;
                         if (vSize2(previous_point - next_point) < half_line_distance_squared
                             && LinearAlg2D::lineLineIntersection(previous_segment->start_, previous_segment->end_, crossing->start_, crossing->end_, intersect)
                             && LinearAlg2D::pointIsProjectedBeyondLine(intersect, previous_segment->start_, previous_segment->end_) == 0
-                            && LinearAlg2D::pointIsProjectedBeyondLine(intersect, crossing->start_, crossing->end_) == 0)
+                            && LinearAlg2D::pointIsProjectedBeyondLine(intersect, crossing->start_, crossing->end_) == 0
+                            && vSize2(previous_point - intersect) > epsilon_sqd
+                            && vSize2(next_point - intersect) > epsilon_sqd)
                         {
                             resolveIntersection(infill_line_width_, intersect, previous_point, next_point, previous_segment, crossing);
                         }

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -938,8 +938,7 @@ void Infill::connectLines(OpenLinesSet& result_lines)
                         if (vSize2(previous_point - next_point) < half_line_distance_squared
                             && LinearAlg2D::lineLineIntersection(previous_segment->start_, previous_segment->end_, crossing->start_, crossing->end_, intersect)
                             && LinearAlg2D::pointIsProjectedBeyondLine(intersect, previous_segment->start_, previous_segment->end_) == 0
-                            && LinearAlg2D::pointIsProjectedBeyondLine(intersect, crossing->start_, crossing->end_) == 0
-                            && vSize2(previous_point - intersect) > epsilon_sqd
+                            && LinearAlg2D::pointIsProjectedBeyondLine(intersect, crossing->start_, crossing->end_) == 0 && vSize2(previous_point - intersect) > epsilon_sqd
                             && vSize2(next_point - intersect) > epsilon_sqd)
                         {
                             resolveIntersection(infill_line_width_, intersect, previous_point, next_point, previous_segment, crossing);


### PR DESCRIPTION
Previously, we created this 'resolveIntersection' function to handle infill line intersections that where very close to the walls and would therefore create 'tiny loops', which created problems, especially when extruding, like for connect infill lines. However, the alternative maneuvre (or at least the calculation thereof) needs at least _some_ space to work in. If the crossing to be prevented is 'on' the line (within an epsilon), the calculation will not be possible in the current state -- and if things are that close, the rest of the algos will take care of it.