### PR TITLE
[CURA-12065] Fix (sort-of) conflict between per-object and per-mesh retraction.

### DIFF
--- a/include/sliceDataStorage.h
+++ b/include/sliceDataStorage.h
@@ -323,6 +323,9 @@ public:
     std::shared_ptr<LightningGenerator> lightning_generator; //!< Pre-computed structure for Lightning type infill
 
     RetractionAndWipeConfig retraction_wipe_config; //!< Per-Object retraction and wipe settings.
+    bool override_extruder_retract_settings = true; //!< The 'per-object' retraction and wipe settings are currently always filled, even if not overridden.
+                                                    //!< This has potential conflicts with per-extruder retract/wipe settings.
+                                                    //!< So, only override the settings on a per-object basis if all extruder retract/wipe settings are the same.
 
     /*!
      * \brief Creates a storage space for slice results of a mesh.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -337,44 +337,27 @@ void FffGcodeWriter::setConfigFanSpeedLayerTime()
 
 static bool retractConfigIsSame(const RetractionConfig& a, const RetractionConfig& b)
 {
-    return a.distance == b.distance
-        && a.prime_volume == b.prime_volume
-        && a.speed == b.speed
-        && a.primeSpeed == b.primeSpeed
-        && a.zHop == b.zHop
-        && a.retraction_min_travel_distance == b.retraction_min_travel_distance
-        && a.retraction_extrusion_window == b.retraction_extrusion_window
+    return a.distance == b.distance && a.prime_volume == b.prime_volume && a.speed == b.speed && a.primeSpeed == b.primeSpeed && a.zHop == b.zHop
+        && a.retraction_min_travel_distance == b.retraction_min_travel_distance && a.retraction_extrusion_window == b.retraction_extrusion_window
         && a.retraction_count_max == b.retraction_count_max;
 }
 
 static bool switchRetractConfigIsSame(const RetractionAndWipeConfig& a, const RetractionAndWipeConfig& b)
 {
     return retractConfigIsSame(a.extruder_switch_retraction_config, b.extruder_switch_retraction_config)
-        && a.retraction_hop_after_extruder_switch == b.retraction_hop_after_extruder_switch
-        && a.switch_extruder_extra_prime_amount == b.switch_extruder_extra_prime_amount;
+        && a.retraction_hop_after_extruder_switch == b.retraction_hop_after_extruder_switch && a.switch_extruder_extra_prime_amount == b.switch_extruder_extra_prime_amount;
 }
 
 static bool wipeConfigIsSame(const WipeScriptConfig& a, const WipeScriptConfig& b)
 {
-    return retractConfigIsSame(a.retraction_config, b.retraction_config)
-        && a.retraction_enable == b.retraction_enable
-        && a.pause == b.pause
-        && a.hop_enable == b.hop_enable
-        && a.hop_amount == b.hop_amount
-        && a.hop_speed == b.hop_speed
-        && a.brush_pos_x == b.brush_pos_x
-        && a.repeat_count == b.repeat_count
-        && a.move_distance == b.move_distance
-        && a.move_speed == b.move_speed
-        && a.max_extrusion_mm3 == b.max_extrusion_mm3
-        && a.clean_between_layers == b.clean_between_layers;
+    return retractConfigIsSame(a.retraction_config, b.retraction_config) && a.retraction_enable == b.retraction_enable && a.pause == b.pause && a.hop_enable == b.hop_enable
+        && a.hop_amount == b.hop_amount && a.hop_speed == b.hop_speed && a.brush_pos_x == b.brush_pos_x && a.repeat_count == b.repeat_count && a.move_distance == b.move_distance
+        && a.move_speed == b.move_speed && a.max_extrusion_mm3 == b.max_extrusion_mm3 && a.clean_between_layers == b.clean_between_layers;
 }
 
 static bool retractAndWipeConfigIsSame(const RetractionAndWipeConfig& a, const RetractionAndWipeConfig& b)
 {
-    return retractConfigIsSame(a.retraction_config, b.retraction_config)
-        && switchRetractConfigIsSame(a, b)
-        && wipeConfigIsSame(a.wipe_config, b.wipe_config);
+    return retractConfigIsSame(a.retraction_config, b.retraction_config) && switchRetractConfigIsSame(a, b) && wipeConfigIsSame(a.wipe_config, b.wipe_config);
 }
 
 static void retractionConfigFromSettings(const Settings& settings, RetractionAndWipeConfig* config)
@@ -451,8 +434,12 @@ void FffGcodeWriter::setConfigRetractionAndWipe(SliceDataStorage& storage)
     // This has potential conflicts with per-extruder retract/wipe settings.
     // So, only override the settings on a per-object basis if all extruder retract/wipe settings are the same.
     const auto& compare_with_first = storage.retraction_wipe_config_per_extruder[0];
-    const bool mesh_overrides_extruder_retraction_and_wipe = ranges::all_of(storage.retraction_wipe_config_per_extruder,
-        [&compare_with_first](const auto& config) { return retractAndWipeConfigIsSame(compare_with_first, config); });
+    const bool mesh_overrides_extruder_retraction_and_wipe = ranges::all_of(
+        storage.retraction_wipe_config_per_extruder,
+        [&compare_with_first](const auto& config)
+        {
+            return retractAndWipeConfigIsSame(compare_with_first, config);
+        });
     for (std::shared_ptr<SliceMeshStorage>& mesh : storage.meshes)
     {
         retractionAndWipeConfigFromSettings(mesh->settings, &mesh->retraction_wipe_config);

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -355,8 +355,9 @@ GCodePath& LayerPlan::addTravel(const Point2LL& p, const bool force_retract, con
 {
     const GCodePathConfig& travel_config = configs_storage_.travel_config_per_extruder[getExtruder()];
 
-    const RetractionConfig& retraction_config
-        = current_mesh_ && current_mesh_->override_extruder_retract_settings ? current_mesh_->retraction_wipe_config.retraction_config : storage_.retraction_wipe_config_per_extruder[getExtruder()].retraction_config;
+    const RetractionConfig& retraction_config = current_mesh_ && current_mesh_->override_extruder_retract_settings
+                                                  ? current_mesh_->retraction_wipe_config.retraction_config
+                                                  : storage_.retraction_wipe_config_per_extruder[getExtruder()].retraction_config;
 
     GCodePath* path = getLatestPathWithConfig(travel_config, SpaceFillType::None, z_offset);
 
@@ -2282,8 +2283,9 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
     {
         ExtruderPlan& extruder_plan = extruder_plans_[extruder_plan_idx];
 
-        const RetractionAndWipeConfig* retraction_config
-            = current_mesh && current_mesh->override_extruder_retract_settings ? &current_mesh->retraction_wipe_config : &storage_.retraction_wipe_config_per_extruder[extruder_plan.extruder_nr_];
+        const RetractionAndWipeConfig* retraction_config = current_mesh && current_mesh->override_extruder_retract_settings
+                                                             ? &current_mesh->retraction_wipe_config
+                                                             : &storage_.retraction_wipe_config_per_extruder[extruder_plan.extruder_nr_];
         coord_t z_hop_height = retraction_config->retraction_config.zHop;
 
         if (extruder_nr != extruder_plan.extruder_nr_)
@@ -2693,8 +2695,9 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         if (extruder.settings_.get<bool>("cool_lift_head") && extruder_plan.extra_time_ > 0.0)
         {
             gcode.writeComment("Small layer, adding delay");
-            const RetractionAndWipeConfig& actual_retraction_config
-                = current_mesh && current_mesh->override_extruder_retract_settings ? current_mesh->retraction_wipe_config : storage_.retraction_wipe_config_per_extruder[gcode.getExtruderNr()];
+            const RetractionAndWipeConfig& actual_retraction_config = current_mesh && current_mesh->override_extruder_retract_settings
+                                                                        ? current_mesh->retraction_wipe_config
+                                                                        : storage_.retraction_wipe_config_per_extruder[gcode.getExtruderNr()];
             gcode.writeRetraction(actual_retraction_config.retraction_config);
             if (extruder_plan_idx == extruder_plans_.size() - 1 || ! extruder.settings_.get<bool>("machine_extruder_end_pos_abs"))
             { // only do the z-hop if it's the last extruder plan; otherwise it's already at the switching bay area


### PR DESCRIPTION
We don't really have a set way to deal with settings that can both be per-extruder and per-mesh (sometimes called per-object in the engine) -- in general, building something like that would be a (new) feature (gap). This represents a workaround for a current issue where the overall settings are taken instead of the per-extruder ones, even though in the frontend, no per-mesh settings are overridden. Which happened because it always prefers the per-mesh settings over the per-extruder ones, and since the per-mesh settings where not overridden, it was just the 'top' ones. If you then overrode less then all of the extruders with a specific setting, it would default back to the 'top' settings (but if all extruders where overridden, that counted as not overridden again w.r.t per-extruder).

This commit 'fixes' that by assuming that if you have any setting different per extruder, you want that rather than the per mesh ones. This isn't necessarily the case (and also definitely not as granular as can be, it takes all retraction and wipe settings as one....) but it may do the job for now.