### PR TITLE
[CURA-12068] Fix missing infill in thin strips of space.

### DIFF
--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2037,10 +2037,11 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
             {
                 AABB hole_aabb = AABB(hole);
                 hole_aabb.expand(EPSILON);
-                if(hole.size() > 1)
+                if (hole.size() > 1)
                 {
                     // The hole contains other branches! It can not be fully removed.
-                    // This may not fully handle this case as there could be a situation where such a hole becomes invalid, but for now this is the best solution not requiring larger changes.
+                    // This may not fully handle this case as there could be a situation where such a hole becomes invalid, but for now this is the best solution not requiring
+                    // larger changes.
                     holes_resting_outside[layer_idx].emplace(idx);
                 }
                 else if (! hole.intersection(PolygonUtils::clipPolygonWithAABB(outer_walls, hole_aabb)).empty())
@@ -2057,8 +2058,7 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
                     for (auto [idx2, hole2] : holeparts[layer_idx - 1] | ranges::views::enumerate)
                     {
                         // TODO should technically be outline: Check if this is fine either way as it would save an offset
-                        if (hole_aabb.hit(AABB(hole2))
-                            && ! hole.intersection(PolygonUtils::clipPolygonWithAABB(hole2, hole_aabb)).empty())
+                        if (hole_aabb.hit(AABB(hole2)) && ! hole.intersection(PolygonUtils::clipPolygonWithAABB(hole2, hole_aabb)).empty())
                         {
                             hole_rest_map[layer_idx][idx].emplace_back(idx2);
                         }

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -529,8 +529,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
                 part.infill_area_per_combine_per_density.emplace_back();
                 std::vector<Shape>& infill_area_per_combine_current_density = part.infill_area_per_combine_per_density.back();
                 const Shape more_dense_infill = infill_area.difference(less_dense_infill);
-                infill_area_per_combine_current_density.push_back(
-                    simplifier.polygon(more_dense_infill.difference(sum_more_dense)));
+                infill_area_per_combine_current_density.push_back(simplifier.polygon(more_dense_infill.difference(sum_more_dense)));
                 if (is_connected)
                 {
                     sum_more_dense = sum_more_dense.unionPolygons(more_dense_infill);


### PR DESCRIPTION
For a previous fix (see ticket CURA-11597 for the support issues fixed --doubling up lines of support-- and the related github discussion Cura/issues/18924 for the infill issues fixed --extra dots of infill at the edges--) we did some morphological operations to attempt to make the output more smooth. This caused more problems than its worth, and was in fact already removed in the original PR w.r.t. support (see commit eeec9636f7b3f749b790a1bea4c2901196cee027 ) -- seems we (read I) forgot to remove it for the infill case as well.

part of CURA-12068 (or a belated contribution to CURA-11597).