### PR TITLE
Add writeGcodeFile function to GCodeExport

### DIFF
--- a/include/gcodeExport.h
+++ b/include/gcodeExport.h
@@ -409,6 +409,8 @@ public:
      */
     bool needPrimeBlob() const;
 
+    void writeGcodeFile();
+
 private:
     /*!
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -4437,6 +4437,7 @@ void FffGcodeWriter::finalize()
     }
 
     gcode.writeComment("End of Gcode");
+    gcode.writeGcodeFile();
     /*
     the profile string below can be executed since the M25 doesn't end the gcode on an UMO and when printing via USB.
     gcode.writeCode("M25 ;Stop reading from this point on.");

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1726,8 +1726,13 @@ void GCodeExport::finalize(const char* endCode)
     for (int n = 1; n < MAX_EXTRUDERS; n++)
         if (getTotalFilamentUsed(n) > 0)
             spdlog::info("Filament {}: {}", n + 1, int(getTotalFilamentUsed(n)));
+}
+
+void GCodeExport::writeGcodeFile()
+{
     output_stream_->flush();
 }
+
 
 double GCodeExport::getExtrudedVolumeAfterLastWipe(size_t extruder)
 {

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1733,7 +1733,6 @@ void GCodeExport::writeGcodeFile()
     output_stream_->flush();
 }
 
-
 double GCodeExport::getExtrudedVolumeAfterLastWipe(size_t extruder)
 {
     return eToMm3(extruder_attr_[extruder].last_e_value_after_wipe_, extruder);


### PR DESCRIPTION
# Description

Introduce a new method writeGcodeFile to the GCodeExport class, which ensures that the output stream is properly flushed. This function is also called at the end of the Gcode writing process to finalize the file.