### PR TITLE
CURA-12252 Fix outer wall being translated

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1291,7 +1291,7 @@ std::vector<LayerPlan::PathCoasting>
 
         for (const auto& reversed_chunk : paths | ranges::views::enumerate | ranges::views::reverse
                                               | ranges::views::chunk_by(
-                                                  [](const auto& path_a, const auto& path_b)
+                                                  [](const auto&path_a, const auto&path_b)
                                                   {
                                                       return (! std::get<1>(path_a).isTravelPath()) || std::get<1>(path_b).isTravelPath();
                                                   }))


### PR DESCRIPTION
Instead of always reusing the results of the split segments destination, we now calculate them from the initial wall segment, avoiding some rounding errors being accumulated over time and translating the whole path significantly.

CURA-12251