### PR TITLE
CURA-12259 Bump grpc_definitions version for 5.9

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -5,6 +5,6 @@ requirements:
 requirements_arcus:
   - "arcus/5.4.1"
 requirements_plugins:
-  - "curaengine_grpc_definitions/0.2.1"
+  - "curaengine_grpc_definitions/0.3.0"
 requirements_cura_resources:
   - "cura_resources/5.9.0-beta.1"


### PR DESCRIPTION
CURA-12259

We made some significant changes between 5.8 and 5.9, so now is the time to bump the version number in order to indicate this.