### PR TITLE
CURA-12268 Fix useless Z move before switching layer

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2748,6 +2748,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                     gcode.writeTravel(current_position, extruder.settings_.get<Velocity>("speed_z_hop"));
 
                     // Prevent the final travel(s) from resetting to the 'previous' layer height.
+                    path.z_offset = final_travel_z_ - z_;
                     gcode.setZ(final_travel_z_);
                 }
                 for (size_t point_idx = 0; point_idx + 1 < path.points.size(); point_idx++)


### PR DESCRIPTION
This was introduced while moving positions to 3D points. The Z offset of the travel move now has to be correct, otherwise we will move the nozzle up for next layer, then move back down for the travel move, then move up again when actually starting to print.

CURA-12268