### PR TITLE
CURA-12265 the wiping movement goes in the wrong direction

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -881,9 +881,10 @@ private:
      * \param compute_distance_to_bridge_start Whether we should compute the distance to start of bridge. This is
      *                                         possible only if PathType is ExtrusionLine and will be ignored otherwise.
      * \param func_add_segment The function to be called to actually add an extrusion segment with the given parameters
+     * \return The index of the last traversed point, and the final position with the scarf seam
      */
     template<class PathType>
-    void addSplitWall(
+    std::tuple<size_t, Point2LL> addSplitWall(
         const PathAdapter<PathType>& wall,
         const coord_t wall_length,
         const size_t start_idx,
@@ -926,10 +927,10 @@ private:
      * \param scarf_seam Indicates whether we may use a scarf seam for the path
      * \param smooth_speed Indicates whether we may use a speed gradient for the path
      * \param func_add_segment The function to be called to actually add an extrusion segment with the given parameters
-     * \return The actual length of the added scarf seam
+     * \return The index of the last traversed point, and the final position with the scarf seam
      */
     template<class PathType>
-    coord_t addWallWithScarfSeam(
+    std::tuple<size_t, Point2LL> addWallWithScarfSeam(
         const PathAdapter<PathType>& wall,
         size_t start_idx,
         const Settings& settings,
@@ -950,10 +951,10 @@ private:
      * \param wipe_distance The length of the wipe move to be added
      * \param backwards Indicates if the path has been processed backwards
      * \param start_index The index of the point where o start printing the path
-     * \param scarf_seam_length The length of the scarf seat that has been added to the path
+     * \param last_path_position The actual last position of the extruder, which may be slightly forwards on the last printed segment
      */
     template<class PathType>
-    void addWipeTravel(const PathAdapter<PathType>& path, const coord_t wipe_distance, const bool backwards, const size_t start_index, const coord_t scarf_seam_length);
+    void addWipeTravel(const PathAdapter<PathType>& path, const coord_t wipe_distance, const bool backwards, const size_t start_index, const Point2LL& last_path_position);
 
     /*!
      * Pre-calculates the coasting to be applied on the paths

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -926,9 +926,10 @@ private:
      * \param scarf_seam Indicates whether we may use a scarf seam for the path
      * \param smooth_speed Indicates whether we may use a speed gradient for the path
      * \param func_add_segment The function to be called to actually add an extrusion segment with the given parameters
+     * \return The actual length of the added scarf seam
      */
     template<class PathType>
-    void addWallWithScarfSeam(
+    coord_t addWallWithScarfSeam(
         const PathAdapter<PathType>& wall,
         size_t start_idx,
         const Settings& settings,
@@ -941,6 +942,18 @@ private:
         const bool scarf_seam,
         const bool smooth_speed,
         const AddExtrusionSegmentFunction& func_add_segment);
+
+    /*!
+     * \brief Add a wipe travel after the given path has been extruded
+     * \tparam PathType The type of path to be processed, either ExtrusionLine or some subclass of Polyline
+     * \param path The path that has just been extruded
+     * \param wipe_distance The length of the wipe move to be added
+     * \param backwards Indicates if the path has been processed backwards
+     * \param start_index The index of the point where o start printing the path
+     * \param scarf_seam_length The length of the scarf seat that has been added to the path
+     */
+    template<class PathType>
+    void addWipeTravel(const PathAdapter<PathType>& path, const coord_t wipe_distance, const bool backwards, const size_t start_index, const coord_t scarf_seam_length);
 
     /*!
      * Pre-calculates the coasting to be applied on the paths


### PR DESCRIPTION
The wiping movement while adding extrusion lines didn't care of the reversed order. We now use a common method while adding either Polygons and ExtrusionLines, which takes care of the reversion.
Also fixes the wipe movement interaction with the scarf seam by taking the actual last printed point, which can now be different from the path last point due to the scarf seam closure.

CURA-12265
CURA-12266