### PR TITLE
Cura 12275 retract before outer wall only works on the initial layer

### DIFF
--- a/include/ExtruderPlan.h
+++ b/include/ExtruderPlan.h
@@ -124,6 +124,11 @@ public:
      */
     void applyBackPressureCompensation(const Ratio back_pressure_compensation);
 
+    /*!
+     * Gets the mesh being printed first on this plan
+     */
+    std::shared_ptr<const SliceMeshStorage> findFirstPrintedMesh() const;
+
 private:
     LayerIndex layer_nr_{ 0 }; //!< The layer number at which we are currently printing.
     bool is_initial_layer_{ false }; //!< Whether this extruder plan is printed on the very first layer (which might be raft)

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -761,6 +761,11 @@ public:
      */
     void applyGradualFlow();
 
+    /*!
+     * Gets the mesh being printed first on this layer
+     */
+    std::shared_ptr<const SliceMeshStorage> findFirstPrintedMesh() const;
+
 private:
     /*!
      * \brief Compute the preferred or minimum combing boundary

--- a/src/ExtruderPlan.cpp
+++ b/src/ExtruderPlan.cpp
@@ -70,4 +70,18 @@ void ExtruderPlan::applyBackPressureCompensation(const Ratio back_pressure_compe
         path.speed_back_pressure_factor = std::max(epsilon_speed_factor, 1.0 + (nominal_width_for_path / line_width_for_path - 1.0) * back_pressure_compensation);
     }
 }
+
+std::shared_ptr<const SliceMeshStorage> ExtruderPlan::findFirstPrintedMesh() const
+{
+    for (const GCodePath& path : paths_)
+    {
+        if (path.mesh)
+        {
+            return path.mesh;
+        }
+    }
+
+    return nullptr;
+}
+
 } // namespace cura

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1292,7 +1292,7 @@ std::vector<LayerPlan::PathCoasting>
 
         for (const auto& reversed_chunk : paths | ranges::views::enumerate | ranges::views::reverse
                                               | ranges::views::chunk_by(
-                                                  [](const auto&path_a, const auto&path_b)
+                                                  [](const auto& path_a, const auto& path_b)
                                                   {
                                                       return (! std::get<1>(path_a).isTravelPath()) || std::get<1>(path_b).isTravelPath();
                                                   }))
@@ -3084,6 +3084,19 @@ void LayerPlan::applyGradualFlow()
     {
         gradual_flow::Processor::process(extruder_plan.paths_, extruder_plan.extruder_nr_, layer_nr_);
     }
+}
+
+std::shared_ptr<const SliceMeshStorage> LayerPlan::findFirstPrintedMesh() const
+{
+    for (const ExtruderPlan& extruder_plan : extruder_plans_)
+    {
+        if (std::shared_ptr<const SliceMeshStorage> mesh = extruder_plan.findFirstPrintedMesh())
+        {
+            return mesh;
+        }
+    }
+
+    return nullptr;
 }
 
 LayerIndex LayerPlan::getLayerNr() const

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1292,7 +1292,7 @@ std::vector<LayerPlan::PathCoasting>
 
         for (const auto& reversed_chunk : paths | ranges::views::enumerate | ranges::views::reverse
                                               | ranges::views::chunk_by(
-                                                  [](const auto& path_a, const auto& path_b)
+                                                  [](const auto&path_a, const auto&path_b)
                                                   {
                                                       return (! std::get<1>(path_a).isTravelPath()) || std::get<1>(path_b).isTravelPath();
                                                   }))

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -99,10 +99,21 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
         const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
         const Settings& extruder_settings = Application::getInstance().current_slice_->scene.extruders[prev_layer->extruder_plans_.back().extruder_nr_].settings_;
         prev_layer->setIsInside(new_layer_destination_state->second);
-        const bool force_retract = extruder_settings.get<bool>("retract_at_layer_change")
-                                || (mesh_group_settings.get<bool>("travel_retract_before_outer_wall")
-                                    && (mesh_group_settings.get<InsetDirection>("inset_direction") == InsetDirection::OUTSIDE_IN
-                                        || mesh_group_settings.get<size_t>("wall_line_count") == 1)); // Moving towards an outer wall.
+
+        const bool travel_retract_before_outer_wall = mesh_group_settings.get<bool>("travel_retract_before_outer_wall");
+        const bool retract_at_layer_change = extruder_settings.get<bool>("retract_at_layer_change");
+        bool next_mesh_retract_before_outer_wall = false;
+        std::shared_ptr<const SliceMeshStorage> first_printed_mesh = newest_layer->findFirstPrintedMesh();
+        if (! retract_at_layer_change && first_printed_mesh && travel_retract_before_outer_wall)
+        {
+            // Check whether we are moving toving towards an outer wall and it should be retracted
+            const Settings& mesh_settings = first_printed_mesh->settings;
+            const InsetDirection inset_direction = mesh_settings.get<InsetDirection>("inset_direction");
+            const size_t wall_line_count = mesh_settings.get<size_t>("wall_line_count");
+
+            next_mesh_retract_before_outer_wall = inset_direction == InsetDirection::OUTSIDE_IN || wall_line_count == 1;
+        }
+        const bool force_retract = retract_at_layer_change || next_mesh_retract_before_outer_wall;
         prev_layer->final_travel_z_ = newest_layer->z_;
         GCodePath& path = prev_layer->addTravel(first_location_new_layer, force_retract);
         if (force_retract && ! path.retract)


### PR DESCRIPTION
The `travel_retract_before_outer_wall` setting is settable per-mesh, but the global value was previously taken in this context. We now take the value of the setting, for the mesh we are moving to.

CURA-12275
Fixes https://github.com/Ultimaker/Cura/issues/19876