### PR TITLE
Fix (some) crash-logs divide-by-zero issues

### DIFF
--- a/include/TreeSupportSettings.h
+++ b/include/TreeSupportSettings.h
@@ -39,7 +39,7 @@ struct TreeSupportSettings
         , maximum_move_distance((angle < TAU / 4) ? std::llround(tan(angle) * layer_height) : std::numeric_limits<coord_t>::max())
         , maximum_move_distance_slow((angle_slow < TAU / 4) ? std::llround(tan(angle_slow) * layer_height) : std::numeric_limits<coord_t>::max())
         , support_bottom_layers(mesh_group_settings.get<bool>("support_bottom_enable") ? round_divide(mesh_group_settings.get<coord_t>("support_bottom_height"), layer_height) : 0)
-        , tip_layers(std::max((branch_radius - min_radius) / (support_line_width / 3), branch_radius / layer_height))
+        , tip_layers(std::max(std::max((branch_radius - min_radius) / (support_line_width / 3), branch_radius / layer_height), 1LL))
         , // Ensure lines always stack nicely even if layer height is large
         diameter_angle_scale_factor(sin(mesh_group_settings.get<AngleRadians>("support_tree_branch_diameter_angle")) * layer_height / branch_radius)
         , max_to_model_radius_increase(mesh_group_settings.get<coord_t>("support_tree_max_diameter_increase_by_merges_when_support_to_model") / 2)

--- a/src/TreeSupportTipGenerator.cpp
+++ b/src/TreeSupportTipGenerator.cpp
@@ -64,7 +64,7 @@ TreeSupportTipGenerator::TreeSupportTipGenerator(const SliceMeshStorage& mesh, T
     const double support_overhang_angle = mesh.settings.get<AngleRadians>("support_angle");
     const coord_t max_overhang_speed = (support_overhang_angle < TAU / 4) ? (coord_t)(tan(support_overhang_angle) * config_.layer_height) : std::numeric_limits<coord_t>::max();
 
-    if (max_overhang_speed == 0)
+    if (max_overhang_speed < 2)
     {
         max_overhang_insert_lag_ = std::numeric_limits<coord_t>::max();
     }

--- a/src/utils/polygonUtils.cpp
+++ b/src/utils/polygonUtils.cpp
@@ -1420,7 +1420,7 @@ void PolygonUtils::fixSelfIntersections(const coord_t epsilon, Shape& polygon)
                 {
                     const Point2LL& other = polygon[poly_idx][(point_idx + 1) % pathlen];
                     const Point2LL vec = LinearAlg2D::pointIsLeftOfLine(other, a, b) > 0 ? b - a : a - b;
-                    const coord_t len = vSize(vec);
+                    const coord_t len = std::max(vSize(vec), 1LL);
                     pt.X += (-vec.Y * move_dist) / len;
                     pt.Y += (vec.X * move_dist) / len;
                 }


### PR DESCRIPTION
Scoured the crash-logs for often-occurring div-by-zero issues, fixed these three.