### PR TITLE
CURA-12324 random seam is not so random

### DIFF
--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -784,17 +784,20 @@ protected:
         best_candidate_finder.appendCriteriaPass(main_criteria_pass);
 
         // ########## Step 2: add fallback passes for criteria with very similar scores (e.g. corner on a cylinder)
-        const AABB path_bounding_box(points);
+        if (path.seam_config_.type_ == EZSeamType::SHARPEST_CORNER)
+        {
+            const AABB path_bounding_box(points);
 
-        { // First fallback strategy is to take points on the back-most position
-            auto fallback_criterion = std::make_shared<DistanceScoringCriterion>(points, path_bounding_box.max_, DistanceScoringCriterion::DistanceType::YOnly);
-            constexpr double outsider_delta_threshold = 0.01;
-            best_candidate_finder.appendSingleCriterionPass(fallback_criterion, outsider_delta_threshold);
-        }
+            { // First fallback strategy is to take points on the back-most position
+                auto fallback_criterion = std::make_shared<DistanceScoringCriterion>(points, path_bounding_box.max_, DistanceScoringCriterion::DistanceType::YOnly);
+                constexpr double outsider_delta_threshold = 0.01;
+                best_candidate_finder.appendSingleCriterionPass(fallback_criterion, outsider_delta_threshold);
+            }
 
-        { // Second fallback strategy, in case we still have multiple points that are aligned on Y (e.g. cube), take the right-most point
-            auto fallback_criterion = std::make_shared<DistanceScoringCriterion>(points, path_bounding_box.max_, DistanceScoringCriterion::DistanceType::XOnly);
-            best_candidate_finder.appendSingleCriterionPass(fallback_criterion);
+            { // Second fallback strategy, in case we still have multiple points that are aligned on Y (e.g. cube), take the right-most point
+                auto fallback_criterion = std::make_shared<DistanceScoringCriterion>(points, path_bounding_box.max_, DistanceScoringCriterion::DistanceType::XOnly);
+                best_candidate_finder.appendSingleCriterionPass(fallback_criterion);
+            }
         }
 
         // ########## Step 3: apply the criteria to find the vertex with the best global score

--- a/include/utils/scoring/BestElementFinder.h
+++ b/include/utils/scoring/BestElementFinder.h
@@ -15,7 +15,7 @@ class ScoringCriterion;
 
 /*!
  * This class implements an algorithm to find an element amongst a list, regarding one or multiple scoring criteria. The
- * criteria are implemented by subclassing the CriterionScoring class. It is also possible to setup multiple passes of
+ * criteria are implemented by subclassing the CriterionScoring class. It is also possible to set up multiple passes of
  * criteria. Thus, if the first pass gives a few best candidates that are too close to each other, we keep only the best
  * candidates and process a second pass with different criteria, and so on until we have a single outsider, or no more
  * criteria.
@@ -60,6 +60,7 @@ public:
          * Once we have calculated the global scores of each element for this pass, we calculate the score difference
          * between the best candidate and the following ones. If the following ones have a score close enough to the
          * best, within this threshold, they will also be considered outsiders and will be run for the next pass.
+         * This value will be ignored for the last pass.
          */
         double outsider_delta_threshold{ 0.0 };
     };


### PR DESCRIPTION
When using a random seam position, the scoring algorithm would still use the fallback criteria, which are useful for the "sharpest corner" strategy. We now don't use them, so that a really random point is always returned.
Also fixed a second bias where the best candidate could also not be returned to the profit of a nearly-best one.

CURA-12324