### PR TITLE
CURA-12340 Seam on vertex does not work as expected with user defined

### DIFF
--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -738,29 +738,26 @@ protected:
 
         BestElementFinder::WeighedCriterion main_criterion;
 
-        if (path.force_start_index_.has_value()) // Actually handles EZSeamType::USER_SPECIFIED
+        if (path.force_start_index_.has_value()) // Handles EZSeamType::USER_SPECIFIED with "seam_on_vertex" disabled
         {
             // Use a much smaller distance divider because we want points around the forced points to be filtered out very easily
             constexpr double distance_divider = 1.0;
             constexpr auto distance_type = DistanceScoringCriterion::DistanceType::Euclidian;
             main_criterion.criterion = std::make_shared<DistanceScoringCriterion>(points, points.at(path.force_start_index_.value()), distance_type, distance_divider);
         }
-        else
+        else if (path.seam_config_.type_ == EZSeamType::SHORTEST || path.seam_config_.type_ == EZSeamType::USER_SPECIFIED)
         {
-            if (path.seam_config_.type_ == EZSeamType::SHORTEST || path.seam_config_.type_ == EZSeamType::USER_SPECIFIED)
-            {
-                main_criterion.criterion = std::make_shared<DistanceScoringCriterion>(points, target_pos);
-            }
-            else if (
-                path.seam_config_.type_ == EZSeamType::SHARPEST_CORNER
-                && (path.seam_config_.corner_pref_ != EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE && path.seam_config_.corner_pref_ != EZSeamCornerPrefType::PLUGIN))
-            {
-                main_criterion.criterion = std::make_shared<CornerScoringCriterion>(points, path.seam_config_.corner_pref_);
-            }
-            else if (path.seam_config_.type_ == EZSeamType::RANDOM)
-            {
-                main_criterion.criterion = std::make_shared<RandomScoringCriterion>();
-            }
+            main_criterion.criterion = std::make_shared<DistanceScoringCriterion>(points, target_pos);
+        }
+        else if (
+            path.seam_config_.type_ == EZSeamType::SHARPEST_CORNER
+            && (path.seam_config_.corner_pref_ != EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_NONE && path.seam_config_.corner_pref_ != EZSeamCornerPrefType::PLUGIN))
+        {
+            main_criterion.criterion = std::make_shared<CornerScoringCriterion>(points, path.seam_config_.corner_pref_);
+        }
+        else if (path.seam_config_.type_ == EZSeamType::RANDOM)
+        {
+            main_criterion.criterion = std::make_shared<RandomScoringCriterion>();
         }
 
         if (main_criterion.criterion)

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -747,7 +747,7 @@ protected:
         }
         else
         {
-            if (path.seam_config_.type_ == EZSeamType::SHORTEST)
+            if (path.seam_config_.type_ == EZSeamType::SHORTEST || path.seam_config_.type_ == EZSeamType::USER_SPECIFIED)
             {
                 main_criterion.criterion = std::make_shared<DistanceScoringCriterion>(points, target_pos);
             }


### PR DESCRIPTION
During the previous refactoring for the seam, this settings combination has been overlooked and was not handled properly, resulting in a warning in the console and a wrong seam position.

CURA-12340