### PR TITLE
Fix wrong retraction settings being used

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -57,15 +57,14 @@ GCodePath* LayerPlan::getLatestPathWithConfig(
     {
         return &paths.back();
     }
-    paths.emplace_back(
-        GCodePath{ .z_offset = z_offset,
-                   .config = config,
-                   .mesh = current_mesh_,
-                   .space_fill_type = space_fill_type,
-                   .flow = flow,
-                   .width_factor = width_factor,
-                   .spiralize = spiralize,
-                   .speed_factor = speed_factor });
+    paths.emplace_back(GCodePath{ .z_offset = z_offset,
+                                  .config = config,
+                                  .mesh = current_mesh_,
+                                  .space_fill_type = space_fill_type,
+                                  .flow = flow,
+                                  .width_factor = width_factor,
+                                  .spiralize = spiralize,
+                                  .speed_factor = speed_factor });
 
     GCodePath* ret = &paths.back();
     ret->skip_agressive_merge_hint = mode_skip_agressive_merge_;
@@ -1323,7 +1322,7 @@ std::vector<LayerPlan::PathCoasting>
 
         for (const auto& reversed_chunk : paths | ranges::views::enumerate | ranges::views::reverse
                                               | ranges::views::chunk_by(
-                                                  [](const auto& path_a, const auto& path_b)
+                                                  [](const auto&path_a, const auto&path_b)
                                                   {
                                                       return (! std::get<1>(path_a).isTravelPath()) || std::get<1>(path_b).isTravelPath();
                                                   }))


### PR DESCRIPTION
In the case where a mesh was printed with multiple extruders, the used retraction settings were always the one of the main extruder. Now we take the settings of the mesh only if using the main extruder. Mesh-specific settings will then be ignored for other extruders.

CURA-12065
Fixes https://github.com/Ultimaker/Cura/issues/19444