### PR TITLE
CURA-12369 extra wipe move with spiralize

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -851,7 +851,7 @@ private:
      *  @param position The start position (which is not included in the path points)
      *  @param extrude_speed The actual used extrusion speed
      */
-    void sendLineTo(const GCodePath& path, const Point3LL& position, const double extrude_speed);
+    void sendLineTo(const GCodePath& path, const Point3LL& position, const double extrude_speed, const std::optional<coord_t>& line_thickness = std::nullopt);
 
     /*!
      *  @brief Write a travel move and properly apply the various Z offsets

--- a/include/geometry/Point3LL.h
+++ b/include/geometry/Point3LL.h
@@ -36,7 +36,7 @@ public:
 
     Point3LL(Point3LL&& point) = default;
     Point3LL(const Point3LL& point) = default;
-    Point3LL(const Point2LL& point);
+    Point3LL(const Point2LL& point, const coord_t z = 0);
 
     Point3LL& operator=(const Point3LL& point) = default;
     Point3LL& operator=(Point3LL&& point) = default;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -3008,8 +3008,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 gcode.writeComment(ss.str());
             }
 
-            if (! path.spiralize && path.travel_to_z && (! path.retract || ! path.perform_z_hop)
-                && (z_ + path.z_offset + path.points.front().z_ != gcode.getPositionZ()) && (path_idx > 0 || layer_nr_ > 0))
+            if (! path.spiralize && path.travel_to_z && (! path.retract || ! path.perform_z_hop) && (z_ + path.z_offset + path.points.front().z_ != gcode.getPositionZ())
+                && (path_idx > 0 || layer_nr_ > 0))
             {
                 // First move to desired height to then make a plain horizontal move
                 gcode.writeTravel(Point3LL(gcode.getPosition().x_, gcode.getPosition().y_, z_ + path.z_offset + path.points.front().z_), speed);
@@ -3086,8 +3086,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
                 double length = 0.0;
                 p0 = gcode.getPositionXY();
-                const auto writeSpiralPath =
-                [&](const GCodePath& spiral_path, const bool end_layer) -> void
+                const auto writeSpiralPath = [&](const GCodePath& spiral_path, const bool end_layer) -> void
                 {
                     for (const auto& p1 : spiral_path.points)
                     {

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -3009,8 +3009,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                 gcode.writeComment(ss.str());
             }
 
-            if (! (path.spiralize || spiralize_finisher) && path.travel_to_z && (! path.retract || ! path.perform_z_hop) && (z_ + path.z_offset + path.points.front().z_ != gcode.getPositionZ())
-                && (path_idx > 0 || layer_nr_ > 0))
+            if (! (path.spiralize || spiralize_finisher) && path.travel_to_z && (! path.retract || ! path.perform_z_hop)
+                && (z_ + path.z_offset + path.points.front().z_ != gcode.getPositionZ()) && (path_idx > 0 || layer_nr_ > 0))
             {
                 // First move to desired height to then make a plain horizontal move
                 gcode.writeTravel(Point3LL(gcode.getPosition().x_, gcode.getPosition().y_, z_ + path.z_offset + path.points.front().z_), speed);
@@ -3067,14 +3067,7 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
                         insertTempOnTime(time, path_idx);
 
                         const double extrude_speed = speed * path.speed_back_pressure_factor;
-                        writeExtrusionRelativeZ(
-                            gcode,
-                            pt,
-                            extrude_speed,
-                            path.z_offset,
-                            path.getExtrusionMM3perMM(),
-                            path.config.type,
-                            update_extrusion_offset);
+                        writeExtrusionRelativeZ(gcode, pt, extrude_speed, path.z_offset, path.getExtrusionMM3perMM(), path.config.type, update_extrusion_offset);
                         sendLineTo(path, pt, extrude_speed);
 
                         prev_point = path.points[point_idx];

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2415,7 +2415,18 @@ void LayerPlan::spiralizeWallSlice(
             }
             // reduce number of paths created when polygon has many points by limiting precision of flow
             constexpr bool no_spiralize = false;
-            addExtrusionMove(p, config, SpaceFillType::Polygons, ((int)(flow * 20)) / 20.0, width_factor, no_spiralize, speed_factor);
+            constexpr double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT;
+            constexpr bool travel_to_z = false;
+            addExtrusionMove(
+                Point3LL(p, layer_thickness_ / 2.0),
+                config,
+                SpaceFillType::Polygons,
+                ((int)(flow * 20)) / 20.0,
+                width_factor,
+                no_spiralize,
+                speed_factor,
+                fan_speed,
+                travel_to_z);
         }
     }
 }

--- a/src/geometry/Point3LL.cpp
+++ b/src/geometry/Point3LL.cpp
@@ -6,9 +6,10 @@
 namespace cura
 {
 
-Point3LL::Point3LL(const Point2LL& point)
+Point3LL::Point3LL(const Point2LL& point, const coord_t z)
     : x_(point.X)
     , y_(point.Y)
+    , z_(z)
 {
 }
 


### PR DESCRIPTION
This restores the previous behavior which was broken during scarf seam implementation. As a bonus, it also improves the display so that it now properly shows the actual spiral moving up during the print. This is much more accurate, however it emphasizes two incorrectnesses of the spiralize mode:
* Flow on bottom and top layer are not correct i.r.t actual layer thickness
* Last layer ends at approximaterly 1/2 layer height over the actual model

Those behaviors were similar in Cura 4.13.1, so I assume they can be safely ignored, and restoring the previous behavior is good enough for now.

CURA-12369