### PR TITLE
CURA-12450 Flooring settings override bridging settings

### DIFF
--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -377,7 +377,7 @@ private:
         const SliceMeshStorage& mesh,
         const size_t extruder_nr,
         const MeshPathConfigs& mesh_config,
-        const SliceLayerPart& part,
+        SliceLayerPart& part,
         LayerPlan& gcode_layer) const;
 
     /*!
@@ -448,7 +448,7 @@ private:
         const SliceMeshStorage& mesh,
         const size_t extruder_nr,
         const MeshPathConfigs& mesh_config,
-        const SliceLayerPart& part) const;
+        SliceLayerPart& part) const;
 
     /*!
      * Generate the a spiralized wall for a given layer part.

--- a/include/utils/SVG.h
+++ b/include/utils/SVG.h
@@ -147,7 +147,7 @@ public:
 
     void writePolygons(const Shape& polys, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;
 
-    void writePolygon(Polygon poly, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;
+    void writePolygon(const Polygon& poly, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;
 
     void writePolylines(const Shape& polys, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;
 

--- a/src/path_ordering.cpp
+++ b/src/path_ordering.cpp
@@ -29,6 +29,12 @@ const PointsSet& PathOrdering<const SliceLayerPart*>::getVertexData()
 }
 
 template<>
+const PointsSet& PathOrdering<SliceLayerPart*>::getVertexData()
+{
+    return vertices_->outline.outerPolygon();
+}
+
+template<>
 const PointsSet& PathOrdering<const SupportInfillPart*>::getVertexData()
 {
     return vertices_->outline_.outerPolygon();

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -69,14 +69,13 @@ void SVG::handleFlush(const bool flush) const
 
 
 SVG::SVG(std::string filename, AABB aabb, Point2LL canvas_size, ColorObject background)
-    : SVG(
-        filename,
-        aabb,
-        std::min(
-            static_cast<double>(canvas_size.X - canvas_size.X / 5 * 2) / static_cast<double>(aabb.max_.X - aabb.min_.X),
-            static_cast<double>(canvas_size.Y - canvas_size.Y / 5) / static_cast<double>(aabb.max_.Y - aabb.min_.Y)),
-        canvas_size,
-        background)
+    : SVG(filename,
+          aabb,
+          std::min(
+              static_cast<double>(canvas_size.X - canvas_size.X / 5 * 2) / static_cast<double>(aabb.max_.X - aabb.min_.X),
+              static_cast<double>(canvas_size.Y - canvas_size.Y / 5) / static_cast<double>(aabb.max_.Y - aabb.min_.Y)),
+          canvas_size,
+          background)
 {
 }
 

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -355,7 +355,7 @@ void SVG::writePolygons(const Shape& polys, const ColorObject color, const doubl
     handleFlush(flush);
 }
 
-void SVG::writePolygon(const Polygon poly, const ColorObject color, const double stroke_width, const bool flush) const
+void SVG::writePolygon(const Polygon& poly, const ColorObject color, const double stroke_width, const bool flush) const
 {
     if (poly.size() == 0)
     {
@@ -364,7 +364,7 @@ void SVG::writePolygon(const Polygon poly, const ColorObject color, const double
     int size = static_cast<int>(poly.size());
     Point2LL p0 = poly.back();
     int i = 0;
-    for (Point2LL p1 : poly)
+    for (const Point2LL& p1 : poly)
     {
         if (color.color_ == Color::RAINBOW)
         {
@@ -382,7 +382,7 @@ void SVG::writePolygon(const Polygon poly, const ColorObject color, const double
         }
         else
         {
-            writeLine(p0, p1, color, stroke_width);
+            writeLine(p0, p1, color, stroke_width, false);
         }
         p0 = p1;
         i++;


### PR DESCRIPTION
This is done be de-registering flooring areas once the briding mask has been calculated, and registering them as being classic skin areas.

This change feels a bit like band-aid though. Flooring areas are calculated very early, and bridging very lately. So we have to change the flooring areas afterwards, but before actually processing them. If the overall processing order changes, this could stop working.

CURA-12450