### PR TITLE
Fix race condition in TreeSupportBaseCircle which may sometimes cause a crash

### DIFF
--- a/include/TreeSupportBaseCircle.h
+++ b/include/TreeSupportBaseCircle.h
@@ -18,37 +18,27 @@ class TreeSupportBaseCircle
 {
 protected:
     inline static Polygon base_circle;
-    inline static bool circle_generated = false;
-    inline static std::mutex critical_sections;
+    inline static std::once_flag flag;
 
 public:
     inline static constexpr int64_t base_radius = 50;
 
     static Polygon getBaseCircle()
     {
-        if (circle_generated)
-        {
-            return base_circle;
-        }
-        else
-        {
-            std::lock_guard<std::mutex> critical_section_progress(critical_sections);
-            if (circle_generated)
+        std::call_once(
+            flag,
+            [&]()
             {
-                return base_circle;
-            }
-
-            constexpr auto support_tree_circle_resolution = 12; // The number of vertices in each circle.
-            Polygon circle;
-            for (const uint64_t i : ranges::views::iota(0, support_tree_circle_resolution))
-            {
-                const AngleRadians angle = static_cast<double>(i) / support_tree_circle_resolution * TAU;
-                circle.emplace_back(static_cast<coord_t>(std::cos(angle) * base_radius), static_cast<coord_t>(std::sin(angle) * base_radius));
-            }
-            base_circle = Polygon(circle);
-            circle_generated = true;
-            return base_circle;
-        }
+                constexpr auto support_tree_circle_resolution = 12; // The number of vertices in each circle.
+                Polygon circle;
+                for (const uint64_t i : ranges::views::iota(0, support_tree_circle_resolution))
+                {
+                    const AngleRadians angle = static_cast<double>(i) / support_tree_circle_resolution * TAU;
+                    circle.emplace_back(static_cast<coord_t>(std::cos(angle) * base_radius), static_cast<coord_t>(std::sin(angle) * base_radius));
+                }
+                base_circle = Polygon(circle);
+            });
+        return base_circle;
     }
 };
 

--- a/include/TreeSupportBaseCircle.h
+++ b/include/TreeSupportBaseCircle.h
@@ -19,6 +19,7 @@ class TreeSupportBaseCircle
 protected:
     inline static Polygon base_circle;
     inline static bool circle_generated = false;
+    inline static std::mutex critical_sections;
 
 public:
     inline static constexpr int64_t base_radius = 50;
@@ -31,7 +32,6 @@ public:
         }
         else
         {
-            std::mutex critical_sections;
             std::lock_guard<std::mutex> critical_section_progress(critical_sections);
             if (circle_generated)
             {


### PR DESCRIPTION
# Description

The non-proper locking of base_circle has caused a crash for me in my cradle support branch. I don't know it that crash can also occur here, but either way the lock should actually do something.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Operating System:

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change