### PR TITLE
Fix wrong returned index

### DIFF
--- a/src/geometry/Shape.cpp
+++ b/src/geometry/Shape.cpp
@@ -262,7 +262,7 @@ size_t Shape::findInside(const Point2LL& p, bool border_result) const
 {
     if (empty())
     {
-        return 0;
+        return NO_INDEX;
     }
 
     // NOTE: Keep these vectors fixed-size, they replace an (non-standard, sized at runtime) arrays.


### PR DESCRIPTION
`Shape::findInside` is supposed to return `NO_INDEX` if there is no point inside, but when empty it was returning 0, which is definitely not a valid polygon index. This causes crashes because the caller function assumes there is a valid polygon at index 0.

CURA-12463