### PR TITLE
[CURA-12478] Fix early-out also skipping support-meshes.

### DIFF
--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1014,7 +1014,8 @@ void AreaSupport::generateSupportAreasForMesh(
         return;
     }
 
-    if (ranges::all_of(
+    if ((! mesh.settings.get<bool>("support_mesh")) &&
+        ranges::all_of(
             mesh.overhang_areas,
             [](const Shape& overhang_area)
             {

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1014,8 +1014,8 @@ void AreaSupport::generateSupportAreasForMesh(
         return;
     }
 
-    if ((! mesh.settings.get<bool>("support_mesh")) &&
-        ranges::all_of(
+    if ((! mesh.settings.get<bool>("support_mesh"))
+        && ranges::all_of(
             mesh.overhang_areas,
             [](const Shape& overhang_area)
             {


### PR DESCRIPTION
Recently, we made an early-out for when there's no support generated (skipping the expensive support generation code), but only looked at wether or not there's overhang -- but support can also be generated when a mesh is a support mesh.