### PR TITLE
[CURA-12503] Remove now unused 'skip agressive merge hint' variable.

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -69,7 +69,6 @@ public:
     const PathConfigStorage configs_storage_; //!< The line configs for this layer for each feature type
     const coord_t z_;
     coord_t final_travel_z_;
-    bool mode_skip_agressive_merge_; //!< Whether to give every new path the 'skip_agressive_merge_hint' property (see GCodePath); default is false.
 
 private:
     // Indicates how coasting should be processed on the given path.

--- a/include/pathPlanning/GCodePath.h
+++ b/include/pathPlanning/GCodePath.h
@@ -45,7 +45,6 @@ struct GCodePath
                                                      //!< an outer wall
     bool perform_z_hop{ false }; //!< Whether to perform a z_hop in this path, which is assumed to be a travel path.
     bool perform_prime{ false }; //!< Whether this path is preceded by a prime (blob)
-    bool skip_agressive_merge_hint{ false }; //!< Wheter this path needs to skip merging if any travel paths are in between the extrusions.
     std::vector<Point3LL> points{}; //!< The points constituting this path. The Z coordinate is an offset relative to the actual layer height, added to the global z_offset.
     bool done{ false }; //!< Path is finished, no more moves should be added, and a new path should be started instead of any appending done to this one.
     double fan_speed{ GCodePathConfig::FAN_SPEED_DEFAULT }; //!< fan speed override for this path, value should be within range 0-100 (inclusive) and ignored otherwise

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3402,9 +3402,6 @@ bool FffGcodeWriter::processSkinPart(
     const SkinPart& skin_part) const
 {
     bool added_something = false;
-
-    gcode_layer.mode_skip_agressive_merge_ = true;
-
     processRoofingFlooring(
         storage,
         gcode_layer,
@@ -3426,8 +3423,6 @@ bool FffGcodeWriter::processSkinPart(
         mesh.flooring_angles,
         added_something);
     processTopBottom(storage, gcode_layer, mesh, extruder_nr, mesh_config, skin_part, added_something);
-
-    gcode_layer.mode_skip_agressive_merge_ = false;
     return added_something;
 }
 

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -67,7 +67,6 @@ GCodePath* LayerPlan::getLatestPathWithConfig(
                                   .speed_factor = speed_factor });
 
     GCodePath* ret = &paths.back();
-    ret->skip_agressive_merge_hint = mode_skip_agressive_merge_;
     return ret;
 }
 
@@ -96,7 +95,6 @@ LayerPlan::LayerPlan(
     : configs_storage_(storage, layer_nr, layer_thickness)
     , z_(z)
     , final_travel_z_(z)
-    , mode_skip_agressive_merge_(false)
     , storage_(storage)
     , layer_nr_(layer_nr)
     , is_initial_layer_(layer_nr == 0 - static_cast<LayerIndex>(Raft::getTotalExtraLayers()))

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -117,8 +117,6 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
         return false; // Nothing to do.
     }
 
-    layer.mode_skip_agressive_merge_ = true;
-
     bool added = false;
     if (! ironing_polygons.empty())
     {
@@ -192,8 +190,6 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
         wall_orderer.addToLayer();
         added = true;
     }
-
-    layer.mode_skip_agressive_merge_ = false;
     return added;
 }
 

--- a/src/plugins/converters.cpp
+++ b/src/plugins/converters.cpp
@@ -374,7 +374,7 @@ gcode_paths_modify_request::value_type
         gcode_path->set_unretract_before_last_travel_move(path.unretract_before_last_travel_move);
         gcode_path->set_perform_z_hop(path.perform_z_hop);
         gcode_path->set_perform_prime(path.perform_prime);
-        gcode_path->set_skip_agressive_merge_hint(path.skip_agressive_merge_hint);
+        gcode_path->set_skip_agressive_merge_hint(false);  // FIXME: Not used anymore.
         gcode_path->set_done(path.done);
         gcode_path->set_fan_speed(path.getFanSpeed());
         gcode_path->set_mesh_name(path.mesh ? path.mesh->mesh_name : "");
@@ -492,7 +492,6 @@ gcode_paths_modify_response::native_value_type
             .unretract_before_last_travel_move = gcode_path_msg.unretract_before_last_travel_move(),
             .perform_z_hop = gcode_path_msg.perform_z_hop(),
             .perform_prime = gcode_path_msg.perform_prime(),
-            .skip_agressive_merge_hint = gcode_path_msg.skip_agressive_merge_hint(),
             .done = gcode_path_msg.done(),
             .fan_speed = gcode_path_msg.fan_speed(),
         };

--- a/src/plugins/converters.cpp
+++ b/src/plugins/converters.cpp
@@ -374,7 +374,7 @@ gcode_paths_modify_request::value_type
         gcode_path->set_unretract_before_last_travel_move(path.unretract_before_last_travel_move);
         gcode_path->set_perform_z_hop(path.perform_z_hop);
         gcode_path->set_perform_prime(path.perform_prime);
-        gcode_path->set_skip_agressive_merge_hint(false);  // FIXME: Not used anymore.
+        gcode_path->set_skip_agressive_merge_hint(false); // FIXME: Not used anymore.
         gcode_path->set_done(path.done);
         gcode_path->set_fan_speed(path.getFanSpeed());
         gcode_path->set_mesh_name(path.mesh ? path.mesh->mesh_name : "");


### PR DESCRIPTION
This is no longer used anywhere.

TODO/Draft: It's still in our API as well, so that'll be next on the list. (See the FIXME.) -> Why not leave it in there as an unused boolean for now, then we don't have to change the interface again if the next thing we need _is_ a boolean.