### PR TITLE
[CURA-12525] Print only done on any extruders > 0 should still set extruder,

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -843,7 +843,7 @@ void GCodeExport::processInitialLayerTemperature(const SliceDataStorage& storage
         wait_start_extruder = true;
         break;
     default:
-        if (used_extruders > 1 || getFlavor() == EGCodeFlavor::REPRAP)
+        if (used_extruders > 1 || getFlavor() == EGCodeFlavor::REPRAP || ! extruders_used[0])
         {
             std::ostringstream tmp;
             tmp << "T" << start_extruder_nr;


### PR DESCRIPTION
... even if it's the only one. (So for instance if a model is sliced to only use extruder 1, the printer should still switch away from the default extruder 0 one at least --and likely at most-- once.)