### PR TITLE
[CURA-12512] Add speed settings for auxilary ('build volume') fan.

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -2719,7 +2719,8 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
         // The machine has a build volume fan.
         if (layer_nr_ == mesh_group_settings.get<size_t>("build_fan_full_layer"))
         {
-            gcode.writeSpecificFanCommand(100, mesh_group_settings.get<size_t>("build_volume_fan_nr"));
+            const auto fan_speed = mesh_group_settings.get<Ratio>("build_volume_fan_speed") * 100.0;
+            gcode.writeSpecificFanCommand(fan_speed, mesh_group_settings.get<size_t>("build_volume_fan_nr"));
         }
     }
 

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -852,6 +852,12 @@ void GCodeExport::processInitialLayerTemperature(const SliceDataStorage& storage
         break;
     }
 
+    if (scene.settings.get<size_t>("build_volume_fan_nr") != 0)
+    {
+        const auto fan_speed = scene.settings.get<Ratio>("build_volume_fan_speed_0") * 100.0;
+        writeSpecificFanCommand(fan_speed, scene.settings.get<size_t>("build_volume_fan_nr"));
+    }
+
     processInitialLayerBedTemperature();
     processInitialLayerExtrudersTemperatures(storage, wait_start_extruder, start_extruder_nr);
 }


### PR DESCRIPTION
Previously you could only set on/off starting on a certain layer.

Frontend PR: https://github.com/Ultimaker/Cura/pull/20562
