### PR TITLE
CURA-12515 Print bridge walls without overhanging speed

### DIFF
--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -1184,16 +1184,8 @@ void LayerPlan::addWallLine(
 
                 if (bridge_line_len > min_line_len)
                 {
-                    addExtrusionMoveWithGradualOverhang(
-                        b1,
-                        bridge_config,
-                        SpaceFillType::Polygons,
-                        flow,
-                        width_factor,
-                        spiralize,
-                        1.0_r,
-                        GCodePathConfig::FAN_SPEED_DEFAULT,
-                        travel_to_z);
+                    addExtrusionMove(b1, bridge_config, SpaceFillType::Polygons, flow, width_factor, spiralize, 1.0_r, GCodePathConfig::FAN_SPEED_DEFAULT, travel_to_z);
+
                     non_bridge_line_volume = 0;
                     cur_point = b1;
                     // after a bridge segment, start slow and accelerate to avoid under-extrusion due to extruder lag


### PR DESCRIPTION
Bridge walls were still explicitely printed using overhanging settings, now we ignore them and just print bridge wall as usual.

CURA-12515