### PR TITLE
[CURA-12622] warn on actual unused extruder(s)

### DIFF
--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -111,6 +111,14 @@ public:
     void setTargetStream(std::ostream* stream);
 
     /*!
+     * Wether or not the extruder is actually used in the print, regardless of enablement.
+     *
+     * \param extruder_nr The extruder number for which to get the useage
+     * \return actual use y/n boolean
+     */
+    bool getExtruderActualUse(int extruder_nr);
+
+    /*!
      * Get the total extruded volume for a specific extruder in mm^3
      *
      * Retractions and unretractions don't contribute to this.

--- a/include/FffProcessor.h
+++ b/include/FffProcessor.h
@@ -1,18 +1,19 @@
-//Copyright (c) 2021 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2021 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef FFF_PROCESSOR_H
 #define FFF_PROCESSOR_H
 
 #include "FffGcodeWriter.h"
 #include "FffPolygonGenerator.h"
-#include "utils/gettime.h"
 #include "utils/NoCopy.h"
+#include "utils/gettime.h"
 
 
-namespace cura {
+namespace cura
+{
 
-//FusedFilamentFabrication processor. Singleton class
+// FusedFilamentFabrication processor. Singleton class
 class FffProcessor : public NoCopy
 {
 private:
@@ -48,18 +49,18 @@ public:
 
     /*!
      * Set the target to write gcode to: to a file.
-     * 
+     *
      * Used when CuraEngine is used as command line tool.
-     * 
+     *
      * \param filename The filename of the file to which to write the gcode.
      */
     bool setTargetFile(const char* filename);
 
     /*!
      * Set the target to write gcode to: an output stream.
-     * 
+     *
      * Used when CuraEngine is NOT used as command line tool.
-     * 
+     *
      * \param stream The stream to write gcode to.
      */
     void setTargetStream(std::ostream* stream);
@@ -74,9 +75,9 @@ public:
 
     /*!
      * Get the total extruded volume for a specific extruder in mm^3
-     * 
+     *
      * Retractions and unretractions don't contribute to this.
-     * 
+     *
      * \param extruder_nr The extruder number for which to get the total netto extruded volume
      * \return total filament printed in mm^3
      */
@@ -84,7 +85,7 @@ public:
 
     /*!
      * Get the total estimated print time in seconds for each feature
-     * 
+     *
      * \return total print time in seconds for each feature
      */
     std::vector<Duration> getTotalPrintTimePerFeature();
@@ -95,6 +96,6 @@ public:
     void finalize();
 };
 
-}//namespace cura
+} // namespace cura
 
-#endif//FFF_PROCESSOR_H
+#endif // FFF_PROCESSOR_H

--- a/include/FffProcessor.h
+++ b/include/FffProcessor.h
@@ -65,6 +65,14 @@ public:
     void setTargetStream(std::ostream* stream);
 
     /*!
+     * Wether or not the extruder is actually used in the print, regardless of enablement.
+     *
+     * \param extruder_nr The extruder number for which to get the useage
+     * \return actual use y/n boolean
+     */
+    bool getExtruderActualUse(int extruder_nr);
+
+    /*!
      * Get the total extruded volume for a specific extruder in mm^3
      * 
      * Retractions and unretractions don't contribute to this.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -63,6 +63,11 @@ void FffGcodeWriter::setTargetStream(std::ostream* stream)
     gcode.setOutputStream(stream);
 }
 
+bool FffGcodeWriter::getExtruderActualUse(int extruder_nr)
+{
+    return gcode.getExtruderIsUsed(extruder_nr);
+}
+
 double FffGcodeWriter::getTotalFilamentUsed(int extruder_nr)
 {
     return gcode.getTotalFilamentUsed(extruder_nr);

--- a/src/FffProcessor.cpp
+++ b/src/FffProcessor.cpp
@@ -1,9 +1,9 @@
-//Copyright (c) 2021 Ultimaker B.V.
-//CuraEngine is released under the terms of the AGPLv3 or higher.
+// Copyright (c) 2021 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "FffProcessor.h"
 
-namespace cura 
+namespace cura
 {
 
 FffProcessor FffProcessor::instance; // definition must be in cpp
@@ -38,4 +38,4 @@ void FffProcessor::finalize()
     gcode_writer.finalize();
 }
 
-} // namespace cura 
+} // namespace cura

--- a/src/FffProcessor.cpp
+++ b/src/FffProcessor.cpp
@@ -18,6 +18,11 @@ void FffProcessor::setTargetStream(std::ostream* stream)
     return gcode_writer.setTargetStream(stream);
 }
 
+bool FffProcessor::getExtruderActualUse(int extruder_nr)
+{
+    return gcode_writer.getExtruderActualUse(extruder_nr);
+}
+
 double FffProcessor::getTotalFilamentUsed(int extruder_nr)
 {
     return gcode_writer.getTotalFilamentUsed(extruder_nr);

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -433,7 +433,15 @@ void ArcusCommunication::sendPrintTimeMaterialEstimates() const
     {
         proto::MaterialEstimates* material_message = message->add_materialestimates();
         material_message->set_id(extruder_nr);
-        material_message->set_material_amount(FffProcessor::getInstance()->getTotalFilamentUsed(extruder_nr));
+        auto fff_proc = FffProcessor::getInstance();
+        material_message->set_material_amount(
+            fff_proc->getExtruderActualUse(extruder_nr) ?
+            fff_proc->getTotalFilamentUsed(extruder_nr) :
+            std::numeric_limits<float>::signaling_NaN()
+        );
+        // NOTE: Set to signalling-NaN to specify that no calculations should be done on the result, and if attempted, should fail fast instead of propagate.
+        //       Instead, it's meant to repressent the state of a completely unused extruder or tool, since a value of 0.0 could be a rounding error.
+        //       (Also future-proof: '0.0' might conceivably signal a state in which a tool is used that doesn't extrude material, 'NaN' still means unused.)
     }
 
     private_data->socket->sendMessage(message);

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -435,10 +435,7 @@ void ArcusCommunication::sendPrintTimeMaterialEstimates() const
         material_message->set_id(extruder_nr);
         auto fff_proc = FffProcessor::getInstance();
         material_message->set_material_amount(
-            fff_proc->getExtruderActualUse(extruder_nr) ?
-            fff_proc->getTotalFilamentUsed(extruder_nr) :
-            std::numeric_limits<float>::signaling_NaN()
-        );
+            fff_proc->getExtruderActualUse(extruder_nr) ? fff_proc->getTotalFilamentUsed(extruder_nr) : std::numeric_limits<float>::signaling_NaN());
         // NOTE: Set to signalling-NaN to specify that no calculations should be done on the result, and if attempted, should fail fast instead of propagate.
         //       Instead, it's meant to repressent the state of a completely unused extruder or tool, since a value of 0.0 could be a rounding error.
         //       (Also future-proof: '0.0' might conceivably signal a state in which a tool is used that doesn't extrude material, 'NaN' still means unused.)


### PR DESCRIPTION
Since the bed-temp (for example) might be influenced by unused but (probably accidentally) enabled extruders, we want to be able to warn the (frontend) user of such.

Frontend: ____