### PR TITLE
[CURA-12675] workaround for anti-virus forcing version of DLL on Cura

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -144,6 +144,9 @@ class CuraEngineConan(ConanFile):
         deps.generate()
 
         tc = CMakeToolchain(self)
+
+        tc.preprocessor_definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
+
         tc.variables["CURA_ENGINE_VERSION"] = self.version
         tc.variables["CURA_ENGINE_HASH"] = self.conan_data["commit"]
         tc.variables["ENABLE_ARCUS"] = self.options.enable_arcus
@@ -197,6 +200,9 @@ class CuraEngineConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+
+        cmake.definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
+
         cmake.configure()
         cmake.build()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -201,7 +201,7 @@ class CuraEngineConan(ConanFile):
     def build(self):
         cmake = CMake(self)
 
-        cmake.definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
+        cmake.compiler_definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
 
         cmake.configure()
         cmake.build()

--- a/conanfile.py
+++ b/conanfile.py
@@ -200,9 +200,6 @@ class CuraEngineConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-
-        cmake.compiler_definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
-
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
The dynamic lib `MSVCP140.dll` (and related) comes in two distinct flavours -- one pre-fix and one post-fix -- according to MS this _technically_ doesn't break compatibility and is 'By Design'. (But it's not _really_ them that are to blame in this particular case.)

In any case, this was a bit of a problem for us -- but one we thought to have (eventually, after some detours) solved with the workaround of just building everything with the newer version and then forcing the newer ones to be high up in our `PATH`.

Que certain anti-virus vendors (McAfee) just straight up forcing programs to use certain DLL's -- which is a can of worms just in and of itself, and from the above context you can begin to guess which particular worm bit _us_ in this case.

Yes, that's right, they're forcing us to use the _old_ version of `MSVCP140.dll`.

Fortunately, MS was at least graceful enough to have 'an escape hatch' as they put it, so that's what we're using here. Even though we _actually_ shouldn't need it, since we where using the newer version (originally).

Anyway we should be good now, whatever version of that DLL anyone has.