### PR TITLE
CURA-12770 Fix closed shaped being completely filled

### DIFF
--- a/include/utils/OBJ.h
+++ b/include/utils/OBJ.h
@@ -22,7 +22,12 @@ public:
 
     ~OBJ();
 
-    void writeSphere(const Point3D& position, const double radius = 1.0, const SVG::Color color = SVG::Color::BLACK);
+    void writeSphere(
+        const Point3D& position,
+        const double radius = 1.0,
+        const SVG::Color color = SVG::Color::BLACK,
+        const size_t latitude_segments = 4,
+        const size_t longitude_segments = 8);
 
     void writeTriangle(
         const Point3D& p0,

--- a/include/utils/SVG.h
+++ b/include/utils/SVG.h
@@ -156,6 +156,9 @@ public:
 
     void writePolylines(const Shape& polys, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;
 
+    template<class LineType>
+    void writePolylines(const LinesSet<LineType>& lines, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;
+
     void writePolyline(const Polygon& poly, const ColorObject color = Color::BLACK, const double stroke_width = 1.0) const;
 
     void writePolyline(const Polyline& poly, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const bool flush = true) const;

--- a/include/utils/VoxelGrid.h
+++ b/include/utils/VoxelGrid.h
@@ -89,6 +89,8 @@ public:
 
     std::optional<uint8_t> getOccupation(const LocalCoordinates& local_position) const;
 
+    bool hasOccupation(const LocalCoordinates& local_position) const;
+
     size_t occupiedCount() const;
 
     /*!

--- a/src/MeshMaterialSplitter.cpp
+++ b/src/MeshMaterialSplitter.cpp
@@ -214,19 +214,40 @@ std::vector<Mesh> makeMeshesFromVoxelsGrid(const VoxelGrid& voxel_grid, const ui
             const int32_t y_plus1 = static_cast<int32_t>(square_start.position.y) + 1;
             const bool y_plus1_valid = y_plus1 <= std::numeric_limits<uint16_t>::max();
 
-            const uint8_t occupation_bit0 = x_plus1_valid && y_plus1_valid
-                                              ? voxel_grid.getOccupation(VoxelGrid::LocalCoordinates(x_plus1, y_plus1, square_start.position.z)).value_or(mesh_extruder_nr)
-                                              : mesh_extruder_nr;
-            const uint8_t occupation_bit1
-                = y_plus1_valid ? voxel_grid.getOccupation(VoxelGrid::LocalCoordinates(square_start.position.x, y_plus1, square_start.position.z)).value_or(mesh_extruder_nr)
-                                : mesh_extruder_nr;
-            const uint8_t occupation_bit2
-                = x_plus1_valid ? voxel_grid.getOccupation(VoxelGrid::LocalCoordinates(x_plus1, square_start.position.y, square_start.position.z)).value_or(mesh_extruder_nr)
-                                : mesh_extruder_nr;
-            const uint8_t occupation_bit3 = voxel_grid.getOccupation(square_start).value_or(mesh_extruder_nr);
+            std::unordered_set<uint8_t> filled_extruders;
+            std::array<uint8_t, 4> occupation_bits;
+            auto add_occupied_extruder = [&voxel_grid,
+                                          &mesh_extruder_nr,
+                                          &filled_extruders,
+                                          &occupation_bits,
+                                          &square_start](const int32_t x, const int32_t y, const bool position_valid, const size_t occupation_bit_index) -> void
+            {
+                if (position_valid)
+                {
+                    const std::optional<uint8_t> occupation = voxel_grid.getOccupation(VoxelGrid::LocalCoordinates(x, y, square_start.position.z));
+                    if (occupation.has_value())
+                    {
+                        filled_extruders.insert(occupation.value());
+                        occupation_bits[occupation_bit_index] = occupation.value();
+                        return;
+                    }
+                }
 
-            const std::unordered_set<uint8_t> extruders = { occupation_bit0, occupation_bit1, occupation_bit2, occupation_bit3 };
-            for (const uint8_t extruder : extruders)
+                occupation_bits[occupation_bit_index] = mesh_extruder_nr;
+            };
+
+            add_occupied_extruder(x_plus1, y_plus1, x_plus1_valid && y_plus1_valid, 0);
+            add_occupied_extruder(square_start.position.x, y_plus1, y_plus1_valid, 1);
+            add_occupied_extruder(x_plus1, square_start.position.y, x_plus1_valid, 2);
+            add_occupied_extruder(square_start.position.x, square_start.position.y, true, 3);
+
+            if (filled_extruders.size() < 2)
+            {
+                // Early-out, since this is not going to generate any segment
+                return;
+            }
+
+            for (const uint8_t extruder : filled_extruders)
             {
                 if (extruder == mesh_extruder_nr)
                 {
@@ -234,8 +255,8 @@ std::vector<Mesh> makeMeshesFromVoxelsGrid(const VoxelGrid& voxel_grid, const ui
                 }
 
                 // Apply the marching squares base principle: calculate the index of the segments list to be added according to the occupations of the 4 positions
-                size_t segments_index = (occupation_bit0 == extruder ? 1 : 0) + ((occupation_bit1 == extruder ? 1 : 0) << 1) + ((occupation_bit2 == extruder ? 1 : 0) << 2)
-                                      + ((occupation_bit3 == extruder ? 1 : 0) << 3);
+                const size_t segments_index = (occupation_bits[0] == extruder ? 1 : 0) + ((occupation_bits[1] == extruder ? 1 : 0) << 1)
+                                            + ((occupation_bits[2] == extruder ? 1 : 0) << 2) + ((occupation_bits[3] == extruder ? 1 : 0) << 3);
                 OpenLinesSet translated_segments = marching_segments[segments_index];
 
                 if (translated_segments.empty())
@@ -295,29 +316,25 @@ std::vector<Mesh> makeMeshesFromVoxelsGrid(const VoxelGrid& voxel_grid, const ui
 
             for (const Polygon& polygon : contour.second.polygons)
             {
-                // Do not export holes, only outer contours
-                if (polygon.area() > 0)
+                const Polygon simplified_polygon = simplifier.polygon(polygon);
+
+                const std::lock_guard lock(mutex);
+                const auto mesh_iterator = meshes.find(extruder);
+                if (mesh_iterator == meshes.end())
                 {
-                    const Polygon simplified_polygon = simplifier.polygon(polygon);
+                    Mesh mesh(Application::getInstance().current_slice_->scene.extruders.at(extruder).settings_);
+                    mesh.settings_.add("cutting_mesh", "true");
+                    mesh.settings_.add("extruder_nr", std::to_string(extruder));
+                    meshes.insert({ extruder, mesh });
+                }
 
-                    const std::lock_guard lock(mutex);
-                    const auto mesh_iterator = meshes.find(extruder);
-                    if (mesh_iterator == meshes.end())
-                    {
-                        Mesh mesh(Application::getInstance().current_slice_->scene.extruders.at(extruder).settings_);
-                        mesh.settings_.add("cutting_mesh", "true");
-                        mesh.settings_.add("extruder_nr", std::to_string(extruder));
-                        meshes.insert({ extruder, mesh });
-                    }
-
-                    Mesh& mesh = meshes[extruder];
-                    for (auto iterator = simplified_polygon.beginSegments(); iterator != simplified_polygon.endSegments(); ++iterator)
-                    {
-                        const Point2LL& start = (*iterator).start;
-                        const Point2LL& end = (*iterator).end;
-                        mesh.addFace(Point3LL(start, z_low), Point3LL(end, z_low), Point3LL(end, z_high));
-                        mesh.addFace(Point3LL(end, z_high), Point3LL(start, z_high), Point3LL(start, z_low));
-                    }
+                Mesh& mesh = meshes[extruder];
+                for (auto iterator = simplified_polygon.beginSegments(); iterator != simplified_polygon.endSegments(); ++iterator)
+                {
+                    const Point2LL& start = (*iterator).start;
+                    const Point2LL& end = (*iterator).end;
+                    mesh.addFace(Point3LL(start, z_low), Point3LL(end, z_low), Point3LL(end, z_high));
+                    mesh.addFace(Point3LL(end, z_high), Point3LL(start, z_high), Point3LL(start, z_low));
                 }
             }
         });
@@ -392,17 +409,12 @@ bool isInside(const VoxelGrid& voxel_grid, const VoxelGrid::LocalCoordinates& po
 
 /*!
  * Find the voxels to be evaluated next, given the ones that have been previously evaluated
- * @param voxel_grid The current voxel grid to be checked. Some voxels may also be directly filled.
+ * @param voxel_grid The current voxel grid to be checked
  * @param previously_evaluated_voxels The list of voxels that were just evaluated
- * @param sliced_mesh The pre-sliced mesh, used to check for points insideness
- * @param mesh_extruder_nr The main mesh extruder number
  * @return The list of new voxels to be evaluated
  */
-boost::concurrent_flat_set<VoxelGrid::LocalCoordinates> findVoxelsToEvaluate(
-    VoxelGrid& voxel_grid,
-    const boost::concurrent_flat_set<VoxelGrid::LocalCoordinates>& previously_evaluated_voxels,
-    const std::vector<Shape>& sliced_mesh,
-    const uint8_t mesh_extruder_nr)
+boost::concurrent_flat_set<VoxelGrid::LocalCoordinates>
+    findVoxelsToEvaluate(const VoxelGrid& voxel_grid, const boost::concurrent_flat_set<VoxelGrid::LocalCoordinates>& previously_evaluated_voxels)
 {
     boost::concurrent_flat_set<VoxelGrid::LocalCoordinates> voxels_to_evaluate;
 
@@ -427,14 +439,7 @@ boost::concurrent_flat_set<VoxelGrid::LocalCoordinates> findVoxelsToEvaluate(
                     continue;
                 }
 
-                if (! isInside(voxel_grid, voxel_around, sliced_mesh))
-                {
-                    voxel_grid.setOccupation(voxel_around, mesh_extruder_nr);
-                }
-                else
-                {
-                    voxels_to_evaluate.emplace(voxel_around);
-                }
+                voxels_to_evaluate.emplace(voxel_around);
             }
         });
 
@@ -446,6 +451,7 @@ boost::concurrent_flat_set<VoxelGrid::LocalCoordinates> findVoxelsToEvaluate(
  * @param voxel_grid The voxel grid to be filled
  * @param voxels_to_evaluate The voxels to be evaluated
  * @param texture_data The lookup containing the rasterized texture data
+ * @param sliced_mesh The pre-sliced mesh matching the voxel grid
  * @param deepness_squared The maximum deepness, squared
  * @param mesh_extruder_nr The main mesh extruder number
  */
@@ -453,6 +459,7 @@ void evaluateVoxels(
     VoxelGrid& voxel_grid,
     const boost::concurrent_flat_set<VoxelGrid::LocalCoordinates>& voxels_to_evaluate,
     const SpatialLookup& texture_data,
+    const std::vector<Shape>& sliced_mesh,
     const coord_t deepness_squared,
     const uint8_t mesh_extruder_nr)
 {
@@ -460,26 +467,38 @@ void evaluateVoxels(
 #ifdef __cpp_lib_execution
         std::execution::par,
 #endif
-        [&voxel_grid, &texture_data, &deepness_squared, &mesh_extruder_nr](const VoxelGrid::LocalCoordinates& voxel_to_evaluate)
+        [&voxel_grid, &texture_data, &sliced_mesh, &deepness_squared, &mesh_extruder_nr](const VoxelGrid::LocalCoordinates& voxel_to_evaluate)
         {
             const Point3D position = voxel_grid.toGlobalCoordinates(voxel_to_evaluate);
 
-            // Find the nearest neighbor
-            std::optional<OccupiedPosition> nearest_occupation = texture_data.findClosestOccupation(position);
-
-            if (nearest_occupation.has_value())
+            if (! isInside(voxel_grid, voxel_to_evaluate, sliced_mesh))
             {
-                const Point3D diff = position - nearest_occupation.value().position;
-                const uint8_t new_occupation = diff.vSize2() <= deepness_squared ? nearest_occupation.value().occupation : mesh_extruder_nr;
-                voxel_grid.setOccupation(voxel_to_evaluate, new_occupation);
+                voxel_grid.setOccupation(voxel_to_evaluate, mesh_extruder_nr);
             }
             else
             {
-                voxel_grid.setOccupation(voxel_to_evaluate, mesh_extruder_nr);
+                // Find the nearest neighbor
+                const std::optional<OccupiedPosition> nearest_occupation = texture_data.findClosestOccupation(position);
+                if (nearest_occupation.has_value())
+                {
+                    const Point3D diff = position - nearest_occupation.value().position;
+                    const uint8_t new_occupation = diff.vSize2() <= deepness_squared ? nearest_occupation.value().occupation : mesh_extruder_nr;
+                    voxel_grid.setOccupation(voxel_to_evaluate, new_occupation);
+                }
+                else
+                {
+                    voxel_grid.setOccupation(voxel_to_evaluate, mesh_extruder_nr);
+                }
             }
         });
 }
 
+/*!
+ * From the given evaluated voxels list, keep only those that have various extruder values around them, so that we will only evaluate voxels on the borders
+ * and skip those that grow inside the modifier meshes
+ * @param evaluated_voxels The previously evaluated voxels
+ * @param voxel_grid The voxel grid being filled
+ */
 void findBoundaryVoxels(boost::concurrent_flat_set<VoxelGrid::LocalCoordinates>& evaluated_voxels, const VoxelGrid& voxel_grid)
 {
     evaluated_voxels.erase_if(
@@ -531,11 +550,11 @@ void propagateVoxels(
 
         // Make the list of new voxels to be evaluated, based on which were evaluated before
         spdlog::debug("Finding voxels around {} voxels for iteration {}", evaluated_voxels.size(), iteration);
-        evaluated_voxels = findVoxelsToEvaluate(voxel_grid, evaluated_voxels, sliced_mesh, mesh_extruder_nr);
+        evaluated_voxels = findVoxelsToEvaluate(voxel_grid, evaluated_voxels);
 
         // Now actually evaluate the candidate voxels, i.e. find their closest outside point and set the according occupation
         spdlog::debug("Evaluating {} voxels", evaluated_voxels.size());
-        evaluateVoxels(voxel_grid, evaluated_voxels, texture_data, deepness_squared, mesh_extruder_nr);
+        evaluateVoxels(voxel_grid, evaluated_voxels, texture_data, sliced_mesh, deepness_squared, mesh_extruder_nr);
 
         // Now we have evaluated the candidates, check which of them are to be processed next. We skip all the voxels that have only voxels with similar occupations around
         // them, because they are obviously not part of the boundaries we are looking for. This avoids filling the inside of the points clouds and speeds up calculation a lot.

--- a/src/utils/OBJ.cpp
+++ b/src/utils/OBJ.cpp
@@ -67,11 +67,8 @@ OBJ::~OBJ()
     }
 }
 
-void OBJ::writeSphere(const Point3D& position, const double radius, const SVG::Color color)
+void OBJ::writeSphere(const Point3D& position, const double radius, const SVG::Color color, const size_t latitude_segments, const size_t longitude_segments)
 {
-    constexpr size_t latitude_segments = 4; // Number of latitude segments
-    constexpr size_t longitude_segments = 8; // Number of longitude segments
-
     std::vector<std::vector<size_t>> vertex_indices(latitude_segments + 1);
     for (size_t i = 0; i <= latitude_segments; ++i)
     {

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -7,6 +7,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include "geometry/OpenPolyline.h"
 #include "geometry/Polygon.h"
 #include "geometry/SingleShape.h"
 #include "utils/ExtrusionLine.h"
@@ -440,6 +441,20 @@ void SVG::writePolylines(const Shape& polys, const ColorObject color, const doub
 
     handleFlush(flush);
 }
+
+template<class LineType>
+void SVG::writePolylines(const LinesSet<LineType>& lines, const ColorObject color, const double stroke_width, const bool flush) const
+{
+    for (const LineType& line : lines)
+    {
+        writePolyline(line, color, stroke_width, false);
+    }
+
+    handleFlush(flush);
+}
+
+template void SVG::writePolylines(const LinesSet<OpenPolyline>& lines, const ColorObject color, const double stroke_width, const bool flush) const;
+template void SVG::writePolylines(const LinesSet<ClosedPolyline>& lines, const ColorObject color, const double stroke_width, const bool flush) const;
 
 void SVG::writePolyline(const Polygon& poly, const ColorObject color, const double stroke_width) const
 {

--- a/src/utils/VoxelGrid.cpp
+++ b/src/utils/VoxelGrid.cpp
@@ -60,6 +60,11 @@ std::optional<uint8_t> VoxelGrid::getOccupation(const LocalCoordinates& local_po
     return result;
 }
 
+bool VoxelGrid::hasOccupation(const LocalCoordinates& local_position) const
+{
+    return occupied_voxels_.contains(local_position);
+}
+
 size_t VoxelGrid::occupiedCount() const
 {
     return occupied_voxels_.size();


### PR DESCRIPTION
TL;DR: wibbly-wobbly geometric stuff, problem fixed
This was due to dropping the holes when making the final horizontal polygons. Although it makes sense for closed polygons, it does not for those who actually have a hole inside. Now the propagation strategy has been changed by checking the insideness at voxel evaluation time, so that voxels considered outside the mesh will also be considered for the next evaluation loop.
In the end, this creates full closed shells around the painted features, so that we can later distinguish the inside of the mesh (which contains unassigned voxels) from the outside (which contains voxels assigned with the mesh extruder), so now we can create properly closed polygons where they should be.

CURA-12770