### PR TITLE
Introduce bridging heuristic(s)

### DIFF
--- a/include/geometry/LinesSet.h
+++ b/include/geometry/LinesSet.h
@@ -258,6 +258,8 @@ public:
 
     [[nodiscard]] Shape offset(coord_t distance, ClipperLib::JoinType join_type = ClipperLib::jtMiter, double miter_limit = 1.2) const;
 
+    [[nodiscard]] LinesSet<LineType> difference(const Shape& other) const;
+
     /*!
      * Utility method for creating the tube (or 'donut') of a shape.
      *

--- a/include/geometry/Point2LL.h
+++ b/include/geometry/Point2LL.h
@@ -15,6 +15,7 @@ Integer points are used to avoid floating point rounding errors, and because Cli
 #include <numbers>
 #include <polyclipping/clipper.hpp>
 
+#include "settings/types/Angle.h"
 #include "utils/Coord_t.h"
 #include "utils/types/generic.h"
 
@@ -198,6 +199,16 @@ INLINE coord_t cross(const Point2LL& p0, const Point2LL& p1)
 INLINE const Point2LL& make_point(const Point2LL& p)
 {
     return p;
+}
+
+INLINE const AngleRadians angle_rad(const Point2LL& p)
+{
+    return std::atan2(p.Y, p.X);
+}
+
+INLINE const AngleDegrees angle_deg(const Point2LL& p)
+{
+    return AngleDegrees(angle_rad(p));
 }
 
 Point2LL operator+(const Point2LL& p2, const Point3LL& p3);

--- a/include/utils/AABB.h
+++ b/include/utils/AABB.h
@@ -116,6 +116,17 @@ public:
     [[nodiscard]] coord_t width() const;
 
     [[nodiscard]] coord_t height() const;
+
+
+    /**
+     * Calculates the Minimum Area Oriented Bounding Box for a given Shape (polygon).
+     * This follows the "Rotating Calipers" logic: the minimum area box must have
+     * one side collinear with an edge of the convex hull.
+     * * @param shape The input points (assumed to be the convex hull for optimal performance).
+     * @return A tuple containing the local AABB (extents) and the rotation angle.
+     */
+    static std::tuple<AABB, AngleRadians> minimumAreaOrientedBoundingBox(const Shape& shape);
+
 };
 
 } // namespace cura

--- a/include/utils/AABB.h
+++ b/include/utils/AABB.h
@@ -126,7 +126,6 @@ public:
      * @return A tuple containing the local AABB (extents) and the rotation angle.
      */
     static std::tuple<AABB, AngleRadians> minimumAreaOrientedBoundingBox(const Shape& shape);
-
 };
 
 } // namespace cura

--- a/src/bridge/bridge.cpp
+++ b/src/bridge/bridge.cpp
@@ -432,6 +432,10 @@ std::optional<AngleDegrees> bridgeAngle(
         // 1. calculate the minimum oriented bounding box
         // 2. bridge lines in the smallest axis of this min oriented
         //    bounding box is considered the best orientation
+        // This heuristic is used since this produces more consistent bridging angles.
+        // While the else-case would produce a better theoretical bridging angle it would
+        // produce a different angle for similar areas within the same print. Since this
+        // would look _chaotic_ on the final print a more consistent approach is used.
         auto skin_outline_ = skin_outline;
         skin_outline_.makeConvex();
         auto [aabb, angle] = AABB::minimumAreaOrientedBoundingBox(skin_outline_);

--- a/src/bridge/bridge.cpp
+++ b/src/bridge/bridge.cpp
@@ -419,6 +419,29 @@ std::optional<AngleDegrees> bridgeAngle(
         std::optional<AngleDegrees> angle;
     };
 
+    OpenLinesSet bridge_area_lines;
+    for (auto& path : skin_outline)
+    {
+        bridge_area_lines.push_back(path.toPseudoOpenPolyline());
+    }
+    bridge_area_lines = bridge_area_lines.difference(supported_regions.offset(10));
+
+    if (bridge_area_lines.empty())
+    {
+        // if bridge lines are supported in all directions, use the following heuristic
+        // 1. calculate the minimum oriented bounding box
+        // 2. bridge lines in the smallest axis of this min oriented
+        //    bounding box is considered the best orientation
+        auto skin_outline_ = skin_outline;
+        skin_outline_.makeConvex();
+        auto [aabb, angle] = AABB::minimumAreaOrientedBoundingBox(skin_outline_);
+        if (aabb.height() > aabb.width())
+        {
+            angle += AngleDegrees(90);
+        }
+        return -AngleDegrees(angle);
+    }
+
     FitAngle best_angle{ std::numeric_limits<coord_t>::lowest(), std::nullopt };
     for (AngleDegrees angle = 0; angle < 180; angle += 1)
     {
@@ -431,7 +454,6 @@ std::optional<AngleDegrees> bridgeAngle(
 
     return best_angle.angle;
 }
-
 /*!
  * Make the expanded ranges for the given segment
  * @param segment The segment to be expanded

--- a/src/geometry/LinesSet.cpp
+++ b/src/geometry/LinesSet.cpp
@@ -227,6 +227,30 @@ Shape OpenLinesSet::offset(coord_t distance, ClipperLib::JoinType join_type, dou
     return Shape{ std::move(result_paths) };
 }
 
+template<>
+[[nodiscard]] OpenLinesSet OpenLinesSet::difference(const Shape& other) const
+{
+    if (empty())
+    {
+        return {};
+    }
+    if (other.empty())
+    {
+        return *this;
+    }
+
+    ClipperLib::PolyTree ret;
+    ClipperLib::Clipper clipper(clipper_init);
+    addPaths(clipper, ClipperLib::ptSubject);
+    other.addPaths(clipper, ClipperLib::ptClip);
+    clipper.Execute(ClipperLib::ctDifference, ret);
+
+    ClipperLib::Paths result_paths;
+    ClipperLib::OpenPathsFromPolyTree(ret, result_paths);
+
+    return OpenLinesSet(std::move(result_paths));
+}
+
 template<class LineType>
 void LinesSet<LineType>::removeDegenerateVerts()
 {

--- a/src/utils/AABB.cpp
+++ b/src/utils/AABB.cpp
@@ -217,13 +217,14 @@ coord_t AABB::height() const
 
 std::tuple<AABB, AngleRadians> AABB::minimumAreaOrientedBoundingBox(const Shape& shape)
 {
-    if (shape[0].size() < 2) {
-        return { {{0, 0}, {0, 0}}, 0.0 };
+    if (shape[0].size() < 2)
+    {
+        return { { { 0, 0 }, { 0, 0 } }, 0.0 };
     }
 
     coord_t minArea = std::numeric_limits<coord_t>::max();
     AngleRadians bestAngle = 0.0;
-    AABB bestAABB = { {0, 0}, {0, 0} };
+    AABB bestAABB = { { 0, 0 }, { 0, 0 } };
 
     // Iterate through every edge of the polygon
     for (auto iterator = shape[0].beginSegments(); iterator != shape[0].endSegments(); ++iterator)
@@ -231,7 +232,7 @@ std::tuple<AABB, AngleRadians> AABB::minimumAreaOrientedBoundingBox(const Shape&
         const Point2LL& p1 = (*iterator).start;
         const Point2LL& p2 = (*iterator).end;
 
-        const auto xHat  = p2 - p1;
+        const auto xHat = p2 - p1;
         const auto length = vSize(xHat);
 
         if (length < 100)


### PR DESCRIPTION
# Description

Apply two different behaviours in the case where the bridge area is completely supported and when it is not.

If the area is completely supported from all sides calculate the minimum oriented bounding box. The orientation of this bounding box is then the angle for the bridging.

For the case where the bridge area is not completely supported the old strategy is used where each angle between $0$ and $180$ is considered, and the best evaluated direction is used.

<img width="2056" height="1289" alt="Screenshot 2026-02-17 at 15 58 08" src="https://github.com/user-attachments/assets/ebfcaf42-edfe-4c1c-b17b-e262c005a2aa" />


CURA-12975