### PR TITLE
CURA-12992 Fix slicing crashes

### DIFF
--- a/include/WallToolPaths.h
+++ b/include/WallToolPaths.h
@@ -102,9 +102,9 @@ protected:
      *
      * Works on both toolpaths and inner contours simultaneously.
      *
-     * \param settings The settings as provided by the user
+     * \param stitch_distance The stitch distance to be used
      */
-    static void stitchToolPaths(std::vector<VariableWidthLines>& toolpaths, const Settings& settings);
+    static void stitchToolPaths(std::vector<VariableWidthLines>& toolpaths, const coord_t stitch_distance);
 
     /*!
      * Remove polylines shorter than half the smallest line width along that polyline, if that polyline isn't part of an outer wall.
@@ -128,8 +128,16 @@ private:
     bool print_thin_walls_; //<! Whether to enable the widening beading meta-strategy for thin features
     coord_t min_feature_size_; //<! The minimum size of the features that can be widened by the widening beading meta-strategy. Features thinner than that will not be printed
     coord_t min_bead_width_; //<! The minimum bead size to use when widening thin model features with the widening beading meta-strategy
-    double small_area_length_; //<! The length of the small features which are to be filtered out, this is squared into a surface
-    coord_t transition_length_; //<! The transitioning length when the amount of extrusion lines changes
+    const AngleRadians wall_transition_angle_;
+    const coord_t wall_transition_length_;
+    const double min_even_wall_line_width_;
+    const double wall_line_width_0_;
+    const double min_odd_wall_line_width_;
+    const double wall_line_width_x_;
+    const int wall_distribution_count_;
+    const coord_t wall_transition_filter_distance_;
+    const coord_t wall_transition_filter_deviation_;
+    const coord_t stitch_distance_;
     bool toolpaths_generated_; //<! Are the toolpaths generated
     std::vector<VariableWidthLines> toolpaths_; //<! The generated toolpaths binned by inset_idx.
     Shape inner_contour_; //<! The inner contour of the generated toolpaths

--- a/include/arachne/SkeletalTrapezoidation.h
+++ b/include/arachne/SkeletalTrapezoidation.h
@@ -249,7 +249,8 @@ protected:
         vd_t::edge_type*& starting_vd_edge,
         vd_t::edge_type*& ending_vd_edge,
         const std::vector<Point2LL>& points,
-        const std::vector<Segment>& segments);
+        const std::vector<Segment>& segments,
+        const Shape& polys);
 
     /*!
      * Compute the range of line segments that surround a cell of the skeletal

--- a/include/arachne/SkeletalTrapezoidation.h
+++ b/include/arachne/SkeletalTrapezoidation.h
@@ -20,6 +20,7 @@
 #include "utils/ExtrusionJunction.h"
 #include "utils/ExtrusionLine.h"
 #include "utils/PolygonsSegmentIndex.h"
+#include "utils/VoronoiUtils.h"
 #include "utils/section_type.h"
 
 namespace cura
@@ -46,8 +47,8 @@ deposition modeling" by Kuipers et al.
  */
 class SkeletalTrapezoidation
 {
-    using pos_t = double;
-    using vd_t = boost::polygon::voronoi_diagram<pos_t>;
+    using pos_t = VoronoiUtils::voronoi_data_t;
+    using vd_t = VoronoiUtils::vd_t;
     using graph_t = SkeletalTrapezoidationGraph;
     using edge_t = STHalfEdge;
     using node_t = STHalfEdgeNode;

--- a/include/arachne/SkeletalTrapezoidationEdge.h
+++ b/include/arachne/SkeletalTrapezoidationEdge.h
@@ -123,9 +123,9 @@ public:
     {
         extrusion_junctions_ = storage;
     }
-    std::shared_ptr<LineJunctions> getExtrusionJunctions()
+    std::shared_ptr<LineJunctions> getExtrusionJunctions() const
     {
-        return extrusion_junctions_.lock();
+        return const_cast<SkeletalTrapezoidationEdge*>(this)->extrusion_junctions_.lock();
     }
 
     Central is_central; //! whether the edge is significant; whether the source segments have a sharp angle; -1 is unknown

--- a/include/infill.h
+++ b/include/infill.h
@@ -390,6 +390,7 @@ private:
         Shape& result_polygons,
         OpenLinesSet& result_lines,
         const Settings& settings,
+        const int layer_idx,
         const std::shared_ptr<SierpinskiFillProvider>& cross_fill_pattern = nullptr,
         const std::shared_ptr<LightningLayer>& lightning_layer = nullptr,
         const SliceMeshStorage* mesh = nullptr);
@@ -438,10 +439,11 @@ private:
     /*!
      * Generate sparse concentric infill
      *
-     * \param toolpaths (output) The resulting toolpaths. Binned by inset_idx.
-     * \param inset_value The offset between each consecutive two polygons
+     * \param[out] toolpaths The resulting toolpaths. Binned by inset_idx.
+     * \param settings The settings to be used for processing
+     * \param layer_idx The current layer index
      */
-    void generateConcentricInfill(std::vector<VariableWidthLines>& toolpaths, const Settings& settings);
+    void generateConcentricInfill(std::vector<VariableWidthLines>& toolpaths, const Settings& settings, const int layer_idx);
 
     /*!
      * Generate a rectangular grid of infill lines

--- a/include/utils/SVG.h
+++ b/include/utils/SVG.h
@@ -196,6 +196,23 @@ public:
         VerticesAttributes vertices{ ColorObject(), 0.0 };
     };
 
+    struct DiagramVisualAttributes : VisualAttributes
+    {
+        bool edges_arrows{ true };
+
+        DiagramVisualAttributes(const SurfaceAttributes surface_attributes, const bool edges_arrows = true)
+            : VisualAttributes({ .surface = surface_attributes })
+            , edges_arrows(edges_arrows)
+        {
+        }
+
+        DiagramVisualAttributes(const LineAttributes line_attributes, const bool edges_arrows = true)
+            : VisualAttributes({ .line = line_attributes })
+            , edges_arrows(edges_arrows)
+        {
+        }
+    };
+
 private:
     static std::string toString(const ColorObject& color);
     static std::string toString(const std::vector<int>& dash_array);
@@ -260,18 +277,18 @@ public:
 
     void write(const std::string& text, const Point2LL& p, const VerticesAttributes& vertices_attributes, const bool flush = true) const;
 
-    void write(const SkeletalTrapezoidationGraph& graph, const VisualAttributes& visual_attributes, const bool flush = true) const;
+    void write(const SkeletalTrapezoidationGraph& graph, const DiagramVisualAttributes& visual_attributes, const bool flush = true) const;
 
-    void write(const STHalfEdge& edge, const VisualAttributes& visual_attributes, const bool flush = true) const;
-
-    template<typename T>
-    void write(const boost::polygon::voronoi_diagram<T>& voronoi_diagram, const VisualAttributes& visual_attributes, const bool flush = true) const;
+    void write(const STHalfEdge& edge, const DiagramVisualAttributes& visual_attributes, const bool flush = true) const;
 
     template<typename T>
-    void write(const boost::polygon::voronoi_edge<T>& edge, const VisualAttributes& visual_attributes, const bool flush = true) const;
+    void write(const boost::polygon::voronoi_diagram<T>& voronoi_diagram, const DiagramVisualAttributes& visual_attributes, const bool flush = true) const;
 
     template<typename T>
-    void write(const boost::polygon::voronoi_cell<T>& cell, const VisualAttributes& visual_attributes, const bool flush = true) const;
+    void write(const boost::polygon::voronoi_edge<T>& edge, const DiagramVisualAttributes& visual_attributes, const bool flush = true) const;
+
+    template<typename T>
+    void write(const boost::polygon::voronoi_cell<T>& cell, const DiagramVisualAttributes& visual_attributes, const bool flush = true) const;
 
     void writeArrow(const Point2LL& a, const Point2LL& b, const ColorObject color = Color::BLACK, const double stroke_width = 1.0, const double head_size = 5.0) const;
 

--- a/include/utils/SVG.h
+++ b/include/utils/SVG.h
@@ -149,7 +149,7 @@ public:
         {
             return LineAttributes(ColorObject(), 0.0);
         }
- bool isDisplayed() const override
+        bool isDisplayed() const override
         {
             return ElementAttributes::isDisplayed() && width > 0.0;
         }

--- a/include/utils/SVG.h
+++ b/include/utils/SVG.h
@@ -21,6 +21,7 @@ class Point2D;
 class MixedLinesSet;
 class SkeletalTrapezoidationGraph;
 class STHalfEdge;
+class STHalfEdgeNode;
 
 class SVG : NoCopy
 {
@@ -144,7 +145,11 @@ public:
 
         ~LineAttributes() override = default;
 
-        bool isDisplayed() const override
+        static LineAttributes hidden()
+        {
+            return LineAttributes(ColorObject(), 0.0);
+        }
+ bool isDisplayed() const override
         {
             return ElementAttributes::isDisplayed() && width > 0.0;
         }
@@ -157,6 +162,14 @@ public:
         double font_size{ 10 };
 
         VerticesAttributes() = default;
+
+        VerticesAttributes(const ColorObject& color, const double radius, const bool write_coords, const double font_size)
+            : ElementAttributes(color)
+            , radius(radius)
+            , write_coords(write_coords)
+            , font_size(font_size)
+        {
+        }
 
         VerticesAttributes(const ColorObject& color, const double radius)
             : ElementAttributes(color)
@@ -183,6 +196,11 @@ public:
 
         ~VerticesAttributes() override = default;
 
+        static VerticesAttributes hidden()
+        {
+            return VerticesAttributes(SVG::ColorObject(), 0.0);
+        }
+
         bool isDisplayed() const override
         {
             return ElementAttributes::isDisplayed() && (radius > 0.0 || (write_coords && font_size > 0.0));
@@ -200,15 +218,25 @@ public:
     {
         bool edges_arrows{ true };
 
-        DiagramVisualAttributes(const SurfaceAttributes surface_attributes, const bool edges_arrows = true)
-            : VisualAttributes({ .surface = surface_attributes })
+        DiagramVisualAttributes(const VisualAttributes& visual_attributes, const bool edges_arrows = true)
+            : VisualAttributes(visual_attributes)
             , edges_arrows(edges_arrows)
         {
         }
+    };
 
-        DiagramVisualAttributes(const LineAttributes line_attributes, const bool edges_arrows = true)
-            : VisualAttributes({ .line = line_attributes })
-            , edges_arrows(edges_arrows)
+    struct STVisualAttributes : DiagramVisualAttributes
+    {
+        VerticesAttributes beads_count;
+        VerticesAttributes junctions;
+
+        STVisualAttributes(
+            const DiagramVisualAttributes& diagram_attributes,
+            const VerticesAttributes& beads_count = VerticesAttributes::hidden(),
+            const VerticesAttributes& junctions = VerticesAttributes::hidden())
+            : DiagramVisualAttributes(diagram_attributes)
+            , beads_count(beads_count)
+            , junctions(junctions)
         {
         }
     };
@@ -277,9 +305,9 @@ public:
 
     void write(const std::string& text, const Point2LL& p, const VerticesAttributes& vertices_attributes, const bool flush = true) const;
 
-    void write(const SkeletalTrapezoidationGraph& graph, const DiagramVisualAttributes& visual_attributes, const bool flush = true) const;
+    void write(const SkeletalTrapezoidationGraph& graph, const STVisualAttributes& visual_attributes, const bool flush = true) const;
 
-    void write(const STHalfEdge& edge, const DiagramVisualAttributes& visual_attributes, const bool flush = true) const;
+    void write(const STHalfEdge& edge, const STVisualAttributes& visual_attributes, const bool flush = true, const std::set<const STHalfEdgeNode*>& drawn_nodes = {}) const;
 
     template<typename T>
     void write(const boost::polygon::voronoi_diagram<T>& voronoi_diagram, const DiagramVisualAttributes& visual_attributes, const bool flush = true) const;

--- a/include/utils/VoronoiUtils.h
+++ b/include/utils/VoronoiUtils.h
@@ -27,7 +27,7 @@ struct voronoi_diagram_traits<cura::coord_t>
     public:
         bool operator()(const vertex_type& v1, const vertex_type& v2) const
         {
-            return cura::fuzzy_equal(v1.x(), v2.x()) && cura::fuzzy_equal(v1.y(), v2.y());
+            return v1.x() == v2.x() && v1.y() == v2.y();
         }
     };
 };

--- a/include/utils/VoronoiUtils.h
+++ b/include/utils/VoronoiUtils.h
@@ -12,6 +12,27 @@
 #include "PolygonsSegmentIndex.h"
 
 
+namespace boost::polygon
+{
+template<>
+struct voronoi_diagram_traits<cura::coord_t>
+{
+    typedef cura::coord_t coordinate_type;
+    typedef voronoi_cell<coordinate_type> cell_type;
+    typedef voronoi_vertex<coordinate_type> vertex_type;
+    typedef voronoi_edge<coordinate_type> edge_type;
+
+    class vertex_equality_predicate_type
+    {
+    public:
+        bool operator()(const vertex_type& v1, const vertex_type& v2) const
+        {
+            return cura::fuzzy_equal(v1.x(), v2.x()) && cura::fuzzy_equal(v1.y(), v2.y());
+        }
+    };
+};
+} // namespace boost::polygon
+
 namespace cura
 {
 
@@ -21,7 +42,7 @@ class VoronoiUtils
 {
 public:
     using Segment = PolygonsSegmentIndex;
-    using voronoi_data_t = double;
+    using voronoi_data_t = coord_t;
     using vd_t = boost::polygon::voronoi_diagram<voronoi_data_t>;
 
     static Point2LL getSourcePoint(const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments);
@@ -30,9 +51,9 @@ public:
 
     static Point2LL p(const vd_t::vertex_type* node);
 
-    static bool isSourcePoint(Point2LL p, const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments, coord_t snap_dist = 10);
+    static bool isSourcePoint(const Point2LL& p, const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments, coord_t snap_dist = 10);
 
-    static coord_t getDistance(Point2LL p, const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments);
+    static coord_t getDistance(const Point2LL& p, const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments);
 
     /*!
      * Discretize a parabola based on (approximate) step size.

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -902,15 +902,17 @@ void TreeModelVolumes::calculateCollisionAvoidance(const std::deque<RadiusLayerP
 // defined by the collision when offsetting to fast.
 Shape TreeModelVolumes::safeOffset(const Shape& me, coord_t distance, ClipperLib::JoinType jt, coord_t max_safe_step_distance, const Shape& collision) const
 {
-    const size_t steps = std::abs(distance / std::max(min_offset_per_step_, std::abs(max_safe_step_distance)));
-    assert(distance * max_safe_step_distance >= 0);
+    assert(distance * max_safe_step_distance >= 0); // Make sure they are the same sign (or one of them is null)
+    const uint8_t offset_sign = sign(distance);
+    const coord_t step_distance = offset_sign * std::max(min_offset_per_step_, std::abs(max_safe_step_distance));
+    const size_t steps = std::abs(distance / step_distance);
     Shape ret = me;
 
     for (size_t i = 0; i < steps; ++i)
     {
-        ret = ret.offset(max_safe_step_distance, jt).unionPolygons(collision);
+        ret = ret.offset(step_distance, jt).unionPolygons(collision);
     }
-    ret = ret.offset(distance % max_safe_step_distance, jt);
+    ret = ret.offset(distance % step_distance, jt);
 
     return ret.unionPolygons(collision);
 }

--- a/src/WallToolPaths.cpp
+++ b/src/WallToolPaths.cpp
@@ -36,9 +36,18 @@ WallToolPaths::WallToolPaths(
     , inset_count_(inset_count)
     , wall_0_inset_(wall_0_inset)
     , print_thin_walls_(settings.get<bool>("fill_outline_gaps"))
-    , min_feature_size_(settings.get<coord_t>("min_feature_size"))
-    , min_bead_width_(settings.get<coord_t>("min_bead_width"))
-    , small_area_length_(INT2MM(static_cast<double>(nominal_bead_width) / 2))
+    , min_feature_size_(nominal_bead_width / 4)
+    , min_bead_width_(std::min(min_even_wall_line_width_, min_odd_wall_line_width_))
+    , wall_transition_angle_(AngleDegrees(10))
+    , wall_transition_length_(nominal_bead_width)
+    , min_even_wall_line_width_(std::llrint(nominal_bead_width * 0.85))
+    , wall_line_width_0_(nominal_bead_width)
+    , min_odd_wall_line_width_(min_even_wall_line_width_)
+    , wall_line_width_x_(nominal_bead_width)
+    , wall_distribution_count_(1)
+    , wall_transition_filter_distance_(MM2INT(100))
+    , wall_transition_filter_deviation_(nominal_bead_width / 4)
+    , stitch_distance_(nominal_bead_width - 1)
     , toolpaths_generated_(false)
     , settings_(settings)
     , layer_idx_(layer_idx)
@@ -63,7 +72,16 @@ WallToolPaths::WallToolPaths(
     , print_thin_walls_(settings.get<bool>("fill_outline_gaps"))
     , min_feature_size_(settings.get<coord_t>("min_feature_size"))
     , min_bead_width_(settings.get<coord_t>("min_bead_width"))
-    , small_area_length_(INT2MM(static_cast<double>(bead_width_0) / 2))
+    , wall_transition_angle_(settings.get<AngleRadians>("wall_transition_angle"))
+    , wall_transition_length_(settings.get<coord_t>("wall_transition_length"))
+    , min_even_wall_line_width_(settings.get<double>("min_even_wall_line_width"))
+    , wall_line_width_0_(settings.get<double>("wall_line_width_0"))
+    , min_odd_wall_line_width_(settings.get<double>("min_odd_wall_line_width"))
+    , wall_line_width_x_(settings.get<double>("wall_line_width_x"))
+    , wall_distribution_count_(settings.get<int>("wall_distribution_count"))
+    , wall_transition_filter_distance_(settings.get<coord_t>("wall_transition_filter_distance"))
+    , wall_transition_filter_deviation_(settings.get<coord_t>("wall_transition_filter_deviation"))
+    , stitch_distance_(settings.get<coord_t>("wall_line_width_x") - 1) // In 0-width contours, junctions can cause up to 1-line-width gaps. Don't stitch more than 1 line width.
     , toolpaths_generated_(false)
     , settings_(settings)
     , layer_idx_(layer_idx)
@@ -80,27 +98,21 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
         return toolpaths_;
     }
 
-    const auto transitioning_angle = settings_.get<AngleRadians>("wall_transition_angle");
+
     constexpr coord_t discretization_step_size = MM2INT(0.8);
-    const coord_t wall_transition_length = settings_.get<coord_t>("wall_transition_length");
 
     // When to split the middle wall into two:
-    const double min_even_wall_line_width = settings_.get<double>("min_even_wall_line_width");
-    const double wall_line_width_0 = settings_.get<double>("wall_line_width_0");
-    const Ratio wall_split_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * (2.0 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0)) / 100.0;
+    const Ratio wall_split_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * (2.0 * min_even_wall_line_width_ - wall_line_width_0_) / wall_line_width_0_)) / 100.0;
 
     // When to add a new middle in between the innermost two walls:
-    const double min_odd_wall_line_width = settings_.get<double>("min_odd_wall_line_width");
-    const double wall_line_width_x = settings_.get<double>("wall_line_width_x");
-    const Ratio wall_add_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * min_odd_wall_line_width / wall_line_width_x)) / 100.0;
+    const Ratio wall_add_middle_threshold = std::max(1.0, std::min(99.0, 100.0 * min_odd_wall_line_width_ / wall_line_width_x_)) / 100.0;
 
-    const int wall_distribution_count = settings_.get<int>("wall_distribution_count");
     const size_t max_bead_count = (inset_count_ < std::numeric_limits<size_t>::max() / 2) ? 2 * inset_count_ : std::numeric_limits<size_t>::max();
     const auto beading_strat = BeadingStrategyFactory::makeStrategy(
         bead_width_0_,
         bead_width_x_,
-        wall_transition_length,
-        transitioning_angle,
+        wall_transition_length_,
+        wall_transition_angle_,
         print_thin_walls_,
         min_bead_width_,
         min_feature_size_,
@@ -108,17 +120,15 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
         wall_add_middle_threshold,
         max_bead_count,
         wall_0_inset_,
-        wall_distribution_count);
-    const auto transition_filter_dist = settings_.get<coord_t>("wall_transition_filter_distance");
-    const auto allowed_filter_deviation = settings_.get<coord_t>("wall_transition_filter_deviation");
+        wall_distribution_count_);
     SkeletalTrapezoidation wall_maker(
         prepared_outline,
         *beading_strat,
         beading_strat->getTransitioningAngle(),
         discretization_step_size,
-        transition_filter_dist,
-        allowed_filter_deviation,
-        wall_transition_length,
+        wall_transition_filter_distance_,
+        wall_transition_filter_deviation_,
+        wall_transition_length_,
         layer_idx_,
         section_type_);
     wall_maker.generateToolpaths(toolpaths_);
@@ -133,7 +143,7 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
         scripta::PointVDI{ "width", &ExtrusionJunction::w_ },
         scripta::PointVDI{ "perimeter_index", &ExtrusionJunction::perimeter_index_ });
 
-    stitchToolPaths(toolpaths_, settings_);
+    stitchToolPaths(toolpaths_, stitch_distance_);
     scripta::log(
         "toolpaths_1",
         toolpaths_,
@@ -206,11 +216,8 @@ const std::vector<VariableWidthLines>& WallToolPaths::generate()
 }
 
 
-void WallToolPaths::stitchToolPaths(std::vector<VariableWidthLines>& toolpaths, const Settings& settings)
+void WallToolPaths::stitchToolPaths(std::vector<VariableWidthLines>& toolpaths, const coord_t stitch_distance)
 {
-    const coord_t stitch_distance
-        = settings.get<coord_t>("wall_line_width_x") - 1; // In 0-width contours, junctions can cause up to 1-line-width gaps. Don't stitch more than 1 line width.
-
     for (unsigned int wall_idx = 0; wall_idx < toolpaths.size(); wall_idx++)
     {
         VariableWidthLines& wall_lines = toolpaths[wall_idx];

--- a/src/arachne/SkeletalTrapezoidation.cpp
+++ b/src/arachne/SkeletalTrapezoidation.cpp
@@ -273,7 +273,8 @@ bool SkeletalTrapezoidation::computePointCellRange(
     vd_t::edge_type*& starting_vd_edge,
     vd_t::edge_type*& ending_vd_edge,
     const std::vector<Point2LL>& points,
-    const std::vector<Segment>& segments)
+    const std::vector<Segment>& segments,
+    const Shape& polys)
 {
     if (cell.incident_edge()->is_infinite())
     {
@@ -428,7 +429,7 @@ void SkeletalTrapezoidation::constructFromPolygons(const Shape& polys)
 
         if (cell.contains_point())
         {
-            const bool keep_going = computePointCellRange(cell, start_source_point, end_source_point, starting_vonoroi_edge, ending_vonoroi_edge, points, segments);
+            const bool keep_going = computePointCellRange(cell, start_source_point, end_source_point, starting_vonoroi_edge, ending_vonoroi_edge, points, segments, polys);
             if (! keep_going)
             {
                 continue;

--- a/src/arachne/SkeletalTrapezoidation.cpp
+++ b/src/arachne/SkeletalTrapezoidation.cpp
@@ -283,20 +283,18 @@ bool SkeletalTrapezoidation::computePointCellRange(
     // Copy whole cell into graph or not at all
 
     const Point2LL source_point = VoronoiUtils::getSourcePoint(cell, points, segments);
-    const PolygonsPointIndex source_point_index = VoronoiUtils::getSourcePointIndex(cell, points, segments);
     Point2LL some_point = VoronoiUtils::p(cell.incident_edge()->vertex0());
     if (some_point == source_point)
     {
         some_point = VoronoiUtils::p(cell.incident_edge()->vertex1());
     }
-    // Test if the some_point is even inside the polygon.
-    // The edge leading out of a polygon must have an endpoint that's not in the corner following the contour of the polygon at that vertex.
-    // So if it's inside the corner formed by the polygon vertex, it's all fine.
-    // But if it's outside of the corner, it must be a vertex of the Voronoi diagram that goes outside of the polygon towards infinity.
-    if (! LinearAlg2D::isInsideCorner(source_point_index.prev().p(), source_point_index.p(), source_point_index.next().p(), some_point))
+
+    // Test if the some_point is even inside the polygon. If not, the whole cell is outside the polygon and must not be considered.
+    if (! polys.inside(some_point))
     {
         return false; // Don't copy any part of this cell
     }
+
     vd_t::edge_type* vd_edge = cell.incident_edge();
     do
     {

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -184,7 +184,7 @@ void Infill::generate(
         Shape generated_result_polygons;
         OpenLinesSet generated_result_lines;
 
-        _generate(toolpaths, generated_result_polygons, generated_result_lines, settings, cross_fill_provider, lightning_trees, mesh);
+        _generate(toolpaths, generated_result_polygons, generated_result_lines, settings, layer_idx, cross_fill_provider, lightning_trees, mesh);
 
         zig_zaggify_ = zig_zaggify_real;
         multiplyInfill(generated_result_polygons, generated_result_lines);
@@ -198,7 +198,7 @@ void Infill::generate(
         Shape generated_result_polygons;
         OpenLinesSet generated_result_lines;
 
-        _generate(toolpaths, generated_result_polygons, generated_result_lines, settings, cross_fill_provider, lightning_trees, mesh);
+        _generate(toolpaths, generated_result_polygons, generated_result_lines, settings, layer_idx, cross_fill_provider, lightning_trees, mesh);
 
         result_polygons.push_back(generated_result_polygons);
         result_lines.push_back(generated_result_lines);
@@ -256,6 +256,7 @@ void Infill::_generate(
     Shape& result_polygons,
     OpenLinesSet& result_lines,
     const Settings& settings,
+    const int layer_idx,
     const std::shared_ptr<SierpinskiFillProvider>& cross_fill_provider,
     const std::shared_ptr<LightningLayer>& lightning_trees,
     const SliceMeshStorage* mesh)
@@ -289,7 +290,7 @@ void Infill::_generate(
         generateTrihexagonInfill(result_lines);
         break;
     case EFillMethod::CONCENTRIC:
-        generateConcentricInfill(toolpaths, settings);
+        generateConcentricInfill(toolpaths, settings, layer_idx);
         break;
     case EFillMethod::ZIG_ZAG:
         generateZigZagInfill(result_lines, line_distance_, fill_angle_);
@@ -454,7 +455,7 @@ void Infill::generateLightningInfill(const std::shared_ptr<LightningLayer>& tree
     result_lines.push_back(trees->convertToLines(inner_contour_, infill_line_width_));
 }
 
-void Infill::generateConcentricInfill(std::vector<VariableWidthLines>& toolpaths, const Settings& settings)
+void Infill::generateConcentricInfill(std::vector<VariableWidthLines>& toolpaths, const Settings& settings, const int layer_idx)
 {
     const coord_t min_area = infill_line_width_ * infill_line_width_;
 
@@ -473,8 +474,7 @@ void Infill::generateConcentricInfill(std::vector<VariableWidthLines>& toolpaths
 
         constexpr size_t inset_wall_count = 1; // 1 wall at a time.
         constexpr coord_t wall_0_inset = 0; // Don't apply any outer wall inset for these. That's just for the outer wall.
-        WallToolPaths wall_toolpaths(current_inset, infill_line_width_, inset_wall_count, wall_0_inset, settings, 0, SectionType::CONCENTRIC_INFILL); // FIXME: @jellespijker pass
-                                                                                                                                                      // the correct layer
+        WallToolPaths wall_toolpaths(current_inset, infill_line_width_, inset_wall_count, wall_0_inset, settings, layer_idx, SectionType::CONCENTRIC_INFILL);
         const std::vector<VariableWidthLines> inset_paths = wall_toolpaths.getToolPaths();
         toolpaths.insert(toolpaths.end(), inset_paths.begin(), inset_paths.end());
 

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -406,14 +406,14 @@ void SVG::write(const std::string& text, const Point2LL& p, const VerticesAttrib
         "<text x=\"%f\" y=\"%f\" style=\"font-size: %fpx;\" fill=\"%s\">%s</text>\n",
         transformed_point.x(),
         transformed_point.y(),
-        vertices_attributes.font_size,
+        vertices_attributes.font_size * scale_,
         toString(vertices_attributes.color).c_str(),
         text.c_str());
 
     handleFlush(flush);
 }
 
-void SVG::write(const SkeletalTrapezoidationGraph& graph, const DiagramVisualAttributes& visual_attributes, const bool flush) const
+void SVG::write(const SkeletalTrapezoidationGraph& graph, const STVisualAttributes& visual_attributes, const bool flush) const
 {
     const size_t start_edges_count = ranges::accumulate(
         graph.edges_,
@@ -423,6 +423,9 @@ void SVG::write(const SkeletalTrapezoidationGraph& graph, const DiagramVisualAtt
             return total + (edge.prev_ == nullptr ? 1 : 0);
         });
 
+    std::set<const STHalfEdge*> drawn_edges;
+    std::set<const STHalfEdgeNode*> drawn_nodes;
+
     for (const auto& [index, edge] : graph.edges_ | ranges::views::enumerate)
     {
         if (edge.prev_ != nullptr)
@@ -430,7 +433,7 @@ void SVG::write(const SkeletalTrapezoidationGraph& graph, const DiagramVisualAtt
             continue;
         }
 
-        DiagramVisualAttributes loop_visual_attributes = visual_attributes;
+        STVisualAttributes loop_visual_attributes = visual_attributes;
         if (loop_visual_attributes.line.isRainbow())
         {
             loop_visual_attributes.line.color = makeRainbowColor(index, start_edges_count);
@@ -439,7 +442,30 @@ void SVG::write(const SkeletalTrapezoidationGraph& graph, const DiagramVisualAtt
         const STHalfEdge* current_edge = &edge;
         while (current_edge != nullptr)
         {
-            write(*current_edge, loop_visual_attributes, false);
+            if (! drawn_edges.contains(current_edge))
+            {
+                write(*current_edge, loop_visual_attributes, false, drawn_nodes);
+
+                STVisualAttributes twin_visual_attributes = loop_visual_attributes;
+                twin_visual_attributes.line = LineAttributes::hidden();
+                if (current_edge->twin_)
+                {
+                    write(*current_edge->twin_, twin_visual_attributes, false, drawn_nodes);
+                }
+
+                if (! visual_attributes.edges_arrows)
+                {
+                    drawn_edges.emplace(current_edge);
+                    drawn_edges.emplace(current_edge->twin_);
+                }
+
+                if (visual_attributes.beads_count.isDisplayed())
+                {
+                    drawn_nodes.emplace(current_edge->from_);
+                    drawn_nodes.emplace(current_edge->to_);
+                }
+            }
+
             current_edge = current_edge->next_;
         }
     }
@@ -447,8 +473,29 @@ void SVG::write(const SkeletalTrapezoidationGraph& graph, const DiagramVisualAtt
     handleFlush(flush);
 }
 
-void SVG::write(const STHalfEdge& edge, const DiagramVisualAttributes& visual_attributes, const bool flush) const
+void SVG::write(const STHalfEdge& edge, const STVisualAttributes& visual_attributes, const bool flush, const std::set<const STHalfEdgeNode*>& drawn_nodes) const
 {
+    if (visual_attributes.beads_count.isDisplayed())
+    {
+        if (! drawn_nodes.contains(edge.from_))
+        {
+            write(std::to_string(edge.from_->data_.bead_count_), edge.from_->p_, visual_attributes.beads_count, false);
+        }
+        if (! drawn_nodes.contains(edge.to_))
+        {
+            write(std::to_string(edge.to_->data_.bead_count_), edge.to_->p_, visual_attributes.beads_count, false);
+        }
+    }
+
+    if (visual_attributes.junctions.isDisplayed() && edge.data_.hasExtrusionJunctions())
+    {
+        std::shared_ptr<LineJunctions> junctions = edge.data_.getExtrusionJunctions();
+        for (const ExtrusionJunction& junction : *junctions)
+        {
+            write(junction.p_, visual_attributes.junctions);
+        }
+    }
+
     if (! visual_attributes.edges_arrows)
     {
         write(edge.from_->p_, edge.to_->p_, visual_attributes, flush);

--- a/src/utils/SVG.cpp
+++ b/src/utils/SVG.cpp
@@ -413,7 +413,7 @@ void SVG::write(const std::string& text, const Point2LL& p, const VerticesAttrib
     handleFlush(flush);
 }
 
-void SVG::write(const SkeletalTrapezoidationGraph& graph, const VisualAttributes& visual_attributes, const bool flush) const
+void SVG::write(const SkeletalTrapezoidationGraph& graph, const DiagramVisualAttributes& visual_attributes, const bool flush) const
 {
     const size_t start_edges_count = ranges::accumulate(
         graph.edges_,
@@ -430,7 +430,7 @@ void SVG::write(const SkeletalTrapezoidationGraph& graph, const VisualAttributes
             continue;
         }
 
-        VisualAttributes loop_visual_attributes = visual_attributes;
+        DiagramVisualAttributes loop_visual_attributes = visual_attributes;
         if (loop_visual_attributes.line.isRainbow())
         {
             loop_visual_attributes.line.color = makeRainbowColor(index, start_edges_count);
@@ -447,8 +447,14 @@ void SVG::write(const SkeletalTrapezoidationGraph& graph, const VisualAttributes
     handleFlush(flush);
 }
 
-void SVG::write(const STHalfEdge& edge, const VisualAttributes& visual_attributes, const bool flush) const
+void SVG::write(const STHalfEdge& edge, const DiagramVisualAttributes& visual_attributes, const bool flush) const
 {
+    if (! visual_attributes.edges_arrows)
+    {
+        write(edge.from_->p_, edge.to_->p_, visual_attributes, flush);
+        return;
+    }
+
     const std::optional<Point2D> direction = toPoint2D(Point2LL(edge.to_->p_ - edge.from_->p_)).vNormalized();
     if (! direction.has_value())
     {
@@ -580,7 +586,7 @@ void SVG::writeCoordinateGrid(const coord_t grid_size, const VisualAttributes& v
 }
 
 template<>
-void SVG::write(const boost::polygon::voronoi_edge<VoronoiUtils::voronoi_data_t>& edge, const VisualAttributes& visual_attributes, const bool flush) const
+void SVG::write(const boost::polygon::voronoi_edge<VoronoiUtils::voronoi_data_t>& edge, const DiagramVisualAttributes& visual_attributes, const bool flush) const
 {
     if (edge.is_infinite())
     {
@@ -608,7 +614,7 @@ void SVG::write(const boost::polygon::voronoi_edge<VoronoiUtils::voronoi_data_t>
 }
 
 template<>
-void SVG::write(const boost::polygon::voronoi_cell<VoronoiUtils::voronoi_data_t>& cell, const VisualAttributes& visual_attributes, const bool flush) const
+void SVG::write(const boost::polygon::voronoi_cell<VoronoiUtils::voronoi_data_t>& cell, const DiagramVisualAttributes& visual_attributes, const bool flush) const
 {
     const VoronoiUtils::vd_t::edge_type* start_edge = cell.incident_edge();
     if (! start_edge)
@@ -651,11 +657,11 @@ void SVG::write(const boost::polygon::voronoi_cell<VoronoiUtils::voronoi_data_t>
 }
 
 template<>
-void SVG::write(const VoronoiUtils::vd_t& voronoi_diagram, const VisualAttributes& visual_attributes, const bool flush) const
+void SVG::write(const VoronoiUtils::vd_t& voronoi_diagram, const DiagramVisualAttributes& visual_attributes, const bool flush) const
 {
     for (const auto& [index, cell] : voronoi_diagram.cells() | ranges::views::enumerate)
     {
-        VisualAttributes cell_visual_attributes = visual_attributes;
+        DiagramVisualAttributes cell_visual_attributes = visual_attributes;
         if (cell_visual_attributes.line.isRainbow())
         {
             cell_visual_attributes.line.color = makeRainbowColor(index, voronoi_diagram.cells().size());

--- a/src/utils/VoronoiUtils.cpp
+++ b/src/utils/VoronoiUtils.cpp
@@ -18,10 +18,10 @@ namespace cura
 
 Point2LL VoronoiUtils::p(const vd_t::vertex_type* node)
 {
-    return toPoint2LL(Point2D(node->x(), node->y()));
+    return Point2LL(node->x(), node->y());
 }
 
-bool VoronoiUtils::isSourcePoint(Point2LL p, const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments, coord_t snap_dist)
+bool VoronoiUtils::isSourcePoint(const Point2LL& p, const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments, coord_t snap_dist)
 {
     if (cell.contains_point())
     {
@@ -34,7 +34,7 @@ bool VoronoiUtils::isSourcePoint(Point2LL p, const vd_t::cell_type& cell, const 
     }
 }
 
-coord_t VoronoiUtils::getDistance(Point2LL p, const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments)
+coord_t VoronoiUtils::getDistance(const Point2LL& p, const vd_t::cell_type& cell, const std::vector<Point2LL>& points, const std::vector<Segment>& segments)
 {
     if (cell.contains_point())
     {


### PR DESCRIPTION
This PRs proposes a few changes to fix the most occuring slicing crashes inside Arachne:
* Use an integer-based voronoi diagram when calculating skeletal trapezoidation: previously we used double values, which would cause unexpected behaviors, because the built diagram would consider some close points to be separate, but when treating them afterwards using a Point2LL, they would end up at the same position. Now the voronoi diagram precision is consistent with the precision of the subsequent algorithms.
* Change the edge insideness check: the previous method was based on a corner insideness check, which is extremely fast but would give a wrong result in some very tricky cases (with the initial shape contains overlapping vertices). Now we use a polygon insideness check.
* Use consistent settings when generating skeletal trapezoidation for non-walls: previously, we would always take the walls settings and apply them to arachne, but e.g. when generating a concentric infill for ironing, the line width is 0.1mm instead of 0.4mm, although the minimum authorized line width is actually 0.2mm. This case would generate impossible cases, thus wrong data and crashes. For the non-walls cases, we now use settings based on the current line width. The calculations are hard-coded to their equivalent formula from fdprinter.def.json.
* Fix a tree support crash: not arachne-related, but I also encountered a possible division by 0 within tree support, which was pretty easy to fix.

### Performance analysis
* Since we output a voronoi diagram that uses integers, it should have less points than previously, possibly speeding up subsequent calculations, and reducing the required conversions.
* The edge insideness check is now based on the polygon insideness, which is a much heavier calculation. This is only for point-based cells of the diagram though.
In practice, I have made performance checks on a complex model and did not see any significant difference. More testing could be done though.

### Risk analysis
Changing the voronoi diagram to integer type is a huge behavioral change. Although it is more consistent with the rest of the algorithm, it changes the input data for arachne of every single case. So far I did not observe any regression, although at first it raised the occurences of the insideness check failure (since it naturally generates more overlapping points).

CURA-12992

Fixes https://github.com/Ultimaker/Cura/issues/21357
Fixes https://github.com/Ultimaker/Cura/issues/21235
Fixes https://github.com/Ultimaker/Cura/issues/21128
Fixes https://github.com/Ultimaker/Cura/issues/20967
Fixes https://github.com/Ultimaker/Cura/issues/20962
Should fix https://github.com/Ultimaker/Cura/issues/20978
Should fix https://github.com/Ultimaker/Cura/issues/21375