### PR TITLE
CURA-12829 Fix tree support top layer generation

### DIFF
--- a/include/geometry/LinesSet.h
+++ b/include/geometry/LinesSet.h
@@ -260,18 +260,6 @@ public:
 
     [[nodiscard]] LinesSet<LineType> difference(const Shape& other) const;
 
-    /*!
-     * Utility method for creating the tube (or 'donut') of a shape.
-     *
-     * \param inner_offset Offset relative to the original shape-outline towards the inside of the
-     *        shape. Sort-of like a negative normal offset, except it's the offset part that's kept,
-     *        not the shape.
-     * \param outer_offset Offset relative to the original shape-outline towards the outside of the
-     *        shape. Comparable to normal offset.
-     * \return The resulting polygons.
-     */
-    [[nodiscard]] Shape createTubeShape(const coord_t inner_offset, const coord_t outer_offset) const;
-
     void translate(const Point2LL& delta);
 
     void applyMatrix(const PointMatrix& matrix);

--- a/include/geometry/Shape.h
+++ b/include/geometry/Shape.h
@@ -260,6 +260,18 @@ public:
      */
     std::vector<float> intersectionsWithSegment(const Point2LL& start, const Point2LL& end) const;
 
+    /*!
+     * Utility method for creating the tube (or 'donut') of a shape.
+     *
+     * \param inner_offset Offset relative to the original shape-outline towards the inside of the
+     *        shape. Sort-of like a negative normal offset, except it's the offset part that's kept,
+     *        not the shape.
+     * \param outer_offset Offset relative to the original shape-outline towards the outside of the
+     *        shape. Comparable to normal offset.
+     * \return The resulting polygons.
+     */
+    [[nodiscard]] Shape createTubeShape(const coord_t inner_offset, const coord_t outer_offset) const;
+
 #ifdef BUILD_TESTS
     /*!
      * @brief Import the polygon from a WKT string

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2207,16 +2207,15 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(
-                        TreeSupportUtils::generateSupportInfillLines(
-                            support_layer_storage[layer_idx],
-                            config,
-                            false,
-                            layer_idx,
-                            config.support_line_distance,
-                            storage.support.cross_fill_provider,
-                            true)
-                            .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
+                                                              support_layer_storage[layer_idx],
+                                                              config,
+                                                              false,
+                                                              layer_idx,
+                                                              config.support_line_distance,
+                                                              storage.support.cross_fill_provider,
+                                                              true)
+                                                              .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2024,7 +2024,7 @@ void TreeSupport::filterFloatingLines(std::vector<Shape>& support_layer_storage)
             }
 
             const Shape& relevant_forbidden = volumes_.getCollision(0, layer_idx, true);
-            Shape outer_walls = TreeSupportUtils::toPolylines(support_layer_storage[layer_idx - 1].getOutsidePolygons()).createTubeShape(closing_dist, 0);
+            Shape outer_walls = support_layer_storage[layer_idx - 1].getOutsidePolygons().createTubeShape(closing_dist, 0);
 
             Shape holes_below;
 
@@ -2207,15 +2207,16 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
-                                                              support_layer_storage[layer_idx],
-                                                              config,
-                                                              false,
-                                                              layer_idx,
-                                                              config.support_line_distance,
-                                                              storage.support.cross_fill_provider,
-                                                              true)
-                                                              .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(
+                        TreeSupportUtils::generateSupportInfillLines(
+                            support_layer_storage[layer_idx],
+                            config,
+                            false,
+                            layer_idx,
+                            config.support_line_distance,
+                            storage.support.cross_fill_provider,
+                            true)
+                            .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }

--- a/src/geometry/LinesSet.cpp
+++ b/src/geometry/LinesSet.cpp
@@ -131,12 +131,6 @@ coord_t LinesSet<LineType>::length() const
 }
 
 template<class LineType>
-Shape LinesSet<LineType>::createTubeShape(const coord_t inner_offset, const coord_t outer_offset) const
-{
-    return offset(outer_offset).difference(offset(-inner_offset));
-}
-
-template<class LineType>
 void LinesSet<LineType>::translate(const Point2LL& delta)
 {
     if (delta.X != 0 || delta.Y != 0)
@@ -358,7 +352,6 @@ template void OpenLinesSet::removeAt(size_t index);
 template void OpenLinesSet::splitIntoSegments(OpenLinesSet& result) const;
 template OpenLinesSet OpenLinesSet::splitIntoSegments() const;
 template coord_t OpenLinesSet::length() const;
-template Shape OpenLinesSet::createTubeShape(const coord_t inner_offset, const coord_t outer_offset) const;
 template void OpenLinesSet::translate(const Point2LL& delta);
 template void OpenLinesSet::applyMatrix(const PointMatrix& matrix);
 template void OpenLinesSet::applyMatrix(const Point3Matrix& matrix);
@@ -374,7 +367,6 @@ template void ClosedLinesSet::removeAt(size_t index);
 template void ClosedLinesSet::splitIntoSegments(OpenLinesSet& result) const;
 template OpenLinesSet ClosedLinesSet::splitIntoSegments() const;
 template coord_t ClosedLinesSet::length() const;
-template Shape ClosedLinesSet::createTubeShape(const coord_t inner_offset, const coord_t outer_offset) const;
 template void ClosedLinesSet::translate(const Point2LL& delta);
 template void ClosedLinesSet::applyMatrix(const PointMatrix& matrix);
 template void ClosedLinesSet::applyMatrix(const Point3Matrix& matrix);
@@ -391,7 +383,6 @@ template void LinesSet<Polygon>::removeAt(size_t index);
 template void LinesSet<Polygon>::splitIntoSegments(OpenLinesSet& result) const;
 template OpenLinesSet LinesSet<Polygon>::splitIntoSegments() const;
 template coord_t LinesSet<Polygon>::length() const;
-template Shape LinesSet<Polygon>::createTubeShape(const coord_t inner_offset, const coord_t outer_offset) const;
 template void LinesSet<Polygon>::translate(const Point2LL& delta);
 template void LinesSet<Polygon>::applyMatrix(const PointMatrix& matrix);
 template void LinesSet<Polygon>::applyMatrix(const Point3Matrix& matrix);

--- a/src/geometry/Shape.cpp
+++ b/src/geometry/Shape.cpp
@@ -915,6 +915,11 @@ std::vector<float> Shape::intersectionsWithSegment(const Point2LL& start, const 
     return result;
 }
 
+Shape Shape::createTubeShape(const coord_t inner_offset, const coord_t outer_offset) const
+{
+    return offset(outer_offset).difference(offset(-inner_offset));
+}
+
 void Shape::ensureManifold()
 {
     std::vector<Point2LL> duplicate_locations;


### PR DESCRIPTION
This bug is a remnant of the geometry classes refactoring, hopefully the last one :smile: 
The `createTubeShape` method was implemented on `LinesSet`, however it could not work with open polylines. It turns out we (almost) always used it with `Shape`s, for which it works. So moving the method to `Shape` and changing the call from the tree support generation (which also saves a conversion step).

CURA-12829