### PR TITLE
CURA-13064 Expand the Retract Before Outer Wall setting

### DIFF
--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -500,6 +500,7 @@ private:
      * @param extruder_nr The extruder for which to print all features of the mesh which should be printed with this extruder
      * @param mesh_config The extruder for which to print all features of the mesh which should be printed with this extruder
      * @param part The part for which to create gcode
+     * @param infill_added Indicates whether infill was added just before
      * @return Whether this function added anything to the layer plan
      */
     bool endProcessInsets(
@@ -509,7 +510,8 @@ private:
         const SliceMeshStorage& mesh,
         const size_t extruder_nr,
         const MeshPathConfigs& mesh_config,
-        SliceLayerPart& part) const;
+        SliceLayerPart& part,
+        const bool infill_added) const;
 
     /*!
      * Generate the a spiralized wall for a given layer part.

--- a/include/ForceRetract.h
+++ b/include/ForceRetract.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 UltiMaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef FORCERETRACT_H
+#define FORCERETRACT_H
+
+namespace cura
+{
+
+/*!
+ * Whether to force a retracted or unretracted travel move
+ */
+enum class ForceRetract
+{
+    AUTOMATIC, // Let retraction be calculated automatically for the travel move
+    RETRACTED, // Force travel move to be retracted
+    NOT_RETRACTED, // Force travel move not to be retracted
+};
+
+} // namespace cura
+
+#endif

--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -49,7 +49,7 @@ public:
         const GCodePathConfig& inset_X_flooring_config,
         const GCodePathConfig& inset_0_bridge_config,
         const GCodePathConfig& inset_X_bridge_config,
-        const bool retract_before_outer_wall,
+        const RetractBeforeOuterWall retract_before_outer_wall,
         const coord_t wall_0_wipe_dist,
         const coord_t wall_x_wipe_dist,
         const size_t wall_0_extruder_nr,
@@ -112,7 +112,7 @@ private:
     const GCodePathConfig& inset_X_flooring_config_;
     const GCodePathConfig& inset_0_bridge_config_;
     const GCodePathConfig& inset_X_bridge_config_;
-    const bool retract_before_outer_wall_;
+    const RetractBeforeOuterWall retract_before_outer_wall_;
     const coord_t wall_0_wipe_dist_;
     const coord_t wall_x_wipe_dist_;
     const size_t wall_0_extruder_nr_;

--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -49,7 +49,6 @@ public:
         const GCodePathConfig& inset_X_flooring_config,
         const GCodePathConfig& inset_0_bridge_config,
         const GCodePathConfig& inset_X_bridge_config,
-        const RetractBeforeOuterWall retract_before_outer_wall,
         const coord_t wall_0_wipe_dist,
         const coord_t wall_x_wipe_dist,
         const size_t wall_0_extruder_nr,
@@ -72,9 +71,10 @@ public:
      *
      * The insets and the layer plan are passed to the constructor of this
      * class, so this optimize function needs no additional information.
+     * \param retract_before_outer_wall The retraction behavior to be applied when moving to outer walls
      * \return Whether anything was added to the layer plan.
      */
-    bool addToLayer();
+    bool addToLayer(const RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC);
 
     /*!
      * Get the order constraints of the insets when printing walls per region / hole.
@@ -112,7 +112,6 @@ private:
     const GCodePathConfig& inset_X_flooring_config_;
     const GCodePathConfig& inset_0_bridge_config_;
     const GCodePathConfig& inset_X_bridge_config_;
-    const RetractBeforeOuterWall retract_before_outer_wall_;
     const coord_t wall_0_wipe_dist_;
     const coord_t wall_x_wipe_dist_;
     const size_t wall_0_extruder_nr_;

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -31,6 +31,8 @@
 #include <optional>
 #include <vector>
 
+#include "ForceRetract.h"
+
 namespace cura
 {
 
@@ -400,9 +402,9 @@ public:
      * no combing and no retraction. This travel move needs to be fixed
      * afterwards.
      * \param p The point to travel to.
-     * \param force_retract Whether to force a retraction to occur.
+     * \param force_retract Whether to force a retraction to occur or not occur.
      */
-    GCodePath& addTravel(const Point2LL& p, const bool force_retract = false, const coord_t z_offset = 0);
+    GCodePath& addTravel(const Point2LL& p, const ForceRetract force_retract = ForceRetract::AUTOMATIC, const coord_t z_offset = 0);
 
     /*!
      * Add a travel path to a certain point and retract if needed.
@@ -472,7 +474,7 @@ public:
      * \param wall_0_wipe_dist The distance to travel along the polygon after it has been laid down, in order to wipe the start and end of the wall together
      * \param spiralize Whether to gradually increase the z height from the normal layer height to the height of the next layer over this polygon
      * \param flow_ratio The ratio with which to multiply the extrusion amount
-     * \param always_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
+     * \param force_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
      * \param scarf_seam Indicates whether we may use a scarf seam for the path
      * \param smooth_speed Indicates whether we may use a speed gradient for the path
      */
@@ -485,7 +487,7 @@ public:
         coord_t wall_0_wipe_dist = 0,
         bool spiralize = false,
         const Ratio& flow_ratio = 1.0_r,
-        bool always_retract = false,
+        const ForceRetract force_retract = ForceRetract::AUTOMATIC,
         bool scarf_seam = false,
         bool smooth_speed = false);
 
@@ -511,7 +513,7 @@ public:
      * normal layer height to the height of the next layer over each polygon
      * printed.
      * \param flow_ratio The ratio with which to multiply the extrusion amount.
-     * \param always_retract Whether to force a retraction when moving to the
+     * \param force_retract Whether to force a retraction when moving to the
      * start of the polygon (used for outer walls).
      * \param reverse_order Adds polygons in reverse order.
      * \param start_near_location Start optimising the path near this location.
@@ -528,7 +530,7 @@ public:
         coord_t wall_0_wipe_dist = 0,
         bool spiralize = false,
         const Ratio flow_ratio = 1.0_r,
-        bool always_retract = false,
+        const ForceRetract force_retract = ForceRetract::AUTOMATIC,
         bool reverse_order = false,
         const std::optional<Point2LL> start_near_location = std::optional<Point2LL>(),
         bool scarf_seam = false,
@@ -617,7 +619,7 @@ public:
      * \param wall_0_wipe_dist The distance to travel along the wall after it
      * has been laid down, in order to wipe the start and end of the wall
      * \param flow_ratio The ratio with which to multiply the extrusion amount.
-     * \param always_retract Whether to force a retraction when moving to the
+     * \param force_retract Whether to force a retraction when moving to the
      * start of the wall (used for outer walls).
      */
     void addWall(
@@ -630,7 +632,7 @@ public:
         const GCodePathConfig& bridge_config,
         coord_t wall_0_wipe_dist,
         double flow_ratio,
-        bool always_retract);
+        const ForceRetract force_retract);
 
     /*!
      * Add a wall to the g-code starting at vertex \p start_idx
@@ -648,7 +650,7 @@ public:
      * \param wall_0_wipe_dist The distance to travel along the wall after it
      * has been laid down, in order to wipe the start and end of the wall
      * \param flow_ratio The ratio with which to multiply the extrusion amount.
-     * \param always_retract Whether to force a retraction when moving to the
+     * \param force_retract Whether to force a retraction when moving to the
      * start of the wall (used for outer walls).
      * \param is_closed Whether this wall is a closed loop (a polygon) or not (a
      * polyline).
@@ -667,7 +669,7 @@ public:
         const GCodePathConfig& bridge_config,
         coord_t wall_0_wipe_dist,
         double flow_ratio,
-        bool always_retract,
+        const ForceRetract force_retract,
         const bool is_closed,
         const bool is_reversed,
         const bool is_linked_path,
@@ -680,7 +682,7 @@ public:
      * \param wall he wall as ExtrusionJunctions
      * \param path_config The config with which to print the wall lines
      */
-    void addInfillWall(const ExtrusionLine& wall, const GCodePathConfig& path_config, bool force_retract);
+    void addInfillWall(const ExtrusionLine& wall, const GCodePathConfig& path_config, const ForceRetract force_retract);
 
     /*!
      * Add walls (polygons) to the gcode with optimized order.
@@ -696,7 +698,7 @@ public:
      * \param z_seam_config Optional configuration for z-seam
      * \param wall_0_wipe_dist The distance to travel along each wall after it has been laid down, in order to wipe the start and end of the wall together
      * \param flow_ratio The ratio with which to multiply the extrusion amount
-     * \param always_retract Whether to force a retraction when moving to the start of a wall (used for outer walls)
+     * \param force_retract Whether to force a retraction when moving to the start of a wall (used for outer walls)
      * \param alternate_inset_direction_modifier Whether to alternate the direction of the walls for each inset.
      */
     void addWalls(
@@ -709,7 +711,7 @@ public:
         const ZSeamConfig& z_seam_config = ZSeamConfig(),
         coord_t wall_0_wipe_dist = 0,
         double flow_ratio = 1.0,
-        bool always_retract = false);
+        const ForceRetract force_retract = ForceRetract::AUTOMATIC);
 
     /*!
      * Add lines to the gcode with optimized order.
@@ -944,7 +946,7 @@ private:
      * normal layer height to the height of the next layer over each polygon
      * printed.
      * \param flow_ratio The ratio with which to multiply the extrusion amount.
-     * \param always_retract Whether to force a retraction when moving to the
+     * \param force_retract Whether to force a retraction when moving to the
      * start of the polygon (used for outer walls).
      * \param reverse_order Adds polygons in reverse order.
      * \param scarf_seam Indicates whether we may use a scarf seam for the path
@@ -958,7 +960,7 @@ private:
         coord_t wall_0_wipe_dist = 0,
         bool spiralize = false,
         const Ratio flow_ratio = 1.0_r,
-        bool always_retract = false,
+        const ForceRetract force_retract = ForceRetract::AUTOMATIC,
         bool reverse_order = false,
         bool scarf_seam = false,
         bool smooth_speed = false);
@@ -1044,7 +1046,7 @@ private:
      * \param flow_ratio The ratio with which to multiply the extrusion amount
      * \param nominal_line_width The nominal line width for the wall
      * \param min_bridge_line_len The minimum line width to allow an extrusion move to be processed as a bridge move
-     * \param always_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
+     * \param force_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
      * \param is_small_feature Indicates whether the wall is so small that it should be processed differently
      * \param small_feature_speed_factor The speed factor to be applied to small feature walls
      * \param max_area_deviation The maximum allowed area deviation to split a segment into pieces
@@ -1072,7 +1074,7 @@ private:
         const size_t max_index,
         const int direction,
         const GCodePathConfig& default_config,
-        const bool always_retract,
+        const ForceRetract force_retract,
         const bool is_small_feature,
         Ratio small_feature_speed_factor,
         const coord_t max_area_deviation,
@@ -1101,7 +1103,7 @@ private:
      * \param settings The settings which should apply to this wall added to the layer plan
      * \param default_config The config with which to print the wall lines that are not spanning a bridge or are exposed to air
      * \param flow_ratio The ratio with which to multiply the extrusion amount
-     * \param always_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
+     * \param force_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
      * \param is_closed Indicates whether the path is closed (or open)
      * \param is_reversed Indicates if the path is to be processed backwards
      * \param is_candidate_small_feature Indicates whether the path should be tested for being treated as a smell feature
@@ -1117,7 +1119,7 @@ private:
         const Settings& settings,
         const GCodePathConfig& default_config,
         const double flow_ratio,
-        bool always_retract,
+        const ForceRetract force_retract,
         const bool is_closed,
         const bool is_reversed,
         const bool is_candidate_small_feature,

--- a/include/settings/EnumSettings.h
+++ b/include/settings/EnumSettings.h
@@ -300,6 +300,17 @@ enum class InfillStartEndPreference
 };
 
 /*!
+ * Whether to force a retracted or unretracted travel move when going to an outer wall
+ */
+enum class RetractBeforeOuterWall
+{
+    AUTOMATIC, // Let retraction be calculated automatically for the travel move
+    RETRACTED, // Force travel move to be retracted
+    NOT_RETRACTED, // Force travel move not to be retracted
+    NOT_RETRACTED_FIRST, // Force the first travel move not to be retracted, others will be use automatic
+};
+
+/*!
  * Convenience binary operator to allow testing brim location easily, like (actual_location & BrimLocation::OUTSIDE)
  */
 [[maybe_unused]] static int operator&(BrimLocation location1, BrimLocation location2)

--- a/include/settings/EnumSettings.h
+++ b/include/settings/EnumSettings.h
@@ -307,7 +307,7 @@ enum class RetractBeforeOuterWall
     AUTOMATIC, // Let retraction be calculated automatically for the travel move
     RETRACTED, // Force travel move to be retracted
     NOT_RETRACTED, // Force travel move not to be retracted
-    NOT_RETRACTED_FIRST, // Force the first travel move not to be retracted, others will be use automatic
+    NOT_RETRACTED_FROM_INFILL, // Force the first travel move coming from an infill area not to be retracted, others will be use automatic
 };
 
 /*!

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -609,7 +609,6 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
     constexpr int infill_multiplier = 1; // rafts use single lines
     constexpr int extra_infill_shift = 0;
     constexpr bool fill_gaps = true;
-    constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
     constexpr coord_t wipe_dist = 0;
 
     Shape raft_polygons;
@@ -734,7 +733,6 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                     config,
                     config,
                     config,
-                    retract_before_outer_wall,
                     wipe_dist,
                     wipe_dist,
                     base_extruder_nr,
@@ -896,7 +894,6 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                 config,
                 config,
                 config,
-                retract_before_outer_wall,
                 wipe_dist,
                 wipe_dist,
                 interface_extruder_nr,
@@ -1070,7 +1067,6 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                     config,
                     config,
                     config,
-                    retract_before_outer_wall,
                     wipe_dist,
                     wipe_dist,
                     surface_extruder_nr,
@@ -1879,6 +1875,7 @@ void FffGcodeWriter::addMeshPartToGCode(
 
     // Pre-process the insets without actually adding them, so that we know where they are going to start printing
     InsetsPreprocessResult insets_preprocess_result = preProcessInsets(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, end_infill_close_to_seam);
+    bool infill_added = false;
 
     if (infill_before_walls)
     {
@@ -1888,10 +1885,11 @@ void FffGcodeWriter::addMeshPartToGCode(
             near_end_location = insets_preprocess_result.walls_optimizer->getStartPosition();
         }
 
-        added_something = added_something | processInfill(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, near_end_location);
+        infill_added = processInfill(storage, gcode_layer, mesh, extruder_nr, mesh_config, part, near_end_location);
+        added_something = added_something | infill_added;
     }
 
-    added_something |= endProcessInsets(insets_preprocess_result, storage, gcode_layer, mesh, extruder_nr, mesh_config, part);
+    added_something |= endProcessInsets(insets_preprocess_result, storage, gcode_layer, mesh, extruder_nr, mesh_config, part, infill_added);
 
     if (! infill_before_walls)
     {
@@ -2882,7 +2880,6 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
             mesh_config.insetX_flooring_config,
             mesh_config.bridge_inset0_config,
             mesh_config.bridge_insetX_config,
-            mesh.settings.get<RetractBeforeOuterWall>("travel_retract_before_outer_wall"),
             mesh.settings.get<coord_t>("wall_0_wipe_dist"),
             wall_x_wipe_dist,
             mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr_,
@@ -2912,7 +2909,8 @@ bool FffGcodeWriter::endProcessInsets(
     const SliceMeshStorage& mesh,
     const size_t extruder_nr,
     const MeshPathConfigs& mesh_config,
-    SliceLayerPart& part) const
+    SliceLayerPart& part,
+    const bool infill_added) const
 {
     if (preprocess_result.spiralize)
     {
@@ -2957,7 +2955,13 @@ bool FffGcodeWriter::endProcessInsets(
     }
     else if (preprocess_result.walls_optimizer != nullptr)
     {
-        return preprocess_result.walls_optimizer->addToLayer();
+        auto travel_retract_before_outer_wall = mesh.settings.get<RetractBeforeOuterWall>("travel_retract_before_outer_wall");
+        if (travel_retract_before_outer_wall == RetractBeforeOuterWall::NOT_RETRACTED_FROM_INFILL && ! infill_added)
+        {
+            travel_retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
+        }
+
+        return preprocess_result.walls_optimizer->addToLayer(travel_retract_before_outer_wall);
     }
 
     return false;
@@ -3398,7 +3402,6 @@ void FffGcodeWriter::processSkinPrintFeature(
         if (! skin_paths.empty())
         {
             // Add skin-walls a.k.a. skin-perimeters, skin-insets.
-            constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
             constexpr coord_t wipe_dist = 0;
             const ZSeamConfig z_seam_config(
                 mesh.settings.get<EZSeamType>("z_seam_type"),
@@ -3418,7 +3421,6 @@ void FffGcodeWriter::processSkinPrintFeature(
                 config,
                 config,
                 config,
-                retract_before_outer_wall,
                 wipe_dist,
                 wipe_dist,
                 extruder_nr,
@@ -3686,7 +3688,6 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
         if (! wall_toolpaths.empty())
         {
             const GCodePathConfig& config = configs[0];
-            constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
             constexpr coord_t wipe_dist = 0;
             const LayerIndex layer_nr = gcode_layer.getLayerNr();
             ZSeamConfig z_seam_config
@@ -3722,7 +3723,6 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                 config,
                 config,
                 config,
-                retract_before_outer_wall,
                 wipe_dist,
                 wipe_dist,
                 extruder_nr,
@@ -3894,7 +3894,6 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
             if (wall_line_count == 0 || ! wall_toolpaths_here.empty())
             {
                 const GCodePathConfig& config = configs[0];
-                constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
                 constexpr coord_t wipe_dist = 0;
                 constexpr coord_t simplify_curvature = 0;
                 const ZSeamConfig z_seam_config(
@@ -3915,7 +3914,6 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                     config,
                     config,
                     config,
-                    retract_before_outer_wall,
                     wipe_dist,
                     wipe_dist,
                     extruder_nr,
@@ -4034,7 +4032,6 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, con
     if (! roof_paths.empty())
     {
         const GCodePathConfig& config = current_roof_config;
-        constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
         constexpr coord_t wipe_dist = 0;
         const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, gcode_layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_INNER, false);
 
@@ -4051,7 +4048,6 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, con
             config,
             config,
             config,
-            retract_before_outer_wall,
             wipe_dist,
             wipe_dist,
             roof_extruder_nr,
@@ -4148,7 +4144,6 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
     if (! bottom_paths.empty())
     {
         const GCodePathConfig& config = gcode_layer.configs_storage_.support_bottom_config;
-        constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
         constexpr coord_t wipe_dist = 0;
         const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, gcode_layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_INNER, false);
 
@@ -4165,7 +4160,6 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
             config,
             config,
             config,
-            retract_before_outer_wall,
             wipe_dist,
             wipe_dist,
             bottom_extruder_nr,

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -609,7 +609,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
     constexpr int infill_multiplier = 1; // rafts use single lines
     constexpr int extra_infill_shift = 0;
     constexpr bool fill_gaps = true;
-    constexpr bool retract_before_outer_wall = false;
+    constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
     constexpr coord_t wipe_dist = 0;
 
     Shape raft_polygons;
@@ -749,7 +749,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             const auto spiralize = false;
             const auto flow_ratio = 1.0_r;
             const auto enable_travel_optimization = false;
-            const auto always_retract = false;
+            const auto always_retract = ForceRetract::AUTOMATIC;
             const auto reverse_order = false;
 
             gcode_layer.addLinesByOptimizer(
@@ -911,7 +911,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
         const auto spiralize = false;
         const auto flow_ratio = 1.0_r;
         const auto enable_travel_optimization = false;
-        const auto always_retract = false;
+        const auto always_retract = ForceRetract::AUTOMATIC;
         const auto reverse_order = false;
 
         gcode_layer.addLinesByOptimizer(
@@ -1085,7 +1085,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             const auto spiralize = false;
             const auto flow_ratio = 1.0_r;
             const auto enable_travel_optimization = false;
-            const auto always_retract = false;
+            const auto always_retract = ForceRetract::AUTOMATIC;
             const auto reverse_order = false;
 
             if (monotonic)
@@ -1766,7 +1766,7 @@ void FffGcodeWriter::addMeshLayerToGCode_meshSurfaceMode(const SliceMeshStorage&
         mesh.settings.get<coord_t>("wall_line_width_0") * 2);
     const bool spiralize = Application::getInstance().current_slice_->scene.current_mesh_group->settings.get<bool>("magic_spiralize");
     constexpr Ratio flow_ratio = 1.0;
-    constexpr bool always_retract = false;
+    constexpr auto always_retract = ForceRetract::AUTOMATIC;
     constexpr bool reverse_order = false;
     const std::optional<Point2LL> start_near_location = std::nullopt;
     constexpr bool scarf_seam = true;
@@ -2882,7 +2882,7 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
             mesh_config.insetX_flooring_config,
             mesh_config.bridge_inset0_config,
             mesh_config.bridge_insetX_config,
-            mesh.settings.get<bool>("travel_retract_before_outer_wall"),
+            mesh.settings.get<RetractBeforeOuterWall>("travel_retract_before_outer_wall"),
             mesh.settings.get<coord_t>("wall_0_wipe_dist"),
             wall_x_wipe_dist,
             mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr_,
@@ -3398,7 +3398,7 @@ void FffGcodeWriter::processSkinPrintFeature(
         if (! skin_paths.empty())
         {
             // Add skin-walls a.k.a. skin-perimeters, skin-insets.
-            constexpr bool retract_before_outer_wall = false;
+            constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
             constexpr coord_t wipe_dist = 0;
             const ZSeamConfig z_seam_config(
                 mesh.settings.get<EZSeamType>("z_seam_type"),
@@ -3430,8 +3430,7 @@ void FffGcodeWriter::processSkinPrintFeature(
         }
         if (! skin_polygons.empty())
         {
-            constexpr bool force_comb_retract = false;
-            gcode_layer.addTravel(skin_polygons[0][0], force_comb_retract);
+            gcode_layer.addTravel(skin_polygons[0][0]);
             gcode_layer.addPolygonsByOptimizer(skin_polygons, config, mesh.settings);
         }
 
@@ -3687,7 +3686,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
         if (! wall_toolpaths.empty())
         {
             const GCodePathConfig& config = configs[0];
-            constexpr bool retract_before_outer_wall = false;
+            constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
             constexpr coord_t wipe_dist = 0;
             const LayerIndex layer_nr = gcode_layer.getLayerNr();
             ZSeamConfig z_seam_config
@@ -3845,14 +3844,13 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
 
             if (! support_polygons.empty())
             {
-                constexpr bool force_comb_retract = false;
-                gcode_layer.addTravel(support_polygons[0][0], force_comb_retract);
+                gcode_layer.addTravel(support_polygons[0][0]);
 
                 const ZSeamConfig& z_seam_config = ZSeamConfig();
                 constexpr coord_t wall_0_wipe_dist = 0;
                 constexpr bool spiralize = false;
                 constexpr Ratio flow_ratio = 1.0_r;
-                constexpr bool always_retract = false;
+                constexpr auto always_retract = ForceRetract::AUTOMATIC;
                 const std::optional<Point2LL> start_near_location = std::optional<Point2LL>();
 
                 gcode_layer.addPolygonsByOptimizer(
@@ -3896,7 +3894,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
             if (wall_line_count == 0 || ! wall_toolpaths_here.empty())
             {
                 const GCodePathConfig& config = configs[0];
-                constexpr bool retract_before_outer_wall = false;
+                constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
                 constexpr coord_t wipe_dist = 0;
                 constexpr coord_t simplify_curvature = 0;
                 const ZSeamConfig z_seam_config(
@@ -4030,14 +4028,13 @@ bool FffGcodeWriter::addSupportRoofsToGCode(const SliceDataStorage& storage, con
     }
     if (! roof_polygons.empty())
     {
-        constexpr bool force_comb_retract = false;
-        gcode_layer.addTravel(roof_polygons[0][0], force_comb_retract);
+        gcode_layer.addTravel(roof_polygons[0][0]);
         gcode_layer.addPolygonsByOptimizer(roof_polygons, current_roof_config, roof_extruder.settings_);
     }
     if (! roof_paths.empty())
     {
         const GCodePathConfig& config = current_roof_config;
-        constexpr bool retract_before_outer_wall = false;
+        constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
         constexpr coord_t wipe_dist = 0;
         const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, gcode_layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_INNER, false);
 
@@ -4145,14 +4142,13 @@ bool FffGcodeWriter::addSupportBottomsToGCode(const SliceDataStorage& storage, L
     gcode_layer.setIsInside(false); // going to print stuff outside print object, i.e. support
     if (! bottom_polygons.empty())
     {
-        constexpr bool force_comb_retract = false;
-        gcode_layer.addTravel(bottom_polygons[0][0], force_comb_retract);
+        gcode_layer.addTravel(bottom_polygons[0][0]);
         gcode_layer.addPolygonsByOptimizer(bottom_polygons, gcode_layer.configs_storage_.support_bottom_config, bottom_extruder.settings_);
     }
     if (! bottom_paths.empty())
     {
         const GCodePathConfig& config = gcode_layer.configs_storage_.support_bottom_config;
-        constexpr bool retract_before_outer_wall = false;
+        constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
         constexpr coord_t wipe_dist = 0;
         const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, gcode_layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_INNER, false);
 

--- a/src/InfillOrderOptimizer.cpp
+++ b/src/InfillOrderOptimizer.cpp
@@ -341,7 +341,7 @@ void InfillOrderOptimizer::addToLayer(
         {
             for (const std::vector<VariableWidthLines>& tool_paths : *part.paths.extrusion_lines)
             {
-                constexpr bool retract_before_outer_wall = false;
+                constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
                 constexpr coord_t wipe_dist = 0;
                 const ZSeamConfig z_seam_config(EZSeamType::USER_SPECIFIED, near_start_location.value_or(mesh.getZSeamHint()));
                 InsetOrderOptimizer wall_orderer(

--- a/src/InfillOrderOptimizer.cpp
+++ b/src/InfillOrderOptimizer.cpp
@@ -341,7 +341,6 @@ void InfillOrderOptimizer::addToLayer(
         {
             for (const std::vector<VariableWidthLines>& tool_paths : *part.paths.extrusion_lines)
             {
-                constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
                 constexpr coord_t wipe_dist = 0;
                 const ZSeamConfig z_seam_config(EZSeamType::USER_SPECIFIED, near_start_location.value_or(mesh.getZSeamHint()));
                 InsetOrderOptimizer wall_orderer(
@@ -357,7 +356,6 @@ void InfillOrderOptimizer::addToLayer(
                     mesh_config.infill_config[0],
                     mesh_config.infill_config[0],
                     mesh_config.infill_config[0],
-                    retract_before_outer_wall,
                     wipe_dist,
                     wipe_dist,
                     extruder_nr,

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -22,6 +22,7 @@
 
 #include "ExtruderTrain.h"
 #include "FffGcodeWriter.h"
+#include "ForceRetract.h"
 #include "LayerPlan.h"
 #include "utils/views/convert.h"
 #include "utils/views/dfs.h"
@@ -45,7 +46,7 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     const GCodePathConfig& inset_X_flooring_config,
     const GCodePathConfig& inset_0_bridge_config,
     const GCodePathConfig& inset_X_bridge_config,
-    const bool retract_before_outer_wall,
+    const RetractBeforeOuterWall retract_before_outer_wall,
     const coord_t wall_0_wipe_dist,
     const coord_t wall_x_wipe_dist,
     const size_t wall_0_extruder_nr,
@@ -160,6 +161,21 @@ bool InsetOrderOptimizer::addToLayer()
     constexpr Ratio flow = 1.0_r;
     bool added_something = false;
 
+    ForceRetract force_retract = ForceRetract::AUTOMATIC;
+    switch (retract_before_outer_wall_)
+    {
+    case RetractBeforeOuterWall::AUTOMATIC:
+        force_retract = ForceRetract::AUTOMATIC;
+        break;
+    case RetractBeforeOuterWall::RETRACTED:
+        force_retract = ForceRetract::RETRACTED;
+        break;
+    case RetractBeforeOuterWall::NOT_RETRACTED:
+    case RetractBeforeOuterWall::NOT_RETRACTED_FIRST:
+        force_retract = ForceRetract::NOT_RETRACTED;
+        break;
+    }
+
     for (const PathOrdering<const ExtrusionLine*>& path : path_optimizer_->paths_)
     {
         if (path.vertices_->empty())
@@ -174,7 +190,7 @@ bool InsetOrderOptimizer::addToLayer()
         const GCodePathConfig& flooring_config = is_outer_wall ? inset_0_flooring_config_ : inset_X_flooring_config_;
         const GCodePathConfig& bridge_config = is_outer_wall ? inset_0_bridge_config_ : inset_X_bridge_config_;
         const coord_t wipe_dist = is_outer_wall && ! is_gap_filler ? wall_0_wipe_dist_ : wall_x_wipe_dist_;
-        const bool retract_before = is_outer_wall ? retract_before_outer_wall_ : false;
+        const ForceRetract retract_before = is_outer_wall ? force_retract : ForceRetract::AUTOMATIC;
         const bool scarf_seam = scarf_seam_ && is_outer_wall;
         const bool smooth_speed = smooth_speed_ && is_outer_wall;
 
@@ -202,6 +218,12 @@ bool InsetOrderOptimizer::addToLayer()
             scarf_seam,
             smooth_speed);
         added_something = true;
+
+        if (retract_before_outer_wall_ == RetractBeforeOuterWall::NOT_RETRACTED_FIRST)
+        {
+            // Only the first should be forced, the next ones use auto
+            force_retract = ForceRetract::AUTOMATIC;
+        }
     }
 
     return added_something;

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -46,7 +46,6 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     const GCodePathConfig& inset_X_flooring_config,
     const GCodePathConfig& inset_0_bridge_config,
     const GCodePathConfig& inset_X_bridge_config,
-    const RetractBeforeOuterWall retract_before_outer_wall,
     const coord_t wall_0_wipe_dist,
     const coord_t wall_x_wipe_dist,
     const size_t wall_0_extruder_nr,
@@ -72,7 +71,6 @@ InsetOrderOptimizer::InsetOrderOptimizer(
     , inset_X_flooring_config_(inset_X_flooring_config)
     , inset_0_bridge_config_(inset_0_bridge_config)
     , inset_X_bridge_config_(inset_X_bridge_config)
-    , retract_before_outer_wall_(retract_before_outer_wall)
     , wall_0_wipe_dist_(wall_0_wipe_dist)
     , wall_x_wipe_dist_(wall_x_wipe_dist)
     , wall_0_extruder_nr_(wall_0_extruder_nr)
@@ -150,7 +148,7 @@ void InsetOrderOptimizer::optimize()
     path_optimizer_->optimize();
 }
 
-bool InsetOrderOptimizer::addToLayer()
+bool InsetOrderOptimizer::addToLayer(const RetractBeforeOuterWall retract_before_outer_wall)
 {
     if (path_optimizer_ == nullptr)
     {
@@ -162,7 +160,7 @@ bool InsetOrderOptimizer::addToLayer()
     bool added_something = false;
 
     ForceRetract force_retract = ForceRetract::AUTOMATIC;
-    switch (retract_before_outer_wall_)
+    switch (retract_before_outer_wall)
     {
     case RetractBeforeOuterWall::AUTOMATIC:
         force_retract = ForceRetract::AUTOMATIC;
@@ -171,7 +169,7 @@ bool InsetOrderOptimizer::addToLayer()
         force_retract = ForceRetract::RETRACTED;
         break;
     case RetractBeforeOuterWall::NOT_RETRACTED:
-    case RetractBeforeOuterWall::NOT_RETRACTED_FIRST:
+    case RetractBeforeOuterWall::NOT_RETRACTED_FROM_INFILL:
         force_retract = ForceRetract::NOT_RETRACTED;
         break;
     }
@@ -219,7 +217,7 @@ bool InsetOrderOptimizer::addToLayer()
             smooth_speed);
         added_something = true;
 
-        if (retract_before_outer_wall_ == RetractBeforeOuterWall::NOT_RETRACTED_FIRST)
+        if (retract_before_outer_wall == RetractBeforeOuterWall::NOT_RETRACTED_FROM_INFILL)
         {
             // Only the first should be forced, the next ones use auto
             force_retract = ForceRetract::AUTOMATIC;

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -361,7 +361,7 @@ std::optional<std::pair<Point2LL, bool>> LayerPlan::getFirstTravelDestinationSta
     return ret;
 }
 
-GCodePath& LayerPlan::addTravel(const Point2LL& p, const bool force_retract, const coord_t z_offset)
+GCodePath& LayerPlan::addTravel(const Point2LL& p, const ForceRetract force_retract, const coord_t z_offset)
 {
     const GCodePathConfig& travel_config = configs_storage_.travel_config_per_extruder[getExtruder()];
 
@@ -394,7 +394,9 @@ GCodePath& LayerPlan::addTravel(const Point2LL& p, const bool force_retract, con
         }
         forceNewPathStart(); // force a new travel path after this first bogus move
     }
-    else if (force_retract && last_planned_position_ && ! shorterThen(last_planned_position_.value().toPoint2LL() - p, retraction_config.retraction_min_travel_distance))
+    else if (
+        force_retract == ForceRetract::RETRACTED && last_planned_position_
+        && ! shorterThen(last_planned_position_.value().toPoint2LL() - p, retraction_config.retraction_min_travel_distance))
     {
         // path is not shorter than min travel distance, force a retraction
         path->retract = true;
@@ -479,6 +481,11 @@ GCodePath& LayerPlan::addTravel(const Point2LL& p, const bool force_retract, con
             // path while it is unretracting, avoiding possible blips.
             path->unretract_before_last_travel_move = path->retract && unretract_before_last_travel_move;
         }
+    }
+
+    if (force_retract == ForceRetract::NOT_RETRACTED)
+    {
+        path->retract = false;
     }
 
     // CURA-6675:
@@ -829,7 +836,7 @@ void LayerPlan::addPolygon(
     coord_t wall_0_wipe_dist,
     bool spiralize,
     const Ratio& flow_ratio,
-    bool always_retract,
+    const ForceRetract force_retract,
     bool scarf_seam,
     bool smooth_speed)
 {
@@ -838,7 +845,7 @@ void LayerPlan::addPolygon(
     const PathAdapter path_adapter(polygon, config.getLineWidth());
 
     Point2LL p0 = polygon[start_idx];
-    addTravel(p0, always_retract, config.z_offset);
+    addTravel(p0, force_retract, config.z_offset);
 
     const std::tuple<size_t, Point2LL> add_wall_result = addWallWithScarfSeam<Polygon>(
         path_adapter,
@@ -846,7 +853,7 @@ void LayerPlan::addPolygon(
         settings,
         config,
         flow_ratio,
-        always_retract,
+        force_retract,
         is_closed,
         backwards,
         is_candidate_small_feature,
@@ -889,7 +896,7 @@ void LayerPlan::addPolygonsByOptimizer(
     coord_t wall_0_wipe_dist,
     bool spiralize,
     const Ratio flow_ratio,
-    bool always_retract,
+    const ForceRetract force_retract,
     bool reverse_order,
     const std::optional<Point2LL> start_near_location,
     bool scarf_seam,
@@ -935,7 +942,7 @@ void LayerPlan::addPolygonsByOptimizer(
         wall_0_wipe_dist,
         spiralize,
         flow_ratio,
-        always_retract,
+        force_retract,
         reverse_order,
         scarf_seam,
         smooth_speed);
@@ -963,8 +970,7 @@ void LayerPlan::addInfillPolygonsByOptimizer(
 
     if (! add_extra_inwards_move)
     {
-        constexpr bool force_comb_retract = false;
-        addTravel(orderOptimizer.paths_[0].vertices_->at(orderOptimizer.paths_[0].start_vertex_), force_comb_retract);
+        addTravel(orderOptimizer.paths_[0].vertices_->at(orderOptimizer.paths_[0].start_vertex_));
         addPolygonsInGivenOrder(orderOptimizer.paths_, config, settings);
         return;
     }
@@ -1263,7 +1269,7 @@ void LayerPlan::addWall(
     const GCodePathConfig& bridge_config,
     coord_t wall_0_wipe_dist,
     double flow_ratio,
-    bool always_retract)
+    const ForceRetract force_retract)
 {
     // TODO: Deprecated in favor of ExtrusionJunction version below.
     if (wall.size() < 3)
@@ -1298,7 +1304,7 @@ void LayerPlan::addWall(
         bridge_config,
         wall_0_wipe_dist,
         flow_ratio,
-        always_retract,
+        force_retract,
         is_closed,
         is_reversed,
         is_linked_path);
@@ -1312,7 +1318,7 @@ std::tuple<size_t, Point2LL> LayerPlan::addSplitWall(
     const size_t max_index,
     const int direction,
     const GCodePathConfig& default_config,
-    const bool always_retract,
+    const ForceRetract force_retract,
     const bool is_small_feature,
     Ratio small_feature_speed_factor,
     const coord_t max_area_deviation,
@@ -1385,7 +1391,7 @@ std::tuple<size_t, Point2LL> LayerPlan::addSplitWall(
 
         if (first_line)
         {
-            addTravel(p0, always_retract);
+            addTravel(p0, force_retract);
             first_line = false;
         }
 
@@ -1491,7 +1497,7 @@ std::tuple<size_t, Point2LL> LayerPlan::addSplitWall(
                         if (first_split)
                         {
                             // Manually add a Z-only travel move to set the nozzle at the height of the first point
-                            addTravel(p0, always_retract, split_origin.z_);
+                            addTravel(p0, force_retract, split_origin.z_);
                             first_split = false;
                         }
                     }
@@ -1776,7 +1782,7 @@ std::tuple<size_t, Point2LL> LayerPlan::addWallWithScarfSeam(
     const Settings& settings,
     const GCodePathConfig& default_config,
     const double flow_ratio,
-    bool always_retract,
+    const ForceRetract force_retract,
     const bool is_closed,
     const bool is_reversed,
     const bool is_candidate_small_feature,
@@ -1834,7 +1840,7 @@ std::tuple<size_t, Point2LL> LayerPlan::addWallWithScarfSeam(
             max_index,
             direction,
             default_config,
-            always_retract,
+            force_retract,
             is_small_feature,
             small_feature_speed_factor,
             max_area_deviation,
@@ -1878,7 +1884,7 @@ void LayerPlan::addWall(
     const GCodePathConfig& bridge_config,
     coord_t wall_0_wipe_dist,
     const double flow_ratio,
-    bool always_retract,
+    const ForceRetract force_retract,
     const bool is_closed,
     const bool is_reversed,
     const bool is_linked_path,
@@ -1900,7 +1906,7 @@ void LayerPlan::addWall(
         settings,
         default_config,
         flow_ratio,
-        always_retract,
+        force_retract,
         is_closed,
         is_reversed,
         wall.inset_idx_ == 0,
@@ -1952,7 +1958,7 @@ void LayerPlan::addWall(
     }
 }
 
-void LayerPlan::addInfillWall(const ExtrusionLine& wall, const GCodePathConfig& path_config, bool force_retract)
+void LayerPlan::addInfillWall(const ExtrusionLine& wall, const GCodePathConfig& path_config, const ForceRetract force_retract)
 {
     assert(! wall.empty() && "All empty walls should have been filtered at this stage");
     ExtrusionJunction junction{ *wall.begin() };
@@ -1978,7 +1984,7 @@ void LayerPlan::addWalls(
     const ZSeamConfig& z_seam_config,
     coord_t wall_0_wipe_dist,
     double flow_ratio,
-    bool always_retract)
+    const ForceRetract force_retract)
 {
     // TODO: Deprecated in favor of ExtrusionJunction version below.
     PathOrderOptimizer<const Polygon*> orderOptimizer(getLastPlannedPositionOrStartingPosition(), z_seam_config);
@@ -1989,7 +1995,7 @@ void LayerPlan::addWalls(
     orderOptimizer.optimize();
     for (const PathOrdering<const Polygon*>& path : orderOptimizer.paths_)
     {
-        addWall(*path.vertices_, path.start_vertex_, settings, default_config, roofing_config, flooring_config, bridge_config, wall_0_wipe_dist, flow_ratio, always_retract);
+        addWall(*path.vertices_, path.start_vertex_, settings, default_config, roofing_config, flooring_config, bridge_config, wall_0_wipe_dist, flow_ratio, force_retract);
     }
 }
 
@@ -2409,7 +2415,7 @@ void LayerPlan::addLinesInGivenOrder(
         }
         else
         {
-            addTravel(start, false, config.z_offset);
+            addTravel(start, ForceRetract::AUTOMATIC, config.z_offset);
         }
 
         Point2LL p0 = start;
@@ -2490,13 +2496,13 @@ void LayerPlan::addPolygonsInGivenOrder(
     coord_t wall_0_wipe_dist,
     bool spiralize,
     const Ratio flow_ratio,
-    bool always_retract,
+    const ForceRetract force_retract,
     bool reverse_order,
     bool scarf_seam,
     bool smooth_speed)
 {
     const auto add_polygons
-        = [this, &config, &settings, &wall_0_wipe_dist, &spiralize, &flow_ratio, &always_retract, &scarf_seam, &smooth_speed](const auto& iterator_begin, const auto& iterator_end)
+        = [this, &config, &settings, &wall_0_wipe_dist, &spiralize, &flow_ratio, &force_retract, &scarf_seam, &smooth_speed](const auto& iterator_begin, const auto& iterator_end)
     {
         for (auto iterator = iterator_begin; iterator != iterator_end; ++iterator)
         {
@@ -2509,7 +2515,7 @@ void LayerPlan::addPolygonsInGivenOrder(
                 wall_0_wipe_dist,
                 spiralize,
                 flow_ratio,
-                always_retract,
+                force_retract,
                 scarf_seam,
                 smooth_speed);
         }

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -199,22 +199,20 @@ void LayerPlanBuffer::insertPreheatCommand(ExtruderPlan& extruder_plan_before, c
         if (acc_time >= time_before_extruder_plan_end)
         {
             constexpr bool wait = false;
-            extruder_plan_before.insertCommand(
-                NozzleTempInsert{ .path_idx = path_idx,
-                                  .extruder = extruder_nr,
-                                  .temperature = temp,
-                                  .wait = wait,
-                                  .time_after_path_start = acc_time - time_before_extruder_plan_end });
+            extruder_plan_before.insertCommand(NozzleTempInsert{ .path_idx = path_idx,
+                                                                 .extruder = extruder_nr,
+                                                                 .temperature = temp,
+                                                                 .wait = wait,
+                                                                 .time_after_path_start = acc_time - time_before_extruder_plan_end });
             return;
         }
     }
     constexpr bool wait = false;
     constexpr size_t path_idx = 0;
-    extruder_plan_before.insertCommand(
-        NozzleTempInsert{ .path_idx = path_idx,
-                          .extruder = extruder_nr,
-                          .temperature = temp,
-                          .wait = wait }); // insert at start of extruder plan if time_after_extruder_plan_start > extruder_plan.time
+    extruder_plan_before.insertCommand(NozzleTempInsert{ .path_idx = path_idx,
+                                                         .extruder = extruder_nr,
+                                                         .temperature = temp,
+                                                         .wait = wait }); // insert at start of extruder plan if time_after_extruder_plan_start > extruder_plan.time
 }
 
 Preheat::WarmUpResult LayerPlanBuffer::computeStandbyTempPlan(std::vector<ExtruderPlan*>& extruder_plans, unsigned int extruder_plan_idx)

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -140,7 +140,7 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
         const Settings& extruder_settings = Application::getInstance().current_slice_->scene.extruders[prev_layer->extruder_plans_.back().extruder_nr_].settings_;
         prev_layer->setIsInside(new_layer_destination_state->second);
 
-        const bool travel_retract_before_outer_wall = mesh_group_settings.get<bool>("travel_retract_before_outer_wall");
+        const bool travel_retract_before_outer_wall = mesh_group_settings.get<RetractBeforeOuterWall>("travel_retract_before_outer_wall") == RetractBeforeOuterWall::RETRACTED;
         const bool retract_at_layer_change = extruder_settings.get<bool>("retract_at_layer_change");
         bool next_mesh_retract_before_outer_wall = false;
         std::shared_ptr<const SliceMeshStorage> first_printed_mesh = newest_layer->findFirstPrintedMesh();
@@ -153,10 +153,10 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
 
             next_mesh_retract_before_outer_wall = inset_direction == InsetDirection::OUTSIDE_IN || wall_line_count == 1;
         }
-        const bool force_retract = retract_at_layer_change || next_mesh_retract_before_outer_wall;
+        const ForceRetract force_retract = retract_at_layer_change || next_mesh_retract_before_outer_wall ? ForceRetract::RETRACTED : ForceRetract::AUTOMATIC;
         prev_layer->final_travel_z_ = newest_layer->z_;
         GCodePath& path = prev_layer->addTravel(first_location_new_layer, force_retract);
-        if (force_retract && ! path.retract)
+        if (force_retract == ForceRetract::RETRACTED && ! path.retract)
         {
             // addTravel() won't use retraction if the travel distance is less than retraction minimum travel setting
             // so to avoid blobs when moving to the new layer height, which can occur if the z-axis speed is very slow,
@@ -199,20 +199,22 @@ void LayerPlanBuffer::insertPreheatCommand(ExtruderPlan& extruder_plan_before, c
         if (acc_time >= time_before_extruder_plan_end)
         {
             constexpr bool wait = false;
-            extruder_plan_before.insertCommand(NozzleTempInsert{ .path_idx = path_idx,
-                                                                 .extruder = extruder_nr,
-                                                                 .temperature = temp,
-                                                                 .wait = wait,
-                                                                 .time_after_path_start = acc_time - time_before_extruder_plan_end });
+            extruder_plan_before.insertCommand(
+                NozzleTempInsert{ .path_idx = path_idx,
+                                  .extruder = extruder_nr,
+                                  .temperature = temp,
+                                  .wait = wait,
+                                  .time_after_path_start = acc_time - time_before_extruder_plan_end });
             return;
         }
     }
     constexpr bool wait = false;
     constexpr size_t path_idx = 0;
-    extruder_plan_before.insertCommand(NozzleTempInsert{ .path_idx = path_idx,
-                                                         .extruder = extruder_nr,
-                                                         .temperature = temp,
-                                                         .wait = wait }); // insert at start of extruder plan if time_after_extruder_plan_start > extruder_plan.time
+    extruder_plan_before.insertCommand(
+        NozzleTempInsert{ .path_idx = path_idx,
+                          .extruder = extruder_nr,
+                          .temperature = temp,
+                          .wait = wait }); // insert at start of extruder plan if time_after_extruder_plan_start > extruder_plan.time
 }
 
 Preheat::WarmUpResult LayerPlanBuffer::computeStandbyTempPlan(std::vector<ExtruderPlan*>& extruder_plans, unsigned int extruder_plan_idx)

--- a/src/LayerPlanBuffer.cpp
+++ b/src/LayerPlanBuffer.cpp
@@ -153,7 +153,7 @@ void LayerPlanBuffer::addConnectingTravelMove(LayerPlan* prev_layer, const Layer
 
             next_mesh_retract_before_outer_wall = inset_direction == InsetDirection::OUTSIDE_IN || wall_line_count == 1;
         }
-        const ForceRetract force_retract = retract_at_layer_change || next_mesh_retract_before_outer_wall ? ForceRetract::RETRACTED : ForceRetract::AUTOMATIC;
+        const ForceRetract force_retract = (retract_at_layer_change || next_mesh_retract_before_outer_wall) ? ForceRetract::RETRACTED : ForceRetract::AUTOMATIC;
         prev_layer->final_travel_z_ = newest_layer->z_;
         GCodePath& path = prev_layer->addTravel(first_location_new_layer, force_retract);
         if (force_retract == ForceRetract::RETRACTED && ! path.retract)

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -119,8 +119,7 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
     bool added = false;
     if (! ironing_polygons.empty())
     {
-        constexpr bool force_comb_retract = false;
-        layer.addTravel(ironing_polygons[0][0], force_comb_retract);
+        layer.addTravel(ironing_polygons[0][0]);
         layer.addPolygonsByOptimizer(ironing_polygons, line_config, mesh.settings, ZSeamConfig());
         added = true;
     }
@@ -161,7 +160,7 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
     }
     if (! ironing_paths.empty())
     {
-        constexpr bool retract_before_outer_wall = false;
+        constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
         constexpr coord_t wipe_dist = 0u;
         const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_INNER, false);
         InsetOrderOptimizer wall_orderer(

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -160,7 +160,6 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
     }
     if (! ironing_paths.empty())
     {
-        constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
         constexpr coord_t wipe_dist = 0u;
         const ZSeamConfig z_seam_config(EZSeamType::SHORTEST, layer.getLastPlannedPositionOrStartingPosition(), EZSeamCornerPrefType::Z_SEAM_CORNER_PREF_INNER, false);
         InsetOrderOptimizer wall_orderer(
@@ -176,7 +175,6 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
             line_config,
             line_config,
             line_config,
-            retract_before_outer_wall,
             wipe_dist,
             wipe_dist,
             extruder_nr,

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -769,9 +769,9 @@ RetractBeforeOuterWall Settings::get<RetractBeforeOuterWall>(const std::string& 
     {
         return RetractBeforeOuterWall::NOT_RETRACTED;
     }
-    else if (value == "force_not_retracted_first")
+    else if (value == "force_not_retracted_from_infill")
     {
-        return RetractBeforeOuterWall::NOT_RETRACTED_FIRST;
+        return RetractBeforeOuterWall::NOT_RETRACTED_FROM_INFILL;
     }
     else // Default.
     {

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -758,6 +758,28 @@ InfillStartEndPreference Settings::get<InfillStartEndPreference>(const std::stri
 }
 
 template<>
+RetractBeforeOuterWall Settings::get<RetractBeforeOuterWall>(const std::string& key) const
+{
+    const std::string& value = get<std::string>(key);
+    if (value == "force_retracted")
+    {
+        return RetractBeforeOuterWall::RETRACTED;
+    }
+    else if (value == "force_not_retracted")
+    {
+        return RetractBeforeOuterWall::NOT_RETRACTED;
+    }
+    else if (value == "force_not_retracted_first")
+    {
+        return RetractBeforeOuterWall::NOT_RETRACTED_FIRST;
+    }
+    else // Default.
+    {
+        return RetractBeforeOuterWall::AUTOMATIC;
+    }
+}
+
+template<>
 std::vector<double> Settings::get<std::vector<double>>(const std::string& key) const
 {
     const std::string& value_string = get<std::string>(key);


### PR DESCRIPTION
We now handle more detailed behaviors regarding the retraction of the travel move when moving to an outer wall.

Requires https://github.com/Ultimaker/Cura/pull/21505
CURA-13064