### PR TITLE
CURA-13065 Fix polygons-based infill not respecting end close to seam

### DIFF
--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -547,6 +547,7 @@ public:
      * @param settings The current settings to retrieve values from
      * @param add_extra_inwards_move Indicates whether extra start/end inwards extrusion moves will be generated
      * @param near_start_location Optional: Location near where to add the first line. If not provided the last position is used.
+     * @param reverse_print_direction Whether to reverse the optimized order and their printing direction.
      */
     void addInfillPolygonsByOptimizer(
         const Shape& polygons,
@@ -554,7 +555,8 @@ public:
         const GCodePathConfig& config,
         const Settings& settings,
         const bool add_extra_inwards_move = false,
-        const std::optional<Point2LL>& near_start_location = std::optional<Point2LL>());
+        const std::optional<Point2LL>& near_start_location = std::optional<Point2LL>(),
+        const bool reverse_print_direction = false);
 
     /*!
      * Add a single line that is part of a wall to the gcode.

--- a/src/InfillOrderOptimizer.cpp
+++ b/src/InfillOrderOptimizer.cpp
@@ -315,7 +315,8 @@ void InfillOrderOptimizer::addToLayer(
                 mesh_config.infill_config[0],
                 settings,
                 start_move_inwards_length > 0 || end_move_inwards_length > 0,
-                near_start_location);
+                near_start_location,
+                reverse_print_direction);
             if (! remaining_lines.empty())
             {
                 addInfillLinesToLayer(

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -947,14 +947,19 @@ void LayerPlan::addInfillPolygonsByOptimizer(
     const GCodePathConfig& config,
     const Settings& settings,
     const bool add_extra_inwards_move,
-    const std::optional<Point2LL>& near_start_location)
+    const std::optional<Point2LL>& near_start_location,
+    const bool reverse_print_direction)
 {
     if (polygons.empty())
     {
         return;
     }
 
-    PathOrderOptimizer<const Polygon*> orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()));
+    const ZSeamConfig seam_config = ZSeamConfig();
+    constexpr bool detect_loops = false;
+    constexpr Shape* combing_boundary = nullptr;
+    PathOrderOptimizer<const Polygon*>
+        orderOptimizer(near_start_location.value_or(getLastPlannedPositionOrStartingPosition()), seam_config, detect_loops, combing_boundary, reverse_print_direction);
     for (size_t poly_idx = 0; poly_idx < polygons.size(); poly_idx++)
     {
         orderOptimizer.addPolygon(&polygons[poly_idx]);


### PR DESCRIPTION
Path optimization for polygons didn't support reverting the optimized path, so for polygons-based infill we would start by the point close to seam instead of end there.
We now have an argument to reverse the paths for polygons, and call it appropriately from the infill optimizer.

CURA-13065