### PR TITLE
CURA-13072 Fix impossible ordering conditions

### DIFF
--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -172,15 +172,6 @@ private:
      * \return A vector of ExtrusionLines with walls that should be printed
      */
     std::vector<ExtrusionLine> getWallsToBeAdded(const bool reverse, const bool use_one_extruder);
-
-    /*!
-     * Appends constraints to the walls ordering so that for the first processed inset, we will start with the longest wall. The first printed wall can have a better seam
-     * quality in some conditions, and the longest one is likely to be the most visible.
-     * @param walls The walls to be ordered
-     * @param[in, out] order The order to which the constraints should be appended
-     * @param outer_to_inner Indicates of the outer walls are printed first (or the inner walls first)
-     */
-    static void addFirstWallOrder(const std::vector<ExtrusionLine>& walls, std::unordered_multimap<const ExtrusionLine*, const ExtrusionLine*>& order, const bool outer_to_inner);
 };
 } // namespace cura
 

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -184,7 +184,7 @@ public:
         // Get the vertex data and store it in the paths.
         for (auto& path : paths_)
         {
-            path.converted_ = path.getVertexData();
+            path.converted_ = &path.getVertexData();
             vertices_to_paths_.emplace(path.vertices_, &path);
         }
 

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -99,6 +99,12 @@ public:
     static const std::unordered_multimap<Path, Path> no_order_requirements_;
 
     /*!
+     * When true and having multiple candidates for the starting path, prefer the longest one over the closest one. It will be set back to false
+     * after being used, so that it will apply only over the very first path.
+     */
+    bool prefer_longest_path_;
+
+    /*!
      * Construct a new optimizer.
      *
      * This doesn't actually optimize the order yet, so the ``paths`` field will
@@ -123,7 +129,8 @@ public:
         const Shape& disallowed_areas_for_seams = {},
         const bool use_shortest_for_inner_walls = false,
         const Shape& overhang_areas = Shape(),
-        const std::shared_ptr<TextureDataProvider>& texture_data_provider = nullptr)
+        const std::shared_ptr<TextureDataProvider>& texture_data_provider = nullptr,
+        const bool prefer_longest_path_first = false)
         : start_point_(start_point)
         , seam_config_(seam_config)
         , combing_boundary_((combing_boundary != nullptr && ! combing_boundary->empty()) ? combing_boundary : nullptr)
@@ -135,6 +142,7 @@ public:
         , use_shortest_for_inner_walls_(use_shortest_for_inner_walls)
         , overhang_areas_(overhang_areas)
         , texture_data_provider_(texture_data_provider)
+        , prefer_longest_path_(prefer_longest_path_first)
     {
     }
 
@@ -176,7 +184,7 @@ public:
         // Get the vertex data and store it in the paths.
         for (auto& path : paths_)
         {
-            path.converted_ = &path.getVertexData();
+            path.converted_ = path.getVertexData();
             vertices_to_paths_.emplace(path.vertices_, &path);
         }
 
@@ -381,7 +389,7 @@ protected:
                 }
             }
 
-            auto best_candidate = findClosestPath(current_position, available_candidates);
+            auto best_candidate = findBestPath(current_position, available_candidates);
 
             auto best_path = best_candidate;
             optimized_order.push_back(*best_path);
@@ -456,7 +464,7 @@ protected:
             auto local_current_position = current_position;
             while (! candidates.empty())
             {
-                Path best_candidate = findClosestPathVertices(local_current_position, candidates);
+                Path best_candidate = findBestPathVertices(local_current_position, candidates);
 
                 candidates.erase(best_candidate);
                 order.push_back(best_candidate);
@@ -526,7 +534,7 @@ protected:
                 // Add all inner walls
                 while (! roots.empty())
                 {
-                    Path root = findClosestPathVertices(current_position, roots);
+                    Path root = findBestPathVertices(current_position, roots);
                     roots.erase(root);
                     actions::dfs(root, order_requirements, handle_node, visited, nullptr, get_neighbours);
                 }
@@ -534,7 +542,7 @@ protected:
                 // Add all outer walls
                 while (! outer_walls.empty())
                 {
-                    Path wall = findClosestPathVertices(current_position, outer_walls);
+                    Path wall = findBestPathVertices(current_position, outer_walls);
                     outer_walls.erase(wall);
                     handle_node(wall, nullptr);
                 }
@@ -548,7 +556,7 @@ protected:
                 std::unordered_set<Path> root_neighbours;
                 while (! outer_walls.empty())
                 {
-                    Path outer_wall = findClosestPathVertices(current_position, outer_walls);
+                    Path outer_wall = findBestPathVertices(current_position, outer_walls);
                     outer_walls.erase(outer_wall);
 
                     handle_node(outer_wall, nullptr);
@@ -562,7 +570,7 @@ protected:
                 // Add all inner walls
                 while (! root_neighbours.empty())
                 {
-                    Path root_neighbour = findClosestPathVertices(current_position, root_neighbours);
+                    Path root_neighbour = findBestPathVertices(current_position, root_neighbours);
                     root_neighbours.erase(root_neighbour);
                     actions::dfs(root_neighbour, order_requirements, handle_node, visited, nullptr, get_neighbours);
                 }
@@ -572,7 +580,7 @@ protected:
         {
             while (! roots.empty())
             {
-                Path root = findClosestPathVertices(current_position, roots);
+                Path root = findBestPathVertices(current_position, roots);
                 roots.erase(root);
 
                 actions::dfs(root, order_requirements, handle_node, visited, nullptr, get_neighbours);
@@ -600,23 +608,48 @@ protected:
         return reversed;
     }
 
-    Path findClosestPathVertices(Point2LL start_position, std::unordered_set<Path> candidate_paths)
+    Path findBestPathVertices(const Point2LL& start_position, const std::unordered_set<Path>& candidate_paths)
     {
-        std::vector<OrderablePath*> candidate_orderable_paths;
+        std::vector<OrderablePath*> orderable_paths;
+        orderable_paths.reserve(candidate_paths.size());
 
         for (auto& path : candidate_paths)
         {
-            candidate_orderable_paths.push_back(vertices_to_paths_.at(path));
+            orderable_paths.push_back(vertices_to_paths_.at(path));
         }
 
-        OrderablePath* best_candidate = findClosestPath(start_position, candidate_orderable_paths);
+        OrderablePath* best_candidate = findBestPath(start_position, orderable_paths);
         return best_candidate->vertices_;
     }
 
-    OrderablePath* findClosestPath(Point2LL start_position, std::vector<OrderablePath*> candidate_paths)
+    OrderablePath* findBestPath(const Point2LL& start_position, const std::vector<OrderablePath*>& candidate_paths)
+    {
+        OrderablePath* best_candidate = prefer_longest_path_ ? findLongestPath(candidate_paths) : findClosestPath(start_position, candidate_paths);
+        prefer_longest_path_ = false;
+        return best_candidate;
+    }
+
+    OrderablePath* findLongestPath(std::vector<OrderablePath*> candidate_paths)
+    {
+        OrderablePath* longest_path = nullptr;
+        coord_t longest_path_length;
+        for (OrderablePath* path : candidate_paths)
+        {
+            const coord_t path_length = path->converted_->length();
+            if (longest_path == nullptr || path_length > longest_path_length)
+            {
+                longest_path = path;
+                longest_path_length = path_length;
+            }
+        }
+
+        return longest_path;
+    }
+
+    OrderablePath* findClosestPath(const Point2LL& start_position, const std::vector<OrderablePath*>& candidate_paths)
     {
         coord_t best_distance2 = std::numeric_limits<coord_t>::max();
-        OrderablePath* best_candidate = 0;
+        OrderablePath* best_candidate = nullptr;
 
         for (OrderablePath* path : candidate_paths)
         {

--- a/include/PathOrderOptimizer.h
+++ b/include/PathOrderOptimizer.h
@@ -7,6 +7,7 @@
 #include <numbers>
 #include <unordered_set>
 
+#include <range/v3/algorithm/max_element.hpp>
 #include <range/v3/algorithm/partition_copy.hpp>
 #include <range/v3/iterator/insert_iterators.hpp>
 #include <range/v3/view/addressof.hpp>
@@ -629,21 +630,17 @@ protected:
         return best_candidate;
     }
 
-    OrderablePath* findLongestPath(std::vector<OrderablePath*> candidate_paths)
+    OrderablePath* findLongestPath(const std::vector<OrderablePath*>& candidate_paths)
     {
-        OrderablePath* longest_path = nullptr;
-        coord_t longest_path_length;
-        for (OrderablePath* path : candidate_paths)
-        {
-            const coord_t path_length = path->converted_->length();
-            if (longest_path == nullptr || path_length > longest_path_length)
+        auto iterator = ranges::max_element(
+            candidate_paths,
+            {},
+            [](const OrderablePath* path)
             {
-                longest_path = path;
-                longest_path_length = path_length;
-            }
-        }
+                return path->converted_->length();
+            });
 
-        return longest_path;
+        return iterator == candidate_paths.end() ? nullptr : *iterator;
     }
 
     OrderablePath* findClosestPath(const Point2LL& start_position, const std::vector<OrderablePath*>& candidate_paths)

--- a/include/path_ordering.h
+++ b/include/path_ordering.h
@@ -50,7 +50,7 @@ struct PathOrdering
      * Vertex data, converted into a Polygon so that the orderer knows how
      * to deal with this data.
      */
-    const PointsSet* converted_{ nullptr };
+    const Polyline* converted_{ nullptr };
 
     /*!
      * Which vertex along the path to start printing with.
@@ -104,7 +104,7 @@ struct PathOrdering
      * for each different type that this class is used with. See the .cpp file
      * for examples and where to add a new specialization.
      */
-    const PointsSet& getVertexData();
+    const Polyline* getVertexData();
 
 protected:
     /*!
@@ -115,7 +115,7 @@ protected:
      * For example, if the ``PathType`` is a list of ``ExtrusionJunction``s,
      * this will store the coordinates of those junctions.
      */
-    std::optional<PointsSet> cached_vertices_;
+    std::optional<Polygon> cached_vertices_;
 };
 
 } // namespace cura

--- a/include/path_ordering.h
+++ b/include/path_ordering.h
@@ -104,7 +104,7 @@ struct PathOrdering
      * for each different type that this class is used with. See the .cpp file
      * for examples and where to add a new specialization.
      */
-    const Polyline* getVertexData();
+    const Polyline& getVertexData();
 
 protected:
     /*!

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -467,8 +467,8 @@ std::optional<Point2LL> InsetOrderOptimizer::getStartPosition() const
 
     PathOrdering<const ExtrusionLine*>& first_path = path_optimizer_->paths_.front();
 
-    const auto vert_data = first_path.getVertexData();
-    return vert_data->at(first_path.start_vertex_);
+    const auto& vert_data = first_path.getVertexData();
+    return vert_data.at(first_path.start_vertex_);
 }
 
 InsetOrderOptimizer::value_type InsetOrderOptimizer::getInsetOrder(const auto& input, const bool outer_to_inner)

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -102,12 +102,8 @@ void InsetOrderOptimizer::optimize()
     const bool use_shortest_for_inner_walls = outer_to_inner;
     walls_to_be_added_ = getWallsToBeAdded(reverse, use_one_extruder);
 
-    std::unordered_multimap<const ExtrusionLine*, const ExtrusionLine*> order
+    const std::unordered_multimap<const ExtrusionLine*, const ExtrusionLine*> order
         = pack_by_inset ? getInsetOrder(walls_to_be_added_, outer_to_inner) : getRegionOrder(walls_to_be_added_, outer_to_inner);
-    if (start_width_longest_wall_)
-    {
-        addFirstWallOrder(walls_to_be_added_, order, outer_to_inner);
-    }
 
     constexpr bool detect_loops = false;
     constexpr Shape* combing_boundary = nullptr;
@@ -125,7 +121,8 @@ void InsetOrderOptimizer::optimize()
         disallowed_areas_for_seams_,
         use_shortest_for_inner_walls,
         overhang_areas_,
-        texture_data_provider_);
+        texture_data_provider_,
+        start_width_longest_wall_);
 
     for (auto& line : walls_to_be_added_)
     {
@@ -471,7 +468,7 @@ std::optional<Point2LL> InsetOrderOptimizer::getStartPosition() const
     PathOrdering<const ExtrusionLine*>& first_path = path_optimizer_->paths_.front();
 
     const auto vert_data = first_path.getVertexData();
-    return vert_data.at(first_path.start_vertex_);
+    return vert_data->at(first_path.start_vertex_);
 }
 
 InsetOrderOptimizer::value_type InsetOrderOptimizer::getInsetOrder(const auto& input, const bool outer_to_inner)
@@ -571,52 +568,6 @@ std::vector<ExtrusionLine> InsetOrderOptimizer::getWallsToBeAdded(const bool rev
         }
     }
     return view | rv::join | rv::remove_if(rg::empty) | rg::to_vector;
-}
-
-void InsetOrderOptimizer::addFirstWallOrder(
-    const std::vector<ExtrusionLine>& walls,
-    std::unordered_multimap<const ExtrusionLine*, const ExtrusionLine*>& order,
-    const bool outer_to_inner)
-{
-    size_t inset_idx = 0;
-    if (! outer_to_inner)
-    {
-        for (const ExtrusionLine& wall : walls)
-        {
-            inset_idx = std::max(inset_idx, wall.inset_idx_);
-        }
-    }
-
-    const ExtrusionLine* longest_wall = nullptr;
-    coord_t longest_wall_length;
-
-    for (const ExtrusionLine& wall : walls)
-    {
-        if (wall.inset_idx_ != inset_idx)
-        {
-            continue;
-        }
-
-        const coord_t wall_length = wall.length();
-        if (longest_wall == nullptr || wall_length > longest_wall_length)
-        {
-            longest_wall = &wall;
-            longest_wall_length = wall_length;
-        }
-    }
-
-    if (longest_wall)
-    {
-        for (const ExtrusionLine& wall : walls)
-        {
-            if (wall.inset_idx_ != inset_idx || &wall == longest_wall)
-            {
-                continue;
-            }
-
-            order.emplace(longest_wall, &wall);
-        }
-    }
 }
 
 } // namespace cura

--- a/src/PathOrderMonotonic.cpp
+++ b/src/PathOrderMonotonic.cpp
@@ -22,7 +22,7 @@ void PathOrderMonotonic<PathType>::optimize()
     // Get the vertex data and store it in the paths.
     for (Path& path : this->paths_)
     {
-        path.converted_ = &path.getVertexData();
+        path.converted_ = path.getVertexData();
     }
 
     std::vector<Path> reordered; // To store the result in. At the end, we'll std::swap with the real paths.

--- a/src/PathOrderMonotonic.cpp
+++ b/src/PathOrderMonotonic.cpp
@@ -22,7 +22,7 @@ void PathOrderMonotonic<PathType>::optimize()
     // Get the vertex data and store it in the paths.
     for (Path& path : this->paths_)
     {
-        path.converted_ = path.getVertexData();
+        path.converted_ = &path.getVertexData();
     }
 
     std::vector<Path> reordered; // To store the result in. At the end, we'll std::swap with the real paths.

--- a/src/path_ordering.cpp
+++ b/src/path_ordering.cpp
@@ -11,49 +11,49 @@ namespace cura
 {
 
 template<typename PathType>
-const Polyline* PathOrdering<PathType>::getVertexData()
+const Polyline& PathOrdering<PathType>::getVertexData()
 {
-    return vertices_;
+    return *vertices_;
 }
 
 template<>
-const Polyline* PathOrdering<const SkinPart*>::getVertexData()
+const Polyline& PathOrdering<const SkinPart*>::getVertexData()
 {
-    return &vertices_->outline.outerPolygon();
+    return vertices_->outline.outerPolygon();
 }
 
 template<>
-const Polyline* PathOrdering<const SliceLayerPart*>::getVertexData()
+const Polyline& PathOrdering<const SliceLayerPart*>::getVertexData()
 {
-    return &vertices_->outline.outerPolygon();
+    return vertices_->outline.outerPolygon();
 }
 
 template<>
-const Polyline* PathOrdering<SliceLayerPart*>::getVertexData()
+const Polyline& PathOrdering<SliceLayerPart*>::getVertexData()
 {
-    return &vertices_->outline.outerPolygon();
+    return vertices_->outline.outerPolygon();
 }
 
 template<>
-const Polyline* PathOrdering<const SupportInfillPart*>::getVertexData()
+const Polyline& PathOrdering<const SupportInfillPart*>::getVertexData()
 {
-    return &vertices_->outline_.outerPolygon();
+    return vertices_->outline_.outerPolygon();
 }
 template<>
-const Polyline* PathOrdering<const ExtrusionLine*>::getVertexData()
+const Polyline& PathOrdering<const ExtrusionLine*>::getVertexData()
 {
     if (! cached_vertices_.has_value())
     {
         cached_vertices_ = vertices_->toPolygon();
     }
-    return &(cached_vertices_.value());
+    return *cached_vertices_;
 }
 
-template const Polyline* PathOrdering<Polygon*>::getVertexData();
-template const Polyline* PathOrdering<Polygon const*>::getVertexData();
-template const Polyline* PathOrdering<const OpenPolyline*>::getVertexData();
-template const Polyline* PathOrdering<OpenPolyline*>::getVertexData();
-template const Polyline* PathOrdering<ClosedPolyline*>::getVertexData();
-template const Polyline* PathOrdering<Polyline const*>::getVertexData();
+template const Polyline& PathOrdering<Polygon*>::getVertexData();
+template const Polyline& PathOrdering<Polygon const*>::getVertexData();
+template const Polyline& PathOrdering<const OpenPolyline*>::getVertexData();
+template const Polyline& PathOrdering<OpenPolyline*>::getVertexData();
+template const Polyline& PathOrdering<ClosedPolyline*>::getVertexData();
+template const Polyline& PathOrdering<Polyline const*>::getVertexData();
 
 } // namespace cura

--- a/src/path_ordering.cpp
+++ b/src/path_ordering.cpp
@@ -11,49 +11,49 @@ namespace cura
 {
 
 template<typename PathType>
-const PointsSet& PathOrdering<PathType>::getVertexData()
+const Polyline* PathOrdering<PathType>::getVertexData()
 {
-    return *vertices_;
+    return vertices_;
 }
 
 template<>
-const PointsSet& PathOrdering<const SkinPart*>::getVertexData()
+const Polyline* PathOrdering<const SkinPart*>::getVertexData()
 {
-    return vertices_->outline.outerPolygon();
+    return &vertices_->outline.outerPolygon();
 }
 
 template<>
-const PointsSet& PathOrdering<const SliceLayerPart*>::getVertexData()
+const Polyline* PathOrdering<const SliceLayerPart*>::getVertexData()
 {
-    return vertices_->outline.outerPolygon();
+    return &vertices_->outline.outerPolygon();
 }
 
 template<>
-const PointsSet& PathOrdering<SliceLayerPart*>::getVertexData()
+const Polyline* PathOrdering<SliceLayerPart*>::getVertexData()
 {
-    return vertices_->outline.outerPolygon();
+    return &vertices_->outline.outerPolygon();
 }
 
 template<>
-const PointsSet& PathOrdering<const SupportInfillPart*>::getVertexData()
+const Polyline* PathOrdering<const SupportInfillPart*>::getVertexData()
 {
-    return vertices_->outline_.outerPolygon();
+    return &vertices_->outline_.outerPolygon();
 }
 template<>
-const PointsSet& PathOrdering<const ExtrusionLine*>::getVertexData()
+const Polyline* PathOrdering<const ExtrusionLine*>::getVertexData()
 {
-    if (! cached_vertices_)
+    if (! cached_vertices_.has_value())
     {
         cached_vertices_ = vertices_->toPolygon();
     }
-    return *cached_vertices_;
+    return &(cached_vertices_.value());
 }
 
-template const PointsSet& PathOrdering<Polygon*>::getVertexData();
-template const PointsSet& PathOrdering<Polygon const*>::getVertexData();
-template const PointsSet& PathOrdering<const OpenPolyline*>::getVertexData();
-template const PointsSet& PathOrdering<OpenPolyline*>::getVertexData();
-template const PointsSet& PathOrdering<ClosedPolyline*>::getVertexData();
-template const PointsSet& PathOrdering<Polyline const*>::getVertexData();
+template const Polyline* PathOrdering<Polygon*>::getVertexData();
+template const Polyline* PathOrdering<Polygon const*>::getVertexData();
+template const Polyline* PathOrdering<const OpenPolyline*>::getVertexData();
+template const Polyline* PathOrdering<OpenPolyline*>::getVertexData();
+template const Polyline* PathOrdering<ClosedPolyline*>::getVertexData();
+template const Polyline* PathOrdering<Polyline const*>::getVertexData();
 
 } // namespace cura


### PR DESCRIPTION
In some cases, adding ordering conditions with the `InsetOrderOptimizer::addFirstWallOrder` method would create unresolvable conditions and leave the wall parts not being added at all.
Since the purpose of this method was to favorize the longer wall to start, we now do it in the `PathOptimizer` when differentiating the starting candidates at the first round.

Part of the code in this PR is due to the type change in the `PathOrdering` struct: in order to calculate the length, we need a `Polyline` instead of a `PointsSet`.

CURA-13072