### PR TITLE
[CURA-13075] Handle LIGHTNING support pattern

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3774,8 +3774,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                 std::shared_ptr<LightningLayer> lightning_layer;
                 if (storage.support.lightning_generator)
                 {
-                    lightning_layer = std::make_shared<LightningLayer>(storage.support.lightning_generator->getTreesForLayer(
-                        std::max(LayerIndex{ 0 }, gcode_layer.getLayerNr())));
+                    lightning_layer = std::make_shared<LightningLayer>(storage.support.lightning_generator->getTreesForLayer(std::max(LayerIndex{ 0 }, gcode_layer.getLayerNr())));
                 }
 
                 constexpr size_t wall_count = 0; // Walls are generated somewhere else, so their layers aren't vertically combined.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3774,7 +3774,8 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                 std::shared_ptr<LightningLayer> lightning_layer;
                 if (storage.support.lightning_generator)
                 {
-                    lightning_layer = std::make_shared<LightningLayer>(storage.support.lightning_generator->getTreesForLayer(gcode_layer.getLayerNr()));
+                    lightning_layer = std::make_shared<LightningLayer>(storage.support.lightning_generator->getTreesForLayer(
+                        std::max(LayerIndex{ 0 }, gcode_layer.getLayerNr())));
                 }
 
                 constexpr size_t wall_count = 0; // Walls are generated somewhere else, so their layers aren't vertically combined.


### PR DESCRIPTION
This pull request makes a targeted fix to the support infill processing logic in `FffGcodeWriter.cpp`. The change ensures that when retrieving trees for a given layer, the layer index is never negative, which prevents potential errors with invalid indices.

- Support infill processing:
  * Updated the call to `getTreesForLayer` to use `std::max(LayerIndex{ 0 }, gcode_layer.getLayerNr())`, ensuring the layer index passed is always zero or greater.

CURA-13075