### PR TITLE
CURA-12636 Non tree support inside tree support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(engine_SRCS # Except main.cpp.
         src/TreeSupportTipGenerator.cpp
         src/TreeModelVolumes.cpp
         src/TreeSupport.cpp
+        src/TreeSupportElement.cpp
         src/WallsComputation.cpp
         src/WallToolPaths.cpp
 

--- a/include/TreeModelVolumes.h
+++ b/include/TreeModelVolumes.h
@@ -402,7 +402,7 @@ private:
     /*!
      * \brief Does at least one mesh allow support to rest on a model.
      */
-    bool support_rests_on_model_;
+    bool support_rests_on_model_{ false };
 
     /*!
      * \brief The progress of the precalculate function for communicating it to the progress bar.

--- a/include/TreeSupport.h
+++ b/include/TreeSupport.h
@@ -19,6 +19,8 @@
 namespace cura
 {
 
+class OBJ;
+
 // The various stages of the process can be weighted differently in the progress bar.
 // These weights are obtained experimentally using a small sample size. Sensible weights can differ drastically based on the assumed default settings and model.
 constexpr auto TREE_PROGRESS_TOTAL = 10000;
@@ -309,6 +311,12 @@ private:
      * \param storage[in,out] The storage where the support should be stored.
      */
     void drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage);
+
+    /*!
+     * Saves the influence areas and the resulting positions of all the given elements to a 3D object
+     * @para move_bounds The elements to be saved, sorted per layer
+     */
+    void saveToObj(const std::vector<std::set<TreeSupportElement*>>& move_bounds, OBJ& obj) const;
 
     /*!
      * \brief Settings with the indexes of meshes that use these settings.

--- a/include/TreeSupportElement.h
+++ b/include/TreeSupportElement.h
@@ -17,19 +17,13 @@
 namespace cura
 {
 
+class OBJ;
+
 struct AreaIncreaseSettings
 {
-    AreaIncreaseSettings()
-        : type_(AvoidanceType::FAST)
-        , increase_speed_(0)
-        , increase_radius_(false)
-        , no_error_(false)
-        , use_min_distance_(false)
-        , move_(false)
-    {
-    }
+    AreaIncreaseSettings() = default;
 
-    AreaIncreaseSettings(AvoidanceType type, coord_t increase_speed, bool increase_radius, bool simplify, bool use_min_distance, bool move)
+    AreaIncreaseSettings(const AvoidanceType type, const coord_t increase_speed, const bool increase_radius, const bool simplify, const bool use_min_distance, const bool move)
         : type_(type)
         , increase_speed_(increase_speed)
         , increase_radius_(increase_radius)
@@ -39,18 +33,14 @@ struct AreaIncreaseSettings
     {
     }
 
-    AvoidanceType type_;
-    coord_t increase_speed_;
-    bool increase_radius_;
-    bool no_error_;
-    bool use_min_distance_;
-    bool move_;
+    AvoidanceType type_{ AvoidanceType::FAST };
+    coord_t increase_speed_{ 0 };
+    bool increase_radius_{ false };
+    bool no_error_{ false };
+    bool use_min_distance_{ false };
+    bool move_{ false };
 
-    bool operator==(const AreaIncreaseSettings& other) const
-    {
-        return increase_radius_ == other.increase_radius_ && increase_speed_ == other.increase_speed_ && type_ == other.type_ && no_error_ == other.no_error_
-            && use_min_distance_ == other.use_min_distance_ && move_ == other.move_;
-    }
+    bool operator==(const AreaIncreaseSettings& other) const = default;
 };
 
 struct TreeSupportElement
@@ -68,93 +58,14 @@ struct TreeSupportElement
         bool force_tips_to_roof,
         bool skip_ovalisation,
         bool influence_area_limit_active,
-        coord_t influence_area_limit_range)
-        : target_height_(target_height)
-        , target_position_(target_position)
-        , next_position_(target_position)
-        , next_height_(target_height)
-        , effective_radius_height_(distance_to_top)
-        , to_buildplate_(to_buildplate)
-        , distance_to_top_(distance_to_top)
-        , area_(nullptr)
-        , result_on_layer_(target_position)
-        , increased_to_model_radius_(0)
-        , to_model_gracious_(to_model_gracious)
-        , buildplate_radius_increases_(0)
-        , use_min_xy_dist_(use_min_xy_dist)
-        , supports_roof_(supports_roof)
-        , dont_move_until_(dont_move_until)
-        , can_use_safe_radius_(can_use_safe_radius)
-        , last_area_increase_(AreaIncreaseSettings(AvoidanceType::FAST, 0, false, false, false, false))
-        , missing_roof_layers_(force_tips_to_roof ? dont_move_until : 0)
-        , skip_ovalisation_(skip_ovalisation)
-        , all_tips_({ target_position })
-        , influence_area_limit_active_(influence_area_limit_active)
-        , influence_area_limit_range_(influence_area_limit_range)
-    {
-        RecreateInfluenceLimitArea();
-    }
+        coord_t influence_area_limit_range);
 
-    TreeSupportElement(const TreeSupportElement& elem, Shape* newArea = nullptr)
-        : // copy constructor with possibility to set a new area
-        target_height_(elem.target_height_)
-        , target_position_(elem.target_position_)
-        , next_position_(elem.next_position_)
-        , next_height_(elem.next_height_)
-        , effective_radius_height_(elem.effective_radius_height_)
-        , to_buildplate_(elem.to_buildplate_)
-        , distance_to_top_(elem.distance_to_top_)
-        , area_(newArea != nullptr ? newArea : elem.area_)
-        , result_on_layer_(elem.result_on_layer_)
-        , increased_to_model_radius_(elem.increased_to_model_radius_)
-        , to_model_gracious_(elem.to_model_gracious_)
-        , buildplate_radius_increases_(elem.buildplate_radius_increases_)
-        , use_min_xy_dist_(elem.use_min_xy_dist_)
-        , supports_roof_(elem.supports_roof_)
-        , dont_move_until_(elem.dont_move_until_)
-        , can_use_safe_radius_(elem.can_use_safe_radius_)
-        , last_area_increase_(elem.last_area_increase_)
-        , missing_roof_layers_(elem.missing_roof_layers_)
-        , skip_ovalisation_(elem.skip_ovalisation_)
-        , all_tips_(elem.all_tips_)
-        , influence_area_limit_active_(elem.influence_area_limit_active_)
-        , influence_area_limit_range_(elem.influence_area_limit_range_)
-        , influence_area_limit_area_(elem.influence_area_limit_area_)
-    {
-        parents_.insert(parents_.begin(), elem.parents_.begin(), elem.parents_.end());
-    }
+    TreeSupportElement(const TreeSupportElement& elem, Shape* newArea = nullptr);
 
     /*!
      * \brief Create a new Element for one layer below the element of the pointer supplied.
      */
-    TreeSupportElement(TreeSupportElement* element_above)
-        : target_height_(element_above->target_height_)
-        , target_position_(element_above->target_position_)
-        , next_position_(element_above->next_position_)
-        , next_height_(element_above->next_height_)
-        , effective_radius_height_(element_above->effective_radius_height_)
-        , to_buildplate_(element_above->to_buildplate_)
-        , distance_to_top_(element_above->distance_to_top_ + 1)
-        , area_(element_above->area_)
-        , result_on_layer_(Point2LL(-1, -1))
-        , // set to invalid as we are a new node on a new layer
-        increased_to_model_radius_(element_above->increased_to_model_radius_)
-        , to_model_gracious_(element_above->to_model_gracious_)
-        , buildplate_radius_increases_(element_above->buildplate_radius_increases_)
-        , use_min_xy_dist_(element_above->use_min_xy_dist_)
-        , supports_roof_(element_above->supports_roof_)
-        , dont_move_until_(element_above->dont_move_until_)
-        , can_use_safe_radius_(element_above->can_use_safe_radius_)
-        , last_area_increase_(element_above->last_area_increase_)
-        , missing_roof_layers_(element_above->missing_roof_layers_)
-        , skip_ovalisation_(false)
-        , all_tips_(element_above->all_tips_)
-        , influence_area_limit_active_(element_above->influence_area_limit_active_)
-        , influence_area_limit_range_(element_above->influence_area_limit_range_)
-        , influence_area_limit_area_(element_above->influence_area_limit_area_)
-    {
-        parents_ = { element_above };
-    }
+    TreeSupportElement(TreeSupportElement* element_above);
 
     // ONLY to be called in merge as it assumes a few assurances made by it.
     TreeSupportElement(
@@ -166,69 +77,51 @@ struct TreeSupportElement
         const std::function<coord_t(size_t, double)>& getRadius,
         double diameter_scale_bp_radius,
         coord_t branch_radius,
-        double diameter_angle_scale_factor)
-        : next_position_(next_position)
-        , next_height_(next_height)
-        , area_(nullptr)
-        , increased_to_model_radius_(increased_to_model_radius)
-        , use_min_xy_dist_(first.use_min_xy_dist_ || second.use_min_xy_dist_)
-        , supports_roof_(first.supports_roof_ || second.supports_roof_)
-        , dont_move_until_(std::max(first.dont_move_until_, second.dont_move_until_))
-        , can_use_safe_radius_(first.can_use_safe_radius_ || second.can_use_safe_radius_)
-        , missing_roof_layers_(std::min(first.missing_roof_layers_, second.missing_roof_layers_))
-        , skip_ovalisation_(false)
+        double diameter_angle_scale_factor);
+
+
+    bool operator==(const TreeSupportElement& other) const
     {
-        if (first.target_height_ > second.target_height_)
-        {
-            target_height_ = first.target_height_;
-            target_position_ = first.target_position_;
-        }
-        else
-        {
-            target_height_ = second.target_height_;
-            target_position_ = second.target_position_;
-        }
-        effective_radius_height_ = std::max(first.effective_radius_height_, second.effective_radius_height_);
-        distance_to_top_ = std::max(first.distance_to_top_, second.distance_to_top_);
-
-        to_buildplate_ = first.to_buildplate_ && second.to_buildplate_;
-        to_model_gracious_ = first.to_model_gracious_ && second.to_model_gracious_; // valid as we do not merge non-gracious with gracious
-
-        AddParents(first.parents_);
-        AddParents(second.parents_);
-
-        buildplate_radius_increases_ = 0;
-        if (diameter_scale_bp_radius > 0)
-        {
-            const coord_t foot_increase_radius = std::abs(
-                std::max(
-                    getRadius(second.effective_radius_height_, second.buildplate_radius_increases_),
-                    getRadius(first.effective_radius_height_, first.buildplate_radius_increases_))
-                - getRadius(effective_radius_height_, buildplate_radius_increases_));
-            // 'buildplate_radius_increases' has to be recalculated, as when a smaller tree with a larger buildplate_radius_increases merge with a larger branch,
-            //   the buildplate_radius_increases may have to be lower as otherwise the radius suddenly increases. This results often in a non integer value.
-            buildplate_radius_increases_ = foot_increase_radius / (branch_radius * (diameter_scale_bp_radius - diameter_angle_scale_factor));
-        }
-
-        // set last settings to the best out of both parents. If this is wrong, it will only cause a small performance penalty instead of weird behavior.
-        last_area_increase_ = AreaIncreaseSettings(
-            std::min(first.last_area_increase_.type_, second.last_area_increase_.type_),
-            std::min(first.last_area_increase_.increase_speed_, second.last_area_increase_.increase_speed_),
-            first.last_area_increase_.increase_radius_ || second.last_area_increase_.increase_radius_,
-            first.last_area_increase_.no_error_ || second.last_area_increase_.no_error_,
-            first.last_area_increase_.use_min_distance_ && second.last_area_increase_.use_min_distance_,
-            first.last_area_increase_.move_ || second.last_area_increase_.move_);
-
-        all_tips_ = first.all_tips_;
-        all_tips_.insert(all_tips_.end(), second.all_tips_.begin(), second.all_tips_.end());
-        influence_area_limit_range_ = std::max(first.influence_area_limit_range_, second.influence_area_limit_range_);
-        influence_area_limit_active_ = first.influence_area_limit_active_ || second.influence_area_limit_active_;
-        RecreateInfluenceLimitArea();
-        if (first.to_buildplate_ != second.to_buildplate_)
-        {
-            setToBuildplateForAllParents(to_buildplate_);
-        }
+        return target_position_ == other.target_position_ && target_height_ == other.target_height_;
     }
+
+    bool operator<(const TreeSupportElement& other) const // true if me < other
+    {
+        return ! (*this == other) && ! (*this > other);
+    }
+
+    bool operator>(const TreeSupportElement& other) const
+    {
+        // Doesn't really have to make sense, only required for ordering in maps to ensure deterministic behavior.
+        if (*this == other)
+        {
+            return false;
+        }
+        if (other.target_height_ != target_height_)
+        {
+            return other.target_height_ < target_height_;
+        }
+        return other.target_position_.X == target_position_.X ? other.target_position_.Y < target_position_.Y : other.target_position_.X < target_position_.X;
+    }
+
+    void AddParents(const std::vector<TreeSupportElement*>& adding);
+
+    void RecreateInfluenceLimitArea();
+
+    void setToBuildplateForAllParents(bool new_value);
+
+    inline bool isResultOnLayerSet() const
+    {
+        return result_on_layer_ != Point2LL(-1, -1);
+    }
+
+    /*!
+     * Saves the influence areas to a 3D object
+     * @param obj The object in which to save the influence area
+     * @param z The Z at which the area is placed
+     * @param layer_height The layer height at which to extrude the influence area
+     */
+    void saveToObj(OBJ& obj, const coord_t z, const coord_t layer_height) const;
 
     /*!
      * \brief The layer this support elements wants reach
@@ -357,87 +250,6 @@ struct TreeSupportElement
      * \brief Additional locations that the tip should reach
      */
     std::vector<Point2LL> additional_ovalization_targets_;
-
-
-    bool operator==(const TreeSupportElement& other) const
-    {
-        return target_position_ == other.target_position_ && target_height_ == other.target_height_;
-    }
-
-    bool operator<(const TreeSupportElement& other) const // true if me < other
-    {
-        return ! (*this == other) && ! (*this > other);
-    }
-
-    bool operator>(const TreeSupportElement& other) const
-    {
-        // Doesn't really have to make sense, only required for ordering in maps to ensure deterministic behavior.
-        if (*this == other)
-        {
-            return false;
-        }
-        if (other.target_height_ != target_height_)
-        {
-            return other.target_height_ < target_height_;
-        }
-        return other.target_position_.X == target_position_.X ? other.target_position_.Y < target_position_.Y : other.target_position_.X < target_position_.X;
-    }
-
-    void AddParents(const std::vector<TreeSupportElement*>& adding)
-    {
-        for (TreeSupportElement* ptr : adding)
-        {
-            parents_.emplace_back(ptr);
-        }
-    }
-
-    void RecreateInfluenceLimitArea()
-    {
-        if (influence_area_limit_active_)
-        {
-            influence_area_limit_area_.clear();
-
-            for (Point2LL p : all_tips_)
-            {
-                Polygon circle;
-                for (Point2LL corner : TreeSupportBaseCircle::getBaseCircle())
-                {
-                    circle.push_back(p + corner * influence_area_limit_range_ / double(TreeSupportBaseCircle::base_radius));
-                }
-                if (influence_area_limit_area_.empty())
-                {
-                    influence_area_limit_area_ = circle.offset(0);
-                }
-                else
-                {
-                    influence_area_limit_area_ = influence_area_limit_area_.intersection(circle.offset(0));
-                }
-            }
-        }
-    }
-
-    void setToBuildplateForAllParents(bool new_value)
-    {
-        to_buildplate_ = new_value;
-        to_model_gracious_ |= new_value;
-        std::vector<TreeSupportElement*> grandparents{ parents_ };
-        while (! grandparents.empty())
-        {
-            std::vector<TreeSupportElement*> next_parents;
-            for (TreeSupportElement* grandparent : grandparents)
-            {
-                next_parents.insert(next_parents.end(), grandparent->parents_.begin(), grandparent->parents_.end());
-                grandparent->to_buildplate_ = new_value;
-                grandparent->to_model_gracious_ |= new_value; // If we set to_buildplate to true, update to_model_gracious
-            }
-            grandparents = next_parents;
-        }
-    }
-
-    inline bool isResultOnLayerSet() const
-    {
-        return result_on_layer_ != Point2LL(-1, -1);
-    }
 };
 
 } // namespace cura

--- a/include/TreeSupportUtils.h
+++ b/include/TreeSupportUtils.h
@@ -108,6 +108,13 @@ public:
 
         const EFillMethod pattern = generate_support_supporting ? EFillMethod::GRID : roof ? config.roof_pattern : config.support_pattern;
 
+        if (pattern == EFillMethod::LIGHTNING)
+        {
+            // This can't be done for lightning infill since it requires the support to be generated first. Final result is good enough though,
+            // because it propagates to properly support the top area, compensating for the same feature of the tree support.
+            return {};
+        }
+
         const bool zig_zaggify_infill = roof ? pattern == EFillMethod::ZIG_ZAG : config.zig_zaggify_support;
         const bool connect_polygons = false;
         constexpr coord_t support_roof_overlap = 0;

--- a/include/utils/OBJ.h
+++ b/include/utils/OBJ.h
@@ -19,7 +19,7 @@ class Mesh;
 class OBJ : NoCopy
 {
 public:
-    OBJ(std::string filename, const double scale = 1.0);
+    OBJ(const std::string& filename, const double scale = 1.0);
 
     ~OBJ();
 
@@ -39,7 +39,11 @@ public:
         const std::optional<Point2F>& uv1 = std::nullopt,
         const std::optional<Point2F>& uv2 = std::nullopt);
 
-    void writeMesh(const Mesh& mesh, const SVG::Color color = SVG::Color::BLACK);
+    void write(const Mesh& mesh, const SVG::Color color = SVG::Color::BLACK);
+
+    void write(const Polyline& polyline, const coord_t z, const coord_t height, const SVG::Color color = SVG::Color::BLACK);
+
+    void write(const Shape& shape, const coord_t z, const coord_t height, const SVG::Color color = SVG::Color::BLACK);
 
 private:
     struct Triangle

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -49,7 +49,6 @@ TreeModelVolumes::TreeModelVolumes(
     coord_t min_maximum_deviation = std::numeric_limits<coord_t>::max();
     coord_t min_maximum_area_deviation = std::numeric_limits<coord_t>::max();
 
-    support_rests_on_model_ = false;
     for (auto [mesh_idx, mesh_ptr] : storage.meshes | ranges::views::enumerate)
     {
         auto& mesh = *mesh_ptr;

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -13,6 +13,7 @@
 #include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/iota.hpp>
+#include <range/v3/view/map.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <scripta/logger.h>
 #include <spdlog/spdlog.h>
@@ -1937,11 +1938,28 @@ void TreeSupport::dropNonGraciousAreas(
                                            && ! elem->to_buildplate_; // If an element has no child, it connects to whatever is below as no support further down for it will exist.
             if (non_gracious_model_contact)
             {
+                std::vector<std::pair<LayerIndex, Shape>>& dropped_down_area = dropped_down_areas[idx];
                 Shape rest_support = layer_tree_polygons[linear_data[idx].first][elem].intersection(volumes_.getAccumulatedPlaceable0(linear_data[idx].first));
-                for (LayerIndex counter = 1; rest_support.area() > 1 && counter < linear_data[idx].first; ++counter)
+                for (LayerIndex counter = 1; rest_support.area() > 1 && counter < linear_data[idx].first && ! rest_support.empty(); ++counter)
                 {
-                    rest_support = rest_support.difference(volumes_.getCollision(0, linear_data[idx].first - counter));
-                    dropped_down_areas[idx].emplace_back(linear_data[idx].first - counter, rest_support);
+                    const LayerIndex layer_index = linear_data[idx].first - counter;
+                    rest_support = rest_support.difference(volumes_.getCollision(0, layer_index));
+                    for (const Shape& layer_tree_polygon : layer_tree_polygons[layer_index] | ranges::views::values)
+                    {
+                        // Remove parts of the support that are absorbed by the actual trees
+                        rest_support = rest_support.difference(layer_tree_polygon.offset(-EPSILON));
+                    }
+                    dropped_down_area.emplace_back(layer_index, rest_support);
+                }
+
+                if (! rest_support.empty())
+                {
+                    // If there is some remainder after dropping the area to the bottom, that means it could not actually reach the model or another branch, so discard the piece
+                    rest_support = rest_support.offset(EPSILON);
+                    for (Shape& dropped_area_on_layer : dropped_down_area | ranges::views::values)
+                    {
+                        dropped_area_on_layer = dropped_area_on_layer.difference(rest_support);
+                    }
                 }
             }
         });

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -25,6 +25,7 @@
 #include "progress/Progress.h"
 #include "settings/EnumSettings.h"
 #include "support.h" //For precomputeCrossInfillTree
+#include "utils/OBJ.h"
 #include "utils/Simplify.h"
 #include "utils/ThreadPool.h"
 #include "utils/algorithm.h"
@@ -2455,6 +2456,19 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
         dur_drop,
         dur_filter,
         dur_finalize);
+}
+
+void TreeSupport::saveToObj(const std::vector<std::set<TreeSupportElement*>>& move_bounds, OBJ& obj) const
+{
+    for (const auto [layer_index, elements] : move_bounds | ranges::views::enumerate)
+    {
+        const coord_t z = layer_index * config.layer_height;
+        for (const TreeSupportElement* element : elements)
+        {
+            element->saveToObj(obj, z, config.layer_height);
+            obj.writeSphere(Point3D(Point3LL(element->result_on_layer_, z), 1.0), config.layer_height / 2.0, SVG::Color::RED);
+        }
+    }
 }
 
 } // namespace cura

--- a/src/TreeSupportElement.cpp
+++ b/src/TreeSupportElement.cpp
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
+
+#include "TreeSupportElement.h"
+
+#include "utils/OBJ.h"
+
+
+namespace cura
+{
+
+TreeSupportElement::TreeSupportElement(
+    coord_t distance_to_top,
+    size_t target_height,
+    Point2LL target_position,
+    bool to_buildplate,
+    bool to_model_gracious,
+    bool use_min_xy_dist,
+    size_t dont_move_until,
+    bool supports_roof,
+    bool can_use_safe_radius,
+    bool force_tips_to_roof,
+    bool skip_ovalisation,
+    bool influence_area_limit_active,
+    coord_t influence_area_limit_range)
+    : target_height_(target_height)
+    , target_position_(target_position)
+    , next_position_(target_position)
+    , next_height_(target_height)
+    , effective_radius_height_(distance_to_top)
+    , to_buildplate_(to_buildplate)
+    , distance_to_top_(distance_to_top)
+    , area_(nullptr)
+    , result_on_layer_(target_position)
+    , increased_to_model_radius_(0)
+    , to_model_gracious_(to_model_gracious)
+    , buildplate_radius_increases_(0)
+    , use_min_xy_dist_(use_min_xy_dist)
+    , supports_roof_(supports_roof)
+    , dont_move_until_(dont_move_until)
+    , can_use_safe_radius_(can_use_safe_radius)
+    , last_area_increase_(AreaIncreaseSettings(AvoidanceType::FAST, 0, false, false, false, false))
+    , missing_roof_layers_(force_tips_to_roof ? dont_move_until : 0)
+    , skip_ovalisation_(skip_ovalisation)
+    , all_tips_({ target_position })
+    , influence_area_limit_active_(influence_area_limit_active)
+    , influence_area_limit_range_(influence_area_limit_range)
+{
+    RecreateInfluenceLimitArea();
+}
+
+TreeSupportElement::TreeSupportElement(const TreeSupportElement& elem, Shape* newArea)
+    : // copy constructor with possibility to set a new area
+    target_height_(elem.target_height_)
+    , target_position_(elem.target_position_)
+    , next_position_(elem.next_position_)
+    , next_height_(elem.next_height_)
+    , effective_radius_height_(elem.effective_radius_height_)
+    , to_buildplate_(elem.to_buildplate_)
+    , distance_to_top_(elem.distance_to_top_)
+    , area_(newArea != nullptr ? newArea : elem.area_)
+    , result_on_layer_(elem.result_on_layer_)
+    , increased_to_model_radius_(elem.increased_to_model_radius_)
+    , to_model_gracious_(elem.to_model_gracious_)
+    , buildplate_radius_increases_(elem.buildplate_radius_increases_)
+    , use_min_xy_dist_(elem.use_min_xy_dist_)
+    , supports_roof_(elem.supports_roof_)
+    , dont_move_until_(elem.dont_move_until_)
+    , can_use_safe_radius_(elem.can_use_safe_radius_)
+    , last_area_increase_(elem.last_area_increase_)
+    , missing_roof_layers_(elem.missing_roof_layers_)
+    , skip_ovalisation_(elem.skip_ovalisation_)
+    , all_tips_(elem.all_tips_)
+    , influence_area_limit_active_(elem.influence_area_limit_active_)
+    , influence_area_limit_range_(elem.influence_area_limit_range_)
+    , influence_area_limit_area_(elem.influence_area_limit_area_)
+{
+    parents_.insert(parents_.begin(), elem.parents_.begin(), elem.parents_.end());
+}
+
+TreeSupportElement::TreeSupportElement(TreeSupportElement* element_above)
+    : target_height_(element_above->target_height_)
+    , target_position_(element_above->target_position_)
+    , next_position_(element_above->next_position_)
+    , next_height_(element_above->next_height_)
+    , effective_radius_height_(element_above->effective_radius_height_)
+    , to_buildplate_(element_above->to_buildplate_)
+    , distance_to_top_(element_above->distance_to_top_ + 1)
+    , area_(element_above->area_)
+    , result_on_layer_(Point2LL(-1, -1))
+    , // set to invalid as we are a new node on a new layer
+    increased_to_model_radius_(element_above->increased_to_model_radius_)
+    , to_model_gracious_(element_above->to_model_gracious_)
+    , buildplate_radius_increases_(element_above->buildplate_radius_increases_)
+    , use_min_xy_dist_(element_above->use_min_xy_dist_)
+    , supports_roof_(element_above->supports_roof_)
+    , dont_move_until_(element_above->dont_move_until_)
+    , can_use_safe_radius_(element_above->can_use_safe_radius_)
+    , last_area_increase_(element_above->last_area_increase_)
+    , missing_roof_layers_(element_above->missing_roof_layers_)
+    , skip_ovalisation_(false)
+    , all_tips_(element_above->all_tips_)
+    , influence_area_limit_active_(element_above->influence_area_limit_active_)
+    , influence_area_limit_range_(element_above->influence_area_limit_range_)
+    , influence_area_limit_area_(element_above->influence_area_limit_area_)
+{
+    parents_ = { element_above };
+}
+
+TreeSupportElement::TreeSupportElement(
+    const TreeSupportElement& first,
+    const TreeSupportElement& second,
+    size_t next_height,
+    Point2LL next_position,
+    coord_t increased_to_model_radius,
+    const std::function<coord_t(size_t, double)>& getRadius,
+    double diameter_scale_bp_radius,
+    coord_t branch_radius,
+    double diameter_angle_scale_factor)
+    : next_position_(next_position)
+    , next_height_(next_height)
+    , area_(nullptr)
+    , increased_to_model_radius_(increased_to_model_radius)
+    , use_min_xy_dist_(first.use_min_xy_dist_ || second.use_min_xy_dist_)
+    , supports_roof_(first.supports_roof_ || second.supports_roof_)
+    , dont_move_until_(std::max(first.dont_move_until_, second.dont_move_until_))
+    , can_use_safe_radius_(first.can_use_safe_radius_ || second.can_use_safe_radius_)
+    , missing_roof_layers_(std::min(first.missing_roof_layers_, second.missing_roof_layers_))
+    , skip_ovalisation_(false)
+{
+    if (first.target_height_ > second.target_height_)
+    {
+        target_height_ = first.target_height_;
+        target_position_ = first.target_position_;
+    }
+    else
+    {
+        target_height_ = second.target_height_;
+        target_position_ = second.target_position_;
+    }
+    effective_radius_height_ = std::max(first.effective_radius_height_, second.effective_radius_height_);
+    distance_to_top_ = std::max(first.distance_to_top_, second.distance_to_top_);
+
+    to_buildplate_ = first.to_buildplate_ && second.to_buildplate_;
+    to_model_gracious_ = first.to_model_gracious_ && second.to_model_gracious_; // valid as we do not merge non-gracious with gracious
+
+    AddParents(first.parents_);
+    AddParents(second.parents_);
+
+    buildplate_radius_increases_ = 0;
+    if (diameter_scale_bp_radius > 0)
+    {
+        const coord_t foot_increase_radius = std::abs(
+            std::max(getRadius(second.effective_radius_height_, second.buildplate_radius_increases_), getRadius(first.effective_radius_height_, first.buildplate_radius_increases_))
+            - getRadius(effective_radius_height_, buildplate_radius_increases_));
+        // 'buildplate_radius_increases' has to be recalculated, as when a smaller tree with a larger buildplate_radius_increases merge with a larger branch,
+        //   the buildplate_radius_increases may have to be lower as otherwise the radius suddenly increases. This results often in a non integer value.
+        buildplate_radius_increases_ = foot_increase_radius / (branch_radius * (diameter_scale_bp_radius - diameter_angle_scale_factor));
+    }
+
+    // set last settings to the best out of both parents. If this is wrong, it will only cause a small performance penalty instead of weird behavior.
+    last_area_increase_ = AreaIncreaseSettings(
+        std::min(first.last_area_increase_.type_, second.last_area_increase_.type_),
+        std::min(first.last_area_increase_.increase_speed_, second.last_area_increase_.increase_speed_),
+        first.last_area_increase_.increase_radius_ || second.last_area_increase_.increase_radius_,
+        first.last_area_increase_.no_error_ || second.last_area_increase_.no_error_,
+        first.last_area_increase_.use_min_distance_ && second.last_area_increase_.use_min_distance_,
+        first.last_area_increase_.move_ || second.last_area_increase_.move_);
+
+    all_tips_ = first.all_tips_;
+    all_tips_.insert(all_tips_.end(), second.all_tips_.begin(), second.all_tips_.end());
+    influence_area_limit_range_ = std::max(first.influence_area_limit_range_, second.influence_area_limit_range_);
+    influence_area_limit_active_ = first.influence_area_limit_active_ || second.influence_area_limit_active_;
+    RecreateInfluenceLimitArea();
+    if (first.to_buildplate_ != second.to_buildplate_)
+    {
+        setToBuildplateForAllParents(to_buildplate_);
+    }
+}
+
+void TreeSupportElement::AddParents(const std::vector<TreeSupportElement*>& adding)
+{
+    for (TreeSupportElement* ptr : adding)
+    {
+        parents_.emplace_back(ptr);
+    }
+}
+
+void TreeSupportElement::RecreateInfluenceLimitArea()
+{
+    if (influence_area_limit_active_)
+    {
+        influence_area_limit_area_.clear();
+
+        for (Point2LL p : all_tips_)
+        {
+            Polygon circle;
+            for (Point2LL corner : TreeSupportBaseCircle::getBaseCircle())
+            {
+                circle.push_back(p + corner * influence_area_limit_range_ / double(TreeSupportBaseCircle::base_radius));
+            }
+            if (influence_area_limit_area_.empty())
+            {
+                influence_area_limit_area_ = circle.offset(0);
+            }
+            else
+            {
+                influence_area_limit_area_ = influence_area_limit_area_.intersection(circle.offset(0));
+            }
+        }
+    }
+}
+
+void TreeSupportElement::setToBuildplateForAllParents(bool new_value)
+{
+    to_buildplate_ = new_value;
+    to_model_gracious_ |= new_value;
+    std::vector<TreeSupportElement*> grandparents{ parents_ };
+    while (! grandparents.empty())
+    {
+        std::vector<TreeSupportElement*> next_parents;
+        for (TreeSupportElement* grandparent : grandparents)
+        {
+            next_parents.insert(next_parents.end(), grandparent->parents_.begin(), grandparent->parents_.end());
+            grandparent->to_buildplate_ = new_value;
+            grandparent->to_model_gracious_ |= new_value; // If we set to_buildplate to true, update to_model_gracious
+        }
+        grandparents = next_parents;
+    }
+}
+
+void TreeSupportElement::saveToObj(OBJ& obj, const coord_t z, const coord_t layer_height) const
+{
+    if (area_)
+    {
+        obj.write(*area_, z, layer_height, SVG::Color::BLUE);
+    }
+}
+
+} // namespace cura

--- a/src/TreeSupportElement.cpp
+++ b/src/TreeSupportElement.cpp
@@ -233,7 +233,7 @@ void TreeSupportElement::saveToObj(OBJ& obj, const coord_t z, const coord_t laye
 {
     if (area_)
     {
-        obj.write(*area_, z, layer_height, SVG::Color::BLUE);
+        obj.write(*area_, z, layer_height, to_model_gracious_ ? SVG::Color::BLUE : SVG::Color::RED);
     }
 }
 

--- a/src/utils/OBJ.cpp
+++ b/src/utils/OBJ.cpp
@@ -15,7 +15,7 @@
 namespace cura
 {
 
-OBJ::OBJ(std::string filename, const double scale)
+OBJ::OBJ(const std::string& filename, const double scale)
     : filename_(filename)
     , scale_(scale)
 {
@@ -154,18 +154,41 @@ void OBJ::writeTriangle(
     triangles_.push_back(Triangle{ scalePosition(p0), scalePosition(p1), scalePosition(p2), color, uv0, uv1, uv2 });
 }
 
-void OBJ::writeMesh(const Mesh& mesh, const SVG::Color color)
+void OBJ::write(const Mesh& mesh, const SVG::Color color)
 {
+    constexpr double scale = 1.0;
     for (const MeshFace& face : mesh.faces_)
     {
         writeTriangle(
-            Point3D(mesh.vertices_[face.vertex_index_[0]].p_),
-            Point3D(mesh.vertices_[face.vertex_index_[1]].p_),
-            Point3D(mesh.vertices_[face.vertex_index_[2]].p_),
+            Point3D(mesh.vertices_[face.vertex_index_[0]].p_, scale),
+            Point3D(mesh.vertices_[face.vertex_index_[1]].p_, scale),
+            Point3D(mesh.vertices_[face.vertex_index_[2]].p_, scale),
             color,
             face.uv_coordinates_[0],
             face.uv_coordinates_[1],
             face.uv_coordinates_[2]);
+    }
+}
+
+void OBJ::write(const Polyline& polyline, const coord_t z, const coord_t height, const SVG::Color color)
+{
+    constexpr double scale = 1.0;
+    const Point3D extrusion(0.0, 0.0, height);
+    for (auto iterator = polyline.beginSegments(); iterator != polyline.endSegments(); ++iterator)
+    {
+        const Point3D start(Point3LL((*iterator).start, z), scale);
+        const Point3D end(Point3LL((*iterator).end, z), scale);
+
+        writeTriangle(start, end, end + extrusion, color);
+        writeTriangle(start, end + extrusion, start + extrusion, color);
+    }
+}
+
+void OBJ::write(const Shape& shape, const coord_t z, const coord_t height, const SVG::Color color)
+{
+    for (const Polygon& polygon : shape)
+    {
+        write(polygon, z, height, color);
     }
 }
 


### PR DESCRIPTION
This PR fixes possible weak non-tree support towers being generated along with tree support, by adding a filter when dropping the "non-gracious" areas of tree support. The filter does the following:
* When the dropped part reaches an actual branch, which is quite likely, it now merges inside the branch without going down further.
* If the dropping ever goes down to reach the buildplate, we remove the remaining part completely because it will not provide any good support anyway.

The PR also provides a small refactoring of the tree support files and adds methods to allow saving the internal tree support data to OBJ for visualization.

CURA-12636