### PR TITLE
Avoid adding extra newline in writeCode

### DIFF
--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1529,7 +1529,7 @@ void GCodeExport::switchExtruder(size_t new_extruder, const RetractionConfig& re
 void GCodeExport::writeCode(const std::string& str)
 {
     *output_stream_ << str;
-    if (str.empty() || str.back() != '\n')
+    if (! str.ends_with('\n'))
     {
         *output_stream_ << new_line_;
     }

--- a/src/gcodeExport.cpp
+++ b/src/gcodeExport.cpp
@@ -1528,7 +1528,11 @@ void GCodeExport::switchExtruder(size_t new_extruder, const RetractionConfig& re
 
 void GCodeExport::writeCode(const std::string& str)
 {
-    *output_stream_ << str << new_line_;
+    *output_stream_ << str;
+    if (str.empty() || str.back() != '\n')
+    {
+        *output_stream_ << new_line_;
+    }
 }
 
 void GCodeExport::writeCodeWithAbsoluteExtrusion(const std::string& str)


### PR DESCRIPTION
Modify GCodeExport::writeCode to write the provided string as-is and only append new_line_ when the string is empty or does not already end with a newline. This prevents adding a duplicate newline when callers pass strings that already include a trailing '\n' such as start/end gcode, while preserving behavior for empty strings.

CURA-13109