### PR TITLE
fix: Temperature preheat command fires at correct time within long co…

### DIFF
--- a/include/ExtruderPlan.h
+++ b/include/ExtruderPlan.h
@@ -78,9 +78,11 @@ public:
      *
      * \param path_idx The index into ExtruderPlan::paths which is currently being consider for temperature command insertion
      * \param gcode The gcode exporter to which to write the temperature command.
-     * \param cumulative_path_time The time spend on this path up to this point.
+     * \param cumulative_path_time The time spent on this path up to this point. Inserts whose path_idx is strictly less
+     *        than the current path_idx are considered overdue and will be fired unconditionally. Inserts whose path_idx
+     *        equals the current path_idx are fired only once cumulative_path_time reaches their time_after_path_start.
      */
-    void handleInserts(const size_t path_idx, GCodeExport& gcode, const double cumulative_path_time = std::numeric_limits<double>::infinity());
+    void handleInserts(const size_t path_idx, GCodeExport& gcode, const double cumulative_path_time);
 
     /*!
      * Insert all remaining temp inserts into gcode, to be called at the end of an extruder plan

--- a/src/ExtruderPlan.cpp
+++ b/src/ExtruderPlan.cpp
@@ -30,8 +30,21 @@ void ExtruderPlan::insertCommand(NozzleTempInsert&& insert)
 
 void ExtruderPlan::handleInserts(const size_t path_idx, GCodeExport& gcode, const double cumulative_path_time)
 {
-    while (! inserts_.empty() && path_idx >= inserts_.front().path_idx && inserts_.front().time_after_path_start < cumulative_path_time)
-    { // handle the Insert to be inserted before this path_idx (and all inserts not handled yet)
+    while (! inserts_.empty())
+    {
+        const NozzleTempInsert& insert = inserts_.front();
+        if (insert.path_idx > path_idx)
+        {
+            // Insert is scheduled for a future path; nothing more to do for now.
+            break;
+        }
+        if (insert.path_idx == path_idx && insert.time_after_path_start > cumulative_path_time)
+        {
+            // Insert is scheduled for this path, but the required time within the path has not been reached yet.
+            break;
+        }
+        // Either the insert is overdue (insert.path_idx < path_idx) and must be fired immediately,
+        // or it is exactly on time (insert.path_idx == path_idx and time threshold reached).
         inserts_.front().write(gcode);
         inserts_.pop_front();
     }

--- a/src/ExtruderPlan.cpp
+++ b/src/ExtruderPlan.cpp
@@ -33,14 +33,10 @@ void ExtruderPlan::handleInserts(const size_t path_idx, GCodeExport& gcode, cons
     while (! inserts_.empty())
     {
         const NozzleTempInsert& insert = inserts_.front();
-        if (insert.path_idx > path_idx)
+        const bool in_future_path = insert.path_idx > path_idx;
+        const bool in_current_path_at_future_time = insert.path_idx == path_idx && insert.time_after_path_start > cumulative_path_time;
+        if (in_future_path || in_current_path_at_future_time)
         {
-            // Insert is scheduled for a future path; nothing more to do for now.
-            break;
-        }
-        if (insert.path_idx == path_idx && insert.time_after_path_start > cumulative_path_time)
-        {
-            // Insert is scheduled for this path, but the required time within the path has not been reached yet.
             break;
         }
         // Either the insert is overdue (insert.path_idx < path_idx) and must be fired immediately,

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -3512,8 +3512,11 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
         for (size_t path_idx = 0; path_idx < paths.size(); path_idx++)
         {
-            extruder_plan.handleInserts(path_idx, gcode);
             cumulative_path_time = 0.; // reset to 0 for current path.
+            // Fire any inserts that are overdue (scheduled for a previous path that has already been written).
+            // Inserts scheduled for the current path are intentionally left pending; they will be fired at the
+            // correct time within the path by the insertTempOnTime callback below.
+            extruder_plan.handleInserts(path_idx, gcode, cumulative_path_time);
 
             GCodePath& path = paths[path_idx];
 

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -3512,11 +3512,10 @@ void LayerPlan::writeGCode(GCodeExport& gcode)
 
         for (size_t path_idx = 0; path_idx < paths.size(); path_idx++)
         {
-            cumulative_path_time = 0.; // reset to 0 for current path.
-            // Fire any inserts that are overdue (scheduled for a previous path that has already been written).
-            // Inserts scheduled for the current path are intentionally left pending; they will be fired at the
-            // correct time within the path by the insertTempOnTime callback below.
+            // Fire any inserts that became overdue during the previous path, using the total
+            // accumulated time from that path.
             extruder_plan.handleInserts(path_idx, gcode, cumulative_path_time);
+            cumulative_path_time = 0.; // reset to 0 for current path.
 
             GCodePath& path = paths[path_idx];
 


### PR DESCRIPTION
# Description

For long zigzag skin (initial layer) the temperature command was firing at the beginning of the path (start of skin) rather than at the end-ish of layer 0 (with consideration for the heat up time).

The fix ensures that at the start of each path only genuinely overdue inserts are fired immediately. Inserts assigned to the current path are held until the insertTempOnTime callback reaches their time_after_path_start, preserving the intended placement regardless of how many paths the feature is split into.

<img width="2136" height="1309" alt="image" src="https://github.com/user-attachments/assets/eb097c1b-5926-42ef-ab26-8a2199a94fd3" />


## Type of change

- [x] Bug fix

# How Has This Been Tested?

- [x] Create a build -> Slice -> inspect Gcode under similar conditions with both before and after having the zigzag initial layer -> check the temperature command is inserted at the correct moment

**Test Configuration**:
* Operating System: Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change


CURA-13115