### PR TITLE
CURA-13070 Allow disabling prime tower wheel pattern

### DIFF
--- a/src/PrimeTower/PrimeTower.cpp
+++ b/src/PrimeTower/PrimeTower.cpp
@@ -138,27 +138,29 @@ std::tuple<ClosedLinesSet, coord_t> PrimeTower::generatePrimeToolpaths(const siz
 ClosedLinesSet PrimeTower::generateSupportToolpaths(const size_t extruder_nr, const coord_t outer_radius, const coord_t inner_radius)
 {
     const Scene& scene = Application::getInstance().current_slice_->scene;
-    const double max_bridging_distance = static_cast<double>(scene.extruders[extruder_nr].settings_.get<coord_t>("prime_tower_max_bridging_distance"));
-    const coord_t line_width = scene.extruders[extruder_nr].settings_.get<coord_t>("prime_tower_line_width");
+    const Settings& extruder_settings = scene.extruders[extruder_nr].settings_;
+    const coord_t line_width = extruder_settings.get<coord_t>("prime_tower_line_width");
+    const double max_bridging_distance = static_cast<double>(std::max(extruder_settings.get<coord_t>("prime_tower_max_bridging_distance"), line_width));
     const coord_t radius_delta = outer_radius - inner_radius;
     const coord_t semi_line_width = line_width / 2;
 
     ClosedLinesSet toolpaths;
-    // Split annuli according to max bridging distance with constraints to ensure we can fit the wheel
-    const coord_t nb_annuli = max_bridging_distance > 0.0 ? static_cast<coord_t>(std::ceil(static_cast<double>(radius_delta) / max_bridging_distance)) : 0;
-    const coord_t actual_radius_step = nb_annuli > 0 ? radius_delta / nb_annuli : 0;
+    // Split annuli according to max bridging distance
+    const coord_t nb_annuli = static_cast<coord_t>(std::ceil(static_cast<double>(radius_delta) / max_bridging_distance));
+    const coord_t nb_circles = radius_delta / line_width;
 
-    if (actual_radius_step <= line_width)
+    if (nb_circles <= nb_annuli)
     {
-        // Bridging distance is 0 or too small for a proper wheel pattern; use solid concentric circles instead.
-        const coord_t nb_circles = radius_delta / line_width;
+        // Bridging distance is too small for a proper wheel pattern; use solid concentric circles instead.
         for (coord_t i = 0; i < nb_circles; ++i)
         {
             toolpaths.push_back(PolygonUtils::makeCircle(middle_, outer_radius - semi_line_width - i * line_width, circle_definition_));
         }
     }
-    else
+    else if (nb_annuli > 0)
     {
+        const coord_t actual_radius_step = radius_delta / nb_annuli;
+
         for (coord_t i = 0; i < nb_annuli; ++i)
         {
             const coord_t annulus_inner_radius = (inner_radius + i * actual_radius_step) + semi_line_width;

--- a/src/PrimeTower/PrimeTower.cpp
+++ b/src/PrimeTower/PrimeTower.cpp
@@ -144,34 +144,29 @@ ClosedLinesSet PrimeTower::generateSupportToolpaths(const size_t extruder_nr, co
     const coord_t semi_line_width = line_width / 2;
 
     ClosedLinesSet toolpaths;
+    // Split annuli according to max bridging distance with constraints to ensure we can fit the wheel
+    const coord_t nb_annuli = max_bridging_distance > 0.0 ? static_cast<coord_t>(std::ceil(static_cast<double>(radius_delta) / max_bridging_distance)) : 0;
+    const coord_t actual_radius_step = nb_annuli > 0 ? radius_delta / nb_annuli : 0;
 
-    // Split annuli according to max bridging distance
-    const coord_t nb_annuli = static_cast<coord_t>(std::ceil(static_cast<double>(radius_delta) / max_bridging_distance));
-    if (nb_annuli > 0)
+    if (nb_annuli == 0 || actual_radius_step <= line_width)
     {
-        const coord_t actual_radius_step = radius_delta / nb_annuli;
-
-        if (actual_radius_step <= line_width)
+        // Bridging distance is 0 or too small for a proper wheel pattern; use solid concentric circles instead.
+        const coord_t nb_circles = radius_delta / line_width;
+        for (coord_t i = 0; i < nb_circles; ++i)
         {
-            // The bridging distance is too small to allow a proper wheel pattern (the annulus width would be <= 0 after
-            // accounting for line width offsets). Fall back to a solid concentric circles pattern instead.
-            const coord_t nb_circles = radius_delta / line_width;
-            for (coord_t i = 0; i < nb_circles; ++i)
-            {
-                toolpaths.push_back(PolygonUtils::makeCircle(middle_, outer_radius - semi_line_width - i * line_width, circle_definition_));
-            }
+            toolpaths.push_back(PolygonUtils::makeCircle(middle_, outer_radius - semi_line_width - i * line_width, circle_definition_));
         }
-        else
+    }
+    else
+    {
+        for (coord_t i = 0; i < nb_annuli; ++i)
         {
-            for (coord_t i = 0; i < nb_annuli; ++i)
-            {
-                const coord_t annulus_inner_radius = (inner_radius + i * actual_radius_step) + semi_line_width;
-                const coord_t annulus_outer_radius = (inner_radius + (i + 1) * actual_radius_step) - semi_line_width;
+            const coord_t annulus_inner_radius = (inner_radius + i * actual_radius_step) + semi_line_width;
+            const coord_t annulus_outer_radius = (inner_radius + (i + 1) * actual_radius_step) - semi_line_width;
 
-                const size_t semi_nb_spokes = static_cast<size_t>(std::ceil((std::numbers::pi * static_cast<double>(annulus_outer_radius)) / max_bridging_distance));
+            const size_t semi_nb_spokes = static_cast<size_t>(std::ceil((std::numbers::pi * static_cast<double>(annulus_outer_radius)) / max_bridging_distance));
 
-                toolpaths.push_back(PolygonUtils::makeWheel(middle_, annulus_inner_radius, annulus_outer_radius, semi_nb_spokes, arc_definition_));
-            }
+            toolpaths.push_back(PolygonUtils::makeWheel(middle_, annulus_inner_radius, annulus_outer_radius, semi_nb_spokes, arc_definition_));
         }
     }
 

--- a/src/PrimeTower/PrimeTower.cpp
+++ b/src/PrimeTower/PrimeTower.cpp
@@ -151,14 +151,27 @@ ClosedLinesSet PrimeTower::generateSupportToolpaths(const size_t extruder_nr, co
     {
         const coord_t actual_radius_step = radius_delta / nb_annuli;
 
-        for (coord_t i = 0; i < nb_annuli; ++i)
+        if (actual_radius_step <= line_width)
         {
-            const coord_t annulus_inner_radius = (inner_radius + i * actual_radius_step) + semi_line_width;
-            const coord_t annulus_outer_radius = (inner_radius + (i + 1) * actual_radius_step) - semi_line_width;
+            // The bridging distance is too small to allow a proper wheel pattern (the annulus width would be <= 0 after
+            // accounting for line width offsets). Fall back to a solid concentric circles pattern instead.
+            const coord_t nb_circles = radius_delta / line_width;
+            for (coord_t i = 0; i < nb_circles; ++i)
+            {
+                toolpaths.push_back(PolygonUtils::makeCircle(middle_, outer_radius - semi_line_width - i * line_width, circle_definition_));
+            }
+        }
+        else
+        {
+            for (coord_t i = 0; i < nb_annuli; ++i)
+            {
+                const coord_t annulus_inner_radius = (inner_radius + i * actual_radius_step) + semi_line_width;
+                const coord_t annulus_outer_radius = (inner_radius + (i + 1) * actual_radius_step) - semi_line_width;
 
-            const size_t semi_nb_spokes = static_cast<size_t>(std::ceil((std::numbers::pi * static_cast<double>(annulus_outer_radius)) / max_bridging_distance));
+                const size_t semi_nb_spokes = static_cast<size_t>(std::ceil((std::numbers::pi * static_cast<double>(annulus_outer_radius)) / max_bridging_distance));
 
-            toolpaths.push_back(PolygonUtils::makeWheel(middle_, annulus_inner_radius, annulus_outer_radius, semi_nb_spokes, arc_definition_));
+                toolpaths.push_back(PolygonUtils::makeWheel(middle_, annulus_inner_radius, annulus_outer_radius, semi_nb_spokes, arc_definition_));
+            }
         }
     }
 

--- a/src/PrimeTower/PrimeTower.cpp
+++ b/src/PrimeTower/PrimeTower.cpp
@@ -148,7 +148,7 @@ ClosedLinesSet PrimeTower::generateSupportToolpaths(const size_t extruder_nr, co
     const coord_t nb_annuli = max_bridging_distance > 0.0 ? static_cast<coord_t>(std::ceil(static_cast<double>(radius_delta) / max_bridging_distance)) : 0;
     const coord_t actual_radius_step = nb_annuli > 0 ? radius_delta / nb_annuli : 0;
 
-    if (nb_annuli == 0 || actual_radius_step <= line_width)
+    if (actual_radius_step <= line_width)
     {
         // Bridging distance is 0 or too small for a proper wheel pattern; use solid concentric circles instead.
         const coord_t nb_circles = radius_delta / line_width;


### PR DESCRIPTION
Disable wheel pattern for prime tower when there is actually not enough space i.r.t the maximum bridging distance to allow a proper pattern. When this is the case, we just fallback to using full circles.

CURA-13070
Requires https://github.com/Ultimaker/Cura/pull/21561