### PR TITLE
Bump curaformulaengine package

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,7 +1,7 @@
 version: "5.14.0-alpha.0"
 commit: "unknown"
 requirements:
-  - "cura-formulae-engine/1.1.0@ultimaker/testing"
+  - "cura-formulae-engine/1.2.0@ultimaker/testing"
   - "scripta/[>=1.1.0]@ultimaker/testing"
   - "libpng/1.6.48"
   - "onetbb/2022.2.0"


### PR DESCRIPTION
Main objective of this PR is to be able to parse the following values in gcode start-end templates
```py
min(extruderValues('adhesion_type'), key=('raft', 'brim', 'skirt', 'none').index)
```
Added support for the following syntax
- **property index** can now write `property.index`
- **key word arguments** can now write `min(..., key=...)`

NP-1333