### PR TITLE
[CURA-13248] Fix quoted extruder capture in template regex

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,7 +1,7 @@
 version: "5.14.0-alpha.0"
 commit: "unknown"
 requirements:
-  - "cura-formulae-engine/1.2.0@ultimaker/testing"
+  - "cura-formulae-engine/1.2.1@ultimaker/testing"
   - "scripta/[>=1.1.0]@ultimaker/testing"
   - "libpng/1.6.48"
   - "onetbb/2022.3.0"

--- a/src/gcode_export/GcodeTemplateResolver.cpp
+++ b/src/gcode_export/GcodeTemplateResolver.cpp
@@ -245,7 +245,7 @@ std::string GcodeTemplateResolver::resolveGCodeTemplate(
     std::string output;
     GcodeConditionState condition_state = GcodeConditionState::OutsideCondition;
 
-    static const boost::regex expression_regex(R"({\s*(?<condition>if|else|elif|endif)?\s*(?<expression>[^{}]*?)\s*(?:,\s*(?<extruder_nr>[^{},]*))?\s*}(?<end_of_line>\n?))");
+    static const boost::regex expression_regex(R"({\s*(?<condition>if|else|elif|endif)?\s*(?<expression>[^{}]*?)\s*(?:,\s*(?<extruder_nr>[^{},'"]+))?\s*}(?<end_of_line>\n?))");
 
     // Create local environment containing the context-specific extra settings, and are chained to the extruder and global environment
     std::map<std::optional<size_t>, std::shared_ptr<cfe::env::LocalEnvironment>> local_environments;


### PR DESCRIPTION
Updated the G-code template resolver regex so the optional `extruder_nr` group no longer matches single or double quotes. This tightens placeholder parsing and prevents invalid quoted values from being treated as extruder identifiers. This allows for comparisons such as if "value in list" which currently results in the last list item being associated as extruder_nr

CURA-13248