### PR TITLE
[CURA-13125] Respect cool_fan_enabled for fan overrides

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3221,7 +3221,8 @@ void FffGcodeWriter::processTopBottom(
 
     double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT;
 
-    if (layer_nr > 0 && skin_config == &mesh_config.skin_config && support_layer_nr >= 0 && mesh.settings.get<bool>("support_fan_enable") && mesh.settings.get<bool>("cool_fan_enabled"))
+    if (layer_nr > 0 && skin_config == &mesh_config.skin_config && support_layer_nr >= 0 && mesh.settings.get<bool>("support_fan_enable")
+        && mesh.settings.get<bool>("cool_fan_enabled"))
     {
         // skin isn't a bridge but is it above support and we need to modify the fan speed?
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -3221,7 +3221,7 @@ void FffGcodeWriter::processTopBottom(
 
     double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT;
 
-    if (layer_nr > 0 && skin_config == &mesh_config.skin_config && support_layer_nr >= 0 && mesh.settings.get<bool>("support_fan_enable"))
+    if (layer_nr > 0 && skin_config == &mesh_config.skin_config && support_layer_nr >= 0 && mesh.settings.get<bool>("support_fan_enable") && mesh.settings.get<bool>("cool_fan_enabled"))
     {
         // skin isn't a bridge but is it above support and we need to modify the fan speed?
 

--- a/src/InfillOrderOptimizer.cpp
+++ b/src/InfillOrderOptimizer.cpp
@@ -482,7 +482,7 @@ void InfillOrderOptimizer::addSkinSupportLinesToLayer(
     const bool enable_travel_optimization,
     const Ratio& flow_ratio) const
 {
-    const auto skin_support_fan_speed = settings.get<double>("skin_support_fan_speed");
+    const auto skin_support_fan_speed = settings.get<bool>("cool_fan_enabled") ? settings.get<double>("skin_support_fan_speed") : GCodePathConfig::FAN_SPEED_DEFAULT;
     constexpr SpaceFillType skin_support_space_fill_type = SpaceFillType::Lines;
     constexpr coord_t skin_support_wipe_dist = 0;
     const auto skin_support_interlace_lines = settings.get<bool>("skin_support_interlace_lines");

--- a/src/settings/MeshPathConfigs.cpp
+++ b/src/settings/MeshPathConfigs.cpp
@@ -78,7 +78,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                    .acceleration = mesh.settings.get<Acceleration>("acceleration_wall_0"),
                                                    .jerk = mesh.settings.get<Velocity>("jerk_wall_0") },
                             .is_bridge_path = true,
-                            .fan_speed = mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 }
+                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_insetX_config{ .type = PrintFeatureType::InnerWall,
                             .line_width = static_cast<coord_t>(
                                 mesh.settings.get<coord_t>("wall_line_width_x")
@@ -89,7 +89,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                    .acceleration = mesh.settings.get<Acceleration>("acceleration_wall_x"),
                                                    .jerk = mesh.settings.get<Velocity>("jerk_wall_x") },
                             .is_bridge_path = true,
-                            .fan_speed = mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 }
+                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
     , skin_config{ .type = PrintFeatureType::Skin,
                    .line_width = static_cast<coord_t>(
                        mesh.settings.get<coord_t>("skin_line_width") * line_width_factor_per_extruder[mesh.settings.get<ExtruderTrain&>("top_bottom_extruder_nr").extruder_nr_]),
@@ -108,7 +108,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                  .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                  .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                           .is_bridge_path = true,
-                          .fan_speed = mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 }
+                          .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_skin_config2{ .type = PrintFeatureType::Skin,
                            .line_width = static_cast<coord_t>(
                                mesh.settings.get<coord_t>("skin_line_width")
@@ -119,7 +119,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                   .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                   .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                            .is_bridge_path = true,
-                           .fan_speed = mesh.settings.get<Ratio>("bridge_fan_speed_2") * 100.0 }
+                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed_2") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_skin_config3{ .type = PrintFeatureType::Skin,
                            .line_width = static_cast<coord_t>(
                                mesh.settings.get<coord_t>("skin_line_width")
@@ -130,7 +130,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                   .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                   .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                            .is_bridge_path = true,
-                           .fan_speed = mesh.settings.get<Ratio>("bridge_fan_speed_3") * 100.0 }
+                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed_3") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
     , roofing_config{ .type = PrintFeatureType::Skin,
                       .line_width = mesh.settings.get<coord_t>("roofing_line_width"),
                       .layer_thickness = layer_thickness,

--- a/src/settings/MeshPathConfigs.cpp
+++ b/src/settings/MeshPathConfigs.cpp
@@ -78,7 +78,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                    .acceleration = mesh.settings.get<Acceleration>("acceleration_wall_0"),
                                                    .jerk = mesh.settings.get<Velocity>("jerk_wall_0") },
                             .is_bridge_path = true,
-                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
+                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_insetX_config{ .type = PrintFeatureType::InnerWall,
                             .line_width = static_cast<coord_t>(
                                 mesh.settings.get<coord_t>("wall_line_width_x")
@@ -89,7 +89,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                    .acceleration = mesh.settings.get<Acceleration>("acceleration_wall_x"),
                                                    .jerk = mesh.settings.get<Velocity>("jerk_wall_x") },
                             .is_bridge_path = true,
-                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
+                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
     , skin_config{ .type = PrintFeatureType::Skin,
                    .line_width = static_cast<coord_t>(
                        mesh.settings.get<coord_t>("skin_line_width") * line_width_factor_per_extruder[mesh.settings.get<ExtruderTrain&>("top_bottom_extruder_nr").extruder_nr_]),
@@ -108,7 +108,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                  .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                  .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                           .is_bridge_path = true,
-                          .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
+                          .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_skin_config2{ .type = PrintFeatureType::Skin,
                            .line_width = static_cast<coord_t>(
                                mesh.settings.get<coord_t>("skin_line_width")
@@ -119,7 +119,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                   .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                   .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                            .is_bridge_path = true,
-                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed_2") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
+                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed_2") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_skin_config3{ .type = PrintFeatureType::Skin,
                            .line_width = static_cast<coord_t>(
                                mesh.settings.get<coord_t>("skin_line_width")
@@ -130,7 +130,7 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                   .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                   .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                            .is_bridge_path = true,
-                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? mesh.settings.get<Ratio>("bridge_fan_speed_3") * 100.0 : GCodePathConfig::FAN_SPEED_DEFAULT }
+                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed_3") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
     , roofing_config{ .type = PrintFeatureType::Skin,
                       .line_width = mesh.settings.get<coord_t>("roofing_line_width"),
                       .layer_thickness = layer_thickness,

--- a/src/settings/MeshPathConfigs.cpp
+++ b/src/settings/MeshPathConfigs.cpp
@@ -78,7 +78,8 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                    .acceleration = mesh.settings.get<Acceleration>("acceleration_wall_0"),
                                                    .jerk = mesh.settings.get<Velocity>("jerk_wall_0") },
                             .is_bridge_path = true,
-                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
+                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0)
+                                                                                     : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_insetX_config{ .type = PrintFeatureType::InnerWall,
                             .line_width = static_cast<coord_t>(
                                 mesh.settings.get<coord_t>("wall_line_width_x")
@@ -89,7 +90,8 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                    .acceleration = mesh.settings.get<Acceleration>("acceleration_wall_x"),
                                                    .jerk = mesh.settings.get<Velocity>("jerk_wall_x") },
                             .is_bridge_path = true,
-                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
+                            .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0)
+                                                                                     : GCodePathConfig::FAN_SPEED_DEFAULT }
     , skin_config{ .type = PrintFeatureType::Skin,
                    .line_width = static_cast<coord_t>(
                        mesh.settings.get<coord_t>("skin_line_width") * line_width_factor_per_extruder[mesh.settings.get<ExtruderTrain&>("top_bottom_extruder_nr").extruder_nr_]),
@@ -108,7 +110,8 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                  .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                  .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                           .is_bridge_path = true,
-                          .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
+                          .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed") * 100.0)
+                                                                                   : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_skin_config2{ .type = PrintFeatureType::Skin,
                            .line_width = static_cast<coord_t>(
                                mesh.settings.get<coord_t>("skin_line_width")
@@ -119,7 +122,8 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                   .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                   .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                            .is_bridge_path = true,
-                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed_2") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
+                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed_2") * 100.0)
+                                                                                    : GCodePathConfig::FAN_SPEED_DEFAULT }
     , bridge_skin_config3{ .type = PrintFeatureType::Skin,
                            .line_width = static_cast<coord_t>(
                                mesh.settings.get<coord_t>("skin_line_width")
@@ -130,7 +134,8 @@ MeshPathConfigs::MeshPathConfigs(const SliceMeshStorage& mesh, const coord_t lay
                                                   .acceleration = mesh.settings.get<Acceleration>("acceleration_topbottom"),
                                                   .jerk = mesh.settings.get<Velocity>("jerk_topbottom") },
                            .is_bridge_path = true,
-                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed_3") * 100.0) : GCodePathConfig::FAN_SPEED_DEFAULT }
+                           .fan_speed = mesh.settings.get<bool>("cool_fan_enabled") ? static_cast<double>(mesh.settings.get<Ratio>("bridge_fan_speed_3") * 100.0)
+                                                                                    : GCodePathConfig::FAN_SPEED_DEFAULT }
     , roofing_config{ .type = PrintFeatureType::Skin,
                       .line_width = mesh.settings.get<coord_t>("roofing_line_width"),
                       .layer_thickness = layer_thickness,


### PR DESCRIPTION
Decision related to larger setting structure:
- Multiple settings that would set fan speed → all of these should not be set when print cooling is disabled
- If you want to disable cooling for certain features → set fan speed to 0%
- If you want fan speed unchanged from current fan speed → use setting formula

Comes with:
https://github.com/Ultimaker/Cura/pull/21689

CURA-13125