### PR TITLE
CURA-13226 Engine adjustments for benchmark tooling

### DIFF
--- a/.github/workflows/gcodeanalyzer.yml
+++ b/.github/workflows/gcodeanalyzer.yml
@@ -102,7 +102,7 @@ jobs:
           ls $CURA_RESOURCES
           for file in `ls NightlyTestModels/*.stl`;
           do
-              ( time ./build/Release/CuraEngine slice --force-read-parent --force-read-nondefault -v -p -j $CURA_RESOURCES/definitions/ultimaker_s3.def.json -l $file -o `basename $file .stl`.gcode ) 2> `basename $file .stl`.time
+              ( time ./build/Release/CuraEngine slice --force-read-parent --force-read-nondefault -v -p -j ${CURA_RESOURCES:1}/definitions/ultimaker_s3.def.json -l $file -o `basename $file .stl`.gcode ) 2> `basename $file .stl`.time
           done
 
       - name: Run GCodeAnalyzer on generated GCode files

--- a/.github/workflows/gcodeanalyzer.yml
+++ b/.github/workflows/gcodeanalyzer.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           source build/Release/generators/conanrun.sh
           echo $CURA_RESOURCES
-          ls $CURA_RESOURCES
+          ls ${CURA_RESOURCES:1}
           for file in `ls NightlyTestModels/*.stl`;
           do
               ( time ./build/Release/CuraEngine slice --force-read-parent --force-read-nondefault -v -p -j ${CURA_RESOURCES:1}/definitions/ultimaker_s3.def.json -l $file -o `basename $file .stl`.gcode ) 2> `basename $file .stl`.time

--- a/Cura.proto
+++ b/Cura.proto
@@ -4,8 +4,8 @@ package cura.proto;
 
 message ObjectList
 {
-    repeated Object objects = 1;
-    repeated Setting settings = 2; // meshgroup settings (for one-at-a-time printing)
+  repeated Object objects = 1;
+  repeated Setting settings = 2; // meshgroup settings (for one-at-a-time printing)
 }
 
 // Resevered IDs:
@@ -14,175 +14,171 @@ message ObjectList
 // 200 ... 299: Generate
 // IMPORTANT: If you add a slot ID also update the SlotID enum in include/plugins/slots.h
 enum SlotID {
-    SETTINGS_BROADCAST = 0;
-    SIMPLIFY_MODIFY = 100;
-    POSTPROCESS_MODIFY = 101;
-    INFILL_MODIFY = 102;
-    GCODE_PATHS_MODIFY = 103;
-    INFILL_GENERATE = 200;
+  SETTINGS_BROADCAST = 0;
+  SIMPLIFY_MODIFY = 100;
+  POSTPROCESS_MODIFY = 101;
+  INFILL_MODIFY = 102;
+  GCODE_PATHS_MODIFY = 103;
+  INFILL_GENERATE = 200;
 }
 
 message EnginePlugin
 {
-    SlotID id = 1;
-    string address = 2;
-    uint32 port = 3;
-    string plugin_name = 4;
-    string plugin_version = 5;
+  SlotID id = 1;
+  string address = 2;
+  uint32 port = 3;
+  string plugin_name = 4;
+  string plugin_version = 5;
 }
 
 message Slice
 {
-    repeated ObjectList object_lists = 1; // The meshgroups to be printed one after another
-    SettingList global_settings = 2; // The global settings used for the whole print job
-    repeated Extruder extruders = 3; // The settings sent to each extruder object
-    repeated SettingExtruder limit_to_extruder = 4; // From which stack the setting would inherit if not defined per object
-    repeated EnginePlugin engine_plugins = 5;
-    string sentry_id = 6; // The anonymized Sentry user id that requested the slice
-    string cura_version = 7; // The version of Cura that requested the slice
-    optional string project_name = 8; // The name of the project that requested the slice
-    optional string user_name = 9; // The Digital Factory account name of the user that requested the slice
+  repeated ObjectList object_lists = 1; // The meshgroups to be printed one after another
+  SettingList global_settings = 2; // The global settings used for the whole print job
+  repeated Extruder extruders = 3; // The settings sent to each extruder object
+  repeated SettingExtruder limit_to_extruder = 4; // From which stack the setting would inherit if not defined per object
+  repeated EnginePlugin engine_plugins = 5;
+  string sentry_id = 6; // The anonymized Sentry user id that requested the slice
+  string cura_version = 7; // The version of Cura that requested the slice
+  optional string project_name = 8; // The name of the project that requested the slice
+  optional string user_name = 9; // The Digital Factory account name of the user that requested the slice
 }
 
 message Extruder
 {
-    int32 id = 1;
-    SettingList settings = 2;
+  int32 id = 1;
+  SettingList settings = 2;
 }
 
 message Object
 {
-    int64 id = 1;
-    bytes vertices = 2; //An array of 3 floats.
-    bytes normals = 3; //An array of 3 floats.
-    bytes indices = 4; //An array of ints.
-    repeated Setting settings = 5; // Setting override per object, overruling the global settings.
-    string name = 6; //Mesh name
-    bytes uv_coordinates = 7; //An array of 2 floats.
-    bytes texture = 8; //PNG-encoded texture data
+  int64 id = 1;
+  bytes vertices = 2; //An array of 3 floats.
+  bytes normals = 3; //An array of 3 floats.
+  bytes indices = 4; //An array of ints.
+  repeated Setting settings = 5; // Setting override per object, overruling the global settings.
+  string name = 6; //Mesh name
+  bytes uv_coordinates = 7; //An array of 2 floats.
+  bytes texture = 8; //PNG-encoded texture data
 }
 
 message Progress
 {
-    float amount = 1;
+  float amount = 1;
 }
 
 message Layer {
-    int32 id = 1;
-    float height = 2; // Z position
-    float thickness = 3; // height of a single layer
+  int32 id = 1;
+  float height = 2; // Z position
+  float thickness = 3; // height of a single layer
 
-    repeated Polygon polygons = 4; // layer data
+  repeated Polygon polygons = 4; // layer data
 }
 
 message Polygon {
-    enum Type {
-        NoneType = 0;
-        Inset0Type = 1;
-        InsetXType = 2;
-        SkinType = 3;
-        SupportType = 4;
-        SkirtType = 5;
-        InfillType = 6;
-        SupportInfillType = 7;
-        MoveUnretracted = 8;
-        MoveRetracted = 9;
-        SupportInterfaceType = 10;
-        PrimeTowerType = 11;
-        MoveWhileRetracting = 12;
-        MoveWhileUnretracting = 13;
-        StationaryRetractUnretract = 14;
-        NumPrintFeatureTypes = 15;
-    }
-    Type type = 1; // Type of move
-    bytes points = 2; // The points of the polygon, or two points if only a line segment (Currently only line segments are used)
-    float line_width = 3; // The width of the line being laid down
-    float line_thickness = 4; // The thickness of the line being laid down
-    float line_feedrate = 5; // The feedrate of the line being laid down
+  enum Type {
+    NoneType = 0;
+    Inset0Type = 1;
+    InsetXType = 2;
+    SkinType = 3;
+    SupportType = 4;
+    SkirtType = 5;
+    InfillType = 6;
+    SupportInfillType = 7;
+    MoveUnretracted = 8;
+    MoveRetracted = 9;
+    SupportInterfaceType = 10;
+    PrimeTowerType = 11;
+    MoveWhileRetracting = 12;
+    MoveWhileUnretracting = 13;
+    StationaryRetractUnretract = 14;
+    NumPrintFeatureTypes = 15;
+  }
+  Type type = 1; // Type of move
+  bytes points = 2; // The points of the polygon, or two points if only a line segment (Currently only line segments are used)
+  float line_width = 3; // The width of the line being laid down
+  float line_thickness = 4; // The thickness of the line being laid down
+  float line_feedrate = 5; // The feedrate of the line being laid down
 }
 
 message LayerOptimized {
-    int32 id = 1;
-    float height = 2; // Z position
-    float thickness = 3; // height of a single layer
+  int32 id = 1;
+  float height = 2; // Z position
+  float thickness = 3; // height of a single layer
 
-    repeated PathSegment path_segment = 4; // layer data
+  repeated PathSegment path_segment = 4; // layer data
 }
 
 
 message PathSegment {
-    int32 extruder = 1; // The extruder used for this path segment
-    enum PointType {
-        Point2D = 0;
-        Point3D = 1;
-    }
-    PointType point_type = 2;
-    bytes points = 3; // The points defining the line segments, bytes of float[2/3] array of length N+1
-    bytes line_type = 4; // Type of line segment as an unsigned char array of length 1 or N, where N is the number of line segments in this path
-    bytes line_width = 5; // The widths of the line segments as bytes of a float array of length 1 or N
-    bytes line_thickness = 6; // The thickness of the line segments as bytes of a float array of length 1 or N
-    bytes line_feedrate = 7; // The feedrate of the line segments as bytes of a float array of length 1 or N
+  int32 extruder = 1; // The extruder used for this path segment
+  enum PointType {
+    Point2D = 0;
+    Point3D = 1;
+  }
+  PointType point_type = 2;
+  bytes points = 3; // The points defining the line segments, bytes of float[2/3] array of length N+1
+  bytes line_type = 4; // Type of line segment as an unsigned char array of length 1 or N, where N is the number of line segments in this path
+  bytes line_width = 5; // The widths of the line segments as bytes of a float array of length 1 or N
+  bytes line_thickness = 6; // The thickness of the line segments as bytes of a float array of length 1 or N
+  bytes line_feedrate = 7; // The feedrate of the line segments as bytes of a float array of length 1 or N
 }
 
 
 message GCodeLayer {
-    bytes data = 2;
+  bytes data = 2;
 }
 
 
-message PrintTimeMaterialEstimates { // The print time for each feature and material estimates for the extruder
-    // Time estimate in each feature
-    float time_none = 1;
-    float time_inset_0 = 2;
-    float time_inset_x = 3;
-    float time_skin = 4;
-    float time_support = 5;
-    float time_skirt = 6;
-    float time_infill = 7;
-    float time_support_infill = 8;
-    float time_travel = 9;
-    float time_retract = 10;
-    float time_support_interface = 11;
-    float time_prime_tower = 12;
+message PrintTimeMaterialEstimates {// The print time for each feature and material estimates for the extruder
+  // Time estimate in each feature
+  float time_none = 1;
+  float time_inset_0 = 2;
+  float time_inset_x = 3;
+  float time_skin = 4;
+  float time_support = 5;
+  float time_skirt = 6;
+  float time_infill = 7;
+  float time_support_infill = 8;
+  float time_travel = 9;
+  float time_retract = 10;
+  float time_support_interface = 11;
+  float time_prime_tower = 12;
 
-    repeated MaterialEstimates materialEstimates = 13; // materialEstimates data
+  repeated MaterialEstimates materialEstimates = 13; // materialEstimates data
 }
 
 message MaterialEstimates {
-    int64 id = 1;
-    float material_amount = 2; // material used in the extruder
-    float material_length = 3; // Length if used filaments, in meters
-    float material_weight = 4; // Weight of used filament, in grams
-    float material_cost = 5;
-    string material_name = 6;
+  int64 id = 1;
+  float material_amount = 2; // material used in the extruder
+  float material_length = 3; // Length if used filaments, in meters
+  float material_weight = 4; // Weight of used filament, in grams
+  float material_cost = 5;
+  string material_name = 6;
 }
 
 message InitialExtruder {
-    uint32 extruder_nr = 1;
+  uint32 extruder_nr = 1;
 }
 
 message SettingList {
-    repeated Setting settings = 1;
+  repeated Setting settings = 1;
 }
 
 message Setting {
-    string name = 1; // Internal key to signify a setting
+  string name = 1; // Internal key to signify a setting
 
-    bytes value = 2; // The value of the setting
+  bytes value = 2; // The value of the setting
 }
 
 message SettingExtruder {
-    string name = 1; //The setting key.
+  string name = 1; //The setting key.
 
-    int32 extruder = 2; //From which extruder stack the setting should inherit.
-}
-
-message GCodePrefix {
-    bytes data = 2; //Header string to be prepended before the rest of the g-code sent from the engine.
+  int32 extruder = 2; //From which extruder stack the setting should inherit.
 }
 
 message SliceUUID {
-    string slice_uuid = 1; //An ID to link the slice in the printer to a statistical data point in the anonymous slice data.
+  string slice_uuid = 1; //An ID to link the slice in the printer to a statistical data point in the anonymous slice data.
 }
 
 message SlicingFinished {

--- a/include/MeshGroup.h
+++ b/include/MeshGroup.h
@@ -4,6 +4,8 @@
 #ifndef MESH_GROUP_H
 #define MESH_GROUP_H
 
+#include <filesystem>
+
 #include "mesh.h"
 #include "utils/NoCopy.h"
 
@@ -63,7 +65,7 @@ public:
  * \param object_parent_settings (optional) The parent settings object of the new mesh. Defaults to \p meshgroup if none is given.
  * \return whether the file could be loaded
  */
-bool loadMeshIntoMeshGroup(MeshGroup* meshgroup, const char* filename, const Matrix4x3D& transformation, Settings& object_parent_settings);
+bool loadMeshIntoMeshGroup(MeshGroup* meshgroup, const std::filesystem::path& filename, const Matrix4x3D& transformation, Settings& object_parent_settings);
 
 bool loadMeshOBJ(Mesh* mesh, const std::string& filename, const Matrix4x3D& matrix);
 

--- a/include/PrintInformation.h
+++ b/include/PrintInformation.h
@@ -24,6 +24,7 @@ struct ExtruderPrintInformation
     float filament_weight{}; // Filament weight in grams
     float filament_cost{}; // Filament cost (unspecified currency)
     std::string material_name; // Material full name
+    std::string material_guid; // Material guid
 };
 
 struct PrintInformation

--- a/include/communication/ArcusCommunication.h
+++ b/include/communication/ArcusCommunication.h
@@ -60,14 +60,6 @@ public:
     void sendGCodePart(const std::string& gcode_part) override;
 
     /*
-     * \brief Indicates that for Arcus we don't need to send the g-code from
-     * start to finish.
-     *
-     * We can send the start g-code out of order if we want.
-     */
-    bool isSequential() const override;
-
-    /*
      * \brief Test if there are any more slices in the queue.
      */
     bool hasSlice() const override;
@@ -87,12 +79,6 @@ public:
      * or otherwise) should be sent any more regarding the last slice job.
      */
     void sendFinishedSlicing() const override;
-
-    /*
-     * \brief Send the starting g-code separately so that it may be processed by
-     * the front-end for its replacement variables.
-     */
-    void sendGCodePrefix(const std::string& prefix) const override;
 
     /*
      * \brief Send the uuid of the generated slice so that it may be processed by

--- a/include/communication/CommandLine.h
+++ b/include/communication/CommandLine.h
@@ -42,14 +42,6 @@ public:
     void sendGCodePart(const std::string& gcode_part) override;
 
     /*
-     * \brief Indicates that for command line output we need to send the g-code
-     * from start to finish.
-     *
-     * We can't go back and erase some g-code very easily.
-     */
-    bool isSequential() const override;
-
-    /*
      * \brief Test if there are any more slices to be made.
      */
     bool hasSlice() const override;
@@ -69,11 +61,6 @@ public:
      * ignored.
      */
     void sendFinishedSlicing() const override;
-
-    /*
-     * \brief Output the g-code header.
-     */
-    void sendGCodePrefix(const std::string&) const override;
 
     /*
      * \brief Send the uuid of the generated slice so that it may be processed by

--- a/include/communication/Communication.h
+++ b/include/communication/Communication.h
@@ -36,18 +36,6 @@ public:
     virtual bool hasSlice() const = 0;
 
     /*
-     * \brief Whether the output needs to be sent from start to finish or not.
-     *
-     * This determines if the g-code output needs to be output from start to
-     * finish in order.
-     * This matters because the start g-code contains information on the
-     * statistics of the print. These statistics can only be generated at the
-     * end of the slice. Preferably we'd send the start g-code last, so that the
-     * statistics in the start g-code can be more accurate.
-     */
-    virtual bool isSequential() const = 0;
-
-    /*
      * \brief Indicate to the communication channel what the current progress of
      * slicing the current slice is.
      */
@@ -120,12 +108,6 @@ public:
 
     /* \brief Sends a piece of GCode that is ready to be exported */
     virtual void sendGCodePart(const std::string& gcode_part) = 0;
-
-    /*
-     * \brief Send the starting g-code separately so that it may be processed by
-     * the front-end for its replacement variables.
-     */
-    virtual void sendGCodePrefix(const std::string& prefix) const = 0;
 
     /*
      * \brief Send the uuid of the generated slice so that it may be processed by

--- a/include/communication/EmscriptenCommunication.h
+++ b/include/communication/EmscriptenCommunication.h
@@ -21,7 +21,6 @@ class EmscriptenCommunication : public CommandLine
 {
 private:
     std::string progress_handler_; ///< Handler for progress messages.
-    std::string gcode_header_handler_; ///< Handler for getting the GCode handler.
     std::string slice_info_handler_; ///< Handler for slice information messages.
     std::string engine_info_handler_; ///< Handler for curaengine info : version and hash.
     /**
@@ -45,22 +44,12 @@ public:
      */
     void sendProgress(double progress) const override;
 
-    /**
-     * \brief Sends GcodeHeader
-     */
-    void sendGCodePrefix(const std::string& prefix) const override;
-
     /*
      * \brief Send an estimate of how long the print would take and how much material it would use.
      * \param time_estimates The calculated time estimations, per extruder
      * \param print_information The calculated materials consumptions, per extruder
      */
     void sendPrintInformation(const std::vector<cura::Duration>& time_estimates, const PrintInformation& print_information) const override;
-
-    bool isSequential() const override
-    {
-        return false;
-    }
 };
 
 } // namespace cura

--- a/include/gcode_export/gcodeExport.h
+++ b/include/gcode_export/gcodeExport.h
@@ -246,21 +246,6 @@ public:
      */
     static std::string flavorToString(const EGCodeFlavor& flavor);
 
-    /*!
-     * Get the gcode file header (e.g. ";FLAVOR:UltiGCode\n")
-     *
-     * \param extruder_is_used For each extruder whether it is used in the print
-     * \param print_time The total print time in seconds of the whole gcode (if known)
-     * \param filament_used The total mm^3 filament used for each extruder or a vector of the wrong size of unknown
-     * \param mat_ids The material GUIDs for each material.
-     * \return The string representing the file header
-     */
-    std::string getFileHeader(
-        const std::vector<bool>& extruder_is_used,
-        const Duration* print_time = nullptr,
-        const std::vector<double>& filament_used = std::vector<double>(),
-        const std::vector<std::string>& mat_ids = std::vector<std::string>());
-
     void setSliceUUID(const std::string& slice_uuid);
 
     void setLayerNr(const LayerIndex& layer_nr);
@@ -455,6 +440,19 @@ public:
     double mm3ToE(double mm3) const;
 
 private:
+    /*!
+     * Get the gcode file header (e.g. ";FLAVOR:UltiGCode\n")
+     *
+     * \param extruder_is_used For each extruder whether it is used in the print
+     * \param filament_used The total mm^3 filament used for each extruder or a vector of the wrong size of unknown
+     * \param mat_ids The material GUIDs for each material.
+     * \return The string representing the file header
+     */
+    std::string getFileHeader(
+        const std::vector<bool>& extruder_is_used,
+        const std::vector<double>& filament_used = std::vector<double>(),
+        const std::vector<std::string>& mat_ids = std::vector<std::string>());
+
     /*!
      * Coordinates are build plate coordinates, which might be offsetted when extruder offsets are encoded in the gcode.
      *

--- a/include/utils/MeshUtils.h
+++ b/include/utils/MeshUtils.h
@@ -4,6 +4,7 @@
 #ifndef UTILS_MESH_UTILS_H
 #define UTILS_MESH_UTILS_H
 
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <vector>
@@ -44,7 +45,7 @@ bool loadTextureFromPngData(const std::vector<unsigned char>& texture_data, Mesh
  * @param texture_filename The path to the PNG texture file
  * @return true if the texture was loaded successfully, false otherwise
  */
-bool loadTextureFromFile(Mesh& mesh, const std::string& texture_filename);
+bool loadTextureFromFile(Mesh& mesh, const std::filesystem::path& texture_filename);
 
 /*!
  * Load texture data from PNG data provided as a string and attach it to a mesh.

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -4238,26 +4238,7 @@ void FffGcodeWriter::finalize()
         gcode.writeBuildVolumeTemperatureCommand(0); // Cool down the build volume.
     }
 
-    const Duration print_time = gcode.getSumTotalPrintTimes();
-    std::vector<double> filament_used;
-    std::vector<std::string> material_ids;
-    std::vector<bool> extruder_is_used;
-    for (size_t extruder_nr = 0; extruder_nr < scene.extruders.size(); extruder_nr++)
-    {
-        filament_used.emplace_back(gcode.getTotalFilamentUsed(extruder_nr));
-        material_ids.emplace_back(scene.extruders[extruder_nr].settings_.get<std::string>("material_guid"));
-        extruder_is_used.push_back(gcode.getExtruderIsUsed(extruder_nr));
-    }
-    std::string prefix = gcode.getFileHeader(extruder_is_used, &print_time, filament_used, material_ids);
-    if (! Application::getInstance().communication_->isSequential())
-    {
-        Application::getInstance().communication_->sendGCodePrefix(prefix);
-        Application::getInstance().communication_->sendSliceUUID(slice_uuid);
-    }
-    else
-    {
-        spdlog::info("Gcode header after slicing: {}", prefix);
-    }
+    Application::getInstance().communication_->sendSliceUUID(slice_uuid);
     if (mesh_group_settings.get<bool>("acceleration_enabled"))
     {
         gcode.writePrintAcceleration(mesh_group_settings.get<Acceleration>("machine_acceleration"));

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -320,7 +320,7 @@ bool loadMeshOBJ(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
     std::regex main_regex(R"((v|vt|f)\s+(.*))");
     const std::string floating_number_pattern = R"(([-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?))";
     std::regex vertex_regex(floating_number_pattern + R"(\s+)" + floating_number_pattern + R"(\s+)" + floating_number_pattern);
-    std::regex uv_regex(floating_number_pattern + R"(\s+)" + floating_number_pattern);
+    std::regex uv_regex(floating_number_pattern + R"(\s+)" + floating_number_pattern + R"((?:\s+)" + floating_number_pattern + ")");
     std::regex face_indices_regex(R"((\d+)(?:\/(\d*))?(?:\/(?:\d*))?)");
 
     auto get_uv_coordinates = [&uv_coordinates](std::optional<size_t> uv_index) -> std::optional<Point2F>

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -15,6 +15,7 @@
 #include <string.h>
 
 #include <fmt/format.h>
+#include <range/v3/algorithm/transform.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <scripta/logger.h>
 #include <spdlog/spdlog.h>
@@ -27,6 +28,9 @@
 #include "utils/gettime.h"
 #include "utils/section_type.h"
 #include "utils/string.h"
+
+
+namespace fs = std::filesystem;
 
 namespace cura
 {
@@ -143,9 +147,9 @@ void MeshGroup::scaleFromBottom(const Ratio factor_xy, const Ratio factor_z)
     }
 }
 
-bool loadMeshSTL_ascii(Mesh* mesh, const char* filename, const Matrix4x3D& matrix)
+bool loadMeshSTL_ascii(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
 {
-    FILE* f = fopen(filename, "rt");
+    FILE* f = fopen(filename.c_str(), "rt");
     char buffer[1024];
     Point3F vertex;
     int n = 0;
@@ -176,9 +180,9 @@ bool loadMeshSTL_ascii(Mesh* mesh, const char* filename, const Matrix4x3D& matri
     return true;
 }
 
-bool loadMeshSTL_binary(Mesh* mesh, const char* filename, const Matrix4x3D& matrix, const std::vector<Point2F>* uv_coordinates = nullptr)
+bool loadMeshSTL_binary(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix, const std::vector<Point2F>* uv_coordinates = nullptr)
 {
-    FILE* f = fopen(filename, "rb");
+    FILE* f = fopen(filename.c_str(), "rb");
 
     fseek(f, 0L, SEEK_END);
     long long file_size = ftell(f); // The file size is the position of the cursor after seeking to the end.
@@ -244,9 +248,9 @@ bool loadMeshSTL_binary(Mesh* mesh, const char* filename, const Matrix4x3D& matr
     return true;
 }
 
-bool loadMeshSTL(Mesh* mesh, const char* filename, const Matrix4x3D& matrix)
+bool loadMeshSTL(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
 {
-    FILE* f = fopen(filename, "rb");
+    FILE* f = fopen(filename.c_str(), "rb");
     if (f == nullptr)
     {
         return false;
@@ -301,12 +305,12 @@ bool loadMeshSTL(Mesh* mesh, const char* filename, const Matrix4x3D& matrix)
     return loadMeshSTL_binary(mesh, filename, matrix);
 }
 
-bool loadMeshOBJ(Mesh* mesh, const std::string& filename, const Matrix4x3D& matrix)
+bool loadMeshOBJ(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
 {
     std::ifstream file(filename);
     if (! file.is_open())
     {
-        spdlog::error("Could not open OBJ file: {}", filename);
+        spdlog::error("Could not open OBJ file: {}", filename.string());
         return false;
     }
 
@@ -419,7 +423,7 @@ bool loadMeshOBJ(Mesh* mesh, const std::string& filename, const Matrix4x3D& matr
  */
 bool loadUVCoordinatesFromFile(const std::string& uv_filename, std::vector<Point2F>& uv_coordinates)
 {
-    if (! std::filesystem::exists(uv_filename))
+    if (! fs::exists(uv_filename))
     {
         return false; // File doesn't exist, not an error
     }
@@ -455,9 +459,9 @@ bool loadUVCoordinatesFromFile(const std::string& uv_filename, std::vector<Point
 }
 
 
-bool loadMeshSTL_with_uv(Mesh* mesh, const char* filename, const Matrix4x3D& matrix, const std::vector<Point2F>& uv_coordinates)
+bool loadMeshSTL_with_uv(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix, const std::vector<Point2F>& uv_coordinates)
 {
-    FILE* f = fopen(filename, "rb");
+    FILE* f = fopen(filename.c_str(), "rb");
     if (f == nullptr)
     {
         return false;
@@ -497,78 +501,91 @@ bool loadMeshSTL_with_uv(Mesh* mesh, const char* filename, const Matrix4x3D& mat
     if (stringcasecompare(buffer, "solid") == 0)
     {
         // ASCII STL with UV coordinates not currently supported
-        spdlog::warn("ASCII STL with UV coordinates not supported, use binary STL: {}", filename);
+        spdlog::warn("ASCII STL with UV coordinates not supported, use binary STL: {}", filename.string());
         return false;
     }
     return loadMeshSTL_binary(mesh, filename, matrix, &uv_coordinates);
 }
 
-bool loadMeshIntoMeshGroup(MeshGroup* meshgroup, const char* filename, const Matrix4x3D& transformation, Settings& object_parent_settings)
+bool loadMeshIntoMeshGroup(MeshGroup* meshgroup, const fs::path& filename, const Matrix4x3D& transformation, Settings& object_parent_settings)
 {
     TimeKeeper load_timer;
 
-    const char* ext = strrchr(filename, '.');
-    if (ext && (strcmp(ext, ".stl") == 0 || strcmp(ext, ".STL") == 0))
+    Mesh mesh(object_parent_settings);
+    bool load_success = false;
+    bool has_uv = false;
+
+    const fs::path base_filename = filename.stem();
+    std::string extension = filename.extension().string();
+    extension = extension.substr(1, extension.size()); // Remove the initial '.'
+    ranges::transform(extension, extension.begin(), static_cast<int (*)(int)>(std::tolower)); // To lowercase
+
+    if (extension == "stl")
     {
-        Mesh mesh(object_parent_settings);
         // Check for corresponding UV and PNG files
-        std::string filename_str(filename);
-        std::string base_filename = filename_str.substr(0, filename_str.find_last_of('.'));
-        std::string uv_filename = base_filename + ".uv";
-        std::string texture_filename = base_filename + ".png";
+        const fs::path uv_filename = fs::path(base_filename).replace_extension("uv");
 
         std::vector<Point2F> uv_coordinates;
-        bool has_uv = loadUVCoordinatesFromFile(uv_filename, uv_coordinates);
+        has_uv = loadUVCoordinatesFromFile(uv_filename, uv_coordinates);
 
-        bool load_success = false;
         if (has_uv)
         {
-            spdlog::info("Loading STL with UV coordinates from: {}", uv_filename);
+            spdlog::info("Loading STL with UV coordinates from: {}", uv_filename.string());
             load_success = loadMeshSTL_with_uv(&mesh, filename, transformation, uv_coordinates);
         }
         else
         {
             load_success = loadMeshSTL(&mesh, filename, transformation);
         }
-        if (load_success) // Load it! If successful...
+
+        if (! load_success)
+        {
+            spdlog::warn("loading STL '{}' failed", filename.string());
+        }
+    }
+    else if (extension == "obj")
+    {
+        if (loadMeshOBJ(&mesh, filename, transformation)) // Load it! If successful...
+        {
+            load_success = true;
+            has_uv = true;
+        }
+        else
+        {
+            spdlog::warn("loading OBJ '{}' failed", filename.string());
+        }
+    }
+    else
+    {
+        spdlog::warn("Unable to recognize the extension of the file. Currently only STL and OBJ are supported.");
+    }
+
+    if (load_success)
+    {
+        if (has_uv)
         {
             // Try to load the PNG texture if it exists
-            if (std::filesystem::exists(texture_filename))
+            const fs::path texture_filename = fs::path(filename).replace_extension("png");
+            if (fs::exists(texture_filename))
             {
-                spdlog::info("Found texture file: {}", texture_filename);
                 if (MeshUtils::loadTextureFromFile(mesh, texture_filename))
                 {
-                    spdlog::info("Successfully loaded texture from: {}", texture_filename);
+                    spdlog::info("Successfully loaded texture from: {}", texture_filename.string());
                 }
                 else
                 {
-                    spdlog::warn("Failed to load texture from: {}", texture_filename);
+                    spdlog::warn("Failed to load texture from: {}", texture_filename.string());
                 }
             }
-
-            meshgroup->meshes.push_back(mesh);
-            spdlog::info("loading '{}' took {:03.3f} seconds", filename, load_timer.restart());
-            return true;
         }
-        spdlog::warn("loading STL '{}' failed", filename);
-        return false;
+
+        spdlog::info("loading '{}' took {:03.3f} seconds", filename.string(), load_timer.restart());
+
+        mesh.mesh_name_ = base_filename.string();
+        meshgroup->meshes.push_back(mesh);
     }
 
-    if (ext && (strcmp(ext, ".obj") == 0 || strcmp(ext, ".OBJ") == 0))
-    {
-        Mesh mesh(object_parent_settings);
-        if (loadMeshOBJ(&mesh, filename, transformation)) // Load it! If successful...
-        {
-            meshgroup->meshes.push_back(mesh);
-            spdlog::info("loading '{}' took {:03.3f} seconds", filename, load_timer.restart());
-            return true;
-        }
-        spdlog::warn("loading OBJ '{}' failed", filename);
-        return false;
-    }
-
-    spdlog::warn("Unable to recognize the extension of the file. Currently only .stl and .STL are supported.");
-    return false;
+    return load_success;
 }
 
 } // namespace cura

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -318,8 +318,9 @@ bool loadMeshOBJ(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
     std::vector<Point2F> uv_coordinates;
     std::string line;
     std::regex main_regex(R"((v|vt|f)\s+(.*))");
-    std::regex vertex_regex(R"(([-+]?[0-9]*\.?[0-9]+)\s+([-+]?[0-9]*\.?[0-9]+)\s+([-+]?[0-9]*\.?[0-9]+))");
-    std::regex uv_regex(R"(([-+]?\d*\.?\d+)\s+([-+]?\d*\.?\d+)\s+(?:[-+]?\d*\.?\d+))");
+    const std::string floating_number_pattern = R"(([-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?))";
+    std::regex vertex_regex(floating_number_pattern + R"(\s+)" + floating_number_pattern + R"(\s+)" + floating_number_pattern);
+    std::regex uv_regex(floating_number_pattern + R"(\s+)" + floating_number_pattern);
     std::regex face_indices_regex(R"((\d+)(?:\/(\d*))?(?:\/(?:\d*))?)");
 
     auto get_uv_coordinates = [&uv_coordinates](std::optional<size_t> uv_index) -> std::optional<Point2F>

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -315,7 +315,7 @@ bool loadMeshOBJ(Mesh* mesh, const std::string& filename, const Matrix4x3D& matr
     std::string line;
     std::regex main_regex(R"((v|vt|f)\s+(.*))");
     std::regex vertex_regex(R"(([-+]?[0-9]*\.?[0-9]+)\s+([-+]?[0-9]*\.?[0-9]+)\s+([-+]?[0-9]*\.?[0-9]+))");
-    std::regex uv_regex(R"(([-+]?[0-9]*\.?[0-9]+)\s+([-+]?[0-9]*\.?[0-9]+))");
+    std::regex uv_regex(R"(([-+]?\d*\.?\d+)\s+([-+]?\d*\.?\d+)\s+(?:[-+]?\d*\.?\d+))");
     std::regex face_indices_regex(R"((\d+)(?:\/(\d*))?(?:\/(?:\d*))?)");
 
     auto get_uv_coordinates = [&uv_coordinates](std::optional<size_t> uv_index) -> std::optional<Point2F>

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -420,7 +420,7 @@ bool loadMeshOBJ(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
  * @param uv_coordinates Vector to store the loaded UV coordinates
  * @return true if UV coordinates were loaded successfully, false otherwise
  */
-bool loadUVCoordinatesFromFile(const std::string& uv_filename, std::vector<Point2F>& uv_coordinates)
+bool loadUVCoordinatesFromFile(const fs::path& uv_filename, std::vector<Point2F>& uv_coordinates)
 {
     if (! fs::exists(uv_filename))
     {
@@ -430,7 +430,7 @@ bool loadUVCoordinatesFromFile(const std::string& uv_filename, std::vector<Point
     std::ifstream file(uv_filename, std::ios::binary);
     if (! file.is_open())
     {
-        spdlog::warn("Failed to open UV file: {}", uv_filename);
+        spdlog::warn("Failed to open UV file: {}", uv_filename.string());
         return false;
     }
 
@@ -438,10 +438,9 @@ bool loadUVCoordinatesFromFile(const std::string& uv_filename, std::vector<Point
     uint32_t vertex_count;
     if (! file.read(reinterpret_cast<char*>(&vertex_count), sizeof(uint32_t)))
     {
-        spdlog::warn("Failed to read vertex count from UV file: {}", uv_filename);
+        spdlog::warn("Failed to read vertex count from UV file: {}", uv_filename.string());
         return false;
     }
-
 
     // Read UV coordinates (2 floats per vertex)
     uv_coordinates.resize(vertex_count);
@@ -449,11 +448,11 @@ bool loadUVCoordinatesFromFile(const std::string& uv_filename, std::vector<Point
 
     if (! file.read(reinterpret_cast<char*>(uv_coordinates.data()), uv_data_size))
     {
-        spdlog::warn("Failed to read UV coordinates from file: {}", uv_filename);
+        spdlog::warn("Failed to read UV coordinates from file: {}", uv_filename.string());
         return false;
     }
 
-    spdlog::info("Loaded {} UV coordinates from: {}", vertex_count, uv_filename);
+    spdlog::info("Loaded {} UV coordinates from: {}", vertex_count, uv_filename.string());
     return true;
 }
 

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -147,7 +147,7 @@ void MeshGroup::scaleFromBottom(const Ratio factor_xy, const Ratio factor_z)
 
 bool loadMeshSTL_ascii(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
 {
-    FILE* f = fopen(static_cast<const char*>(filename.c_str()), "rt");
+    FILE* f = fopen(filename.string().c_str(), "rt");
     char buffer[1024];
     Point3F vertex;
     int n = 0;
@@ -180,7 +180,7 @@ bool loadMeshSTL_ascii(Mesh* mesh, const fs::path& filename, const Matrix4x3D& m
 
 bool loadMeshSTL_binary(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix, const std::vector<Point2F>* uv_coordinates = nullptr)
 {
-    FILE* f = fopen(static_cast<const char*>(filename.c_str()), "rb");
+    FILE* f = fopen(filename.string().c_str(), "rb");
 
     fseek(f, 0L, SEEK_END);
     long long file_size = ftell(f); // The file size is the position of the cursor after seeking to the end.
@@ -248,7 +248,7 @@ bool loadMeshSTL_binary(Mesh* mesh, const fs::path& filename, const Matrix4x3D& 
 
 bool loadMeshSTL(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
 {
-    FILE* f = fopen(static_cast<const char*>(filename.c_str()), "rb");
+    FILE* f = fopen(filename.string().c_str(), "rb");
     if (f == nullptr)
     {
         return false;
@@ -460,7 +460,7 @@ bool loadUVCoordinatesFromFile(const std::string& uv_filename, std::vector<Point
 
 bool loadMeshSTL_with_uv(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix, const std::vector<Point2F>& uv_coordinates)
 {
-    FILE* f = fopen(static_cast<const char*>(filename.c_str()), "rb");
+    FILE* f = fopen(filename.string().c_str(), "rb");
     if (f == nullptr)
     {
         return false;

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -467,7 +467,7 @@ bool loadMeshSTL_with_uv(Mesh* mesh, const fs::path& filename, const Matrix4x3D&
     }
 
     // assign filename to mesh_name
-    mesh->mesh_name_ = filename;
+    mesh->mesh_name_ = filename.string();
 
     // Skip any whitespace at the beginning of the file.
     unsigned long long num_whitespace = 0; // Number of whitespace characters.

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -35,8 +35,6 @@ namespace fs = std::filesystem;
 namespace cura
 {
 
-FILE* binaryMeshBlob = nullptr;
-
 /* Custom fgets function to support Mac line-ends in Ascii STL files. OpenSCAD produces this when used on Mac */
 void* fgets_(char* ptr, size_t len, FILE* f)
 {
@@ -149,7 +147,7 @@ void MeshGroup::scaleFromBottom(const Ratio factor_xy, const Ratio factor_z)
 
 bool loadMeshSTL_ascii(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
 {
-    FILE* f = fopen(filename.c_str(), "rt");
+    FILE* f = fopen(static_cast<const char*>(filename.c_str()), "rt");
     char buffer[1024];
     Point3F vertex;
     int n = 0;
@@ -182,7 +180,7 @@ bool loadMeshSTL_ascii(Mesh* mesh, const fs::path& filename, const Matrix4x3D& m
 
 bool loadMeshSTL_binary(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix, const std::vector<Point2F>* uv_coordinates = nullptr)
 {
-    FILE* f = fopen(filename.c_str(), "rb");
+    FILE* f = fopen(static_cast<const char*>(filename.c_str()), "rb");
 
     fseek(f, 0L, SEEK_END);
     long long file_size = ftell(f); // The file size is the position of the cursor after seeking to the end.
@@ -250,14 +248,14 @@ bool loadMeshSTL_binary(Mesh* mesh, const fs::path& filename, const Matrix4x3D& 
 
 bool loadMeshSTL(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix)
 {
-    FILE* f = fopen(filename.c_str(), "rb");
+    FILE* f = fopen(static_cast<const char*>(filename.c_str()), "rb");
     if (f == nullptr)
     {
         return false;
     }
 
     // assign filename to mesh_name
-    mesh->mesh_name_ = filename;
+    mesh->mesh_name_ = filename.string();
 
     // Skip any whitespace at the beginning of the file.
     unsigned long long num_whitespace = 0; // Number of whitespace characters.
@@ -462,7 +460,7 @@ bool loadUVCoordinatesFromFile(const std::string& uv_filename, std::vector<Point
 
 bool loadMeshSTL_with_uv(Mesh* mesh, const fs::path& filename, const Matrix4x3D& matrix, const std::vector<Point2F>& uv_coordinates)
 {
-    FILE* f = fopen(filename.c_str(), "rb");
+    FILE* f = fopen(static_cast<const char*>(filename.c_str()), "rb");
     if (f == nullptr)
     {
         return false;

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -395,9 +395,10 @@ const Shape& TreeModelVolumes::getAccumulatedPlaceable0(LayerIndex layer_idx)
 {
     {
         std::lock_guard<std::mutex> critical_section_support_max_layer_nr(*critical_accumulated_placeables_cache_radius_0_);
-        if (accumulated_placeables_cache_radius_0_.count(layer_idx))
+        auto iterator = accumulated_placeables_cache_radius_0_.find(layer_idx);
+        if (iterator != accumulated_placeables_cache_radius_0_.end())
         {
-            return accumulated_placeables_cache_radius_0_[layer_idx];
+            return iterator->second;
         }
     }
     calculateAccumulatedPlaceable0(layer_idx);
@@ -804,18 +805,26 @@ void TreeModelVolumes::calculateAccumulatedPlaceable0(const LayerIndex max_layer
 {
     LayerIndex start_layer = -1;
 
-    // the placeable on model areas do not exist on layer 0, as there can not be model below it. As such it may be possible that layer 1 is available, but layer 0 does not exist.
+    if (max_layer <= 0)
+    {
+        // the placeable on model areas do not exist on layer 0, as there can not be model below it. As such it may be possible that layer 1 is available, but layer 0 does not
+        // exist.
+        std::lock_guard<std::mutex> critical_section_support_max_layer_nr(*critical_accumulated_placeables_cache_radius_0_);
+        accumulated_placeables_cache_radius_0_[max_layer] = Shape();
+        return;
+    }
+
     {
         std::lock_guard<std::mutex> critical_section(*critical_accumulated_placeables_cache_radius_0_);
-        while (accumulated_placeables_cache_radius_0_.count(start_layer + 1))
+        while (accumulated_placeables_cache_radius_0_.contains(start_layer + 1))
         {
-            start_layer++;
+            ++start_layer;
         }
         start_layer = std::max(LayerIndex{ start_layer + 1 }, LayerIndex{ 1 });
     }
     if (start_layer > max_layer)
     {
-        spdlog::debug("Requested calculation for value already calculated ?");
+        spdlog::warn("Requested calculation for value already calculated ?");
         return;
     }
     Shape accumulated_placeable_0

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -288,7 +288,6 @@ void ArcusCommunication::connect(const std::string& ip, const uint16_t port)
     private_data->socket->registerMessageType(&cura::proto::GCodeLayer::default_instance());
     private_data->socket->registerMessageType(&cura::proto::PrintTimeMaterialEstimates::default_instance());
     private_data->socket->registerMessageType(&cura::proto::SettingList::default_instance());
-    private_data->socket->registerMessageType(&cura::proto::GCodePrefix::default_instance());
     private_data->socket->registerMessageType(&cura::proto::SlicingFinished::default_instance());
     private_data->socket->registerMessageType(&cura::proto::SettingExtruder::default_instance());
 
@@ -325,11 +324,6 @@ void ArcusCommunication::sendGCodePart(const std::string& gcode_part)
     private_data->socket->sendMessage(message);
 }
 
-bool ArcusCommunication::isSequential() const
-{
-    return false; // We don't necessarily need to send the start g-code before the rest. We can send it afterwards when we have more accurate print statistics.
-}
-
 bool ArcusCommunication::hasSlice() const
 {
     return private_data->socket->getState() != Arcus::SocketState::Closed && private_data->socket->getState() != Arcus::SocketState::Error
@@ -339,14 +333,6 @@ bool ArcusCommunication::hasSlice() const
 void ArcusCommunication::sendCurrentPosition(const Point3LL& position)
 {
     path_compiler->setCurrentPosition(position);
-}
-
-void ArcusCommunication::sendGCodePrefix(const std::string& prefix) const
-{
-    std::shared_ptr<proto::GCodePrefix> message = std::make_shared<proto::GCodePrefix>();
-    std::string message_str = prefix;
-    message->set_data(slots::instance().modify<plugins::v0::SlotID::POSTPROCESS_MODIFY>(message_str));
-    private_data->socket->sendMessage(message);
 }
 
 void ArcusCommunication::sendSliceUUID(const std::string& slice_uuid) const

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -279,9 +279,9 @@ void CommandLine::sliceNext()
 
                     const auto transformation = last_settings->get<Matrix4x3D>("mesh_rotation_matrix"); // The transformation applied to the model when loaded.
 
-                    if (! loadMeshIntoMeshGroup(&slice->scene.mesh_groups[mesh_group_index], argument.c_str(), transformation, last_extruder->settings_))
+                    if (! loadMeshIntoMeshGroup(&slice->scene.mesh_groups[mesh_group_index], argument, transformation, last_extruder->settings_))
                     {
-                        spdlog::error("Failed to load model: {}. (error number {})", argument, errno);
+                        spdlog::error("Failed to load model: {} (error number {})", argument, errno);
                         exit(1);
                     }
                     else
@@ -440,9 +440,9 @@ void CommandLine::sliceNext()
                         const auto transformation = slice->scene.mesh_groups[mesh_group_index].settings.get<Matrix4x3D>("mesh_rotation_matrix");
                         const auto extruder_nr = slice->scene.mesh_groups[mesh_group_index].settings.get<size_t>("extruder_nr");
 
-                        if (! loadMeshIntoMeshGroup(&slice->scene.mesh_groups[mesh_group_index], model_name.c_str(), transformation, slice->scene.extruders[extruder_nr].settings_))
+                        if (! loadMeshIntoMeshGroup(&slice->scene.mesh_groups[mesh_group_index], model_name, transformation, slice->scene.extruders[extruder_nr].settings_))
                         {
-                            spdlog::error("Failed to load model: {}. (error number {})", model_name, errno);
+                            spdlog::error("Failed to load model: {} (error number {})", model_name, errno);
                             exit(1);
                         }
                     }

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -32,6 +32,9 @@
 #include "utils/format/filesystem_path.h"
 #include "utils/views/split_paths.h"
 
+
+namespace fs = std::filesystem;
+
 namespace cura
 {
 
@@ -371,7 +374,9 @@ void CommandLine::sliceNext()
                         exit(1);
                     }
                     argument = arguments_[argument_index];
-                    const auto settings = readResolvedJsonValues(std::filesystem::path{ argument });
+                    const fs::path settings_path(argument);
+                    const fs::path settings_folder(settings_path.parent_path());
+                    const auto settings = readResolvedJsonValues(settings_path);
 
                     if (! settings.has_value())
                     {
@@ -381,7 +386,6 @@ void CommandLine::sliceNext()
 
                     constexpr std::string_view global_identifier = "global";
                     constexpr std::string_view extruder_identifier = "extruder.";
-                    constexpr std::string_view model_identifier = "model.";
                     constexpr std::string_view limit_to_extruder_identifier = "limit_to_extruder";
 
                     // Split the settings into global, extruder and model settings. This is needed since the order in which the settings are applied is important.
@@ -440,7 +444,11 @@ void CommandLine::sliceNext()
                         const auto transformation = slice->scene.mesh_groups[mesh_group_index].settings.get<Matrix4x3D>("mesh_rotation_matrix");
                         const auto extruder_nr = slice->scene.mesh_groups[mesh_group_index].settings.get<size_t>("extruder_nr");
 
-                        if (! loadMeshIntoMeshGroup(&slice->scene.mesh_groups[mesh_group_index], model_name, transformation, slice->scene.extruders[extruder_nr].settings_))
+                        if (! loadMeshIntoMeshGroup(
+                                &slice->scene.mesh_groups[mesh_group_index],
+                                settings_folder / model_name,
+                                transformation,
+                                slice->scene.extruders[extruder_nr].settings_))
                         {
                             spdlog::error("Failed to load model: {} (error number {})", model_name, errno);
                             exit(1);

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -81,16 +81,6 @@ bool CommandLine::hasSlice() const
     return ! arguments_.empty();
 }
 
-bool CommandLine::isSequential() const
-{
-    return true; // We have to receive the g-code in sequential order. Start g-code before the rest and so on.
-}
-
-void CommandLine::sendGCodePrefix(const std::string&) const
-{
-    // TODO: Right now this is done directly in the g-code writer. For consistency it should be moved here?
-}
-
 void CommandLine::sendSliceUUID([[maybe_unused]] const std::string& slice_uuid) const
 {
     // pass

--- a/src/communication/EmscriptenCommunication.cpp
+++ b/src/communication/EmscriptenCommunication.cpp
@@ -34,10 +34,6 @@ EmscriptenCommunication::EmscriptenCommunication(const std::vector<std::string>&
     {
         slice_info_handler_ = *ranges::next(slice_info_flag);
     }
-    if (auto gcode_header_flag = ranges::find(arguments_, "--gcode_header_cb"); gcode_header_flag != arguments_.end())
-    {
-        gcode_header_handler_ = *ranges::next(gcode_header_flag);
-    }
     if (auto engine_info_flag = ranges::find(arguments_, "--engine_info_cb"); engine_info_flag != arguments_.end())
     {
         engine_info_handler_ = *ranges::next(engine_info_flag);
@@ -45,11 +41,6 @@ EmscriptenCommunication::EmscriptenCommunication(const std::vector<std::string>&
 
     auto engine_info = createEngineInfoMessage();
     emscripten_run_script(fmt::format("globalThis[\"{}\"]({})", engine_info_handler_, engine_info).c_str());
-}
-
-void EmscriptenCommunication::sendGCodePrefix(const std::string& prefix) const
-{
-    emscripten_run_script(fmt::format("globalThis[\"{}\"](\"{}\")", gcode_header_handler_, convertTobase64(prefix)).c_str());
 }
 
 void EmscriptenCommunication::sendProgress(double progress) const

--- a/src/gcode_export/gcodeExport.cpp
+++ b/src/gcode_export/gcodeExport.cpp
@@ -213,19 +213,18 @@ std::string GCodeExport::flavorToString(const EGCodeFlavor& flavor)
     }
 }
 
-std::string GCodeExport::getFileHeader(
-    const std::vector<bool>& extruder_is_used,
-    const Duration* print_time,
-    const std::vector<double>& filament_used,
-    const std::vector<std::string>& mat_ids)
+std::string GCodeExport::getFileHeader(const std::vector<bool>& extruder_is_used, const std::vector<double>& filament_used, const std::vector<std::string>& mat_ids)
 {
     std::ostringstream prefix;
 
     const size_t extruder_count = Application::getInstance().current_slice_->scene.extruders.size();
+    const Duration print_time = getSumTotalPrintTimes();
+
     switch (flavor_)
     {
     case EGCodeFlavor::GRIFFIN:
     case EGCodeFlavor::CHEETAH:
+    {
         prefix << ";START_OF_HEADER" << new_line_;
         prefix << ";HEADER_VERSION:0.1" << new_line_;
         prefix << ";FLAVOR:" << flavorToString(flavor_) << new_line_;
@@ -260,11 +259,7 @@ std::string GCodeExport::getFileHeader(
             prefix << ";BUILD_VOLUME.TEMPERATURE:" << build_volume_temperature_ << new_line_;
         }
 
-        if (print_time)
-        {
-            prefix << ";PRINT.TIME:" << static_cast<int>(*print_time) << new_line_;
-        }
-
+        prefix << ";PRINT.TIME:" << static_cast<int>(print_time) << new_line_;
         prefix << ";PRINT.GROUPS:" << Application::getInstance().current_slice_->scene.mesh_groups.size() << new_line_;
 
         if (total_bounding_box_.min_.x_ > total_bounding_box_.max_.x_) // We haven't encountered any movement (yet). This probably means we're command-line slicing.
@@ -304,9 +299,10 @@ std::string GCodeExport::getFileHeader(
         }
         prefix << ";END_OF_HEADER" << new_line_;
         break;
+    }
     default:
         prefix << ";FLAVOR:" << flavorToString(flavor_) << new_line_;
-        prefix << ";TIME:" << ((print_time) ? static_cast<int>(*print_time) : 6666) << new_line_;
+        prefix << ";TIME:" << static_cast<int>(print_time) << new_line_;
         if (flavor_ == EGCodeFlavor::ULTIGCODE)
         {
             prefix << ";MATERIAL:" << ((filament_used.size() >= 1) ? static_cast<int>(filament_used[0]) : 6666) << new_line_;
@@ -700,13 +696,6 @@ bool GCodeExport::initializeExtruderTrains(const SliceDataStorage& storage, cons
 {
     bool should_prime_extruder = true;
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
-
-    if (Application::getInstance().communication_->isSequential()) // If we must output the g-code sequentially, we must already place the g-code header here even if we don't know
-                                                                   // the exact time/material usages yet.
-    {
-        std::string prefix = getFileHeader(storage.getExtrudersUsed());
-        writeLine(prefix);
-    }
 
     writeComment("Generated with Cura_SteamEngine " CURA_ENGINE_VERSION);
 
@@ -1476,6 +1465,7 @@ std::vector<std::optional<ExtruderPrintInformation>> GCodeExport::calculateMater
         const double material_spool_cost = extruder_settings.get<double>("material_spool_cost");
 
         extruder_info.material_name = extruder_settings.get<std::string>("material_name");
+        extruder_info.material_guid = extruder_settings.get<std::string>("material_guid");
         extruder_info.filament_amount = getTotalFilamentUsed(extruder_nr);
         extruder_info.filament_length = (extruder_info.filament_amount / (std::numbers::pi * square(material_radius))) / 1000;
         extruder_info.filament_weight = extruder_info.filament_amount * material_density / 1000.0;
@@ -1988,15 +1978,19 @@ void GCodeExport::finalize(const std::string& end_code, PrintInformation& print_
     }
 
     const size_t used_extruders = print_info.extruders_info.size();
+    std::vector<double> filaments_volumes(used_extruders);
     std::vector<cfe::eval::Value> filaments_amounts(used_extruders);
     std::vector<cfe::eval::Value> filaments_weights(used_extruders);
     std::vector<cfe::eval::Value> filaments_costs(used_extruders);
+    std::vector<std::string> materials_ids(used_extruders);
     for (const auto& [extruder_nr, extruder_info_opt] : print_info.extruders_info | ranges::views::enumerate)
     {
         const ExtruderPrintInformation extruder_info = extruder_info_opt.value_or(ExtruderPrintInformation());
+        filaments_volumes[extruder_nr] = extruder_info.filament_amount;
         filaments_amounts[extruder_nr] = extruder_info.filament_length;
         filaments_weights[extruder_nr] = extruder_info.filament_weight;
         filaments_costs[extruder_nr] = extruder_info.filament_cost;
+        materials_ids[extruder_nr] = extruder_info.material_guid;
     }
 
     extra_global_settings.emplace("filament_amount", filaments_amounts);
@@ -2021,18 +2015,25 @@ void GCodeExport::finalize(const std::string& end_code, PrintInformation& print_
     extra_global_settings.emplace("total_bb_depth", INT2MM(total_bounding_box_.spanY()));
     extra_global_settings.emplace("total_bb_height", INT2MM(total_bounding_box_.spanZ()));
 
-    std::vector<cfe::eval::Value> is_extruder_used(MAX_EXTRUDERS);
+    std::vector<cfe::eval::Value> is_extruder_used(MAX_EXTRUDERS); // To be used by the formula engine
+    std::vector<bool> is_extruder_used_bool(MAX_EXTRUDERS); // To be used for the header creation
     for (size_t extruder_nr = 0; extruder_nr < MAX_EXTRUDERS; ++extruder_nr)
     {
-        is_extruder_used[extruder_nr] = (extruder_nr < used_extruders && print_info.extruders_info[extruder_nr].has_value());
+        const bool is_this_extruder_used = extruder_nr < used_extruders && print_info.extruders_info[extruder_nr].has_value();
+        is_extruder_used_bool[extruder_nr] = is_this_extruder_used;
+        is_extruder_used[extruder_nr] = is_this_extruder_used;
     }
     extra_global_settings.emplace("is_extruder_used", is_extruder_used);
 
     template_resolver_->prepareForResolving(print_info.initial_extruder_nr.value_or(0), extra_global_settings);
 
+    std::shared_ptr<Communication> communication = Application::getInstance().communication_;
+
+    communication->sendGCodePart(getFileHeader(is_extruder_used_bool, filaments_volumes, materials_ids));
+
     sendFinalGCode();
 
-    Application::getInstance().communication_->sendPrintInformation(total_print_times_, print_info);
+    communication->sendPrintInformation(total_print_times_, print_info);
 }
 
 void GCodeExport::finalizeExtruder(const std::string& extruder_end_code)

--- a/src/utils/MeshUtils.cpp
+++ b/src/utils/MeshUtils.cpp
@@ -222,7 +222,7 @@ bool loadTextureFromPngData(const std::vector<unsigned char>& texture_data, Mesh
     return false;
 }
 
-bool loadTextureFromFile(Mesh& mesh, const std::string& texture_filename)
+bool loadTextureFromFile(Mesh& mesh, const std::filesystem::path& texture_filename)
 {
     if (! std::filesystem::exists(texture_filename))
     {
@@ -233,7 +233,7 @@ bool loadTextureFromFile(Mesh& mesh, const std::string& texture_filename)
     std::ifstream file(texture_filename, std::ios::binary | std::ios::ate);
     if (! file.is_open())
     {
-        spdlog::warn("Failed to open texture file: {}", texture_filename);
+        spdlog::warn("Failed to open texture file: {}", texture_filename.string());
         return false;
     }
 
@@ -243,7 +243,7 @@ bool loadTextureFromFile(Mesh& mesh, const std::string& texture_filename)
     std::vector<unsigned char> file_data(file_size);
     if (! file.read(reinterpret_cast<char*>(file_data.data()), file_size))
     {
-        spdlog::warn("Failed to read texture file: {}", texture_filename);
+        spdlog::warn("Failed to read texture file: {}", texture_filename.string());
         return false;
     }
 

--- a/src/utils/MeshUtils.cpp
+++ b/src/utils/MeshUtils.cpp
@@ -247,7 +247,7 @@ bool loadTextureFromFile(Mesh& mesh, const std::filesystem::path& texture_filena
         return false;
     }
 
-    return loadTextureFromPngData(file_data, mesh, texture_filename, true);
+    return loadTextureFromPngData(file_data, mesh, texture_filename.string(), true);
 }
 
 void loadTextureFromString(const std::string& texture_str, Mesh& mesh)

--- a/tests/GCodeExportTest.cpp
+++ b/tests/GCodeExportTest.cpp
@@ -103,17 +103,19 @@ TEST_F(GCodeExportTest, CommentSimple)
 
 TEST_F(GCodeExportTest, CommentMultiLine)
 {
-    gcode.writeComment("If you catch a chinchilla in Chile\n"
-                       "And cut off its beard, willy-nilly\n"
-                       "You can honestly say\n"
-                       "You made on that day\n"
-                       "A Chilean chinchilla's chin chilly");
+    gcode.writeComment(
+        "If you catch a chinchilla in Chile\n"
+        "And cut off its beard, willy-nilly\n"
+        "You can honestly say\n"
+        "You made on that day\n"
+        "A Chilean chinchilla's chin chilly");
     EXPECT_EQ(
-        std::string(";If you catch a chinchilla in Chile\n"
-                    ";And cut off its beard, willy-nilly\n"
-                    ";You can honestly say\n"
-                    ";You made on that day\n"
-                    ";A Chilean chinchilla's chin chilly\n"),
+        std::string(
+            ";If you catch a chinchilla in Chile\n"
+            ";And cut off its beard, willy-nilly\n"
+            ";You can honestly say\n"
+            ";You made on that day\n"
+            ";A Chilean chinchilla's chin chilly\n"),
         output().str())
         << "Each line must be preceded by a semicolon.";
 }
@@ -124,9 +126,10 @@ TEST_F(GCodeExportTest, CommentMultiple)
     gcode.writeComment("Very very frightening me");
     gcode.writeComment(" - Galileo (1638)");
     EXPECT_EQ(
-        std::string(";Thunderbolt and lightning\n"
-                    ";Very very frightening me\n"
-                    "; - Galileo (1638)\n"),
+        std::string(
+            ";Thunderbolt and lightning\n"
+            ";Very very frightening me\n"
+            "; - Galileo (1638)\n"),
         output().str())
         << "Semicolon before each line, and newline in between.";
 }
@@ -281,6 +284,8 @@ TEST_P(GriffinHeaderTest, HeaderGriffinFormat)
     std::getline(result, token, '\n');
     EXPECT_EQ(std::string(";BUILD_PLATE.INITIAL_TEMPERATURE:"), token.substr(0, 33)); // Actual temperature doesn't matter in this test.
     std::getline(result, token, '\n');
+    EXPECT_EQ(std::string(";PRINT.TIME:0"), token);
+    std::getline(result, token, '\n');
     EXPECT_EQ(std::string(";PRINT.GROUPS:0"), token);
     std::getline(result, token, '\n');
     EXPECT_EQ(std::string(";PRINT.SIZE.MIN.X:"), token.substr(0, 18)); // Actual bounds don't matter in this test.
@@ -310,7 +315,6 @@ TEST_F(GCodeExportTest, HeaderUltiGCode)
     gcode.flavor_ = EGCodeFlavor::ULTIGCODE;
     constexpr size_t num_extruders = 2;
     const std::vector<bool> extruder_is_used(num_extruders, true);
-    constexpr Duration print_time = 1337;
     const std::vector<double> filament_used = { 100, 200 };
     for (size_t extruder_index = 0; extruder_index < num_extruders; extruder_index++)
     {
@@ -320,11 +324,11 @@ TEST_F(GCodeExportTest, HeaderUltiGCode)
     }
     gcode.total_bounding_box_ = AABB3D(Point3LL(0, 0, 0), Point3LL(1000, 1000, 1000));
 
-    std::string result = gcode.getFileHeader(extruder_is_used, &print_time, filament_used);
+    std::string result = gcode.getFileHeader(extruder_is_used, filament_used);
 
     EXPECT_EQ(
         result,
-        ";FLAVOR:UltiGCode\n;TIME:1337\n;MATERIAL:100\n;MATERIAL2:200\n;NOZZLE_DIAMETER:0.4\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;"
+        ";FLAVOR:UltiGCode\n;TIME:0\n;MATERIAL:100\n;MATERIAL2:200\n;NOZZLE_DIAMETER:0.4\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;"
         "MAXY:1\n;MAXZ:1\n;TARGET_MACHINE.NAME:Your favourite 3D printer\n");
 }
 
@@ -336,15 +340,14 @@ TEST_F(GCodeExportTest, HeaderRepRap)
     gcode.extruder_attr_[1].filament_area_ = 4.0;
     constexpr size_t num_extruders = 2;
     const std::vector<bool> extruder_is_used(num_extruders, true);
-    constexpr Duration print_time = 1337;
     const std::vector<double> filament_used = { 100, 200 };
     gcode.total_bounding_box_ = AABB3D(Point3LL(0, 0, 0), Point3LL(1000, 1000, 1000));
 
-    std::string result = gcode.getFileHeader(extruder_is_used, &print_time, filament_used);
+    std::string result = gcode.getFileHeader(extruder_is_used, filament_used);
 
     EXPECT_EQ(
         result,
-        ";FLAVOR:RepRap\n;TIME:1337\n;Filament used: 0.02m, 0.05m\n;Layer height: "
+        ";FLAVOR:RepRap\n;TIME:0\n;Filament used: 0.02m, 0.05m\n;Layer height: "
         "0.123\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;MAXY:1\n;MAXZ:1\n;TARGET_MACHINE.NAME:Your favourite 3D printer\n");
 }
 
@@ -356,15 +359,14 @@ TEST_F(GCodeExportTest, HeaderMarlin)
     gcode.extruder_attr_[1].filament_area_ = 4.0;
     constexpr size_t num_extruders = 2;
     const std::vector<bool> extruder_is_used(num_extruders, true);
-    constexpr Duration print_time = 1337;
     const std::vector<double> filament_used = { 100, 200 };
     gcode.total_bounding_box_ = AABB3D(Point3LL(0, 0, 0), Point3LL(1000, 1000, 1000));
 
-    std::string result = gcode.getFileHeader(extruder_is_used, &print_time, filament_used);
+    std::string result = gcode.getFileHeader(extruder_is_used, filament_used);
 
     EXPECT_EQ(
         result,
-        ";FLAVOR:Marlin\n;TIME:1337\n;Filament used: 0.02m, 0.05m\n;Layer height: "
+        ";FLAVOR:Marlin\n;TIME:0\n;Filament used: 0.02m, 0.05m\n;Layer height: "
         "0.123\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;MAXY:1\n;MAXZ:1\n;TARGET_MACHINE.NAME:Your favourite 3D printer\n");
 }
 
@@ -374,15 +376,14 @@ TEST_F(GCodeExportTest, HeaderMarlinVolumetric)
     gcode.flavor_ = EGCodeFlavor::MARLIN_VOLUMATRIC;
     constexpr size_t num_extruders = 2;
     const std::vector<bool> extruder_is_used(num_extruders, true);
-    constexpr Duration print_time = 1337;
     const std::vector<double> filament_used = { 100, 200 };
     gcode.total_bounding_box_ = AABB3D(Point3LL(0, 0, 0), Point3LL(1000, 1000, 1000));
 
-    std::string result = gcode.getFileHeader(extruder_is_used, &print_time, filament_used);
+    std::string result = gcode.getFileHeader(extruder_is_used, filament_used);
 
     EXPECT_EQ(
         result,
-        ";FLAVOR:Marlin(Volumetric)\n;TIME:1337\n;Filament used: 100mm3, 200mm3\n;Layer height: "
+        ";FLAVOR:Marlin(Volumetric)\n;TIME:0\n;Filament used: 100mm3, 200mm3\n;Layer height: "
         "0.123\n;MINX:0\n;MINY:0\n;MINZ:0\n;MAXX:1\n;MAXY:1\n;MAXZ:1\n;TARGET_MACHINE.NAME:Your favourite 3D printer\n");
 }
 

--- a/tests/arcus/ArcusCommunicationTest.cpp
+++ b/tests/arcus/ArcusCommunicationTest.cpp
@@ -108,35 +108,11 @@ TEST_F(ArcusCommunicationTest, SendGCodePartTest)
     EXPECT_EQ(test_gcode, message->data());
 }
 
-TEST_F(ArcusCommunicationTest, IsSequential)
-{
-    EXPECT_FALSE(ac->isSequential());
-}
-
 TEST_F(ArcusCommunicationTest, HasSlice)
 {
     EXPECT_TRUE(ac->hasSlice());
     ac->private_data->slice_count = 1;
     EXPECT_FALSE(ac->hasSlice()) << "Can't slice more than once.";
-}
-
-TEST_F(ArcusCommunicationTest, SendGCodePrefix)
-{
-    const std::string prefix = ";bladiblhjvouyvu\n;iuboua";
-    const std::string& encoded_prefix = convertTobase64(prefix);
-
-    ac->sendGCodePrefix(encoded_prefix);
-    EXPECT_GT(socket->sent_messages.size(), 0);
-    bool found_prefix = false;
-    for (const auto& message : socket->sent_messages)
-    {
-        if (message->DebugString().find(encoded_prefix) != std::string::npos)
-        {
-            found_prefix = true;
-            break;
-        }
-    }
-    EXPECT_TRUE(found_prefix);
 }
 
 TEST_F(ArcusCommunicationTest, SendFinishedSlicingTest)

--- a/tests/arcus/MockCommunication.h
+++ b/tests/arcus/MockCommunication.h
@@ -22,7 +22,6 @@ class MockCommunication : public Communication
 {
 public:
     MOCK_CONST_METHOD0(hasSlice, bool());
-    MOCK_CONST_METHOD0(isSequential, bool());
     MOCK_CONST_METHOD1(sendProgress, void(double progress));
     MOCK_METHOD3(sendLayerComplete, void(const LayerIndex::value_type& layer_nr, const coord_t& z, const coord_t& thickness));
     MOCK_METHOD5(sendLineTo, void(const PrintFeatureType& type, const Point3LL& to, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity));
@@ -31,7 +30,6 @@ public:
     MOCK_METHOD1(setLayerForSend, void(const LayerIndex::value_type& layer_nr));
     MOCK_METHOD0(sendOptimizedLayerData, void());
     MOCK_CONST_METHOD0(sendPrintTimeMaterialEstimates, void());
-    MOCK_CONST_METHOD1(sendGCodePrefix, void(const std::string& prefix));
     MOCK_CONST_METHOD1(sendSliceUUID, void(const std::string& slice_uuid));
     MOCK_CONST_METHOD0(sendFinishedSlicing, void());
     MOCK_METHOD0(sliceNext, void());


### PR DESCRIPTION
This PR provides two minor improvements that were necessary for the new benchmarking tools:
* Improve the OBJ file loading to fully support files exported with assimp
* Export the GCode header irregardless of the communication type. Since we now resolve the whole GCode at the end of the slicing, the header can be treated the same and always be fully generated. Thus the `Communication` objects don't need the `isSequential` method anymore, and they will all get the very same GCode header. The header is also now sent as a regular GCode part, so we don't need the specific `GCodePrefix` message.

CURA-13226