### PR TITLE
Apply fuzzy skin to the spiral wall when spiralize is enabled

### DIFF
--- a/src/FffPolygonGenerator.cpp
+++ b/src/FffPolygonGenerator.cpp
@@ -1205,6 +1205,72 @@ void FffPolygonGenerator::processFuzzyWalls(SliceMeshStorage& mesh)
                 }
             }
             part.wall_toolpaths = result_paths;
+
+            // Also fuzz the spiral wall, if any. In spiralize mode the outer wall isn't stored in wall_toolpaths but in spiral_wall (as plain polygons),
+            // so it needs to be processed separately, like it used to be before the variable-width toolpaths existed.
+            if (part.spiral_wall.empty())
+            {
+                continue;
+            }
+            if (apply_outside_only)
+            {
+                hole_area = part.print_outline.getOutsidePolygons().offset(-line_width);
+            }
+            Shape fuzzy_spiral_walls;
+            for (const Polygon& wall : part.spiral_wall)
+            {
+                if (wall.size() < 3
+                    || (apply_outside_only
+                        && std::any_of(
+                            wall.begin(),
+                            wall.end(),
+                            [&hole_area](const Point2LL& point)
+                            {
+                                return hole_area.inside(point);
+                            })))
+                {
+                    fuzzy_spiral_walls.push_back(wall);
+                    continue;
+                }
+
+                Polygon fuzzy_wall;
+
+                // generate points in between p0 and p1
+                int64_t dist_left_over
+                    = (min_dist_between_points / 4) + rand() % (min_dist_between_points / 4); // the distance to be traversed on the line before making the first new point
+                const Point2LL* p0 = &wall.back();
+                for (const Point2LL& p1 : wall)
+                {
+                    if (*p0 == p1) // avoid seams
+                    {
+                        p0 = &p1;
+                        continue;
+                    }
+
+                    // 'a' is the (next) new point between p0 and p1
+                    const Point2LL p0p1 = p1 - *p0;
+                    const int64_t p0p1_size = vSize(p0p1);
+                    int64_t p0pa_dist = dist_left_over;
+                    for (; p0pa_dist < p0p1_size; p0pa_dist += min_dist_between_points + rand() % range_random_point_dist)
+                    {
+                        const int r = rand() % (fuzziness * 2) - fuzziness;
+                        const Point2LL perp_to_p0p1 = turn90CCW(p0p1);
+                        const Point2LL fuzz = normal(perp_to_p0p1, r);
+                        const Point2LL pa = *p0 + normal(p0p1, p0pa_dist);
+                        fuzzy_wall.push_back(pa + fuzz);
+                    }
+                    // p0pa_dist > p0p1_size now because we broke out of the for-loop
+                    dist_left_over = p0pa_dist - p0p1_size;
+
+                    p0 = &p1;
+                }
+                if (fuzzy_wall.size() < 3)
+                {
+                    fuzzy_wall = wall; // the polygon was too small to fuzz; keep it unchanged
+                }
+                fuzzy_spiral_walls.push_back(std::move(fuzzy_wall));
+            }
+            part.spiral_wall = fuzzy_spiral_walls;
         }
     }
 }


### PR DESCRIPTION
# Description

This fixes fuzzy skin not being applied when Spiralize Outer Contour is enabled, a regression introduced with the variable-width wall toolpaths (Arachne) in Cura 5.0.

`FffPolygonGenerator::processFuzzyWalls()` only processes `part.wall_toolpaths`, but in spiralize mode the wall is stored as plain polygons in `part.spiral_wall`, so fuzzy skin was only visible on the initial bottom layers (the only layers that get wall toolpaths). Before 5.0 the spiral wall was handled explicitly (`spiralize ? part.spiral_wall : part.insets[0]`).

This restores that behavior by applying the same fuzzing to the spiral wall polygons, including the "Fuzzy Skin Outside Only" hole check and the first-layer brim exception.

Fixes Ultimaker/Cura#12850

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Headless CLI slices of `tests/integration/resources/cylinder1000.stl` with `magic_spiralize=true` and `magic_fuzzy_skin_enabled=true` (otherwise default fdmprinter settings), comparing the radial deviation of the wall from the layer centroid per layer:
  - Before: spiralized layers were perfect circles (radial std. dev. ≈ 0.004 mm, i.e. only simplification noise); only the initial bottom layers were fuzzed.
  - After: every spiralized layer shows the expected jitter (std. dev. ≈ 0.15 mm at the default 0.3 mm fuzzy thickness), while the bottom layers are unchanged.
- Regression check: slicing with fuzzy skin enabled but spiralize disabled is unaffected.
- Visual check of the sliced result in the Cura preview.

**Test Configuration**:
* Operating System: Windows 11

# IMPORTANT
The code was generated using Claude's Fable model. I was annoyed by this bug for quite a while (the issue on Github is almost 4 years old) so I decided to give it a go using Fable. Looks fine and works as expected but I'd really appreciate if someone could take a look at it and verify that it can be merged, thank you!
