### PR TITLE
[CURA-13054] Don't take support into account w.r.t. seam overhang.

### DIFF
--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2684,7 +2684,9 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
             gcode_layer.setBridgeWallMask(Shape());
         }
 
-        const Shape model_supported_region = non_support_outlines_below.offset(-half_outer_wall_width);
+        Shape model_supported_region = non_support_outlines_below.offset(-half_outer_wall_width);
+        // remove those parts of the layer below that are narrower than a wall line width as they will not be printed
+        model_supported_region = model_supported_region.offset(-half_outer_wall_width).offset(half_outer_wall_width);
 
         const auto get_supported_region = [&model_supported_region, &layer_height](const AngleDegrees& overhang_angle) -> Shape
         {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2691,7 +2691,7 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
         const auto get_supported_region = [&model_supported_region, &layer_height](const AngleDegrees& overhang_angle) -> Shape
         {
             // the overhang mask is set to the area of the current part's outline minus the region that is considered to be supported
-            // the supported region is made up of those areas that really are supported by (either) the model (or support, if 'full') on the layer below
+            // the supported region is made up of those areas that are supported by the model on the layer below
             // expanded to take into account the overhang angle, the greater the overhang angle, the larger the supported area is
             // considered to be
             if (overhang_angle < 90.0)

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2595,7 +2595,7 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
                 }
             }
         }
-        Shape non_support_outlines_below = outlines_below;
+        const Shape& non_support_outlines_below = outlines_below;
 
         const coord_t layer_height = mesh_config.inset0_config.getLayerThickness();
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2595,6 +2595,7 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
                 }
             }
         }
+        Shape non_support_outlines_below = outlines_below;
 
         const coord_t layer_height = mesh_config.inset0_config.getLayerThickness();
 
@@ -2684,18 +2685,19 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
         }
 
         const Shape fully_supported_region = outlines_below.offset(-half_outer_wall_width);
+        const Shape model_supported_region = non_support_outlines_below.offset(-half_outer_wall_width);
         const Shape part_print_region = part.outline.offset(-half_outer_wall_width);
 
-        const auto get_supported_region = [&fully_supported_region, &layer_height](const AngleDegrees& overhang_angle) -> Shape
+        const auto get_supported_region = [&fully_supported_region, &model_supported_region, &layer_height](const AngleDegrees& overhang_angle, bool full = true) -> Shape
         {
             // the overhang mask is set to the area of the current part's outline minus the region that is considered to be supported
-            // the supported region is made up of those areas that really are supported by either model or support on the layer below
+            // the supported region is made up of those areas that really are supported by (either) the model (or support, if 'full') on the layer below
             // expanded to take into account the overhang angle, the greater the overhang angle, the larger the supported area is
             // considered to be
             if (overhang_angle < 90.0)
             {
                 const coord_t overhang_width = layer_height * std::tan(AngleRadians(overhang_angle));
-                return fully_supported_region.offset(overhang_width + 10);
+                return (full ? fully_supported_region : model_supported_region).offset(overhang_width + 10);
             }
 
             return Shape();
@@ -2758,7 +2760,8 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
         const AngleDegrees seam_overhang_angle = mesh.settings.get<AngleDegrees>("seam_overhang_angle");
         if (seam_overhang_angle < 90.0)
         {
-            const Shape supported_region_seam = get_supported_region(seam_overhang_angle);
+            constexpr bool not_full = false; // Do not take support into account for the seam overhang.
+            const Shape supported_region_seam = get_supported_region(seam_overhang_angle, not_full);
             gcode_layer.setSeamOverhangMask(part_print_region.difference(supported_region_seam).offset(10));
         }
         else

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2759,9 +2759,8 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
         const AngleDegrees seam_overhang_angle = mesh.settings.get<AngleDegrees>("seam_overhang_angle");
         if (seam_overhang_angle < 90.0)
         {
-            const auto seam_overhang_mask = 
-                storage.getMachineBorder(mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr_)
-                .difference(get_supported_region(seam_overhang_angle));
+            const auto seam_overhang_mask
+                = storage.getMachineBorder(mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr_).difference(get_supported_region(seam_overhang_angle));
             gcode_layer.setSeamOverhangMask(seam_overhang_mask);
         }
         else

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2749,7 +2749,7 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
                 for (const auto& regions : merged_regions)
                 {
                     const SpeedRegion& last_region = *ranges::prev(regions.end());
-                    constexpr bool not_full = false; // Do not take support into account for the seam overhang.
+                    constexpr bool not_full = false; // Do not take support into account for the wall overhang.
                     overhang_masks.push_back(LayerPlan::OverhangMask{
                         get_supported_region(last_region.overhang_angle, not_full),
                         last_region.speed_factor,

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2685,7 +2685,6 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
         }
 
         const Shape model_supported_region = non_support_outlines_below.offset(-half_outer_wall_width);
-        const Shape part_print_region = part.outline.offset(-half_outer_wall_width);
 
         const auto get_supported_region = [&model_supported_region, &layer_height](const AngleDegrees& overhang_angle) -> Shape
         {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2595,7 +2595,7 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
                 }
             }
         }
-        const Shape& non_support_outlines_below = outlines_below;
+        const Shape non_support_outlines_below = outlines_below;
 
         const coord_t layer_height = mesh_config.inset0_config.getLayerThickness();
 

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2749,7 +2749,11 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
                 for (const auto& regions : merged_regions)
                 {
                     const SpeedRegion& last_region = *ranges::prev(regions.end());
-                    overhang_masks.push_back(LayerPlan::OverhangMask{ get_supported_region(last_region.overhang_angle), last_region.speed_factor });
+                    constexpr bool not_full = false; // Do not take support into account for the seam overhang.
+                    overhang_masks.push_back(LayerPlan::OverhangMask{
+                        get_supported_region(last_region.overhang_angle, not_full),
+                        last_region.speed_factor,
+                    });
                 }
             }
         }
@@ -2760,8 +2764,8 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
         const AngleDegrees seam_overhang_angle = mesh.settings.get<AngleDegrees>("seam_overhang_angle");
         if (seam_overhang_angle < 90.0)
         {
-            constexpr bool not_full = false; // Do not take support into account for the seam overhang.
-            const Shape supported_region_seam = get_supported_region(seam_overhang_angle, not_full);
+            constexpr bool full = true; // Do not take support into account for the seam overhang.
+            const Shape supported_region_seam = get_supported_region(seam_overhang_angle, full);
             gcode_layer.setSeamOverhangMask(part_print_region.difference(supported_region_seam).offset(10));
         }
         else

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2749,11 +2749,7 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
                 for (const auto& regions : merged_regions)
                 {
                     const SpeedRegion& last_region = *ranges::prev(regions.end());
-                    constexpr bool not_full = false; // Do not take support into account for the wall overhang.
-                    overhang_masks.push_back(LayerPlan::OverhangMask{
-                        get_supported_region(last_region.overhang_angle, not_full),
-                        last_region.speed_factor,
-                    });
+                    overhang_masks.push_back(LayerPlan::OverhangMask{ get_supported_region(last_region.overhang_angle), last_region.speed_factor });
                 }
             }
         }
@@ -2764,8 +2760,8 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
         const AngleDegrees seam_overhang_angle = mesh.settings.get<AngleDegrees>("seam_overhang_angle");
         if (seam_overhang_angle < 90.0)
         {
-            constexpr bool full = true; // Do not take support into account for the seam overhang.
-            const Shape supported_region_seam = get_supported_region(seam_overhang_angle, full);
+            constexpr bool not_full = false; // Do not take support into account for the seam overhang.
+            const Shape supported_region_seam = get_supported_region(seam_overhang_angle, not_full);
             gcode_layer.setSeamOverhangMask(part_print_region.difference(supported_region_seam).offset(10));
         }
         else

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -2684,11 +2684,10 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
             gcode_layer.setBridgeWallMask(Shape());
         }
 
-        const Shape fully_supported_region = outlines_below.offset(-half_outer_wall_width);
         const Shape model_supported_region = non_support_outlines_below.offset(-half_outer_wall_width);
         const Shape part_print_region = part.outline.offset(-half_outer_wall_width);
 
-        const auto get_supported_region = [&fully_supported_region, &model_supported_region, &layer_height](const AngleDegrees& overhang_angle, bool full = true) -> Shape
+        const auto get_supported_region = [&model_supported_region, &layer_height](const AngleDegrees& overhang_angle) -> Shape
         {
             // the overhang mask is set to the area of the current part's outline minus the region that is considered to be supported
             // the supported region is made up of those areas that really are supported by (either) the model (or support, if 'full') on the layer below
@@ -2697,7 +2696,7 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
             if (overhang_angle < 90.0)
             {
                 const coord_t overhang_width = layer_height * std::tan(AngleRadians(overhang_angle));
-                return (full ? fully_supported_region : model_supported_region).offset(overhang_width + 10);
+                return model_supported_region.offset(overhang_width + 10);
             }
 
             return Shape();
@@ -2760,9 +2759,10 @@ FffGcodeWriter::InsetsPreprocessResult FffGcodeWriter::preProcessInsets(
         const AngleDegrees seam_overhang_angle = mesh.settings.get<AngleDegrees>("seam_overhang_angle");
         if (seam_overhang_angle < 90.0)
         {
-            constexpr bool not_full = false; // Do not take support into account for the seam overhang.
-            const Shape supported_region_seam = get_supported_region(seam_overhang_angle, not_full);
-            gcode_layer.setSeamOverhangMask(part_print_region.difference(supported_region_seam).offset(10));
+            const auto seam_overhang_mask = 
+                storage.getMachineBorder(mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr_)
+                .difference(get_supported_region(seam_overhang_angle));
+            gcode_layer.setSeamOverhangMask(seam_overhang_mask);
         }
         else
         {


### PR DESCRIPTION
It was using the `outlines_below` value, which included the support, as it probably should for the other thing(s) we use it for.

CURA-13054