### PR TITLE
[NP-1357] Harden CI for arbitrary script executions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+@ultimaker:registry=https://npm.pkg.github.com
+always-auth=true
+ignore-scripts=true


### PR DESCRIPTION
### Why
Harden CI and local npm installations against arbitrary preinstall/postinstall script execution (such as the Shai-Hulud worm supply-chain attack).

### What
Added project `.npmrc` with `ignore-scripts=true`.

### How
Disables automatic lifecycle script execution during `npm install` and `npm ci`.

### Verification
- Verified `.npmrc` configuration.

- [x] Initiating developer reviewed AI-generated code