### PR TITLE
CURA-13252 smooth tree support branches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(ENABLE_MORE_COMPILER_OPTIMIZATION_FLAGS "Enable more optimization flags" 
 option(USE_SYSTEM_LIBS "Use the system libraries if available" OFF)
 option(OLDER_APPLE_CLANG "Apple Clang <= 13 used" OFF)
 option(ENABLE_THREADING "Enable threading support" ON)
-option(ENABLE_CURAVIZ "Build with CuraViz toolbox" ON)
+option(ENABLE_CURAVIZ "Build with CuraViz toolbox" OFF)
 
 if (${ENABLE_ARCUS} OR ${ENABLE_PLUGINS} OR ${ENABLE_CURAVIZ})
     find_package(protobuf REQUIRED)

--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -105,8 +105,7 @@ private:
     struct ProcessLayerResult
     {
         LayerPlan* layer_plan;
-        double total_elapsed_time;
-        TimeKeeper::RegisteredTimes stages_times;
+        TimeKeeper time_keeper;
     };
 
     struct RoofingFlooringSettingsNames

--- a/include/TreeModelVolumes.h
+++ b/include/TreeModelVolumes.h
@@ -25,6 +25,7 @@ class SliceDataStorage;
 class SliceMeshStorage;
 class LayerIndex;
 class Settings;
+class TimeKeeper;
 
 /*!
  * \brief Lazily generates tree guidance volumes.
@@ -56,7 +57,7 @@ public:
      * Not calling this will cause the class to lazily calculate avoidances and collisions as needed, which will be a lot slower on systems with more then one or two cores!
      *
      */
-    void precalculate(coord_t max_layer);
+    void precalculate(coord_t max_layer, TimeKeeper& time_keeper);
 
     /*!
      * \brief Provides the areas that have to be avoided by the tree's branches to prevent collision with the model on this layer.

--- a/include/TreeModelVolumes.h
+++ b/include/TreeModelVolumes.h
@@ -52,6 +52,7 @@ public:
 
     /*!
      * \brief Precalculate avoidances and collisions up to this layer.
+     * \param time_keeper The object used to record the duration of the sub-steps
      *
      * This uses knowledge about branch angle to only calculate avoidances and collisions that could actually be needed.
      * Not calling this will cause the class to lazily calculate avoidances and collisions as needed, which will be a lot slower on systems with more then one or two cores!

--- a/include/TreeSupport.h
+++ b/include/TreeSupport.h
@@ -102,6 +102,7 @@ private:
      *
      * \param storage[in] Background storage to access meshes.
      * \param currently_processing_meshes[in] Indexes of all meshes that are processed in this iteration
+     * \param time_keeper The object used to record the duration of the sub-steps
      * \return Uppermost layer precalculated. -1 if no layer were precalculated as no overhang is present.
      */
     LayerIndex precalculate(const SliceDataStorage& storage, std::vector<size_t> currently_processing_meshes, TimeKeeper& time_keeper);
@@ -227,6 +228,7 @@ private:
      * \brief Propagates influence downwards, and merges overlapping ones.
      *
      * \param move_bounds[in,out] All currently existing influence areas
+     * \param time_keeper The object used to record the duration of the sub-steps
      */
     void createLayerPathing(std::vector<std::set<TreeSupportElement*>>& move_bounds, TimeKeeper& time_keeper);
 
@@ -316,6 +318,7 @@ private:
      *
      * \param move_bounds[in] All currently existing influence areas
      * \param storage[in,out] The storage where the support should be stored.
+     * \param time_keeper The object used to record the duration of the sub-steps
      */
     void drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage, TimeKeeper& time_keeper);
 

--- a/include/TreeSupport.h
+++ b/include/TreeSupport.h
@@ -275,6 +275,10 @@ private:
      */
     void smoothBranchAreas(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons);
 
+    /*!
+     * Smoothes the skeleton of the tree structure according to the smoothing factor
+     * @param layer_tree_polygons The base tree structure to be smoothed
+     */
     void smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*>>& layer_tree_polygons);
 
     /*!

--- a/include/TreeSupport.h
+++ b/include/TreeSupport.h
@@ -20,6 +20,7 @@ namespace cura
 {
 
 class OBJ;
+class TimeKeeper;
 
 // The various stages of the process can be weighted differently in the progress bar.
 // These weights are obtained experimentally using a small sample size. Sensible weights can differ drastically based on the assumed default settings and model.
@@ -103,7 +104,7 @@ private:
      * \param currently_processing_meshes[in] Indexes of all meshes that are processed in this iteration
      * \return Uppermost layer precalculated. -1 if no layer were precalculated as no overhang is present.
      */
-    LayerIndex precalculate(const SliceDataStorage& storage, std::vector<size_t> currently_processing_meshes);
+    LayerIndex precalculate(const SliceDataStorage& storage, std::vector<size_t> currently_processing_meshes, TimeKeeper& time_keeper);
 
 
     /*!
@@ -227,7 +228,7 @@ private:
      *
      * \param move_bounds[in,out] All currently existing influence areas
      */
-    void createLayerPathing(std::vector<std::set<TreeSupportElement*>>& move_bounds);
+    void createLayerPathing(std::vector<std::set<TreeSupportElement*>>& move_bounds, TimeKeeper& time_keeper);
 
 
     /*!
@@ -274,6 +275,8 @@ private:
      */
     void smoothBranchAreas(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons);
 
+    void smoothBranchSkeletons(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons);
+
     /*!
      * \brief Drop down areas that do rest non-gracefully on the model to ensure the branch actually rests on something.
      *
@@ -310,7 +313,7 @@ private:
      * \param move_bounds[in] All currently existing influence areas
      * \param storage[in,out] The storage where the support should be stored.
      */
-    void drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage);
+    void drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage, TimeKeeper& time_keeper);
 
     /*!
      * Saves the influence areas and the resulting positions of all the given elements to a 3D object

--- a/include/TreeSupport.h
+++ b/include/TreeSupport.h
@@ -275,7 +275,7 @@ private:
      */
     void smoothBranchAreas(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons);
 
-    void smoothBranchSkeletons(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons);
+    void smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*>>& layer_tree_polygons);
 
     /*!
      * \brief Drop down areas that do rest non-gracefully on the model to ensure the branch actually rests on something.

--- a/include/TreeSupportElement.h
+++ b/include/TreeSupportElement.h
@@ -43,8 +43,9 @@ struct AreaIncreaseSettings
     bool operator==(const AreaIncreaseSettings& other) const = default;
 };
 
-struct TreeSupportElement
+class TreeSupportElement
 {
+public:
     TreeSupportElement(
         coord_t distance_to_top,
         size_t target_height,
@@ -104,7 +105,17 @@ struct TreeSupportElement
         return other.target_position_.X == target_position_.X ? other.target_position_.Y < target_position_.Y : other.target_position_.X < target_position_.X;
     }
 
-    void AddParents(const std::vector<TreeSupportElement*>& adding);
+    const std::vector<TreeSupportElement*>& getParents() const
+    {
+        return parents_;
+    }
+
+    void addParents(const std::vector<TreeSupportElement*>& new_parents);
+
+    TreeSupportElement* getChild() const
+    {
+        return child_;
+    }
 
     void RecreateInfluenceLimitArea();
 
@@ -155,11 +166,6 @@ struct TreeSupportElement
      */
 
     bool to_buildplate_;
-
-    /*!
-     * \brief All elements in the layer above the current one that are supported by this element
-     */
-    std::vector<TreeSupportElement*> parents_;
 
     /*!
      * \brief The amount of layers this element is below the topmost layer of this branch.
@@ -250,6 +256,14 @@ struct TreeSupportElement
      * \brief Additional locations that the tip should reach
      */
     std::vector<Point2LL> additional_ovalization_targets_;
+
+private:
+    /*!
+     * \brief All elements in the layer above the current one that are supported by this element
+     */
+    std::vector<TreeSupportElement*> parents_;
+
+    TreeSupportElement* child_{ nullptr };
 };
 
 } // namespace cura

--- a/include/TreeSupportElement.h
+++ b/include/TreeSupportElement.h
@@ -105,13 +105,16 @@ public:
         return other.target_position_.X == target_position_.X ? other.target_position_.Y < target_position_.Y : other.target_position_.X < target_position_.X;
     }
 
+    /*! \brief Gets the list of parent elements, which are those above the current element */
     const std::vector<TreeSupportElement*>& getParents() const
     {
         return parents_;
     }
 
+    /*! \brief Adds the given elements to be parents of the current element. Parents will also be properly modified to have the element as a child. */
     void addParents(const std::vector<TreeSupportElement*>& new_parents);
 
+    /*! \brief Gets the child element, which is the one beloe the current element. It could also be null if the element lies on the buildplate or on the model */
     TreeSupportElement* getChild() const
     {
         return child_;
@@ -263,6 +266,9 @@ private:
      */
     std::vector<TreeSupportElement*> parents_;
 
+    /*!
+     * \brief The element in the layer below that is supporting this element
+     */
     TreeSupportElement* child_{ nullptr };
 };
 

--- a/include/TreeSupportSettings.h
+++ b/include/TreeSupportSettings.h
@@ -384,6 +384,9 @@ public:
      */
     bool fill_outline_gaps;
 
+    /*!
+     * \brief Number of layers on which to smooth the tree support branches
+     */
     size_t support_tree_smooth_layers;
 
     /*!

--- a/include/TreeSupportSettings.h
+++ b/include/TreeSupportSettings.h
@@ -82,6 +82,7 @@ struct TreeSupportSettings
         , min_feature_size(mesh_group_settings.get<coord_t>("min_feature_size"))
         , min_wall_line_width(settings.get<coord_t>("min_wall_line_width"))
         , fill_outline_gaps(settings.get<bool>("fill_outline_gaps"))
+        , support_tree_smooth_layers(settings.get<size_t>("support_tree_smooth_layers"))
         , simplifier(Simplify(mesh_group_settings))
     {
         layer_start_bp_radius = (bp_radius - branch_radius) / (branch_radius * diameter_scale_bp_radius);
@@ -383,6 +384,8 @@ public:
      */
     bool fill_outline_gaps;
 
+    size_t support_tree_smooth_layers;
+
     /*!
      * \brief Simplifier to simplify polygons.
      */
@@ -412,7 +415,7 @@ public:
             && zag_skip_count == other.zag_skip_count && connect_zigzags == other.connect_zigzags && interface_preference == other.interface_preference
             && min_feature_size == other.min_feature_size && // interface_preference should be identical to ensure the tree will correctly interact with the roof.
                support_rest_preference == other.support_rest_preference && max_radius == other.max_radius && min_wall_line_width == other.min_wall_line_width
-            && fill_outline_gaps == other.fill_outline_gaps &&
+            && fill_outline_gaps == other.fill_outline_gaps && support_tree_smooth_layers == other.support_tree_smooth_layers &&
                // The infill class now wants the settings object and reads a lot of settings, and as the infill class is used to calculate support roof lines for
                // interface-preference. Not all of these may be required to be identical, but as I am not sure, better safe than sorry
                (interface_preference == InterfacePreference::INTERFACE_AREA_OVERWRITES_SUPPORT || interface_preference == InterfacePreference::SUPPORT_AREA_OVERWRITES_INTERFACE

--- a/include/progress/Progress.h
+++ b/include/progress/Progress.h
@@ -91,12 +91,11 @@ public:
      *
      * \param layer_nr The processed layer number
      * \param total_layers The total number of layers to be processed
-     * \param total_time The total layer processing time, in seconds
-     * \param stage The detailed stages time reporting for this layer
+     * \param time_keeper The time keeper containing the detailed stages time reporting for this layer
      * \param skip_threshold The time threshold under which we consider that the full layer time reporting should be skipped
      *                       because it is not relevant
      */
-    static void messageProgressLayer(LayerIndex layer_nr, size_t total_layers, double total_time, const TimeKeeper::RegisteredTimes& stages, double skip_threshold = 0.1);
+    static void messageProgressLayer(const LayerIndex layer_nr, const size_t total_layers, const TimeKeeper& time_keeper, const std::chrono::milliseconds skip_threshold = 100ms);
 };
 
 

--- a/include/utils/gettime.h
+++ b/include/utils/gettime.h
@@ -10,6 +10,8 @@
 
 #include <spdlog/stopwatch.h>
 
+using namespace std::chrono_literals;
+
 namespace cura
 {
 
@@ -19,27 +21,34 @@ public:
     struct RegisteredTime
     {
         std::string stage;
-        double duration;
+        std::chrono::milliseconds duration;
     };
 
     using RegisteredTimes = std::vector<RegisteredTime>;
 
 private:
     spdlog::stopwatch watch;
-    double start_time;
+    spdlog::stopwatch watch_total;
     RegisteredTimes registered_times;
+    std::chrono::milliseconds total_duration;
 
 public:
     TimeKeeper();
 
-    double restart();
+    std::chrono::milliseconds restart();
 
-    void registerTime(const std::string& stage, double threshold = 0.01);
+    void registerTime(const std::string& stage, std::chrono::milliseconds threshold = 10ms);
 
     const RegisteredTimes& getRegisteredTimes() const
     {
         return registered_times;
     }
+
+    void end();
+
+    std::chrono::milliseconds getTotalDuration() const;
+
+    void logRegisteredTimes(const std::string& global_desc) const;
 };
 
 } // namespace cura

--- a/include/utils/gettime.h
+++ b/include/utils/gettime.h
@@ -37,7 +37,7 @@ public:
 
     std::chrono::milliseconds restart();
 
-    void registerTime(const std::string& stage, std::chrono::milliseconds threshold = 10ms);
+    void registerTime(const std::string& stage, const std::chrono::milliseconds threshold = 10ms, const std::optional<std::chrono::milliseconds> duration = std::nullopt);
 
     const RegisteredTimes& getRegisteredTimes() const
     {

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -165,7 +165,7 @@ void FffGcodeWriter::writeGCode(SliceDataStorage& storage, TimeKeeper& time_keep
         [this, total_layers](std::optional<ProcessLayerResult> result_opt)
         {
             const ProcessLayerResult& result = result_opt.value();
-            Progress::messageProgressLayer(result.layer_plan->getLayerNr(), total_layers, result.total_elapsed_time, result.stages_times);
+            Progress::messageProgressLayer(result.layer_plan->getLayerNr(), total_layers, result.time_keeper);
             layer_plan_buffer.handle(*result.layer_plan, gcode);
             print_info_.updateWithLayer(result.layer_plan);
         });
@@ -1130,7 +1130,6 @@ FffGcodeWriter::ProcessLayerResult FffGcodeWriter::processLayer(const SliceDataS
 {
     spdlog::debug("GcodeWriter processing layer {} of {}", layer_nr, total_layers);
     TimeKeeper time_keeper;
-    spdlog::stopwatch timer_total;
 
     const Settings& mesh_group_settings = Application::getInstance().current_slice_->scene.current_mesh_group->settings;
     coord_t layer_thickness = mesh_group_settings.get<coord_t>("layer_height");
@@ -1288,7 +1287,9 @@ FffGcodeWriter::ProcessLayerResult FffGcodeWriter::processLayer(const SliceDataS
     gcode_layer.applyBackPressureCompensation();
     time_keeper.registerTime("Back pressure comp.");
 
-    return { &gcode_layer, timer_total.elapsed().count(), time_keeper.getRegisteredTimes() };
+    time_keeper.end();
+
+    return { &gcode_layer, time_keeper };
 }
 
 bool FffGcodeWriter::getExtruderNeedPrimeBlobDuringFirstLayer(const SliceDataStorage& storage, const size_t extruder_nr) const

--- a/src/MeshGroup.cpp
+++ b/src/MeshGroup.cpp
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <fmt/chrono.h>
 #include <fmt/format.h>
 #include <range/v3/algorithm/transform.hpp>
 #include <range/v3/view/enumerate.hpp>
@@ -577,7 +578,7 @@ bool loadMeshIntoMeshGroup(MeshGroup* meshgroup, const fs::path& filename, const
             }
         }
 
-        spdlog::info("loading '{}' took {:03.3f} seconds", filename.string(), load_timer.restart());
+        spdlog::info("loading '{}' took {}", filename.string(), std::chrono::duration<double>(load_timer.restart()));
 
         mesh.mesh_name_ = base_filename.string();
         meshgroup->meshes.push_back(mesh);

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -3,6 +3,7 @@
 
 #include "Scene.h"
 
+#include <fmt/chrono.h>
 #include <spdlog/spdlog.h>
 
 #include "Application.h"
@@ -81,7 +82,7 @@ void Scene::processMeshGroup(MeshGroup& mesh_group)
     if (empty)
     {
         Progress::messageProgress(Progress::Stage::FINISH, 1, 1); // 100% on this meshgroup
-        spdlog::info("Total time elapsed {:03.3f}s", time_keeper_total.restart());
+        spdlog::info("Total time elapsed {}", std::chrono::duration<double>(time_keeper_total.restart()));
         return;
     }
 
@@ -96,7 +97,7 @@ void Scene::processMeshGroup(MeshGroup& mesh_group)
 
     Progress::messageProgress(Progress::Stage::FINISH, 1, 1); // 100% on this meshgroup
     Application::getInstance().communication_->sendOptimizedLayerData();
-    spdlog::info("Total time elapsed {:03.3f}s\n", time_keeper_total.restart());
+    spdlog::info("Total time elapsed {}\n", std::chrono::duration<double>(time_keeper_total.restart()));
 }
 
 } // namespace cura

--- a/src/TreeModelVolumes.cpp
+++ b/src/TreeModelVolumes.cpp
@@ -169,9 +169,8 @@ TreeModelVolumes::TreeModelVolumes(
     simplifier_ = Simplify(min_maximum_resolution, min_maximum_deviation, min_maximum_area_deviation);
 }
 
-void TreeModelVolumes::precalculate(coord_t max_layer)
+void TreeModelVolumes::precalculate(coord_t max_layer, TimeKeeper& time_keeper)
 {
-    const auto t_start = std::chrono::high_resolution_clock::now();
     precalculated_ = true;
 
     // Get the config corresponding to one mesh that is in the current group. Which one has to be irrelevant.
@@ -264,15 +263,13 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
 
     // ### Calculate collisions without holes, build from regular collision
     calculateCollisionHolefree(relevant_hole_collision_radiis);
-
-    const auto t_coll = std::chrono::high_resolution_clock::now();
-    auto t_acc = std::chrono::high_resolution_clock::now();
+    time_keeper.registerTime("Pre-calculate collision");
 
 
     if (max_layer_idx_without_blocker_ < max_layer && support_rests_on_model_)
     {
         calculateAccumulatedPlaceable0(max_layer);
-        t_acc = std::chrono::high_resolution_clock::now();
+        time_keeper.registerTime("Pre-calculate avoidance");
     }
 
     // ### Calculate the relevant avoidances in parallel as far as possible
@@ -302,30 +299,16 @@ void TreeModelVolumes::precalculate(coord_t max_layer)
         }
         // FIXME: When nowait (parellel-for) is implemented, ensure here the following is calculated: calculateWallRestrictions.
     }
-    const auto t_avo = std::chrono::high_resolution_clock::now();
+    time_keeper.registerTime("Pre-calculate accumulated Placeables");
 
-    auto t_colAvo = std::chrono::high_resolution_clock::now();
     if (max_layer_idx_without_blocker_ < max_layer && support_rests_on_model_)
     {
         // FIXME: When nowait (parellel-for) is implemented, ensure here the following is calculated: calculateAccumulatedPlaceable0.
         calculateCollisionAvoidance(relevant_avoidance_radiis);
-        t_colAvo = std::chrono::high_resolution_clock::now();
+        time_keeper.registerTime("Pre-calculate collision-avoidance");
     }
 
     precalculation_finished_ = true;
-    const auto dur_col = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_coll - t_start).count();
-    const auto dur_acc = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_acc - t_coll).count();
-    const auto dur_avo = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_avo - t_acc).count();
-    const auto dur_col_avo = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_colAvo - t_avo).count();
-
-
-    spdlog::info(
-        "Pre-calculating collision took {} ms. Pre-calculating avoidance took {} ms. Pre-calculating accumulated Placeables with radius 0 took {} ms. Pre-calculating "
-        "collision-avoidance took {} ms. ",
-        dur_col,
-        dur_avo,
-        dur_acc,
-        dur_col_avo);
 }
 
 const Shape& TreeModelVolumes::getCollision(coord_t radius, LayerIndex layer_idx, bool min_xy_dist)

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2259,16 +2259,15 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(
-                        TreeSupportUtils::generateSupportInfillLines(
-                            support_layer_storage[layer_idx],
-                            config,
-                            false,
-                            layer_idx,
-                            config.support_line_distance,
-                            storage.support.cross_fill_provider,
-                            true)
-                            .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
+                                                              support_layer_storage[layer_idx],
+                                                              config,
+                                                              false,
+                                                              layer_idx,
+                                                              config.support_line_distance,
+                                                              storage.support.cross_fill_provider,
+                                                              true)
+                                                              .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -1914,14 +1914,17 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
 void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*>>& layer_tree_polygons)
 {
     const size_t smooth_window = config.support_tree_smooth_layers;
-    boost::concurrent_flat_map<TreeSupportElement*, Point2LL> smoothed_positions;
+    if (smooth_window < 2) // Smoothing on 1 layer will give a similar result, so can be skipped
+    {
+        return;
+    }
 
-    // TODO: This can definitely be optimized by caching the parents chains and sums of points, but for now performance is more than decent so leaving as is.
-    // If the feature is validated after the spike, then we should definitely do it.
+    // First go through every element and calculate their average position i.r.t their chain of children
+    boost::concurrent_flat_map<TreeSupportElement*, Point2LL> smoothed_positions;
     cura::parallel_for<size_t>(
         0,
         layer_tree_polygons.size(),
-        [&layer_tree_polygons, &smooth_window, &smoothed_positions](size_t layer_index)
+        [&layer_tree_polygons, &smooth_window, &smoothed_positions](const size_t layer_index)
         {
             for (TreeSupportElement* element : layer_tree_polygons[layer_index])
             {
@@ -1940,6 +1943,7 @@ void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*
             }
         });
 
+    // Now apply the smoothed positions
     smoothed_positions.visit_all(
 #ifdef __cpp_lib_execution
         std::execution::par,

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -3,7 +3,6 @@
 
 #include "TreeSupport.h"
 
-#include <absl/time/time.h>
 #include <chrono>
 #include <fstream>
 #include <optional>

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -1698,7 +1698,7 @@ void TreeSupport::generateBranchAreas(
                     // Visualization: https://jsfiddle.net/0zvcq39L/2/
                     // Ovalizes the circle to an ellipse, that contains both old center and new target position.
                     double used_scale = (movement.second + offset) / (1.0 * config.branch_radius);
-                    Point2LL center_position = elem->result_on_layer_ + movement.first / static_cast<coord_t>(2);
+                    Point2LL center_position = elem->result_on_layer_ + movement.first / coord_t{ 2 };
                     const double moveX = movement.first.X / (used_scale * config.branch_radius);
                     const double moveY = movement.first.Y / (used_scale * config.branch_radius);
                     const double vsize_inv = 0.5 / (0.01 + std::sqrt(moveX * moveX + moveY * moveY));
@@ -2258,15 +2258,16 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
-                                                              support_layer_storage[layer_idx],
-                                                              config,
-                                                              false,
-                                                              layer_idx,
-                                                              config.support_line_distance,
-                                                              storage.support.cross_fill_provider,
-                                                              true)
-                                                              .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(
+                        TreeSupportUtils::generateSupportInfillLines(
+                            support_layer_storage[layer_idx],
+                            config,
+                            false,
+                            layer_idx,
+                            config.support_line_distance,
+                            storage.support.cross_fill_provider,
+                            true)
+                            .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -1931,12 +1931,11 @@ void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*
                 const size_t actual_smooth_window = std::min(smooth_window, element->distance_to_top_);
                 const TreeSupportElement* child = element->getChild();
                 Point2LL interlayer_position_sum = element->result_on_layer_;
-                size_t added_layers = 1;
-                while (child && child->isResultOnLayerSet() && added_layers < actual_smooth_window)
+                size_t added_layers;
+                for (added_layers = 1; child && child->isResultOnLayerSet() && added_layers < actual_smooth_window; ++added_layers)
                 {
                     interlayer_position_sum += child->result_on_layer_;
                     child = child->getChild();
-                    ++added_layers;
                 }
 
                 smoothed_positions.emplace(element, interlayer_position_sum / added_layers);

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -1929,7 +1929,7 @@ void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*
                 const TreeSupportElement* child = element->getChild();
                 Point2LL interlayer_position_sum = element->result_on_layer_;
                 size_t added_layers = 1;
-                while (child && added_layers < actual_smooth_window)
+                while (child && child->isResultOnLayerSet() && added_layers < actual_smooth_window)
                 {
                     interlayer_position_sum += child->result_on_layer_;
                     child = child->getChild();

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -3,6 +3,7 @@
 
 #include "TreeSupport.h"
 
+#include <absl/time/time.h>
 #include <chrono>
 #include <fstream>
 #include <optional>
@@ -128,7 +129,7 @@ void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
 
         spdlog::info("Processing support tree mesh group {} of {} containing {} meshes.", counter + 1, grouped_meshes.size(), grouped_meshes[counter].second.size());
         std::vector<Shape> exclude(storage.support.supportLayers.size());
-        auto t_start = std::chrono::high_resolution_clock::now();
+        TimeKeeper time_keeper;
 
         // get all already existing support areas and exclude them
         cura::parallel_for<coord_t>(
@@ -161,13 +162,13 @@ void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
             exclude);
 
         // ### Precalculate avoidances, collision etc.
-        const LayerIndex max_required_layer = precalculate(storage, processing.second);
+        const LayerIndex max_required_layer = precalculate(storage, processing.second, time_keeper);
         if (max_required_layer < 0)
         {
             spdlog::info("Support tree mesh group {} does not have any overhang. Skipping tree support generation for this support tree mesh group.", counter + 1);
             continue; // If there is no overhang to support, skip these meshes
         }
-        const auto t_precalc = std::chrono::high_resolution_clock::now();
+        time_keeper.registerTime("Calculate Avoidance");
 
         // ### Place tips of the support tree
         for (size_t mesh_idx : processing.second)
@@ -175,36 +176,21 @@ void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
             generateInitialAreas(*storage.meshes[mesh_idx], move_bounds, storage);
         }
         const auto t_gen = std::chrono::high_resolution_clock::now();
+        time_keeper.registerTime("Create inital influence areas");
 
         // ### Propagate the influence areas downwards.
-        createLayerPathing(move_bounds);
-        const auto t_path = std::chrono::high_resolution_clock::now();
+        createLayerPathing(move_bounds, time_keeper);
+        time_keeper.registerTime("Create influence area");
 
         // ### Set a point in each influence area
         createNodesFromArea(move_bounds);
-        const auto t_place = std::chrono::high_resolution_clock::now();
+        time_keeper.registerTime("Place Points in InfluenceAreas");
 
         // ### draw these points as circles
-        drawAreas(move_bounds, storage);
+        drawAreas(move_bounds, storage, time_keeper);
 
-        const auto t_draw = std::chrono::high_resolution_clock::now();
-        const auto dur_pre_gen = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_precalc - t_start).count();
-        const auto dur_gen = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_gen - t_precalc).count();
-        const auto dur_path = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_path - t_gen).count();
-        const auto dur_place = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_place - t_path).count();
-        const auto dur_draw = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_draw - t_place).count();
-        const auto dur_total = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_draw - t_start).count();
-        spdlog::info(
-            "Total time used creating Tree support for the currently grouped meshes: {} ms. Different subtasks:\n"
-            "Calculating Avoidance: {} ms Creating inital influence areas: {} ms Influence area creation: {} ms Placement of Points in InfluenceAreas: {} ms Drawing result as "
-            "support {} ms",
-            dur_total,
-            dur_pre_gen,
-            dur_gen,
-            dur_path,
-            dur_place,
-            dur_draw);
-
+        time_keeper.end();
+        time_keeper.logRegisteredTimes("Tree support generation");
 
         for (auto& layer : move_bounds)
         {
@@ -219,7 +205,7 @@ void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
     storage.support.generated = true;
 }
 
-LayerIndex TreeSupport::precalculate(const SliceDataStorage& storage, std::vector<size_t> currently_processing_meshes)
+LayerIndex TreeSupport::precalculate(const SliceDataStorage& storage, std::vector<size_t> currently_processing_meshes, TimeKeeper& time_keeper)
 {
     // Calculate top most layer that is relevant for support.
     LayerIndex max_layer = -1;
@@ -253,7 +239,7 @@ LayerIndex TreeSupport::precalculate(const SliceDataStorage& storage, std::vecto
     // ### The actual precalculation happens in TreeModelVolumes.
     if (max_layer >= 0)
     {
-        volumes_.precalculate(max_layer);
+        volumes_.precalculate(max_layer, time_keeper);
     }
     return max_layer;
 }
@@ -1284,16 +1270,13 @@ void TreeSupport::increaseAreas(
         });
 }
 
-void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement*>>& move_bounds)
+void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement*>>& move_bounds, TimeKeeper& time_keeper)
 {
     const double data_size_inverse = 1 / double(move_bounds.size());
     double progress_total = TREE_PROGRESS_PRECALC_AVO + TREE_PROGRESS_PRECALC_COLL + TREE_PROGRESS_GENERATE_NODES;
 
     auto dur_inc = std::chrono::duration_values<std::chrono::nanoseconds>::zero();
     auto dur_merge = std::chrono::duration_values<std::chrono::nanoseconds>::zero();
-
-    const auto dur_inc_recent = std::chrono::duration_values<std::chrono::nanoseconds>::zero();
-    const auto dur_merge_recent = std::chrono::duration_values<std::chrono::nanoseconds>::zero();
 
     LayerIndex last_merge = move_bounds.size();
     bool new_element = false;
@@ -1380,7 +1363,8 @@ void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement*>>&
         Progress::messageProgress(Progress::Stage::SUPPORT, progress_total * progress_multiplier + progress_offset, TREE_PROGRESS_TOTAL);
     }
 
-    spdlog::info("Time spent with creating influence areas' subtasks: Increasing areas {} ms merging areas: {} ms", dur_inc.count() / 1000000, dur_merge.count() / 1000000);
+    time_keeper.registerTime("Creating influence areas: increase", 10ms, std::chrono::duration_cast<std::chrono::milliseconds>(dur_inc));
+    time_keeper.registerTime("Creating influence areas: merge", 10ms, std::chrono::duration_cast<std::chrono::milliseconds>(dur_merge));
 }
 
 void TreeSupport::setPointsOnAreas(const TreeSupportElement* elem)
@@ -1926,6 +1910,10 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
     Progress::messageProgress(Progress::Stage::SUPPORT, progress_total * progress_multiplier + progress_offset, TREE_PROGRESS_TOTAL);
 }
 
+void TreeSupport::smoothBranchSkeletons(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons)
+{
+}
+
 void TreeSupport::dropNonGraciousAreas(
     std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons,
     const std::vector<std::pair<LayerIndex, TreeSupportElement*>>& linear_data,
@@ -2230,15 +2218,16 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
-                                                              support_layer_storage[layer_idx],
-                                                              config,
-                                                              false,
-                                                              layer_idx,
-                                                              config.support_line_distance,
-                                                              storage.support.cross_fill_provider,
-                                                              true)
-                                                              .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(
+                        TreeSupportUtils::generateSupportInfillLines(
+                            support_layer_storage[layer_idx],
+                            config,
+                            false,
+                            layer_idx,
+                            config.support_line_distance,
+                            storage.support.cross_fill_provider,
+                            true)
+                            .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }
@@ -2328,7 +2317,7 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
         });
 }
 
-void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage)
+void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage, TimeKeeper& time_keeper)
 {
     std::vector<Shape> support_layer_storage(move_bounds.size());
     std::vector<Shape> support_layer_storage_fractional(move_bounds.size());
@@ -2363,19 +2352,21 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
         }
     }
 
-
     // Reorder the processed data by layers again. The map also could be a vector<pair<SupportElement*,Shape>>:
     std::vector<std::unordered_map<TreeSupportElement*, Shape>> layer_tree_polygons(move_bounds.size());
-    const auto t_start = std::chrono::high_resolution_clock::now();
+    time_keeper.registerTime("drawArea::init");
 
     // Generate the circles that will be the branches.
     generateBranchAreas(linear_data, layer_tree_polygons, inverse_tree_order);
-    const auto t_generate = std::chrono::high_resolution_clock::now();
+    time_keeper.registerTime("drawAreas::generateBranchAreas");
 
     // In some edge-cases a branch may go through a hole, where the regular radius does not fit. This can result in an apparent jump in branch radius. As such this cases need to be
     // caught and smoothed out.
     smoothBranchAreas(layer_tree_polygons);
-    const auto t_smooth = std::chrono::high_resolution_clock::now();
+    time_keeper.registerTime("drawAreas::smoothBranchAreas");
+
+    smoothBranchSkeletons(layer_tree_polygons);
+    time_keeper.registerTime("drawAreas::smoothBranchSkeletons");
 
     // Drop down all trees that connect non gracefully with the model.
     std::vector<std::vector<std::pair<LayerIndex, Shape>>> dropped_down_areas(linear_data.size());
@@ -2460,24 +2451,10 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
     }
 
     filterFloatingLines(support_layer_storage);
-    const auto t_filter = std::chrono::high_resolution_clock::now();
+    time_keeper.registerTime("drawAreas::filterFloatingLines");
 
     finalizeInterfaceAndSupportAreas(support_layer_storage, support_roof_storage, support_layer_storage_fractional, storage);
-    const auto t_end = std::chrono::high_resolution_clock::now();
-
-    const auto dur_gen_tips = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_generate - t_start).count();
-    const auto dur_smooth = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_smooth - t_generate).count();
-    const auto dur_drop = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_drop - t_smooth).count();
-    const auto dur_filter = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_filter - t_drop).count();
-    const auto dur_finalize = 0.001 * std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_filter).count();
-    spdlog::info(
-        "Time used for drawing subfuctions: generateBranchAreas: {} ms smoothBranchAreas: {} ms dropNonGraciousAreas: {} ms filterFloatingLines: {} ms "
-        "finalizeInterfaceAndSupportAreas {} ms",
-        dur_gen_tips,
-        dur_smooth,
-        dur_drop,
-        dur_filter,
-        dur_finalize);
+    time_keeper.registerTime("drawAreas::finalizeInterfaceAndSupportAreas");
 }
 
 void TreeSupport::saveToObj(const std::vector<std::set<TreeSupportElement*>>& move_bounds, OBJ& obj) const

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -1948,7 +1948,7 @@ void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*
                     ++added_layers;
                 }
 
-                smoothed_positions.emplace(element, interlayer_position_sum / static_cast<coord_t>(added_layers));
+                smoothed_positions.emplace(element, interlayer_position_sum / added_layers);
             }
         });
 

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2254,16 +2254,15 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(
-                        TreeSupportUtils::generateSupportInfillLines(
-                            support_layer_storage[layer_idx],
-                            config,
-                            false,
-                            layer_idx,
-                            config.support_line_distance,
-                            storage.support.cross_fill_provider,
-                            true)
-                            .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
+                                                              support_layer_storage[layer_idx],
+                                                              config,
+                                                              false,
+                                                              layer_idx,
+                                                              config.support_line_distance,
+                                                              storage.support.cross_fill_provider,
+                                                              true)
+                                                              .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -1925,20 +1925,8 @@ void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*
         {
             for (TreeSupportElement* element : layer_tree_polygons[layer_index])
             {
-                std::vector<TreeSupportElement*> parents = element->getParents();
-                size_t actual_smooth_window = 1;
-                while (! parents.empty() && actual_smooth_window < smooth_window)
-                {
-                    std::vector<TreeSupportElement*> grand_parents;
-                    for (TreeSupportElement* parent : parents)
-                    {
-                        grand_parents.insert(grand_parents.end(), parent->getParents().begin(), parent->getParents().end());
-                    }
-                    parents = std::move(grand_parents);
-                    ++actual_smooth_window;
-                }
-
-                TreeSupportElement* child = element->getChild();
+                const size_t actual_smooth_window = std::min(smooth_window, element->distance_to_top_);
+                const TreeSupportElement* child = element->getChild();
                 Point2LL interlayer_position_sum = element->result_on_layer_;
                 size_t added_layers = 1;
                 while (child && added_layers < actual_smooth_window)

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2257,16 +2257,15 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(
-                        TreeSupportUtils::generateSupportInfillLines(
-                            support_layer_storage[layer_idx],
-                            config,
-                            false,
-                            layer_idx,
-                            config.support_line_distance,
-                            storage.support.cross_fill_provider,
-                            true)
-                            .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
+                                                              support_layer_storage[layer_idx],
+                                                              config,
+                                                              false,
+                                                              layer_idx,
+                                                              config.support_line_distance,
+                                                              storage.support.cross_fill_provider,
+                                                              true)
+                                                              .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <thread>
 
+#include <boost/unordered/concurrent_flat_map.hpp>
 #include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/iota.hpp>
@@ -1345,7 +1346,7 @@ void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement*>>&
 
             if (new_area->area() < 1)
             {
-                spdlog::error("Insert Error of Influence area on layer {}. Origin of {} areas. Was to bp {}", layer_idx - 1, elem.parents_.size(), elem.to_buildplate_);
+                spdlog::error("Insert Error of Influence area on layer {}. Origin of {} areas. Was to bp {}", layer_idx - 1, elem.getParents().size(), elem.to_buildplate_);
             }
         }
 
@@ -1377,7 +1378,7 @@ void TreeSupport::setPointsOnAreas(const TreeSupportElement* elem)
         return;
     }
 
-    for (TreeSupportElement* next_elem : elem->parents_)
+    for (TreeSupportElement* next_elem : elem->getParents())
     {
         if (next_elem->result_on_layer_
             != Point2LL(-1, -1)) // If the value was set somewhere else it it kept. This happens when a branch tries not to move after being unable to create a roof.
@@ -1430,9 +1431,9 @@ bool TreeSupport::setToModelContact(std::vector<std::set<TreeSupportElement*>>& 
                 valid_place_area = check_valid_place_area;
             }
             checked.emplace_back(check);
-            if (check->parents_.size() == 1)
+            if (check->getParents().size() == 1)
             {
-                check = check->parents_[0];
+                check = check->getParents().front();
             }
             else
             {
@@ -1594,7 +1595,7 @@ void TreeSupport::createNodesFromArea(std::vector<std::set<TreeSupportElement*>>
                     }
                     remove.emplace(elem); // We dont need to remove yet the parents as they will have a lower dtt and also no result_on_layer set.
                     removed = true;
-                    for (TreeSupportElement* parent : elem->parents_)
+                    for (TreeSupportElement* parent : elem->getParents())
                     {
                         // When the roof was not able to generate downwards enough, the top elements may have not moved, and have result_on_layer already set. As this branch needs
                         // to be removed => all parents result_on_layer have to be invalidated.
@@ -1671,7 +1672,7 @@ void TreeSupport::generateBranchAreas(
                     Point2LL movement = (child_elem->result_on_layer_ - elem->result_on_layer_);
                     movement_directions.emplace_back(movement, radius);
                 }
-                for (TreeSupportElement* parent : elem->parents_)
+                for (TreeSupportElement* parent : elem->getParents())
                 {
                     Point2LL movement = (parent->result_on_layer_ - elem->result_on_layer_);
                     movement_directions.emplace_back(movement, std::max(config.getRadius(parent), config.support_line_width));
@@ -1697,7 +1698,7 @@ void TreeSupport::generateBranchAreas(
                     // Visualization: https://jsfiddle.net/0zvcq39L/2/
                     // Ovalizes the circle to an ellipse, that contains both old center and new target position.
                     double used_scale = (movement.second + offset) / (1.0 * config.branch_radius);
-                    Point2LL center_position = elem->result_on_layer_ + movement.first / 2;
+                    Point2LL center_position = elem->result_on_layer_ + movement.first / static_cast<coord_t>(2);
                     const double moveX = movement.first.X / (used_scale * config.branch_radius);
                     const double moveY = movement.first.Y / (used_scale * config.branch_radius);
                     const double vsize_inv = 0.5 / (0.01 + std::sqrt(moveX * moveX + moveY * moveY));
@@ -1809,7 +1810,7 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
 
                 coord_t max_outer_wall_distance = 0;
                 bool do_something = false;
-                for (TreeSupportElement* parent : data_pair.first->parents_)
+                for (TreeSupportElement* parent : data_pair.first->getParents())
                 {
                     if (config.getRadius(*parent) != config.getCollisionRadius(*parent))
                     {
@@ -1824,7 +1825,7 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
                 if (do_something)
                 {
                     Shape max_allowed_area = data_pair.second.offset(max_outer_wall_distance);
-                    for (TreeSupportElement* parent : data_pair.first->parents_)
+                    for (TreeSupportElement* parent : data_pair.first->getParents())
                     {
                         if (config.getRadius(*parent) != config.getCollisionRadius(*parent))
                         {
@@ -1867,9 +1868,9 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
                 std::pair<TreeSupportElement*, Shape> data_pair = processing[processing_idx];
                 bool do_something = false;
                 Shape max_allowed_area;
-                for (size_t idx = 0; idx < data_pair.first->parents_.size(); idx++)
+                for (size_t idx = 0; idx < data_pair.first->getParents().size(); idx++)
                 {
-                    TreeSupportElement* parent = data_pair.first->parents_[idx];
+                    TreeSupportElement* parent = data_pair.first->getParents()[idx];
                     const coord_t max_outer_line_increase = max_radius_change_per_layer;
                     Shape result = layer_tree_polygons[layer_idx + 1][parent].offset(max_outer_line_increase);
                     const Point2LL direction = data_pair.first->result_on_layer_ - parent->result_on_layer_;
@@ -1910,8 +1911,55 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
     Progress::messageProgress(Progress::Stage::SUPPORT, progress_total * progress_multiplier + progress_offset, TREE_PROGRESS_TOTAL);
 }
 
-void TreeSupport::smoothBranchSkeletons(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons)
+void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*>>& layer_tree_polygons)
 {
+    const size_t smooth_window = config.support_tree_smooth_layers;
+    boost::concurrent_flat_map<TreeSupportElement*, Point2LL> smoothed_positions;
+
+    // TODO: This can definitely be optimized by caching the parents chains and sums of points, but for now performance is more than decent so leaving as is.
+    // If the feature is validated after the spike, then we should definitely do it.
+    cura::parallel_for<size_t>(
+        0,
+        layer_tree_polygons.size(),
+        [&layer_tree_polygons, &smooth_window, &smoothed_positions](size_t layer_index)
+        {
+            for (TreeSupportElement* element : layer_tree_polygons[layer_index])
+            {
+                std::vector<TreeSupportElement*> parents = element->getParents();
+                size_t actual_smooth_window = 1;
+                while (! parents.empty() && actual_smooth_window < smooth_window)
+                {
+                    std::vector<TreeSupportElement*> grand_parents;
+                    for (TreeSupportElement* parent : parents)
+                    {
+                        grand_parents.insert(grand_parents.end(), parent->getParents().begin(), parent->getParents().end());
+                    }
+                    parents = std::move(grand_parents);
+                    ++actual_smooth_window;
+                }
+
+                TreeSupportElement* child = element->getChild();
+                Point2LL interlayer_position_sum = element->result_on_layer_;
+                size_t added_layers = 1;
+                while (child && added_layers < actual_smooth_window)
+                {
+                    interlayer_position_sum += child->result_on_layer_;
+                    child = child->getChild();
+                    ++added_layers;
+                }
+
+                smoothed_positions.emplace(element, interlayer_position_sum / static_cast<coord_t>(added_layers));
+            }
+        });
+
+    smoothed_positions.visit_all(
+#ifdef __cpp_lib_execution
+        std::execution::par,
+#endif
+        [](auto& element)
+        {
+            element.first->result_on_layer_ = element.second;
+        });
 }
 
 void TreeSupport::dropNonGraciousAreas(
@@ -2340,7 +2388,7 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
                 continue;
             }
 
-            for (TreeSupportElement* par : elem->parents_)
+            for (TreeSupportElement* par : elem->getParents())
             {
                 if (par->result_on_layer_ == Point2LL(-1, -1))
                 {
@@ -2351,10 +2399,12 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
             linear_data.emplace_back(layer_idx, elem);
         }
     }
-
     // Reorder the processed data by layers again. The map also could be a vector<pair<SupportElement*,Shape>>:
     std::vector<std::unordered_map<TreeSupportElement*, Shape>> layer_tree_polygons(move_bounds.size());
     time_keeper.registerTime("drawArea::init");
+
+    smoothBranchSkeletons(move_bounds);
+    time_keeper.registerTime("drawAreas::smoothBranchSkeletons");
 
     // Generate the circles that will be the branches.
     generateBranchAreas(linear_data, layer_tree_polygons, inverse_tree_order);
@@ -2364,9 +2414,6 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
     // caught and smoothed out.
     smoothBranchAreas(layer_tree_polygons);
     time_keeper.registerTime("drawAreas::smoothBranchAreas");
-
-    smoothBranchSkeletons(layer_tree_polygons);
-    time_keeper.registerTime("drawAreas::smoothBranchSkeletons");
 
     // Drop down all trees that connect non gracefully with the model.
     std::vector<std::vector<std::pair<LayerIndex, Shape>>> dropped_down_areas(linear_data.size());
@@ -2419,7 +2466,7 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
         {
             for (std::pair<TreeSupportElement*, Shape> data_pair : layer_tree_polygons[layer_idx])
             {
-                if (data_pair.first->parents_.empty() && ! data_pair.first->supports_roof_ && layer_idx + 1 < support_roof_storage_fractional.size()
+                if (data_pair.first->getParents().empty() && ! data_pair.first->supports_roof_ && layer_idx + 1 < support_roof_storage_fractional.size()
                     && config.z_distance_top % config.layer_height > 0)
                 {
                     if (data_pair.first->missing_roof_layers_ > data_pair.first->distance_to_top_)

--- a/src/TreeSupportElement.cpp
+++ b/src/TreeSupportElement.cpp
@@ -75,7 +75,7 @@ TreeSupportElement::TreeSupportElement(const TreeSupportElement& elem, Shape* ne
     , influence_area_limit_range_(elem.influence_area_limit_range_)
     , influence_area_limit_area_(elem.influence_area_limit_area_)
 {
-    parents_.insert(parents_.begin(), elem.parents_.begin(), elem.parents_.end());
+    addParents(elem.parents_);
 }
 
 TreeSupportElement::TreeSupportElement(TreeSupportElement* element_above)
@@ -104,7 +104,7 @@ TreeSupportElement::TreeSupportElement(TreeSupportElement* element_above)
     , influence_area_limit_range_(element_above->influence_area_limit_range_)
     , influence_area_limit_area_(element_above->influence_area_limit_area_)
 {
-    parents_ = { element_above };
+    addParents({ element_above });
 }
 
 TreeSupportElement::TreeSupportElement(
@@ -144,8 +144,8 @@ TreeSupportElement::TreeSupportElement(
     to_buildplate_ = first.to_buildplate_ && second.to_buildplate_;
     to_model_gracious_ = first.to_model_gracious_ && second.to_model_gracious_; // valid as we do not merge non-gracious with gracious
 
-    AddParents(first.parents_);
-    AddParents(second.parents_);
+    addParents(first.parents_);
+    addParents(second.parents_);
 
     buildplate_radius_increases_ = 0;
     if (diameter_scale_bp_radius > 0)
@@ -178,11 +178,12 @@ TreeSupportElement::TreeSupportElement(
     }
 }
 
-void TreeSupportElement::AddParents(const std::vector<TreeSupportElement*>& adding)
+void TreeSupportElement::addParents(const std::vector<TreeSupportElement*>& new_parents)
 {
-    for (TreeSupportElement* ptr : adding)
+    parents_.insert(parents_.begin(), new_parents.begin(), new_parents.end());
+    for (TreeSupportElement* parent : new_parents)
     {
-        parents_.emplace_back(ptr);
+        parent->child_ = this;
     }
 }
 

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -19,6 +19,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include <fmt/chrono.h>
 #include <range/v3/all.hpp>
 #include <spdlog/details/os.h>
 #include <spdlog/spdlog.h>
@@ -481,7 +482,7 @@ void CommandLine::sliceNext()
     {
 #endif // DEBUG
         slice->scene.mesh_groups[mesh_group_index].finalize();
-        spdlog::info("Loaded from disk in {:3}s\n", FffProcessor::getInstance()->time_keeper.restart());
+        spdlog::info("Loaded from disk in {}\n", FffProcessor::getInstance()->time_keeper.restart());
 
         // Start slicing.
         slice->compute();

--- a/src/progress/Progress.cpp
+++ b/src/progress/Progress.cpp
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <optional>
 
-#include <range/v3/view/enumerate.hpp>
+#include <fmt/chrono.h>
 #include <spdlog/spdlog.h>
 
 #include "Application.h" //To get the communication channel to send progress through.
@@ -49,7 +49,7 @@ void Progress::messageProgressStage(Progress::Stage stage, TimeKeeper* time_keep
     {
         if (static_cast<int>(stage) > 0)
         {
-            spdlog::info("Progress: {} accomplished in {:03.3f}s", names.at(static_cast<size_t>(stage) - 1), time_keeper->restart());
+            spdlog::info("Progress: {} processed in {}", names.at(static_cast<size_t>(stage) - 1), std::chrono::duration<double>(time_keeper->restart()));
         }
         else
         {
@@ -63,9 +63,9 @@ void Progress::messageProgressStage(Progress::Stage stage, TimeKeeper* time_keep
     }
 }
 
-void Progress::messageProgressLayer(LayerIndex layer_nr, size_t total_layers, double total_time, const TimeKeeper::RegisteredTimes& stages, double skip_threshold)
+void Progress::messageProgressLayer(const LayerIndex layer_nr, const size_t total_layers, const TimeKeeper& time_keeper, const std::chrono::milliseconds skip_threshold)
 {
-    if (total_time < skip_threshold)
+    if (time_keeper.getTotalDuration() < skip_threshold)
     {
         if (! first_skipped_layer)
         {
@@ -82,25 +82,7 @@ void Progress::messageProgressLayer(LayerIndex layer_nr, size_t total_layers, do
 
         messageProgress(Stage::EXPORT, std::max(layer_nr.value, LayerIndex::value_type(0)) + 1, total_layers);
 
-        spdlog::info("┌ Layer export [{}] accomplished in {:03.3f}s", layer_nr, total_time);
-
-        size_t padding = 0;
-        auto iterator_max_size = std::max_element(
-            stages.begin(),
-            stages.end(),
-            [](const TimeKeeper::RegisteredTime& time1, const TimeKeeper::RegisteredTime& time2)
-            {
-                return time1.stage.size() < time2.stage.size();
-            });
-        if (iterator_max_size != stages.end())
-        {
-            padding = iterator_max_size->stage.size();
-
-            for (const auto& [index, time] : stages | ranges::views::enumerate)
-            {
-                spdlog::info("{}── {}:{} {:03.3f}s", index < stages.size() - 1 ? "├" : "└", time.stage, std::string(padding - time.stage.size(), ' '), time.duration);
-            }
-        }
+        time_keeper.logRegisteredTimes(fmt::format("Layer export [{}]", layer_nr));
     }
 }
 

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <numbers>
 
+#include <fmt/chrono.h>
 #include <scripta/logger.h>
 #include <spdlog/spdlog.h>
 
@@ -835,11 +836,11 @@ Slicer::Slicer(
 
     buildSegments(*mesh, zbbox, slicing_tolerance, layers);
 
-    spdlog::info("Slice of mesh took {:03.3f} seconds", slice_timer.restart());
+    spdlog::info("Slice of mesh took {}", std::chrono::duration<double>(slice_timer.restart()));
 
     makePolygons(*i_mesh, slicing_tolerance, layers);
     scripta::log("sliced_polygons", layers, SectionType::NA);
-    spdlog::info("Make polygons took {:03.3f} seconds", slice_timer.restart());
+    spdlog::info("Make polygons took {}", std::chrono::duration<double>(slice_timer.restart()));
 }
 
 void Slicer::buildSegments(const Mesh& mesh, const std::vector<std::pair<int32_t, int32_t>>& zbbox, const SlicingTolerance& slicing_tolerance, std::vector<SlicerLayer>& layers)

--- a/src/utils/gettime.cpp
+++ b/src/utils/gettime.cpp
@@ -21,12 +21,13 @@ std::chrono::milliseconds TimeKeeper::restart()
     return ret;
 }
 
-void TimeKeeper::registerTime(const std::string& stage, std::chrono::milliseconds threshold)
+void TimeKeeper::registerTime(const std::string& stage, const std::chrono::milliseconds threshold, const std::optional<std::chrono::milliseconds> duration)
 {
-    std::chrono::milliseconds duration = restart();
-    if (duration >= threshold)
+    const std::chrono::milliseconds measured_duration = restart();
+    const std::chrono::milliseconds actual_duration = duration.value_or(measured_duration);
+    if (actual_duration >= threshold)
     {
-        registered_times.emplace_back(RegisteredTime{ stage, duration });
+        registered_times.emplace_back(RegisteredTime{ stage, actual_duration });
     }
 }
 

--- a/src/utils/gettime.cpp
+++ b/src/utils/gettime.cpp
@@ -3,28 +3,67 @@
 
 #include "utils/gettime.h"
 
+#include <fmt/chrono.h>
+#include <range/v3/view/enumerate.hpp>
+#include <spdlog/spdlog.h>
 #include <spdlog/stopwatch.h>
 
 namespace cura
 {
-
 TimeKeeper::TimeKeeper()
 {
 }
 
-double TimeKeeper::restart()
+std::chrono::milliseconds TimeKeeper::restart()
 {
-    double ret = watch.elapsed().count();
+    std::chrono::milliseconds ret = watch.elapsed_ms();
     watch.reset();
     return ret;
 }
 
-void TimeKeeper::registerTime(const std::string& stage, double threshold)
+void TimeKeeper::registerTime(const std::string& stage, std::chrono::milliseconds threshold)
 {
-    double duration = restart();
+    std::chrono::milliseconds duration = restart();
     if (duration >= threshold)
     {
         registered_times.emplace_back(RegisteredTime{ stage, duration });
+    }
+}
+
+void TimeKeeper::end()
+{
+    total_duration = watch_total.elapsed_ms();
+}
+
+std::chrono::milliseconds TimeKeeper::getTotalDuration() const
+{
+    return total_duration;
+}
+
+void TimeKeeper::logRegisteredTimes(const std::string& global_desc) const
+{
+    spdlog::info("┌ {} processed in {}", global_desc, std::chrono::duration<double>(total_duration));
+
+    auto iterator_max_size = std::max_element(
+        registered_times.begin(),
+        registered_times.end(),
+        [](const RegisteredTime& time1, const RegisteredTime& time2)
+        {
+            return time1.stage.size() < time2.stage.size();
+        });
+    if (iterator_max_size != registered_times.end())
+    {
+        size_t padding = iterator_max_size->stage.size();
+
+        for (const auto& [index, time] : registered_times | ranges::views::enumerate)
+        {
+            spdlog::info(
+                "{}── {}:{} {}",
+                index < registered_times.size() - 1 ? "├" : "└",
+                time.stage,
+                std::string(padding - time.stage.size(), ' '),
+                std::chrono::duration<double>(time.duration));
+        }
     }
 }
 


### PR DESCRIPTION
Implements the tree support branches smoothing, as previously developed on the spike branch.
Smoothing is made starting from the current layer and going down only, so that branches separation does not generate position jumps.
Also the smoothing distance is capped to the distance to the top of the tree, so that smoothing decreases when moving up, and ends up ineffective on the top-most layers, that should keep their original shape to properly support the interface.

CURA-13252
Comes with https://github.com/Ultimaker/Cura/pull/21749