### PR TITLE
Display engine plugins in gcode

### DIFF
--- a/include/plugins/pluginproxy.h
+++ b/include/plugins/pluginproxy.h
@@ -165,6 +165,16 @@ public:
     }
     ~PluginProxy() = default;
 
+    const slot_metadata& slotInfo() const
+    {
+        return slot_info_;
+    }
+
+    const std::optional<plugin_metadata>& pluginInfo() const
+    {
+        return plugin_info_;
+    }
+
     value_type generate(auto&&... args)
     {
         agrpc::GrpcContext grpc_context;

--- a/include/plugins/slotproxy.h
+++ b/include/plugins/slotproxy.h
@@ -64,6 +64,21 @@ public:
     }
 
     /**
+     * @brief Applies the visitor function on all the loaded plugins
+     * @param function The function to be called on each plugin
+     */
+    void forEachPlugin(const std::invocable<const slot_metadata&, const plugin_metadata&> auto& function) const
+    {
+        for (const value_type& plugin : plugins_)
+        {
+            if (plugin.pluginInfo().has_value())
+            {
+                function(plugin.slotInfo(), plugin.pluginInfo().value());
+            }
+        }
+    }
+
+    /**
      * @brief Executes the plugin operation.
      *
      * This operator allows the SlotProxy object to be invoked as a callable, which delegates the

--- a/include/plugins/slots.h
+++ b/include/plugins/slots.h
@@ -127,6 +127,10 @@ public:
     constexpr void broadcast([[maybe_unused]] auto&&... args) noexcept
     {
     } // Base case, do nothing
+
+    void forEachPlugin(const std::invocable<const slot_metadata&, const plugin_metadata&> auto& function) noexcept
+    {
+    }
 };
 
 template<typename T, typename... Types, template<typename> class Unit>
@@ -171,6 +175,12 @@ public:
     {
         value_.proxy.template broadcast<S>(std::forward<decltype(args)>(args)...);
         Base::template broadcast<S>(std::forward<decltype(args)>(args)...);
+    }
+
+    void forEachPlugin(const std::invocable<const slot_metadata&, const plugin_metadata&> auto& function)
+    {
+        value_.proxy.forEachPlugin(function);
+        Base::forEachPlugin(std::forward<decltype(function)>(function));
     }
 
 protected:

--- a/src/gcode_export/gcodeExport.cpp
+++ b/src/gcode_export/gcodeExport.cpp
@@ -25,6 +25,7 @@
 #include "gcode_export/FixedGCodePart.h"
 #include "gcode_export/GcodeTemplateResolver.h"
 #include "gcode_export/ResolvedGCodePart.h"
+#include "plugins/slots.h"
 #include "settings/types/LayerIndex.h"
 #include "sliceDataStorage.h"
 #include "utils/Date.h"
@@ -345,6 +346,21 @@ std::string GCodeExport::getFileHeader(const std::vector<bool>& extruder_is_used
         prefix << ";MAXY:" << INT2MM(total_bounding_box_.max_.y_) << new_line_;
         prefix << ";MAXZ:" << INT2MM(total_bounding_box_.max_.z_) << new_line_;
         prefix << ";TARGET_MACHINE.NAME:" << transliterate(machine_name_) << new_line_;
+    }
+
+    std::vector<std::pair<std::string, std::string>> plugins; // For each plugin: slot name, plugin name
+    slots::instance().forEachPlugin(
+        [&plugins](const plugins::slot_metadata& slot, const plugins::plugin_metadata& plugin)
+        {
+            plugins.push_back(std::make_pair(plugins::v0::SlotID_Name(slot.slot_id), plugin.plugin_name));
+        });
+    if (! plugins.empty())
+    {
+        prefix << ";ENGINE PLUGINS" << new_line_;
+        for (const std::pair<std::string, std::string>& plugin : plugins)
+        {
+            prefix << fmt::format(";  [{} ({})]", plugin.second, plugin.first) << new_line_;
+        }
     }
 
     return prefix.str();

--- a/src/gcode_export/gcodeExport.cpp
+++ b/src/gcode_export/gcodeExport.cpp
@@ -348,6 +348,7 @@ std::string GCodeExport::getFileHeader(const std::vector<bool>& extruder_is_used
         prefix << ";TARGET_MACHINE.NAME:" << transliterate(machine_name_) << new_line_;
     }
 
+#ifdef ENABLE_PLUGINS
     std::vector<std::pair<std::string, std::string>> plugins; // For each plugin: slot name, plugin name
     slots::instance().forEachPlugin(
         [&plugins](const plugins::slot_metadata& slot, const plugins::plugin_metadata& plugin)
@@ -362,6 +363,7 @@ std::string GCodeExport::getFileHeader(const std::vector<bool>& extruder_is_used
             prefix << fmt::format(";  [{} ({})]", plugin.second, plugin.first) << new_line_;
         }
     }
+#endif
 
     return prefix.str();
 }


### PR DESCRIPTION
Add the list of active engine plugins in the generated gcode. Syntax is based on the post-processing plugins: https://github.com/Ultimaker/Cura/blob/05e2c8937da42b48f8502f3ac69bcf8ed44b7307/plugins/PostProcessingPlugin/PostProcessingPlugin.py#L94

Result is something like:
```
;ENGINE PLUGINS
;  [valve (GCODE_PATHS_MODIFY)]
```

CURA-11212