### PR TITLE
CURA-9839 add bridging and overhang line type color scheme

### DIFF
--- a/Cura.proto
+++ b/Cura.proto
@@ -122,7 +122,7 @@ message PathSegment {
   bytes line_width = 5; // The widths of the line segments as bytes of a float array of length 1 or N
   bytes line_thickness = 6; // The thickness of the line segments as bytes of a float array of length 1 or N
   bytes line_feedrate = 7; // The feedrate of the line segments as bytes of a float array of length 1 or N
-  repeated uint32 attributes = 8;
+  repeated uint32 attributes = 8; // Print attributes of each segment, e.g. overhanging or bridging
 }
 
 

--- a/Cura.proto
+++ b/Cura.proto
@@ -122,6 +122,7 @@ message PathSegment {
   bytes line_width = 5; // The widths of the line segments as bytes of a float array of length 1 or N
   bytes line_thickness = 6; // The thickness of the line segments as bytes of a float array of length 1 or N
   bytes line_feedrate = 7; // The feedrate of the line segments as bytes of a float array of length 1 or N
+  repeated uint32 attributes = 8;
 }
 
 

--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -601,6 +601,7 @@ private:
      * \param[out] added_something Whether this function added anything to the layer plan
      * \param fan_speed fan speed override for this skin area
      * \param forced_small_area_width A specific value to be used for small_area_width when generating the infill, or nullopt to use the normal value
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void processSkinPrintFeature(
         const SliceDataStorage& storage,

--- a/include/FffGcodeWriter.h
+++ b/include/FffGcodeWriter.h
@@ -617,7 +617,8 @@ private:
         const bool is_roofing_flooring,
         bool& added_something,
         double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT,
-        std::optional<coord_t> forced_small_area_width = std::nullopt) const;
+        std::optional<coord_t> forced_small_area_width = std::nullopt,
+        const PrintSegmentAttributes& print_attributes = {}) const;
 
     /*!
      *  see if we can avoid printing a lines or zig zag style skin part in multiple segments by moving to

--- a/include/InsetOrderOptimizer.h
+++ b/include/InsetOrderOptimizer.h
@@ -6,6 +6,7 @@
 
 #include <unordered_set>
 
+#include "PrintSegmentAttributes.h"
 #include "settings/ZSeamConfig.h"
 #include "sliceDataStorage.h"
 
@@ -74,7 +75,7 @@ public:
      * \param retract_before_outer_wall The retraction behavior to be applied when moving to outer walls
      * \return Whether anything was added to the layer plan.
      */
-    bool addToLayer(const RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC);
+    bool addToLayer(const RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC, const PrintSegmentAttributes& print_attributes = {});
 
     /*!
      * Get the order constraints of the insets when printing walls per region / hole.

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -192,6 +192,7 @@ private:
      * \param spiralize Whether to gradually increase the z while printing. (Note that this path may be part of a sequence of spiralized paths, forming one polygon)
      * \param speed_factor (optional) a factor which the speed will be multiplied by.
      * \param travel_to_z Indicates whether we should add a Z travel before the initial move of this path
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      * \return A path with the given config which is now the last path in LayerPlan::paths
      */
     GCodePath* getLatestPathWithConfig(
@@ -447,6 +448,7 @@ public:
      * (Note that this path may be part of a sequence of spiralized paths,
      * forming one polygon.)
      * \param fan_speed Fan speed override for this path.
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void addExtrusionMove(
         const Point3LL& p,
@@ -458,7 +460,7 @@ public:
         const Ratio speed_factor = 1.0_r,
         const double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT,
         const bool travel_to_z = true,
-        const PrintSegmentAttributes& attributes = {});
+        const PrintSegmentAttributes& print_attributes = {});
 
     void addExtrusionMoveWithGradualOverhang(
         const Point3LL& p,
@@ -483,6 +485,7 @@ public:
      * @param width_factor The width factor to be used to extruder
      * @param spiralize Whether we are extruding using spiralize mode
      * @param travel_to_z Whether we should add a Z travel before starting the segment if necessary
+     * @param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void addSkinExtrusion(
         const Point3LL& p0,
@@ -508,6 +511,7 @@ public:
      * \param force_retract Whether to force a retraction when moving to the start of the polygon (used for outer walls)
      * \param scarf_seam Indicates whether we may use a scarf seam for the path
      * \param smooth_speed Indicates whether we may use a speed gradient for the path
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void addPolygon(
         const Polygon& polygon,
@@ -537,6 +541,7 @@ public:
      * \param polygons The polygons.
      * \param config The config with which to print the polygon lines.
      * for each given segment (optionally nullptr).
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      * \param z_seam_config Optional configuration for z-seam.
      * \param wall_0_wipe_dist The distance to travel along each polygon after
      * it has been laid down, in order to wipe the start and end of the wall
@@ -620,6 +625,7 @@ public:
      * a bridge line.
      * \param distance_to_bridge_start The distance along the wall from p0 to
      * the first bridge segment.
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void addWallLine(
         const PathAdapter<ExtrusionLine>& wall,
@@ -694,6 +700,7 @@ public:
      * \param is_linked_path Whether the path is a continuation off the previous path
      * \param scarf_seam Indicates whether we may use a scarf seam for the path
      * \param smooth_speed Indicates whether we may use a speed gradient for the path
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void addWall(
         const ExtrusionLine& wall,
@@ -760,6 +767,7 @@ public:
      * \param flow_ratio The ratio with which to multiply the extrusion amount
      * \param near_start_location Optional: Location near where to add the first line. If not provided the last position is used.
      * \param fan_speed optional fan speed override for this path
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      * \param reverse_print_direction Whether to reverse the optimized order and their printing direction.
      * \param order_requirements Pairs where first needs to be printed before second. Pointers are pointing to elements of \p lines
      * \param extra_inwards_start_move_length The length of the extra inwards moves to be added at the start of each infill line
@@ -828,6 +836,7 @@ public:
      * line.
      * \param flow_ratio The ratio with which to multiply the extrusion amount.
      * \param fan_speed Fan speed override for this path.
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void addLinesMonotonic(
         const Shape& area,
@@ -966,6 +975,7 @@ private:
      * \param wipe_dist (optional) the distance wiped without extruding after laying down a line.
      * \param flow_ratio The ratio with which to multiply the extrusion amount
      * \param fan_speed optional fan speed override for this path
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      * \param extra_inwards_start_move_length The length of the extra inwards moves to be added at the start of each infill line
      * \param extra_inwards_end_move_length The length of the extra inwards moves to be added at the end of each infill line
      * \param extra_inwards_move_contour The contour to be considered in order to add the inwards moves
@@ -1003,6 +1013,7 @@ private:
      * \param reverse_order Adds polygons in reverse order.
      * \param scarf_seam Indicates whether we may use a scarf seam for the path
      * \param smooth_speed Indicates whether we may use a speed gradient for the path
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void addPolygonsInGivenOrder(
         const std::vector<PathOrdering<const Polygon*>>& polygons,

--- a/include/LayerPlan.h
+++ b/include/LayerPlan.h
@@ -202,7 +202,8 @@ private:
         const Ratio width_factor = 1.0_r,
         const bool spiralize = false,
         const Ratio speed_factor = 1.0_r,
-        const bool travel_to_z = true);
+        const bool travel_to_z = true,
+        const PrintSegmentAttributes print_attributes = {});
 
 public:
     /*!
@@ -456,7 +457,8 @@ public:
         const bool spiralize = false,
         const Ratio speed_factor = 1.0_r,
         const double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT,
-        const bool travel_to_z = true);
+        const bool travel_to_z = true,
+        const PrintSegmentAttributes& attributes = {});
 
     void addExtrusionMoveWithGradualOverhang(
         const Point3LL& p,
@@ -467,7 +469,8 @@ public:
         const bool spiralize = false,
         const Ratio speed_factor = 1.0_r,
         const double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT,
-        const bool travel_to_z = true);
+        const bool travel_to_z = true,
+        const PrintSegmentAttributes& print_attributes = {});
 
     /*!
      * Adds an extrusion move that may go through a skin area
@@ -490,7 +493,8 @@ public:
         const Ratio& flow,
         const Ratio& width_factor,
         const bool spiralize,
-        const bool travel_to_z);
+        const bool travel_to_z,
+        const PrintSegmentAttributes& print_attributes = {});
 
     /*!
      * Add polygon to the gcode starting at vertex \p startIdx
@@ -516,7 +520,8 @@ public:
         const Ratio& flow_ratio = 1.0_r,
         const ForceRetract force_retract = ForceRetract::AUTOMATIC,
         bool scarf_seam = false,
-        bool smooth_speed = false);
+        bool smooth_speed = false,
+        const PrintSegmentAttributes& print_attributes = {});
 
     /*!
      * Add polygons to the gcode with optimized order.
@@ -553,6 +558,7 @@ public:
         const Shape& polygons,
         const GCodePathConfig& config,
         const Settings& settings,
+        const PrintSegmentAttributes& print_attributes = {},
         const ZSeamConfig& z_seam_config = ZSeamConfig(),
         coord_t wall_0_wipe_dist = 0,
         bool spiralize = false,
@@ -632,7 +638,8 @@ public:
         double& non_bridge_line_volume,
         Ratio speed_factor,
         double distance_to_bridge_start,
-        const bool travel_to_z = true);
+        const bool travel_to_z = true,
+        const PrintSegmentAttributes& print_attributes = {});
 
     /*!
      * Add a wall to the g-code starting at vertex \p start_idx
@@ -703,7 +710,8 @@ public:
         const bool is_reversed,
         const bool is_linked_path,
         const bool scarf_seam = false,
-        const bool smooth_speed = false);
+        const bool smooth_speed = false,
+        const PrintSegmentAttributes& print_attributes = {});
 
     /*!
      * Add an infill wall to the g-code
@@ -768,6 +776,7 @@ public:
         const Ratio flow_ratio = 1.0,
         const std::optional<Point2LL> near_start_location = std::optional<Point2LL>(),
         const double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT,
+        const PrintSegmentAttributes& print_attributes = {},
         const bool reverse_print_direction = false,
         const std::unordered_multimap<const Polyline*, const Polyline*>& order_requirements = PathOrderOptimizer<const Polyline*>::no_order_requirements_,
         const coord_t extra_inwards_start_move_length = 0,
@@ -831,7 +840,8 @@ public:
         const coord_t wipe_dist = 0,
         const Ratio flow_ratio = 1.0_r,
         const double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT,
-        const bool interlaced = false);
+        const bool interlaced = false,
+        const PrintSegmentAttributes& print_attributes = {});
 
     /*!
      * Add a spiralized slice of wall that is interpolated in X/Y between \p last_wall and \p wall.
@@ -967,6 +977,7 @@ private:
         const coord_t wipe_dist,
         const Ratio flow_ratio,
         const double fan_speed,
+        const PrintSegmentAttributes& print_attributes = {},
         const coord_t extra_inwards_start_move_length = 0,
         const coord_t extra_inwards_end_move_length = 0,
         const MendedShape& extra_inwards_move_contour = MendedShape());
@@ -1004,7 +1015,8 @@ private:
         const ForceRetract force_retract = ForceRetract::AUTOMATIC,
         bool reverse_order = false,
         bool scarf_seam = false,
-        bool smooth_speed = false);
+        bool smooth_speed = false,
+        const PrintSegmentAttributes& print_attributes = {});
 
     /*!
      *  @brief Send a GCodePath line to the communication object, applying proper Z offsets

--- a/include/PrintFeature.h
+++ b/include/PrintFeature.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
+
 #ifndef PRINT_FEATURE
 #define PRINT_FEATURE
 

--- a/include/PrintSegmentAttributes.h
+++ b/include/PrintSegmentAttributes.h
@@ -11,6 +11,11 @@
 namespace cura
 {
 
+/*!
+ * Print attributes are flags that can be added to some print segments to indicate that they have been processed a specific way,
+ * e.g. by using overhanging or bridging settings. They are used for display purposes.
+ * This enumeration has an equivalent in Cura/cura/PrintSegmentAttributes.py
+ */
 enum class PrintSegmentAttribute : uint8_t
 {
     None = 0,

--- a/include/PrintSegmentAttributes.h
+++ b/include/PrintSegmentAttributes.h
@@ -18,9 +18,11 @@ namespace cura
  */
 enum class PrintSegmentAttribute : uint8_t
 {
-    None = 0,
-    Overhanging = 0x1,
-    Bridging = 0x2,
+    // clang-format off
+    None        = 0b00,
+    Overhanging = 0b01,
+    Bridging    = 0b10,
+    // clang-format on
 };
 
 using PrintSegmentAttributes = Flags<PrintSegmentAttribute>;

--- a/include/PrintSegmentAttributes.h
+++ b/include/PrintSegmentAttributes.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 UltiMaker
+// CuraEngine is released under the terms of the AGPLv3 or higher
+
+#ifndef PRINT_SEGMENT_FLAG
+#define PRINT_SEGMENT_FLAG
+
+#include <cstdint>
+
+#include "utils/Flags.h"
+
+namespace cura
+{
+
+enum class PrintSegmentAttribute : uint8_t
+{
+    None = 0,
+    Overhanging = 0x1,
+    Bridging = 0x2,
+};
+
+using PrintSegmentAttributes = Flags<PrintSegmentAttribute>;
+
+} // namespace cura
+
+#endif

--- a/include/communication/ArcusCommunication.h
+++ b/include/communication/ArcusCommunication.h
@@ -109,6 +109,7 @@ public:
      * \param line_width The width of the line.
      * \param line_thickness The thickness (in the Z direction) of the line.
      * \param velocity The velocity of printing this polygon.
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void sendLineTo(
         const PrintFeatureType& type,
@@ -116,7 +117,7 @@ public:
         const coord_t& line_width,
         const coord_t& line_thickness,
         const Velocity& velocity,
-        const PrintSegmentAttributes& segment_attributes) override;
+        const PrintSegmentAttributes& print_attributes) override;
 
     /*
      * \brief Send the sliced layer data to the front-end after the optimisation

--- a/include/communication/ArcusCommunication.h
+++ b/include/communication/ArcusCommunication.h
@@ -110,7 +110,13 @@ public:
      * \param line_thickness The thickness (in the Z direction) of the line.
      * \param velocity The velocity of printing this polygon.
      */
-    void sendLineTo(const PrintFeatureType& type, const Point3LL& to, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity) override;
+    void sendLineTo(
+        const PrintFeatureType& type,
+        const Point3LL& to,
+        const coord_t& line_width,
+        const coord_t& line_thickness,
+        const Velocity& velocity,
+        const PrintSegmentAttributes& segment_attributes) override;
 
     /*
      * \brief Send the sliced layer data to the front-end after the optimisation

--- a/include/communication/CommandLine.h
+++ b/include/communication/CommandLine.h
@@ -81,7 +81,7 @@ public:
      *
      * The command line doesn't show any layer view so this is ignored.
      */
-    void sendLineTo(const PrintFeatureType&, const Point3LL&, const coord_t&, const coord_t&, const Velocity&) override;
+    void sendLineTo(const PrintFeatureType&, const Point3LL&, const coord_t&, const coord_t&, const Velocity&, const PrintSegmentAttributes&) override;
 
     /*
      * \brief Complete a layer to show it in layer view.

--- a/include/communication/Communication.h
+++ b/include/communication/Communication.h
@@ -66,6 +66,7 @@ public:
      * \param line_width The width of the line.
      * \param line_thickness The thickness (in the Z direction) of the line.
      * \param velocity The velocity of printing this polygon.
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     virtual void sendLineTo(
         const PrintFeatureType& type,
@@ -73,7 +74,7 @@ public:
         const coord_t& line_width,
         const coord_t& line_thickness,
         const Velocity& velocity,
-        const PrintSegmentAttributes& segment_attributes = {})
+        const PrintSegmentAttributes& print_attributes = {})
         = 0;
 
     /*

--- a/include/communication/Communication.h
+++ b/include/communication/Communication.h
@@ -5,6 +5,7 @@
 #define COMMUNICATION_H
 
 #include "PrintInformation.h"
+#include "PrintSegmentAttributes.h"
 #include "geometry/Point2LL.h"
 #include "settings/types/LayerIndex.h"
 #include "settings/types/Velocity.h"
@@ -66,7 +67,14 @@ public:
      * \param line_thickness The thickness (in the Z direction) of the line.
      * \param velocity The velocity of printing this polygon.
      */
-    virtual void sendLineTo(const PrintFeatureType& type, const Point3LL& to, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity) = 0;
+    virtual void sendLineTo(
+        const PrintFeatureType& type,
+        const Point3LL& to,
+        const coord_t& line_width,
+        const coord_t& line_thickness,
+        const Velocity& velocity,
+        const PrintSegmentAttributes& segment_attributes = {})
+        = 0;
 
     /*
      * \brief Send the current position to visualise.

--- a/include/pathPlanning/GCodePath.h
+++ b/include/pathPlanning/GCodePath.h
@@ -51,7 +51,7 @@ struct GCodePath
     double fan_speed{ GCodePathConfig::FAN_SPEED_DEFAULT }; //!< fan speed override for this path, value should be within range 0-100 (inclusive) and ignored otherwise
     TimeMaterialEstimates estimates{}; //!< Naive time and material estimates
     bool travel_to_z{ true }; //! Indicates whether we should add a travel move to the Z height of the first point before processing the path
-    PrintSegmentAttributes print_attributes;
+    PrintSegmentAttributes print_attributes; //! Indicates if the line is processed with specific settings, e.g. overhanging or bridging
 
     /*!
      * Whether this config is the config of a travel path.

--- a/include/pathPlanning/GCodePath.h
+++ b/include/pathPlanning/GCodePath.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "GCodePathConfig.h"
+#include "PrintSegmentAttributes.h"
 #include "SpaceFillType.h"
 #include "TimeMaterialEstimates.h"
 #include "geometry/Point2LL.h"
@@ -50,6 +51,7 @@ struct GCodePath
     double fan_speed{ GCodePathConfig::FAN_SPEED_DEFAULT }; //!< fan speed override for this path, value should be within range 0-100 (inclusive) and ignored otherwise
     TimeMaterialEstimates estimates{}; //!< Naive time and material estimates
     bool travel_to_z{ true }; //! Indicates whether we should add a travel move to the Z height of the first point before processing the path
+    PrintSegmentAttributes print_attributes;
 
     /*!
      * Whether this config is the config of a travel path.

--- a/include/utils/Flags.h
+++ b/include/utils/Flags.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Ultimaker B.V.
+// Copyright (c) 2026 UltiMaker
 // CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #ifndef UTILS_FLAGS_H
@@ -6,6 +6,12 @@
 
 #include <type_traits>
 
+/*!
+ * Utility class to handle enumerations that are actually combinable bit flags. It adds convenient methods to combine the values, compare and test
+ * them in a type-safe way.
+ * @tparam EnumClass The enumeration class which values are to be used. All the values should set a single and different bit. There should also be
+ *                   some `none` value that contains 0.
+ */
 template<typename EnumClass>
 class Flags
 {

--- a/include/utils/Flags.h
+++ b/include/utils/Flags.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Ultimaker B.V.
+// CuraEngine is released under the terms of the AGPLv3 or higher.
+
+#ifndef UTILS_FLAGS_H
+#define UTILS_FLAGS_H
+
+#include <type_traits>
+
+template<typename EnumClass>
+class Flags
+{
+public:
+    using enum_int_type = std::underlying_type_t<EnumClass>;
+
+public:
+    Flags() = default;
+
+    constexpr Flags(const EnumClass value)
+        : value_(static_cast<enum_int_type>(value))
+    {
+    }
+
+    Flags(const Flags& other) = default;
+
+    enum_int_type value() const
+    {
+        return value_;
+    }
+
+    Flags operator|(const Flags& other) const
+    {
+        return Flags(static_cast<EnumClass>(value_ | other.value_));
+    }
+
+    void operator|=(const Flags other)
+    {
+        value_ |= other.value_;
+    }
+
+    bool operator&(const EnumClass& value) const
+    {
+        return (value_ & static_cast<enum_int_type>(value)) != 0;
+    }
+
+    bool operator==(const Flags& other) const
+    {
+        return value_ == other.value_;
+    }
+
+private:
+    enum_int_type value_{ 0 };
+};
+
+#endif

--- a/src/FffGcodeWriter.cpp
+++ b/src/FffGcodeWriter.cpp
@@ -713,12 +713,13 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                 wall_orderer.addToLayer();
             }
 
-            const auto wipe_dist = 0;
-            const auto spiralize = false;
-            const auto flow_ratio = 1.0_r;
-            const auto enable_travel_optimization = false;
-            const auto always_retract = ForceRetract::AUTOMATIC;
-            const auto reverse_order = false;
+            constexpr auto wipe_dist = 0;
+            constexpr auto spiralize = false;
+            constexpr auto flow_ratio = 1.0_r;
+            constexpr auto enable_travel_optimization = false;
+            constexpr auto always_retract = ForceRetract::AUTOMATIC;
+            constexpr auto reverse_order = false;
+            constexpr PrintSegmentAttributes print_attributes;
 
             gcode_layer.addLinesByOptimizer(
                 raft_lines,
@@ -733,6 +734,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                 raft_polygons,
                 gcode_layer.configs_storage_.raft_base_config,
                 mesh_group_settings,
+                print_attributes,
                 ZSeamConfig(),
                 wipe_dist,
                 spiralize,
@@ -874,12 +876,13 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             wall_orderer.addToLayer();
         }
 
-        const auto wipe_dist = 0;
-        const auto spiralize = false;
-        const auto flow_ratio = 1.0_r;
-        const auto enable_travel_optimization = false;
-        const auto always_retract = ForceRetract::AUTOMATIC;
-        const auto reverse_order = false;
+        constexpr auto wipe_dist = 0;
+        constexpr auto spiralize = false;
+        constexpr auto flow_ratio = 1.0_r;
+        constexpr auto enable_travel_optimization = false;
+        constexpr auto always_retract = ForceRetract::AUTOMATIC;
+        constexpr auto reverse_order = false;
+        constexpr PrintSegmentAttributes print_attributes;
 
         gcode_layer.addLinesByOptimizer(
             raft_lines,
@@ -894,6 +897,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
             raft_polygons,
             gcode_layer.configs_storage_.raft_interface_config,
             mesh_group_settings,
+            print_attributes,
             ZSeamConfig(),
             wipe_dist,
             spiralize,
@@ -1047,12 +1051,13 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                 wall_orderer.addToLayer();
             }
 
-            const auto wipe_dist = 0;
-            const auto spiralize = false;
-            const auto flow_ratio = 1.0_r;
-            const auto enable_travel_optimization = false;
-            const auto always_retract = ForceRetract::AUTOMATIC;
-            const auto reverse_order = false;
+            constexpr auto wipe_dist = 0;
+            constexpr auto spiralize = false;
+            constexpr auto flow_ratio = 1.0_r;
+            constexpr auto enable_travel_optimization = false;
+            constexpr auto always_retract = ForceRetract::AUTOMATIC;
+            constexpr auto reverse_order = false;
+            constexpr PrintSegmentAttributes print_attributes;
 
             if (monotonic)
             {
@@ -1077,6 +1082,7 @@ void FffGcodeWriter::processRaft(const SliceDataStorage& storage)
                     raft_polygons,
                     gcode_layer.configs_storage_.raft_surface_config,
                     mesh_group_settings,
+                    print_attributes,
                     ZSeamConfig(),
                     wipe_dist,
                     spiralize,
@@ -1749,11 +1755,13 @@ void FffGcodeWriter::addMeshLayerToGCode_meshSurfaceMode(const SliceMeshStorage&
     const std::optional<Point2LL> start_near_location = std::nullopt;
     constexpr bool scarf_seam = true;
     constexpr bool smooth_speed = true;
+    constexpr PrintSegmentAttributes print_attributes;
 
     gcode_layer.addPolygonsByOptimizer(
         polygons,
         mesh_config.inset0_config,
         mesh.settings,
+        print_attributes,
         z_seam_config,
         mesh.settings.get<coord_t>("wall_0_wipe_dist"),
         spiralize,
@@ -2064,6 +2072,7 @@ bool FffGcodeWriter::processMultiLayerInfill(
                 const bool enable_travel_optimization = mesh.settings.get<bool>("infill_enable_travel_optimization");
                 constexpr Ratio flow_ratio = 1.0_r;
                 constexpr double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT;
+                constexpr PrintSegmentAttributes print_attributes;
                 const std::unordered_multimap<const Polyline*, const Polyline*> order_requirements = PathOrderOptimizer<const Polyline*>::no_order_requirements_;
 
                 gcode_layer.addLinesByOptimizer(
@@ -2075,6 +2084,7 @@ bool FffGcodeWriter::processMultiLayerInfill(
                     flow_ratio,
                     near_start_location,
                     fan_speed,
+                    print_attributes,
                     reverse_print_direction,
                     order_requirements,
                     start_move_inwards_length,
@@ -2930,8 +2940,7 @@ bool FffGcodeWriter::endProcessInsets(
             {
                 gcode_layer.addTravel(spiral_inset[spiral_start_vertex]);
             }
-            int wall_0_wipe_dist(0);
-            gcode_layer.addPolygonsByOptimizer(part.spiral_wall, mesh_config.inset0_config, mesh.settings, ZSeamConfig(), wall_0_wipe_dist);
+            gcode_layer.addPolygonsByOptimizer(part.spiral_wall, mesh_config.inset0_config, mesh.settings);
         }
 
         if (extruder_nr == mesh.settings.get<ExtruderTrain&>("wall_0_extruder_nr").extruder_nr_ && ! part.spiral_wall.empty())
@@ -3165,6 +3174,7 @@ void FffGcodeWriter::processTopBottom(
     const Ratio support_threshold = bridge_settings_enabled ? mesh.settings.get<Ratio>("bridge_skin_support_threshold") : 0.0_r;
     const size_t bottom_layers = mesh.settings.get<size_t>("bottom_layers");
     std::optional<coord_t> forced_small_area_width;
+    PrintSegmentAttributes print_attributes;
 
     // if support is enabled, consider the support outlines so we don't generate bridges over support
 
@@ -3226,6 +3236,7 @@ void FffGcodeWriter::processTopBottom(
             pattern = EFillMethod::LINES; // force lines pattern when bridging
             if (bridge_settings_enabled)
             {
+                print_attributes |= PrintSegmentAttribute::Bridging;
                 skin_config = config;
                 skin_density = density;
             }
@@ -3324,7 +3335,8 @@ void FffGcodeWriter::processTopBottom(
         is_roofing_flooring,
         added_something,
         fan_speed,
-        forced_small_area_width);
+        forced_small_area_width,
+        print_attributes);
 }
 
 void FffGcodeWriter::processSkinPrintFeature(
@@ -3342,7 +3354,8 @@ void FffGcodeWriter::processSkinPrintFeature(
     const bool is_roofing_flooring,
     bool& added_something,
     double fan_speed,
-    std::optional<coord_t> forced_small_area_width) const
+    std::optional<coord_t> forced_small_area_width,
+    const PrintSegmentAttributes& print_attributes) const
 {
     Shape skin_polygons;
     OpenLinesSet skin_lines;
@@ -3415,6 +3428,7 @@ void FffGcodeWriter::processSkinPrintFeature(
         {
             // Add skin-walls a.k.a. skin-perimeters, skin-insets.
             constexpr coord_t wipe_dist = 0;
+            constexpr RetractBeforeOuterWall retract_before_outer_wall = RetractBeforeOuterWall::AUTOMATIC;
             const ZSeamConfig z_seam_config(
                 mesh.settings.get<EZSeamType>("z_seam_type"),
                 mesh.getZSeamHint(),
@@ -3440,12 +3454,12 @@ void FffGcodeWriter::processSkinPrintFeature(
                 z_seam_config,
                 skin_paths,
                 mesh.bounding_box.flatten().getMiddle());
-            added_something |= wall_orderer.addToLayer();
+            added_something |= wall_orderer.addToLayer(retract_before_outer_wall, print_attributes);
         }
         if (! skin_polygons.empty())
         {
             gcode_layer.addTravel(skin_polygons[0][0]);
-            gcode_layer.addPolygonsByOptimizer(skin_polygons, config, mesh.settings);
+            gcode_layer.addPolygonsByOptimizer(skin_polygons, config, mesh.settings, print_attributes);
         }
 
         if (ordering == LinesOrderingMethod::Monotonic || ordering == LinesOrderingMethod::Interlaced)
@@ -3472,7 +3486,8 @@ void FffGcodeWriter::processSkinPrintFeature(
                     mesh.settings.get<coord_t>("infill_wipe_dist"),
                     flow,
                     fan_speed,
-                    interlaced);
+                    interlaced,
+                    print_attributes);
             }
             else
             {
@@ -3489,7 +3504,8 @@ void FffGcodeWriter::processSkinPrintFeature(
                     wipe_dist,
                     flow,
                     fan_speed,
-                    interlaced);
+                    interlaced,
+                    print_attributes);
             }
         }
         else
@@ -3516,13 +3532,14 @@ void FffGcodeWriter::processSkinPrintFeature(
                     mesh.settings.get<coord_t>("infill_wipe_dist"),
                     flow,
                     near_start_location,
-                    fan_speed);
+                    fan_speed,
+                    print_attributes);
             }
             else
             {
                 SpaceFillType space_fill_type = (actual_pattern == EFillMethod::ZIG_ZAG) ? SpaceFillType::PolyLines : SpaceFillType::Lines;
                 constexpr coord_t wipe_dist = 0;
-                gcode_layer.addLinesByOptimizer(skin_lines, config, space_fill_type, enable_travel_optimization, wipe_dist, flow, near_start_location, fan_speed);
+                gcode_layer.addLinesByOptimizer(skin_lines, config, space_fill_type, enable_travel_optimization, wipe_dist, flow, near_start_location, fan_speed, print_attributes);
             }
         }
     }
@@ -3855,6 +3872,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
 
             const bool alternate_inset_direction = infill_extruder.settings_.get<bool>("material_alternate_walls");
             const bool alternate_layer_print_direction = alternate_inset_direction && gcode_layer.getLayerNr() % 2 == 1;
+            constexpr PrintSegmentAttributes print_attributes;
 
             if (! support_polygons.empty())
             {
@@ -3871,6 +3889,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                     support_polygons,
                     configs[combine_idx],
                     mesh_group_settings,
+                    print_attributes,
                     z_seam_config,
                     wall_0_wipe_dist,
                     spiralize,
@@ -3898,6 +3917,7 @@ bool FffGcodeWriter::processSupportInfill(const SliceDataStorage& storage, Layer
                     flow_ratio,
                     near_start_location,
                     fan_speed,
+                    print_attributes,
                     alternate_layer_print_direction);
 
                 added_something = true;

--- a/src/InfillOrderOptimizer.cpp
+++ b/src/InfillOrderOptimizer.cpp
@@ -453,6 +453,7 @@ void InfillOrderOptimizer::addInfillLinesToLayer(
         wipe_dist = 0;
     }
 
+    constexpr PrintSegmentAttributes print_attributes;
     layer_plan.addLinesByOptimizer(
         lines,
         mesh_config.infill_config[0],
@@ -462,6 +463,7 @@ void InfillOrderOptimizer::addInfillLinesToLayer(
         flow_ratio,
         near_start_location,
         fan_speed,
+        print_attributes,
         reverse_print_direction,
         order_requirements,
         start_move_inwards_length,
@@ -485,6 +487,7 @@ void InfillOrderOptimizer::addSkinSupportLinesToLayer(
     const auto skin_support_fan_speed = settings.get<bool>("cool_fan_enabled") ? settings.get<double>("skin_support_fan_speed") : GCodePathConfig::FAN_SPEED_DEFAULT;
     constexpr SpaceFillType skin_support_space_fill_type = SpaceFillType::Lines;
     constexpr coord_t skin_support_wipe_dist = 0;
+    constexpr PrintSegmentAttributes print_attributes;
     const auto skin_support_interlace_lines = settings.get<bool>("skin_support_interlace_lines");
     if (skin_support_interlace_lines)
     {
@@ -515,6 +518,7 @@ void InfillOrderOptimizer::addSkinSupportLinesToLayer(
             flow_ratio,
             near_start_location,
             skin_support_fan_speed,
+            print_attributes,
             reverse_print_direction);
     }
 }

--- a/src/InsetOrderOptimizer.cpp
+++ b/src/InsetOrderOptimizer.cpp
@@ -145,7 +145,7 @@ void InsetOrderOptimizer::optimize()
     path_optimizer_->optimize();
 }
 
-bool InsetOrderOptimizer::addToLayer(const RetractBeforeOuterWall retract_before_outer_wall)
+bool InsetOrderOptimizer::addToLayer(const RetractBeforeOuterWall retract_before_outer_wall, const PrintSegmentAttributes& print_attributes)
 {
     if (path_optimizer_ == nullptr)
     {
@@ -211,7 +211,8 @@ bool InsetOrderOptimizer::addToLayer(const RetractBeforeOuterWall retract_before
             backwards,
             linked_path,
             scarf_seam,
-            smooth_speed);
+            smooth_speed,
+            print_attributes);
         added_something = true;
 
         if (retract_before_outer_wall == RetractBeforeOuterWall::NOT_RETRACTED_FROM_INFILL)

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -583,9 +583,9 @@ void LayerPlan::addExtrusionMove(
     const Ratio speed_factor,
     const double fan_speed,
     const bool travel_to_z,
-    const PrintSegmentAttributes& attributes)
+    const PrintSegmentAttributes& print_attributes)
 {
-    GCodePath* path = getLatestPathWithConfig(config, space_fill_type, config.z_offset, flow, width_factor, spiralize, speed_factor, travel_to_z, attributes);
+    GCodePath* path = getLatestPathWithConfig(config, space_fill_type, config.z_offset, flow, width_factor, spiralize, speed_factor, travel_to_z, print_attributes);
     path->points.push_back(p);
     path->setFanSpeed(fan_speed);
     if (! static_cast<bool>(first_extrusion_acc_jerk_))

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -58,26 +58,29 @@ GCodePath* LayerPlan::getLatestPathWithConfig(
     const Ratio width_factor,
     const bool spiralize,
     const Ratio speed_factor,
-    const bool travel_to_z)
+    const bool travel_to_z,
+    const PrintSegmentAttributes print_attributes)
 {
     std::vector<GCodePath>& paths = extruder_plans_.back().paths_;
-    if (paths.size() > 0 && paths.back().config == config && ! paths.back().done && paths.back().flow == flow && paths.back().width_factor == width_factor
-        && paths.back().speed_factor == speed_factor && paths.back().z_offset == z_offset
-        && paths.back().mesh == current_mesh_) // spiralize can only change when a travel path is in between
+    if (! paths.empty() && paths.back().config == config && ! paths.back().done && paths.back().flow == flow && paths.back().width_factor == width_factor
+        && paths.back().speed_factor == speed_factor && paths.back().z_offset == z_offset && paths.back().mesh == current_mesh_
+        && paths.back().print_attributes == print_attributes) // spiralize can only change when a travel path is in between
     {
         return &paths.back();
     }
-    paths.emplace_back(GCodePath{
-        .z_offset = z_offset,
-        .config = config,
-        .mesh = current_mesh_,
-        .space_fill_type = space_fill_type,
-        .flow = flow,
-        .width_factor = width_factor,
-        .spiralize = spiralize,
-        .speed_factor = speed_factor,
-        .travel_to_z = travel_to_z,
-    });
+    paths.emplace_back(
+        GCodePath{
+            .z_offset = z_offset,
+            .config = config,
+            .mesh = current_mesh_,
+            .space_fill_type = space_fill_type,
+            .flow = flow,
+            .width_factor = width_factor,
+            .spiralize = spiralize,
+            .speed_factor = speed_factor,
+            .travel_to_z = travel_to_z,
+            .print_attributes = print_attributes,
+        });
 
     GCodePath* ret = &paths.back();
     return ret;
@@ -580,9 +583,10 @@ void LayerPlan::addExtrusionMove(
     const bool spiralize,
     const Ratio speed_factor,
     const double fan_speed,
-    const bool travel_to_z)
+    const bool travel_to_z,
+    const PrintSegmentAttributes& attributes)
 {
-    GCodePath* path = getLatestPathWithConfig(config, space_fill_type, config.z_offset, flow, width_factor, spiralize, speed_factor, travel_to_z);
+    GCodePath* path = getLatestPathWithConfig(config, space_fill_type, config.z_offset, flow, width_factor, spiralize, speed_factor, travel_to_z, attributes);
     path->points.push_back(p);
     path->setFanSpeed(fan_speed);
     if (! static_cast<bool>(first_extrusion_acc_jerk_))
@@ -601,12 +605,18 @@ void LayerPlan::addExtrusionMoveWithGradualOverhang(
     const bool spiralize,
     const Ratio speed_factor,
     const double fan_speed,
-    const bool travel_to_z)
+    const bool travel_to_z,
+    const PrintSegmentAttributes& print_attributes)
 {
     const auto add_extrusion_move = [&](const Point3LL& target, const std::optional<size_t> speed_region_index = std::nullopt)
     {
+        PrintSegmentAttributes final_attributes = print_attributes;
+        if (speed_region_index.has_value() && speed_region_index.value() > 0)
+        {
+            final_attributes |= PrintSegmentAttribute::Overhanging;
+        }
         const Ratio overhang_speed_factor = speed_region_index.has_value() ? overhang_masks_[speed_region_index.value()].speed_ratio : 1.0_r;
-        addExtrusionMove(target, config, space_fill_type, flow, width_factor, spiralize, speed_factor * overhang_speed_factor, fan_speed, travel_to_z);
+        addExtrusionMove(target, config, space_fill_type, flow, width_factor, spiralize, speed_factor * overhang_speed_factor, fan_speed, travel_to_z, final_attributes);
     };
 
     const auto update_is_overhanging = [this](const Point3LL& target, std::optional<Point3LL> current_position, const bool is_overhanging = false)
@@ -801,7 +811,8 @@ void LayerPlan::addSkinExtrusion(
     const Ratio& flow,
     const Ratio& width_factor,
     const bool spiralize,
-    bool travel_to_z)
+    bool travel_to_z,
+    const PrintSegmentAttributes& print_attributes)
 {
     // The line segment is wholly or partially in the skin area. The line is intersected
     // with the skin area into line segments. Each line segment left in this intersection
@@ -858,7 +869,8 @@ void LayerPlan::addSkinExtrusion(
                 spiralize,
                 1.0_r,
                 GCodePathConfig::FAN_SPEED_DEFAULT,
-                travel_to_z);
+                travel_to_z,
+                print_attributes);
 
             travel_to_z = false; // Only travel to Z for the first sub-segment
         }
@@ -918,7 +930,8 @@ void LayerPlan::addPolygon(
     const Ratio& flow_ratio,
     const ForceRetract force_retract,
     bool scarf_seam,
-    bool smooth_speed)
+    bool smooth_speed,
+    const PrintSegmentAttributes& print_attributes)
 {
     constexpr bool is_closed = true;
     constexpr bool is_candidate_small_feature = false;
@@ -939,7 +952,7 @@ void LayerPlan::addPolygon(
         is_candidate_small_feature,
         scarf_seam,
         smooth_speed,
-        [this, &config, &spiralize](
+        [this, &config, &spiralize, &print_attributes](
             const PathAdapter<Polygon>& /*wall*/,
             const size_t /*segment_index*/,
             const Ratio& /*segment_start_ratio*/,
@@ -955,7 +968,7 @@ void LayerPlan::addPolygon(
             constexpr double fan_speed = GCodePathConfig::FAN_SPEED_DEFAULT;
             constexpr bool travel_to_z = false;
 
-            addExtrusionMove(end, config, SpaceFillType::Polygons, actual_flow_ratio, line_width_ratio, spiralize, speed_factor, fan_speed, travel_to_z);
+            addExtrusionMove(end, config, SpaceFillType::Polygons, actual_flow_ratio, line_width_ratio, spiralize, speed_factor, fan_speed, travel_to_z, print_attributes);
         });
 
 
@@ -973,6 +986,7 @@ void LayerPlan::addPolygonsByOptimizer(
     const Shape& polygons,
     const GCodePathConfig& config,
     const Settings& settings,
+    const PrintSegmentAttributes& print_attributes,
     const ZSeamConfig& z_seam_config,
     coord_t wall_0_wipe_dist,
     bool spiralize,
@@ -1026,7 +1040,8 @@ void LayerPlan::addPolygonsByOptimizer(
         force_retract,
         reverse_order,
         scarf_seam,
-        smooth_speed);
+        smooth_speed,
+        print_attributes);
 }
 
 void LayerPlan::addInfillPolygonsByOptimizer(
@@ -1092,7 +1107,8 @@ void LayerPlan::addWallLine(
     double& non_bridge_line_volume,
     Ratio speed_factor,
     double distance_to_bridge_start,
-    const bool travel_to_z)
+    const bool travel_to_z,
+    const PrintSegmentAttributes& print_attributes)
 {
     constexpr double acceleration_segment_len = MM2INT(1); // accelerate using segments of this length
     constexpr double acceleration_factor = 0.75; // must be < 1, the larger the value, the slower the acceleration
@@ -1156,7 +1172,8 @@ void LayerPlan::addWallLine(
                             spiralize,
                             speed_factor,
                             GCodePathConfig::FAN_SPEED_DEFAULT,
-                            travel_to_z);
+                            travel_to_z,
+                            print_attributes);
                     }
                     // then coast to start of bridge segment
                     constexpr Ratio no_flow = 0.0_r; // Coasting has no flow rate.
@@ -1174,7 +1191,8 @@ void LayerPlan::addWallLine(
                         spiralize,
                         speed_factor,
                         GCodePathConfig::FAN_SPEED_DEFAULT,
-                        travel_to_z);
+                        travel_to_z,
+                        print_attributes);
                 }
 
                 distance_to_bridge_start -= len;
@@ -1191,7 +1209,8 @@ void LayerPlan::addWallLine(
                     spiralize,
                     speed_factor,
                     GCodePathConfig::FAN_SPEED_DEFAULT,
-                    travel_to_z);
+                    travel_to_z,
+                    print_attributes);
             }
             non_bridge_line_volume += (cur_point - segment_end).vSize() * segment_flow * width_factor * speed_factor * default_config.getSpeed();
             cur_point = segment_end;
@@ -1217,7 +1236,7 @@ void LayerPlan::addWallLine(
 
     if (use_skin_config(roofing_mask_, roofing_config))
     {
-        addSkinExtrusion(p0, p1, roofing_mask_, roofing_config, default_config, flow, width_factor, spiralize, travel_to_z);
+        addSkinExtrusion(p0, p1, roofing_mask_, roofing_config, default_config, flow, width_factor, spiralize, travel_to_z, print_attributes);
     }
     else if (bridge_wall_mask_.empty())
     {
@@ -1231,7 +1250,8 @@ void LayerPlan::addWallLine(
             spiralize,
             speed_factor,
             GCodePathConfig::FAN_SPEED_DEFAULT,
-            travel_to_z);
+            travel_to_z,
+            print_attributes);
     }
     else if (std::vector<std::tuple<Ratio, Ratio>> bridging_subsegments = wallSegmentUsesBridging(
                  bridge_wall_mask_bb_,
@@ -1244,6 +1264,8 @@ void LayerPlan::addWallLine(
                  default_config.line_width);
              ! bridging_subsegments.empty())
     {
+        const PrintSegmentAttributes attributes_bridging = print_attributes | PrintSegmentAttribute::Bridging;
+
         // the line crosses the boundary between supported and non-supported regions so one or more bridges are required
         for (const std::tuple<Ratio, Ratio>& bridging_subsegment : bridging_subsegments)
         {
@@ -1251,7 +1273,17 @@ void LayerPlan::addWallLine(
             const Point3LL bridging_subsegment_p1 = lerp(p0, p1, std::get<1>(bridging_subsegment).value);
 
             addNonBridgeLine(bridging_subsegment_p0);
-            addExtrusionMove(bridging_subsegment_p1, bridge_config, SpaceFillType::Polygons, flow, width_factor, spiralize, 1.0_r, GCodePathConfig::FAN_SPEED_DEFAULT, travel_to_z);
+            addExtrusionMove(
+                bridging_subsegment_p1,
+                bridge_config,
+                SpaceFillType::Polygons,
+                flow,
+                width_factor,
+                spiralize,
+                1.0_r,
+                GCodePathConfig::FAN_SPEED_DEFAULT,
+                travel_to_z,
+                attributes_bridging);
 
             non_bridge_line_volume = 0;
             cur_point = bridging_subsegment_p1;
@@ -1264,7 +1296,7 @@ void LayerPlan::addWallLine(
     }
     else if (use_skin_config(flooring_mask_, flooring_config))
     {
-        addSkinExtrusion(p0, p1, flooring_mask_, flooring_config, default_config, flow, width_factor, spiralize, travel_to_z);
+        addSkinExtrusion(p0, p1, flooring_mask_, flooring_config, default_config, flow, width_factor, spiralize, travel_to_z, print_attributes);
     }
     else
     {
@@ -1897,7 +1929,8 @@ void LayerPlan::addWall(
     const bool is_reversed,
     const bool is_linked_path,
     const bool scarf_seam,
-    const bool smooth_speed)
+    const bool smooth_speed,
+    const PrintSegmentAttributes& print_attributes)
 {
     if (wall.empty())
     {
@@ -1949,7 +1982,8 @@ void LayerPlan::addWall(
                 non_bridge_line_volume,
                 speed_factor,
                 distance_to_bridge_start,
-                travel_to_z);
+                travel_to_z,
+                print_attributes);
         });
 
     if (wall.size() >= 2)
@@ -2196,6 +2230,7 @@ void LayerPlan::addLinesByOptimizer(
     const Ratio flow_ratio,
     const std::optional<Point2LL> near_start_location,
     const double fan_speed,
+    const PrintSegmentAttributes& print_attributes,
     const bool reverse_print_direction,
     const std::unordered_multimap<const Polyline*, const Polyline*>& order_requirements,
     const coord_t extra_inwards_start_move_length,
@@ -2255,6 +2290,7 @@ void LayerPlan::addLinesByOptimizer(
         wipe_dist,
         flow_ratio,
         fan_speed,
+        print_attributes,
         extra_inwards_start_move_length,
         extra_inwards_end_move_length,
         extra_inwards_move_contour);
@@ -2326,6 +2362,7 @@ void LayerPlan::addLinesInGivenOrder(
     const coord_t wipe_dist,
     const Ratio flow_ratio,
     const double fan_speed,
+    const PrintSegmentAttributes& print_attributes,
     const coord_t extra_inwards_start_move_length,
     const coord_t extra_inwards_end_move_length,
     const MendedShape& extra_inwards_move_contour)
@@ -2418,7 +2455,8 @@ void LayerPlan::addLinesInGivenOrder(
             constexpr Ratio width_factor = 1.0_r;
             constexpr bool spiralize = false;
             constexpr Ratio speed_factor = 1.0_r;
-            addExtrusionMove(start, config, space_fill_type, flow, width_factor, spiralize, speed_factor, fan_speed);
+            constexpr bool travel_to_z = true;
+            addExtrusionMove(start, config, space_fill_type, flow, width_factor, spiralize, speed_factor, fan_speed, travel_to_z, print_attributes);
         }
         else
         {
@@ -2455,7 +2493,8 @@ void LayerPlan::addLinesInGivenOrder(
                 constexpr Ratio width_factor = 1.0_r;
                 constexpr bool spiralize = false;
                 constexpr Ratio speed_factor = 1.0_r;
-                addExtrusionMove(p1, config, space_fill_type, flow_ratio, width_factor, spiralize, speed_factor, fan_speed);
+                constexpr bool travel_to_z = true;
+                addExtrusionMove(p1, config, space_fill_type, flow_ratio, width_factor, spiralize, speed_factor, fan_speed, travel_to_z, print_attributes);
                 p0 = p1;
             }
         }
@@ -2494,7 +2533,8 @@ void LayerPlan::addLinesInGivenOrder(
                 constexpr Ratio width_factor = 1.0_r;
                 constexpr bool spiralize = false;
                 constexpr Ratio speed_factor = 1.0_r;
-                addExtrusionMove(p1 + normal(p1 - p0, wipe_dist), config, space_fill_type, flow, width_factor, spiralize, speed_factor, fan_speed);
+                constexpr bool travel_to_z = true;
+                addExtrusionMove(p1 + normal(p1 - p0, wipe_dist), config, space_fill_type, flow, width_factor, spiralize, speed_factor, fan_speed, travel_to_z, print_attributes);
             }
         }
     }
@@ -2511,10 +2551,12 @@ void LayerPlan::addPolygonsInGivenOrder(
     const ForceRetract force_retract,
     bool reverse_order,
     bool scarf_seam,
-    bool smooth_speed)
+    bool smooth_speed,
+    const PrintSegmentAttributes& print_attributes)
 {
-    const auto add_polygons
-        = [this, &config, &settings, &wall_0_wipe_dist, &spiralize, &flow_ratio, &force_retract, &scarf_seam, &smooth_speed](const auto& iterator_begin, const auto& iterator_end)
+    const auto add_polygons = [this, &config, &settings, &wall_0_wipe_dist, &spiralize, &flow_ratio, &force_retract, &scarf_seam, &smooth_speed, &print_attributes](
+                                  const auto& iterator_begin,
+                                  const auto& iterator_end)
     {
         for (auto iterator = iterator_begin; iterator != iterator_end; ++iterator)
         {
@@ -2529,7 +2571,8 @@ void LayerPlan::addPolygonsInGivenOrder(
                 flow_ratio,
                 force_retract,
                 scarf_seam,
-                smooth_speed);
+                smooth_speed,
+                print_attributes);
         }
     };
 
@@ -2831,7 +2874,8 @@ void LayerPlan::sendLineTo(const GCodePath& path, const Point3LL& position, cons
         position + Point3LL(0, 0, z_ + path.z_offset),
         path.getLineWidthForLayerView(),
         line_thickness.value_or(path.config.getLayerThickness() + path.z_offset + position.z_),
-        extrude_speed);
+        extrude_speed,
+        path.print_attributes);
 }
 
 void LayerPlan::writeTravelRelativeZ(GCodeExport& gcode, const Point3LL& position, const Velocity& speed, const coord_t path_z_offset, const std::optional<double> retract_distance)
@@ -2876,7 +2920,8 @@ void LayerPlan::addLinesMonotonic(
     const coord_t wipe_dist,
     const Ratio flow_ratio,
     const double fan_speed,
-    const bool interlaced)
+    const bool interlaced,
+    const PrintSegmentAttributes& print_attributes)
 {
     const Shape exclude_areas = area.createTubeShape(exclude_distance, exclude_distance);
     const coord_t exclude_dist2 = exclude_distance * exclude_distance;
@@ -2922,10 +2967,10 @@ void LayerPlan::addLinesMonotonic(
     order.optimize();
 
     // Read out and process the monotonically ordered lines.
-    addLinesInGivenOrder(order.paths_, config, space_fill_type, wipe_dist, flow_ratio, fan_speed);
+    addLinesInGivenOrder(order.paths_, config, space_fill_type, wipe_dist, flow_ratio, fan_speed, print_attributes);
 
     // Add all lines in the excluded areas the 'normal' way.
-    addLinesByOptimizer(left_over, config, space_fill_type, true, wipe_dist, flow_ratio, getLastPlannedPositionOrStartingPosition(), fan_speed);
+    addLinesByOptimizer(left_over, config, space_fill_type, true, wipe_dist, flow_ratio, getLastPlannedPositionOrStartingPosition(), fan_speed, print_attributes);
 }
 
 void LayerPlan::spiralizeWallSlice(
@@ -4188,6 +4233,7 @@ template void LayerPlan::addLinesByOptimizer(
     const Ratio flow_ratio,
     const std::optional<Point2LL> near_start_location,
     const double fan_speed,
+    const PrintSegmentAttributes& print_attributes,
     const bool reverse_print_direction,
     const std::unordered_multimap<const Polyline*, const Polyline*>& order_requirements,
     const coord_t extra_inwards_start_move_length,
@@ -4203,6 +4249,7 @@ template void LayerPlan::addLinesByOptimizer(
     const Ratio flow_ratio,
     const std::optional<Point2LL> near_start_location,
     const double fan_speed,
+    const PrintSegmentAttributes& print_attributes,
     const bool reverse_print_direction,
     const std::unordered_multimap<const Polyline*, const Polyline*>& order_requirements,
     const coord_t extra_inwards_start_move_length,

--- a/src/LayerPlan.cpp
+++ b/src/LayerPlan.cpp
@@ -68,19 +68,18 @@ GCodePath* LayerPlan::getLatestPathWithConfig(
     {
         return &paths.back();
     }
-    paths.emplace_back(
-        GCodePath{
-            .z_offset = z_offset,
-            .config = config,
-            .mesh = current_mesh_,
-            .space_fill_type = space_fill_type,
-            .flow = flow,
-            .width_factor = width_factor,
-            .spiralize = spiralize,
-            .speed_factor = speed_factor,
-            .travel_to_z = travel_to_z,
-            .print_attributes = print_attributes,
-        });
+    paths.emplace_back(GCodePath{
+        .z_offset = z_offset,
+        .config = config,
+        .mesh = current_mesh_,
+        .space_fill_type = space_fill_type,
+        .flow = flow,
+        .width_factor = width_factor,
+        .spiralize = spiralize,
+        .speed_factor = speed_factor,
+        .travel_to_z = travel_to_z,
+        .print_attributes = print_attributes,
+    });
 
     GCodePath* ret = &paths.back();
     return ret;

--- a/src/TopSurface.cpp
+++ b/src/TopSurface.cpp
@@ -120,7 +120,7 @@ bool TopSurface::ironing(const SliceDataStorage& storage, const SliceMeshStorage
     if (! ironing_polygons.empty())
     {
         layer.addTravel(ironing_polygons[0][0]);
-        layer.addPolygonsByOptimizer(ironing_polygons, line_config, mesh.settings, ZSeamConfig());
+        layer.addPolygonsByOptimizer(ironing_polygons, line_config, mesh.settings);
         added = true;
     }
     if (! ironing_lines.empty())

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -66,7 +66,7 @@ class ArcusCommunication::PathCompiler
     std::vector<float> line_velocities; //!< Line feedrates for the line segments stored, the size of this vector is N.
     std::vector<float> points; //!< The points used to define the line segments, the size of this vector is D*(N+1) as each line segment is defined from one point to the next. D is
                                //!< the dimensionality of the point.
-    std::vector<uint32_t> line_attributes;
+    std::vector<uint32_t> line_attributes; //! Indicates if the line is processed with specific settings, e.g. overhanging or bridging, the size of this vector is N.
 
     Point3LL last_point;
 
@@ -214,6 +214,7 @@ public:
      * \param line_width The width of the line.
      * \param line_thickness The thickness (in the Z direction) of the line.
      * \param velocity The velocity of printing this polygon.
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void sendLineTo(
         const PrintFeatureType& print_feature_type,
@@ -221,13 +222,13 @@ public:
         const coord_t& width,
         const coord_t& thickness,
         const Velocity& feedrate,
-        const PrintSegmentAttributes& segment_attributes)
+        const PrintSegmentAttributes& print_attributes)
     {
         assert(! points.empty() && "A point must already be in the buffer for sendLineTo(.) to function properly.");
 
         if (to != last_point)
         {
-            addLineSegment(print_feature_type, to, width, thickness, feedrate, segment_attributes);
+            addLineSegment(print_feature_type, to, width, thickness, feedrate, print_attributes);
         }
     }
 
@@ -257,6 +258,7 @@ private:
      * \param width The width of the lines of the polygon.
      * \param thickness The layer thickness of the polygon.
      * \param velocity How fast the polygon is printed.
+     * \param print_attributes Print attributes to be set for this segment, e.g. overhanging or bridging
      */
     void addLineSegment(
         const PrintFeatureType& print_feature_type,
@@ -264,14 +266,14 @@ private:
         const coord_t& width,
         const coord_t& thickness,
         const Velocity& velocity,
-        const PrintSegmentAttributes& segment_attributes)
+        const PrintSegmentAttributes& print_attributes)
     {
         addPoint3D(point);
         line_types.push_back(print_feature_type);
         line_widths.push_back(INT2MM(width));
         line_thicknesses.push_back(INT2MM(thickness));
         line_velocities.push_back(velocity);
-        line_attributes.push_back(uint32_t{ segment_attributes.value() });
+        line_attributes.push_back(static_cast<uint32_t>(print_attributes.value()));
     }
 };
 
@@ -374,9 +376,9 @@ void ArcusCommunication::sendLineTo(
     const coord_t& line_width,
     const coord_t& line_thickness,
     const Velocity& velocity,
-    const PrintSegmentAttributes& segment_attributes)
+    const PrintSegmentAttributes& print_attributes)
 {
-    path_compiler->sendLineTo(type, to, line_width, line_thickness, velocity, segment_attributes);
+    path_compiler->sendLineTo(type, to, line_width, line_thickness, velocity, print_attributes);
 }
 
 void ArcusCommunication::sendOptimizedLayerData()

--- a/src/communication/ArcusCommunication.cpp
+++ b/src/communication/ArcusCommunication.cpp
@@ -56,9 +56,9 @@ class ArcusCommunication::PathCompiler
     //! Reference to the private data of the CommandSocket used to send the data to the front end.
     ArcusCommunication::Private& _cs_private_data;
     //! Keeps track of the current layer number being processed. If layer number is set to a different value, the current data is flushed to CommandSocket.
-    LayerIndex _layer_nr;
-    size_t extruder;
-    PointType data_point_type;
+    LayerIndex _layer_nr{ 0 };
+    size_t extruder{ 0 };
+    PointType data_point_type{ cura::proto::PathSegment::Point3D };
 
     std::vector<PrintFeatureType> line_types; //!< Line types for the line segments stored, the size of this vector is N.
     std::vector<float> line_widths; //!< Line widths for the line segments stored, the size of this vector is N.
@@ -66,6 +66,7 @@ class ArcusCommunication::PathCompiler
     std::vector<float> line_velocities; //!< Line feedrates for the line segments stored, the size of this vector is N.
     std::vector<float> points; //!< The points used to define the line segments, the size of this vector is D*(N+1) as each line segment is defined from one point to the next. D is
                                //!< the dimensionality of the point.
+    std::vector<uint32_t> line_attributes;
 
     Point3LL last_point;
 
@@ -78,14 +79,6 @@ public:
      */
     PathCompiler(ArcusCommunication::Private& cs_private_data)
         : _cs_private_data(cs_private_data)
-        , _layer_nr(0)
-        , extruder(0)
-        , data_point_type(cura::proto::PathSegment::Point3D)
-        , line_types()
-        , line_widths()
-        , line_thicknesses()
-        , line_velocities()
-        , points()
     {
     }
 
@@ -150,7 +143,7 @@ public:
         }
         else if (initial_point != last_point)
         {
-            addLineSegment(PrintFeatureType::NoneType, initial_point, 1, 0, 0.0);
+            addLineSegment(PrintFeatureType::NoneType, initial_point, 1, 0, 0.0, {});
         }
     }
 
@@ -195,6 +188,12 @@ public:
         line_velocity_data.append(reinterpret_cast<const char*>(line_velocities.data()), line_velocities.size() * sizeof(float));
         line_velocities.clear();
         path_segment->set_line_feedrate(line_velocity_data);
+
+        for (const uint32_t line_attribute : line_attributes)
+        {
+            path_segment->add_attributes(line_attribute);
+        }
+        line_attributes.clear();
     }
 
     /*!
@@ -216,13 +215,19 @@ public:
      * \param line_thickness The thickness (in the Z direction) of the line.
      * \param velocity The velocity of printing this polygon.
      */
-    void sendLineTo(const PrintFeatureType& print_feature_type, const Point3LL& to, const coord_t& width, const coord_t& thickness, const Velocity& feedrate)
+    void sendLineTo(
+        const PrintFeatureType& print_feature_type,
+        const Point3LL& to,
+        const coord_t& width,
+        const coord_t& thickness,
+        const Velocity& feedrate,
+        const PrintSegmentAttributes& segment_attributes)
     {
         assert(! points.empty() && "A point must already be in the buffer for sendLineTo(.) to function properly.");
 
         if (to != last_point)
         {
-            addLineSegment(print_feature_type, to, width, thickness, feedrate);
+            addLineSegment(print_feature_type, to, width, thickness, feedrate, segment_attributes);
         }
     }
 
@@ -253,13 +258,20 @@ private:
      * \param thickness The layer thickness of the polygon.
      * \param velocity How fast the polygon is printed.
      */
-    void addLineSegment(const PrintFeatureType& print_feature_type, const Point3LL& point, const coord_t& width, const coord_t& thickness, const Velocity& velocity)
+    void addLineSegment(
+        const PrintFeatureType& print_feature_type,
+        const Point3LL& point,
+        const coord_t& width,
+        const coord_t& thickness,
+        const Velocity& velocity,
+        const PrintSegmentAttributes& segment_attributes)
     {
         addPoint3D(point);
         line_types.push_back(print_feature_type);
         line_widths.push_back(INT2MM(width));
         line_thicknesses.push_back(INT2MM(thickness));
         line_velocities.push_back(velocity);
+        line_attributes.push_back(uint32_t{ segment_attributes.value() });
     }
 };
 
@@ -356,9 +368,15 @@ void ArcusCommunication::sendLayerComplete(const LayerIndex::value_type& layer_n
     layer->set_thickness(thickness);
 }
 
-void ArcusCommunication::sendLineTo(const PrintFeatureType& type, const Point3LL& to, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity)
+void ArcusCommunication::sendLineTo(
+    const PrintFeatureType& type,
+    const Point3LL& to,
+    const coord_t& line_width,
+    const coord_t& line_thickness,
+    const Velocity& velocity,
+    const PrintSegmentAttributes& segment_attributes)
 {
-    path_compiler->sendLineTo(type, to, line_width, line_thickness, velocity);
+    path_compiler->sendLineTo(type, to, line_width, line_thickness, velocity, segment_attributes);
 }
 
 void ArcusCommunication::sendOptimizedLayerData()

--- a/src/communication/CommandLine.cpp
+++ b/src/communication/CommandLine.cpp
@@ -63,7 +63,7 @@ void CommandLine::sendFinishedSlicing() const
 void CommandLine::sendLayerComplete(const LayerIndex::value_type&, const coord_t&, const coord_t&)
 {
 }
-void CommandLine::sendLineTo(const PrintFeatureType&, const Point3LL&, const coord_t&, const coord_t&, const Velocity&)
+void CommandLine::sendLineTo(const PrintFeatureType&, const Point3LL&, const coord_t&, const coord_t&, const Velocity&, const PrintSegmentAttributes&)
 {
 }
 void CommandLine::sendOptimizedLayerData()

--- a/src/sliceDataStorage.cpp
+++ b/src/sliceDataStorage.cpp
@@ -384,9 +384,9 @@ Shape SliceDataStorage::getLayerOutlines(
         }
         if (include_support && (extruder_nr == -1 || extruder_nr == int(mesh_group_settings.get<ExtruderTrain&>("support_infill_extruder_nr").extruder_nr_)))
         {
-            const SupportLayer& support_layer = support.supportLayers[std::max(LayerIndex(0), layer_nr)];
-            if (support.generated)
+            if (support.generated && ! support.supportLayers.empty())
             {
+                const SupportLayer& support_layer = support.supportLayers[std::max(LayerIndex(0), layer_nr)];
                 for (const SupportInfillPart& support_infill_part : support_layer.support_infill_parts)
                 {
                     if (include_support_base)

--- a/tests/GCodeExportTest.cpp
+++ b/tests/GCodeExportTest.cpp
@@ -557,7 +557,7 @@ TEST_F(GCodeExportTest, insertWipeScriptSingleMove)
     config.move_speed = 10.0;
     config.pause = 0;
 
-    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
+    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
     gcode.insertWipeScript(config);
 
     std::string token;
@@ -589,7 +589,7 @@ TEST_F(GCodeExportTest, insertWipeScriptMultipleMoves)
     config.move_speed = 10.0;
     config.pause = 0;
 
-    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(6);
+    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_)).Times(6);
     gcode.insertWipeScript(config);
 
     std::string token;
@@ -627,7 +627,7 @@ TEST_F(GCodeExportTest, insertWipeScriptOptionalDelay)
     config.move_speed = 10.0;
     config.pause = 1.5; // 1.5 sec = 1500 ms.
 
-    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
+    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
     gcode.insertWipeScript(config);
 
     std::string token;
@@ -672,7 +672,7 @@ TEST_F(GCodeExportTest, insertWipeScriptRetractionEnable)
     config.move_speed = 10.0;
     config.pause = 0;
 
-    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
+    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_)).Times(3);
     gcode.insertWipeScript(config);
 
     std::string token;
@@ -708,7 +708,7 @@ TEST_F(GCodeExportTest, insertWipeScriptHopEnable)
     config.move_speed = 10.0;
     config.pause = 0;
 
-    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_)).Times(5);
+    EXPECT_CALL(*mock_communication, sendLineTo(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_)).Times(5);
     gcode.insertWipeScript(config);
 
     std::string token;

--- a/tests/arcus/ArcusCommunicationPrivateTest.cpp
+++ b/tests/arcus/ArcusCommunicationPrivateTest.cpp
@@ -156,6 +156,7 @@ TEST_F(ArcusCommunicationPrivateTest, ReadMeshGroupMessage)
 {
     // Setup:
     cura::proto::ObjectList mesh_message;
+    Application::getInstance().current_slice_->scene.extruders.push_back(ExtruderTrain(0, nullptr)); // We do need the extruder to be declared first
 
     // - Load 'global' settings:
     std::unordered_map<std::string, std::string> raw_settings;

--- a/tests/arcus/MockCommunication.h
+++ b/tests/arcus/MockCommunication.h
@@ -24,7 +24,15 @@ public:
     MOCK_CONST_METHOD0(hasSlice, bool());
     MOCK_CONST_METHOD1(sendProgress, void(double progress));
     MOCK_METHOD3(sendLayerComplete, void(const LayerIndex::value_type& layer_nr, const coord_t& z, const coord_t& thickness));
-    MOCK_METHOD5(sendLineTo, void(const PrintFeatureType& type, const Point3LL& to, const coord_t& line_width, const coord_t& line_thickness, const Velocity& velocity));
+    MOCK_METHOD6(
+        sendLineTo,
+        void(
+            const PrintFeatureType& type,
+            const Point3LL& to,
+            const coord_t& line_width,
+            const coord_t& line_thickness,
+            const Velocity& velocity,
+            const PrintSegmentAttributes& print_attributes));
     MOCK_METHOD1(sendCurrentPosition, void(const Point3LL& position));
     MOCK_METHOD1(setExtruderForSend, void(const ExtruderTrain& extruder));
     MOCK_METHOD1(setLayerForSend, void(const LayerIndex::value_type& layer_nr));

--- a/tests/integration/SlicePhaseTest.cpp
+++ b/tests/integration/SlicePhaseTest.cpp
@@ -63,6 +63,9 @@ class SlicePhaseTest : public testing::Test
         scene.settings.add("cutting_mesh", "false");
         scene.settings.add("infill_mesh", "false");
         scene.settings.add("adhesion_type", "none");
+
+        // Register an extruder
+        Application::getInstance().current_slice_->scene.extruders.push_back(ExtruderTrain(0, &scene.settings));
     }
 };
 


### PR DESCRIPTION
This PR adds the possibility to set special attributes to print segments. Those attributes are sent to front-end for display purposes.

In this case, we are interested in displaying the segment that are overhanging and bridging, so we also add 2 flags for those cases and set them when appropriate.

Comes with https://github.com/Ultimaker/Cura/pull/21766

CURA-9839