### PR TITLE
CURA-13297 Fix wall thickness instead of walls count

### DIFF
--- a/include/TreeSupportUtils.h
+++ b/include/TreeSupportUtils.h
@@ -120,7 +120,9 @@ public:
         constexpr coord_t support_roof_overlap = 0;
         constexpr size_t infill_multiplier = 1;
         const int support_shift = roof ? 0 : support_infill_distance / 2;
-        const size_t wall_line_count = include_walls ? (! roof ? config.support_wall_thickness : config.support_roof_wall_count) : 0;
+        const coord_t wall_line_count = include_walls
+            ? (! roof ? config.support_wall_thickness : static_cast<coord_t>(config.support_roof_wall_count) * config.support_roof_line_width)
+            : coord_t{ 0 };
         constexpr coord_t narrow_area_width = 0;
         const Point2LL infill_origin;
         constexpr bool skip_stitching = false;

--- a/include/TreeSupportUtils.h
+++ b/include/TreeSupportUtils.h
@@ -120,9 +120,8 @@ public:
         constexpr coord_t support_roof_overlap = 0;
         constexpr size_t infill_multiplier = 1;
         const int support_shift = roof ? 0 : support_infill_distance / 2;
-        const coord_t wall_line_count = include_walls
-            ? (! roof ? config.support_wall_thickness : static_cast<coord_t>(config.support_roof_wall_count) * config.support_roof_line_width)
-            : coord_t{ 0 };
+        const coord_t wall_line_count
+            = include_walls ? (! roof ? config.support_wall_thickness : static_cast<coord_t>(config.support_roof_wall_count) * config.support_roof_line_width) : coord_t{ 0 };
         constexpr coord_t narrow_area_width = 0;
         const Point2LL infill_origin;
         constexpr bool skip_stitching = false;

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -656,7 +656,7 @@ void SkinInfillAreaComputation::generateGradualInfill(SliceMeshStorage& mesh)
             const Shape& infill_area = Infill::generateWallToolPaths(
                 part.infill_wall_toolpaths,
                 part.getOwnInfillArea(),
-                infill_wall_count,
+                static_cast<coord_t>(infill_wall_count) * infill_wall_width,
                 infill_wall_width,
                 mesh.settings,
                 layer_idx,


### PR DESCRIPTION
Following the changes for the tree support dynamic wall thickness, some methods now need to properly handle either a wall count or a thickness. This PR fixes a few cases where they were mismatched.

On behalf of @HellAholic 
CURA-13297