### PR TITLE
Fix tree support crash generation

### DIFF
--- a/include/TreeSupport.h
+++ b/include/TreeSupport.h
@@ -48,8 +48,8 @@ constexpr auto SUPPORT_TREE_EXPONENTIAL_FACTOR = 1.5;
 constexpr size_t SUPPORT_TREE_PRE_EXPONENTIAL_STEPS = 1;
 constexpr coord_t SUPPORT_TREE_COLLISION_RESOLUTION = 500; // Only has an effect if SUPPORT_TREE_USE_EXPONENTIAL_COLLISION_RESOLUTION is false
 
-using PropertyAreasUnordered = std::unordered_map<TreeSupportElement, Shape>;
-using PropertyAreas = std::map<TreeSupportElement, Shape>;
+using PropertyAreasUnordered = std::unordered_map<TreeSupportElement::Ptr, Shape>;
+using PropertyAreas = std::map<TreeSupportElement::Ptr, Shape>;
 
 struct FakeRoofArea
 {
@@ -120,7 +120,7 @@ private:
      * \param move_bounds[out] Storage for the influence areas.
      * \param storage[in] Background storage, required for adding roofs.
      */
-    void generateInitialAreas(const SliceMeshStorage& mesh, std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage);
+    void generateInitialAreas(const SliceMeshStorage& mesh, std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, SliceDataStorage& storage);
 
 
     /*!
@@ -140,15 +140,15 @@ private:
      * of avoidance) \param erase[out] Elements that should be deleted from the above dictionaries. \param layer_idx[in] The Index of the current Layer.
      */
     void mergeHelper(
-        std::map<TreeSupportElement, AABB>& reduced_aabb,
-        std::map<TreeSupportElement, AABB>& input_aabb,
+        std::map<TreeSupportElement::Ptr, AABB>& reduced_aabb,
+        std::map<TreeSupportElement::Ptr, AABB>& input_aabb,
         const PropertyAreasUnordered& to_bp_areas,
         const PropertyAreas& to_model_areas,
         const PropertyAreas& influence_areas,
         PropertyAreasUnordered& insert_bp_areas,
         PropertyAreasUnordered& insert_model_areas,
         PropertyAreasUnordered& insert_influence,
-        std::vector<TreeSupportElement>& erase,
+        std::vector<TreeSupportElement::Ptr>& erase,
         const LayerIndex layer_idx);
 
     /*!
@@ -188,10 +188,10 @@ private:
      * called on this layer. This information is required as some calculation can be avoided if they are not required for merging. \return A valid support element for the next
      * layer regarding the calculated influence areas. Empty if no influence are can be created using the supplied influence area and settings.
      */
-    std::optional<TreeSupportElement> increaseSingleArea(
+    TreeSupportElement::Ptr increaseSingleArea(
         AreaIncreaseSettings settings,
         LayerIndex layer_idx,
-        TreeSupportElement* parent,
+        TreeSupportElement::Ptr parent,
         const Shape& relevant_offset,
         Shape& to_bp_data,
         Shape& to_model_data,
@@ -222,8 +222,8 @@ private:
         PropertyAreasUnordered& to_bp_areas,
         PropertyAreas& to_model_areas,
         PropertyAreas& influence_areas,
-        std::vector<TreeSupportElement*>& bypass_merge_areas,
-        const std::vector<TreeSupportElement*>& last_layer,
+        std::vector<TreeSupportElement::Ptr>& bypass_merge_areas,
+        const std::vector<TreeSupportElement::Ptr>& last_layer,
         const LayerIndex layer_idx,
         const bool mergelayer);
 
@@ -233,7 +233,7 @@ private:
      * \param move_bounds[in,out] All currently existing influence areas
      * \param time_keeper The object used to record the duration of the sub-steps
      */
-    void createLayerPathing(std::vector<std::set<TreeSupportElement*>>& move_bounds, TimeKeeper& time_keeper);
+    void createLayerPathing(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, TimeKeeper& time_keeper);
 
 
     /*!
@@ -241,7 +241,7 @@ private:
      *
      * \param elem[in] The SupportElements, which parent's position should be determined.
      */
-    void setPointsOnAreas(const TreeSupportElement* elem);
+    void setPointsOnAreas(const TreeSupportElement::Ptr elem);
 
     /*!
      * \brief Get the best point to connect to the model and set the result_on_layer of the relevant SupportElement accordingly.
@@ -251,14 +251,14 @@ private:
      * \param layer_idx[in] The current layer.
      * \return Should elem be deleted.
      */
-    bool setToModelContact(std::vector<std::set<TreeSupportElement*>>& move_bounds, TreeSupportElement* first_elem, const LayerIndex layer_idx);
+    bool setToModelContact(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, TreeSupportElement::Ptr first_elem, const LayerIndex layer_idx);
 
     /*!
      * \brief Set the result_on_layer point for all influence areas
      *
      * \param move_bounds[in,out] All currently existing influence areas
      */
-    void createNodesFromArea(std::vector<std::set<TreeSupportElement*>>& move_bounds);
+    void createNodesFromArea(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds);
 
     /*!
      * \brief Draws circles around result_on_layer points of the influence areas
@@ -269,22 +269,22 @@ private:
      * corresponding branch area in layer_tree_polygons. \param inverse_tree_order[in] A mapping that returns the child of every influence area.
      */
     void generateBranchAreas(
-        std::vector<std::pair<LayerIndex, TreeSupportElement*>>& linear_data,
-        std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons,
-        const std::map<TreeSupportElement*, TreeSupportElement*>& inverse_tree_order);
+        std::vector<std::pair<LayerIndex, TreeSupportElement::Ptr>>& linear_data,
+        std::vector<std::unordered_map<TreeSupportElement::Ptr, Shape>>& layer_tree_polygons,
+        const std::map<TreeSupportElement::Ptr, TreeSupportElement::Ptr>& inverse_tree_order);
 
     /*!
      * \brief Applies some smoothing to the outer wall, intended to smooth out sudden jumps as they can happen when a branch moves though a hole.
      *
      * \param layer_tree_polygons[in,out] Resulting branch areas with the layerindex they appear on.
      */
-    void smoothBranchAreas(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons);
+    void smoothBranchAreas(std::vector<std::unordered_map<TreeSupportElement::Ptr, Shape>>& layer_tree_polygons);
 
     /*!
      * Smoothes the skeleton of the tree structure according to the smoothing factor
      * @param layer_tree_polygons The base tree structure to be smoothed
      */
-    void smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*>>& layer_tree_polygons);
+    void smoothBranchSkeletons(std::vector<std::set<TreeSupportElement::Ptr>>& layer_tree_polygons);
 
     /*!
      * \brief Drop down areas that do rest non-gracefully on the model to ensure the branch actually rests on something.
@@ -295,10 +295,10 @@ private:
      * \param inverse_tree_order[in] A mapping that returns the child of every influence area.
      */
     void dropNonGraciousAreas(
-        std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons,
-        const std::vector<std::pair<LayerIndex, TreeSupportElement*>>& linear_data,
+        std::vector<std::unordered_map<TreeSupportElement::Ptr, Shape>>& layer_tree_polygons,
+        const std::vector<std::pair<LayerIndex, TreeSupportElement::Ptr>>& linear_data,
         std::vector<std::vector<std::pair<LayerIndex, Shape>>>& dropped_down_areas,
-        const std::map<TreeSupportElement*, TreeSupportElement*>& inverse_tree_order);
+        const std::map<TreeSupportElement::Ptr, TreeSupportElement::Ptr>& inverse_tree_order);
 
 
     void filterFloatingLines(std::vector<Shape>& support_layer_storage);
@@ -325,13 +325,13 @@ private:
      * \param storage[in,out] The storage where the support should be stored.
      * \param time_keeper The object used to record the duration of the sub-steps
      */
-    void drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage, TimeKeeper& time_keeper);
+    void drawAreas(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, SliceDataStorage& storage, TimeKeeper& time_keeper);
 
     /*!
      * Saves the influence areas and the resulting positions of all the given elements to a 3D object
      * @para move_bounds The elements to be saved, sorted per layer
      */
-    void saveToObj(const std::vector<std::set<TreeSupportElement*>>& move_bounds, OBJ& obj) const;
+    void saveToObj(const std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, OBJ& obj) const;
 
     /*!
      * \brief Settings with the indexes of meshes that use these settings.

--- a/include/TreeSupportElement.h
+++ b/include/TreeSupportElement.h
@@ -43,9 +43,11 @@ struct AreaIncreaseSettings
     bool operator==(const AreaIncreaseSettings& other) const = default;
 };
 
-class TreeSupportElement
+class TreeSupportElement : public std::enable_shared_from_this<TreeSupportElement>
 {
 public:
+    using Ptr = std::shared_ptr<TreeSupportElement>;
+
     TreeSupportElement(
         coord_t distance_to_top,
         size_t target_height,
@@ -61,61 +63,17 @@ public:
         bool influence_area_limit_active,
         coord_t influence_area_limit_range);
 
-    TreeSupportElement(const TreeSupportElement& elem, Shape* newArea = nullptr);
-
-    /*!
-     * \brief Create a new Element for one layer below the element of the pointer supplied.
-     */
-    TreeSupportElement(TreeSupportElement* element_above);
-
-    // ONLY to be called in merge as it assumes a few assurances made by it.
-    TreeSupportElement(
-        const TreeSupportElement& first,
-        const TreeSupportElement& second,
-        size_t next_height,
-        Point2LL next_position,
-        coord_t increased_to_model_radius,
-        const std::function<coord_t(size_t, double)>& getRadius,
-        double diameter_scale_bp_radius,
-        coord_t branch_radius,
-        double diameter_angle_scale_factor);
-
-
-    bool operator==(const TreeSupportElement& other) const
-    {
-        return target_position_ == other.target_position_ && target_height_ == other.target_height_;
-    }
-
-    bool operator<(const TreeSupportElement& other) const // true if me < other
-    {
-        return ! (*this == other) && ! (*this > other);
-    }
-
-    bool operator>(const TreeSupportElement& other) const
-    {
-        // Doesn't really have to make sense, only required for ordering in maps to ensure deterministic behavior.
-        if (*this == other)
-        {
-            return false;
-        }
-        if (other.target_height_ != target_height_)
-        {
-            return other.target_height_ < target_height_;
-        }
-        return other.target_position_.X == target_position_.X ? other.target_position_.Y < target_position_.Y : other.target_position_.X < target_position_.X;
-    }
-
     /*! \brief Gets the list of parent elements, which are those above the current element */
-    const std::vector<TreeSupportElement*>& getParents() const
+    const std::vector<TreeSupportElement::Ptr>& getParents() const
     {
         return parents_;
     }
 
     /*! \brief Adds the given elements to be parents of the current element. Parents will also be properly modified to have the element as a child. */
-    void addParents(const std::vector<TreeSupportElement*>& new_parents);
+    void addParents(const std::vector<TreeSupportElement::Ptr>& new_parents);
 
     /*! \brief Gets the child element, which is the one beloe the current element. It could also be null if the element lies on the buildplate or on the model */
-    TreeSupportElement* getChild() const
+    TreeSupportElement::Ptr getChild() const
     {
         return child_;
     }
@@ -136,6 +94,21 @@ public:
      * @param layer_height The layer height at which to extrude the influence area
      */
     void saveToObj(OBJ& obj, const coord_t z, const coord_t layer_height) const;
+
+    static TreeSupportElement::Ptr makeFromElementAbove(const TreeSupportElement::Ptr& element_above);
+
+    static TreeSupportElement::Ptr makeCopy(const TreeSupportElement::Ptr& elem, Shape* newArea = nullptr);
+
+    static TreeSupportElement::Ptr makeMerged(
+        const TreeSupportElement::Ptr& first,
+        const TreeSupportElement::Ptr& second,
+        size_t next_height,
+        Point2LL next_position,
+        coord_t increased_to_model_radius,
+        const std::function<coord_t(size_t, double)>& getRadius,
+        double diameter_scale_bp_radius,
+        coord_t branch_radius,
+        double diameter_angle_scale_factor);
 
     /*!
      * \brief The layer this support elements wants reach
@@ -262,29 +235,35 @@ public:
 
 private:
     /*!
+     * \brief Create a new Element for one layer below the element of the pointer supplied.
+     */
+    explicit TreeSupportElement(const TreeSupportElement::Ptr& element_above);
+
+    TreeSupportElement(const TreeSupportElement::Ptr& elem, Shape* newArea);
+
+    // ONLY to be called in merge as it assumes a few assurances made by it.
+    TreeSupportElement(
+        const TreeSupportElement::Ptr& first,
+        const TreeSupportElement::Ptr& second,
+        size_t next_height,
+        Point2LL next_position,
+        coord_t increased_to_model_radius,
+        const std::function<coord_t(size_t, double)>& getRadius,
+        double diameter_scale_bp_radius,
+        coord_t branch_radius,
+        double diameter_angle_scale_factor);
+
+    /*!
      * \brief All elements in the layer above the current one that are supported by this element
      */
-    std::vector<TreeSupportElement*> parents_;
+    std::vector<TreeSupportElement::Ptr> parents_;
 
     /*!
      * \brief The element in the layer below that is supporting this element
      */
-    TreeSupportElement* child_{ nullptr };
+    TreeSupportElement::Ptr child_{ nullptr };
 };
 
 } // namespace cura
 
-namespace std
-{
-template<>
-struct hash<cura::TreeSupportElement>
-{
-    size_t operator()(const cura::TreeSupportElement& node) const
-    {
-        size_t hash_node = hash<cura::Point2LL>()(node.target_position_);
-        boost::hash_combine(hash_node, size_t(node.target_height_));
-        return hash_node;
-    }
-};
-} // namespace std
 #endif /* TREESUPPORTELEMENT_H */

--- a/include/TreeSupportSettings.h
+++ b/include/TreeSupportSettings.h
@@ -465,10 +465,11 @@ public:
      * \brief Get the Distance to top regarding the real radius this part will have. This is different from distance_to_top, which is can be used to calculate the top most layer of
      * the branch. \param elem[in] The SupportElement one wants to know the effectiveDTT \return The Effective DTT.
      */
-    [[nodiscard]] inline size_t getEffectiveDTT(const TreeSupportElement& elem) const
+    [[nodiscard]] inline size_t getEffectiveDTT(const TreeSupportElement::Ptr& elem) const
     {
-        return elem.effective_radius_height_ < increase_radius_until_dtt ? (elem.distance_to_top_ < increase_radius_until_dtt ? elem.distance_to_top_ : increase_radius_until_dtt)
-                                                                         : elem.effective_radius_height_;
+        return elem->effective_radius_height_ < increase_radius_until_dtt
+                 ? (elem->distance_to_top_ < increase_radius_until_dtt ? elem->distance_to_top_ : increase_radius_until_dtt)
+                 : elem->effective_radius_height_;
     }
 
     /*!
@@ -493,9 +494,9 @@ public:
      * \param elem[in] The Element.
      * \return The radius the element has.
      */
-    [[nodiscard]] inline coord_t getRadius(const TreeSupportElement& elem) const
+    [[nodiscard]] inline coord_t getRadius(const TreeSupportElement::Ptr& elem) const
     {
-        return getRadius(getEffectiveDTT(elem), (elem.isResultOnLayerSet() || ! support_rests_on_model) && elem.to_buildplate_ ? elem.buildplate_radius_increases_ : 0);
+        return getRadius(getEffectiveDTT(elem), (elem->isResultOnLayerSet() || ! support_rests_on_model) && elem->to_buildplate_ ? elem->buildplate_radius_increases_ : 0);
     }
 
     /*!
@@ -503,9 +504,9 @@ public:
      * \param elem[in] The Element.
      * \return The collision radius the element has.
      */
-    [[nodiscard]] inline coord_t getCollisionRadius(const TreeSupportElement& elem) const
+    [[nodiscard]] inline coord_t getCollisionRadius(const TreeSupportElement::Ptr& elem) const
     {
-        return getRadius(elem.effective_radius_height_, elem.buildplate_radius_increases_);
+        return getRadius(elem->effective_radius_height_, elem->buildplate_radius_increases_);
     }
 
     /*!

--- a/include/TreeSupportTipGenerator.h
+++ b/include/TreeSupportTipGenerator.h
@@ -40,7 +40,7 @@ public:
     void generateTips(
         SliceDataStorage& storage,
         const SliceMeshStorage& mesh,
-        std::vector<std::set<TreeSupportElement*>>& move_bounds,
+        std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds,
         std::vector<Shape>& additional_support_areas,
         std::vector<std::vector<FakeRoofArea>>& placed_fake_roof_areas);
 
@@ -141,7 +141,7 @@ private:
      * \param skip_ovalisation[in] Whether the tip may be ovalized when drawn later.
      */
     void addPointAsInfluenceArea(
-        std::vector<std::set<TreeSupportElement*>>& move_bounds,
+        std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds,
         std::pair<Point2LL, LineStatus> p,
         size_t dtt,
         LayerIndex insert_layer,
@@ -161,7 +161,7 @@ private:
      * \param dont_move_until[in] Until which dtt the branch should not move if possible.
      */
     void addLinesAsInfluenceAreas(
-        std::vector<std::set<TreeSupportElement*>>& move_bounds,
+        std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds,
         std::vector<TreeSupportTipGenerator::LineInformation> lines,
         size_t roof_tip_layers,
         LayerIndex insert_layer_idx,
@@ -175,7 +175,7 @@ private:
      * \param storage[in] Background storage, required for adding roofs.
      * \param additional_support_areas[in] Areas that should have been roofs, but are now support, as they would not generate any lines as roof.
      */
-    void removeUselessAddedPoints(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage, std::vector<Shape>& additional_support_areas);
+    void removeUselessAddedPoints(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, SliceDataStorage& storage, std::vector<Shape>& additional_support_areas);
 
     /*!
      * \brief Contains config settings to avoid loading them in every function. This was done to improve readability of the code.

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -2254,16 +2254,15 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(
-                        TreeSupportUtils::generateSupportInfillLines(
-                            support_layer_storage[layer_idx],
-                            config,
-                            false,
-                            layer_idx,
-                            config.support_line_distance,
-                            storage.support.cross_fill_provider,
-                            true)
-                            .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
+                                                              support_layer_storage[layer_idx],
+                                                              config,
+                                                              false,
+                                                              layer_idx,
+                                                              config.support_line_distance,
+                                                              storage.support.cross_fill_provider,
+                                                              true)
+                                                              .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }

--- a/src/TreeSupport.cpp
+++ b/src/TreeSupport.cpp
@@ -121,7 +121,7 @@ void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
     for (auto [counter, processing] : grouped_meshes | ranges::views::enumerate)
     {
         // process each combination of meshes
-        std::vector<std::set<TreeSupportElement*>> move_bounds(
+        std::vector<std::set<TreeSupportElement::Ptr>> move_bounds(
             storage.support.supportLayers
                 .size()); // Value is the area where support may be placed. As this is calculated in CreateLayerPathing it is saved and reused in drawAreas.
 
@@ -198,7 +198,6 @@ void TreeSupport::generateSupportAreas(SliceDataStorage& storage)
             for (auto elem : layer)
             {
                 delete elem->area_;
-                delete elem;
             }
         }
     }
@@ -246,22 +245,22 @@ LayerIndex TreeSupport::precalculate(const SliceDataStorage& storage, std::vecto
 }
 
 
-void TreeSupport::generateInitialAreas(const SliceMeshStorage& mesh, std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage)
+void TreeSupport::generateInitialAreas(const SliceMeshStorage& mesh, std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, SliceDataStorage& storage)
 {
     TreeSupportTipGenerator tip_gen(mesh, volumes_);
     tip_gen.generateTips(storage, mesh, move_bounds, additional_required_support_area, fake_roof_areas);
 }
 
 void TreeSupport::mergeHelper(
-    std::map<TreeSupportElement, AABB>& reduced_aabb,
-    std::map<TreeSupportElement, AABB>& input_aabb,
+    std::map<TreeSupportElement::Ptr, AABB>& reduced_aabb,
+    std::map<TreeSupportElement::Ptr, AABB>& input_aabb,
     const PropertyAreasUnordered& to_bp_areas,
     const PropertyAreas& to_model_areas,
     const PropertyAreas& influence_areas,
     PropertyAreasUnordered& insert_bp_areas,
     PropertyAreasUnordered& insert_model_areas,
     PropertyAreasUnordered& insert_influence,
-    std::vector<TreeSupportElement>& erase,
+    std::vector<TreeSupportElement::Ptr>& erase,
     const LayerIndex layer_idx)
 {
     const bool first_merge_iteration = reduced_aabb.empty(); // If this is the first iteration, all elements in input have to be merged with each other
@@ -285,15 +284,15 @@ void TreeSupport::mergeHelper(
                     break; // Do not try to merge elements that already should have been merged. Done for potential performance improvement.
                 }
 
-                const bool merging_gracious_and_non_gracious = reduced_check.first.to_model_gracious_ != influence.first.to_model_gracious_;
+                const bool merging_gracious_and_non_gracious = reduced_check.first->to_model_gracious_ != influence.first->to_model_gracious_;
                 // ^^^ We do not want to merge a gracious with a non gracious area as bad placement could negatively impact the dependability of the whole subtree.
-                const bool merging_to_bp = reduced_check.first.to_buildplate_ && influence.first.to_buildplate_;
-                const bool merging_min_and_regular_xy = reduced_check.first.use_min_xy_dist_ != influence.first.use_min_xy_dist_;
+                const bool merging_to_bp = reduced_check.first->to_buildplate_ && influence.first->to_buildplate_;
+                const bool merging_min_and_regular_xy = reduced_check.first->use_min_xy_dist_ != influence.first->use_min_xy_dist_;
                 // ^^^ Could cause some issues with the increase of one area, as it is assumed that if the smaller is increased by the delta to the larger it is engulfed by it
                 // already.
                 //     But because a different collision may be removed from the in drawArea generated circles, this assumption could be wrong.
-                const bool merging_different_range_limits = reduced_check.first.influence_area_limit_active_ && influence.first.influence_area_limit_active_
-                                                         && influence.first.influence_area_limit_range_ != reduced_check.first.influence_area_limit_range_;
+                const bool merging_different_range_limits = reduced_check.first->influence_area_limit_active_ && influence.first->influence_area_limit_active_
+                                                         && influence.first->influence_area_limit_range_ != reduced_check.first->influence_area_limit_range_;
                 coord_t increased_to_model_radius = 0;
                 size_t larger_to_model_dtt = 0;
 
@@ -301,30 +300,30 @@ void TreeSupport::mergeHelper(
                 {
                     const coord_t infl_radius = config.getRadius(influence.first); // Get the real radius increase as the user does not care for the collision model.
                     const coord_t redu_radius = config.getRadius(reduced_check.first);
-                    if (reduced_check.first.to_buildplate_ != influence.first.to_buildplate_)
+                    if (reduced_check.first->to_buildplate_ != influence.first->to_buildplate_)
                     {
-                        if (reduced_check.first.to_buildplate_)
+                        if (reduced_check.first->to_buildplate_)
                         {
                             if (infl_radius < redu_radius)
                             {
-                                increased_to_model_radius = influence.first.increased_to_model_radius_ + redu_radius - infl_radius;
+                                increased_to_model_radius = influence.first->increased_to_model_radius_ + redu_radius - infl_radius;
                             }
                         }
                         else
                         {
                             if (infl_radius > redu_radius)
                             {
-                                increased_to_model_radius = reduced_check.first.increased_to_model_radius_ + infl_radius - redu_radius;
+                                increased_to_model_radius = reduced_check.first->increased_to_model_radius_ + infl_radius - redu_radius;
                             }
                         }
                     }
-                    larger_to_model_dtt = std::max(influence.first.distance_to_top_, reduced_check.first.distance_to_top_);
+                    larger_to_model_dtt = std::max(influence.first->distance_to_top_, reduced_check.first->distance_to_top_);
                 }
 
                 // If a merge could place a stable branch on unstable ground, would be increasing the radius further than allowed to when merging to model and to_bp trees or
                 //   would merge to model before it is known they will even been drawn the merge is skipped
                 if (merging_min_and_regular_xy || merging_gracious_and_non_gracious || increased_to_model_radius > config.max_to_model_radius_increase
-                    || (! merging_to_bp && larger_to_model_dtt < config.min_dtt_to_model && ! reduced_check.first.supports_roof_ && ! influence.first.supports_roof_)
+                    || (! merging_to_bp && larger_to_model_dtt < config.min_dtt_to_model && ! reduced_check.first->supports_roof_ && ! influence.first->supports_roof_)
                     || merging_different_range_limits)
                 {
                     continue;
@@ -347,15 +346,15 @@ void TreeSupport::mergeHelper(
                 }
 
                 const bool red_bigger = config.getCollisionRadius(reduced_check.first) > config.getCollisionRadius(influence.first);
-                std::pair<TreeSupportElement, Shape> smaller_rad
-                    = red_bigger ? std::pair<TreeSupportElement, Shape>(influence.first, relevant_infl) : std::pair<TreeSupportElement, Shape>(reduced_check.first, relevant_redu);
-                std::pair<TreeSupportElement, Shape> bigger_rad
-                    = red_bigger ? std::pair<TreeSupportElement, Shape>(reduced_check.first, relevant_redu) : std::pair<TreeSupportElement, Shape>(influence.first, relevant_infl);
+                std::pair<TreeSupportElement::Ptr, Shape> smaller_rad
+                    = red_bigger ? std::make_pair(influence.first, relevant_infl) : std::make_pair(reduced_check.first, relevant_redu);
+                std::pair<TreeSupportElement::Ptr, Shape> bigger_rad
+                    = red_bigger ? std::make_pair(reduced_check.first, relevant_redu) : std::make_pair(influence.first, relevant_infl);
                 const coord_t real_radius_delta = std::abs(config.getRadius(bigger_rad.first) - config.getRadius(smaller_rad.first));
                 const coord_t smaller_collision_radius = config.getCollisionRadius(smaller_rad.first);
 
                 // the area of the bigger radius is used to ensure correct placement regarding the relevant avoidance, so if that would change an invalid area may be created
-                if (! bigger_rad.first.can_use_safe_radius_ && smaller_rad.first.can_use_safe_radius_)
+                if (! bigger_rad.first->can_use_safe_radius_ && smaller_rad.first->can_use_safe_radius_)
                 {
                     continue;
                 }
@@ -363,7 +362,7 @@ void TreeSupport::mergeHelper(
                 // The bigger radius is used to verify that the area is still valid after the increase with the delta.
                 // If there were a point where the big influence area could be valid with can_use_safe_radius the element would already be can_use_safe_radius.
                 // The smaller radius, which gets increased by delta may reach into the area where use_min_xy_dist is no longer required.
-                bool use_min_radius = bigger_rad.first.use_min_xy_dist_ && smaller_rad.first.use_min_xy_dist_;
+                bool use_min_radius = bigger_rad.first->use_min_xy_dist_ && smaller_rad.first->use_min_xy_dist_;
 
                 // The idea is that the influence area with the smaller collision radius is increased by the radius difference.
                 // If this area has any intersections with the influence area of the larger collision radius,
@@ -396,7 +395,7 @@ void TreeSupport::mergeHelper(
                     // Calculate which point is closest to the point of the last merge (or tip center if no merge above it has happened)
                     // Used at the end to estimate where to best place the branch on the bottom most layer
                     // Could be replaced with a random point inside the new area
-                    Point2LL new_pos = reduced_check.first.next_position_;
+                    Point2LL new_pos = reduced_check.first->next_position_;
                     if (! intersect.inside(new_pos, true))
                     {
                         PolygonUtils::moveInside(intersect, new_pos);
@@ -404,10 +403,10 @@ void TreeSupport::mergeHelper(
 
                     if (increased_to_model_radius == 0)
                     {
-                        increased_to_model_radius = std::max(reduced_check.first.increased_to_model_radius_, influence.first.increased_to_model_radius_);
+                        increased_to_model_radius = std::max(reduced_check.first->increased_to_model_radius_, influence.first->increased_to_model_radius_);
                     }
 
-                    const TreeSupportElement key(
+                    auto key = TreeSupportElement::makeMerged(
                         reduced_check.first,
                         influence.first,
                         layer_idx - 1,
@@ -517,7 +516,7 @@ void TreeSupport::mergeInfluenceAreas(PropertyAreasUnordered& to_bp_areas, Prope
     // Each thread will then process two buckets by merging all elements in the second bucket into the first one as mergeHelper will disable not trying to merge elements from the
     // same bucket in this case.
     std::vector<PropertyAreas> buckets_area(2 * bucket_count);
-    std::vector<std::map<TreeSupportElement, AABB>> buckets_aabb(2 * bucket_count);
+    std::vector<std::map<TreeSupportElement::Ptr, AABB>> buckets_aabb(2 * bucket_count);
 
 
     size_t position = 0, counter = 0;
@@ -545,7 +544,7 @@ void TreeSupport::mergeInfluenceAreas(PropertyAreasUnordered& to_bp_areas, Prope
         [&](size_t idx) // +=2 as in the beginning only uneven buckets will be filled
         {
             idx = idx * 2 + 1; // this is eqivalent to a parallel for(size_t idx=1;idx<buckets_area.size(),idx+=2)
-            for (const std::pair<TreeSupportElement, Shape>& input_pair : buckets_area[idx])
+            for (const std::pair<TreeSupportElement::Ptr, Shape>& input_pair : buckets_area[idx])
             {
                 AABB outer_support_wall_aabb = AABB(input_pair.second);
                 outer_support_wall_aabb.expand(config.getRadius(input_pair.first));
@@ -559,7 +558,7 @@ void TreeSupport::mergeInfluenceAreas(PropertyAreasUnordered& to_bp_areas, Prope
         std::vector<PropertyAreasUnordered> insert_main(buckets_area.size() / 2);
         std::vector<PropertyAreasUnordered> insert_secondary(buckets_area.size() / 2);
         std::vector<PropertyAreasUnordered> insert_influence(buckets_area.size() / 2);
-        std::vector<std::vector<TreeSupportElement>> erase(buckets_area.size() / 2);
+        std::vector<std::vector<TreeSupportElement::Ptr>> erase(buckets_area.size() / 2);
 
         cura::parallel_for<size_t>(
             0,
@@ -586,23 +585,23 @@ void TreeSupport::mergeInfluenceAreas(PropertyAreasUnordered& to_bp_areas, Prope
         // Note the division in the limit of the loop!
         for (const coord_t i : ranges::views::iota(0UL, buckets_area.size() / 2))
         {
-            for (TreeSupportElement& del : erase[i])
+            for (TreeSupportElement::Ptr& del : erase[i])
             {
                 to_bp_areas.erase(del);
                 to_model_areas.erase(del);
                 influence_areas.erase(del);
             }
 
-            for (const std::pair<TreeSupportElement, Shape>& tup : insert_main[i])
+            for (const std::pair<TreeSupportElement::Ptr, Shape>& tup : insert_main[i])
             {
                 to_bp_areas.emplace(tup);
             }
 
-            for (const std::pair<TreeSupportElement, Shape>& tup : insert_secondary[i])
+            for (const std::pair<TreeSupportElement::Ptr, Shape>& tup : insert_secondary[i])
             {
                 to_model_areas.emplace(tup);
             }
-            for (const std::pair<TreeSupportElement, Shape>& tup : insert_influence[i])
+            for (const std::pair<TreeSupportElement::Ptr, Shape>& tup : insert_influence[i])
             {
                 influence_areas.emplace(tup);
             }
@@ -611,7 +610,7 @@ void TreeSupport::mergeInfluenceAreas(PropertyAreasUnordered& to_bp_areas, Prope
         const auto position_rem = std::remove_if(
             buckets_area.begin(),
             buckets_area.end(),
-            [&](const PropertyAreas x) mutable
+            [&](const PropertyAreas& x) mutable
             {
                 return x.empty();
             });
@@ -620,7 +619,7 @@ void TreeSupport::mergeInfluenceAreas(PropertyAreasUnordered& to_bp_areas, Prope
         const auto position_aabb = std::remove_if(
             buckets_aabb.begin(),
             buckets_aabb.end(),
-            [&](const std::map<TreeSupportElement, AABB> x) mutable
+            [&](const std::map<TreeSupportElement::Ptr, AABB>& x) mutable
             {
                 return x.empty();
             });
@@ -628,10 +627,10 @@ void TreeSupport::mergeInfluenceAreas(PropertyAreasUnordered& to_bp_areas, Prope
     }
 }
 
-std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
+TreeSupportElement::Ptr TreeSupport::increaseSingleArea(
     AreaIncreaseSettings settings,
     LayerIndex layer_idx,
-    TreeSupportElement* parent,
+    TreeSupportElement::Ptr parent,
     const Shape& relevant_offset,
     Shape& to_bp_data,
     Shape& to_model_data,
@@ -639,11 +638,11 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
     const coord_t overspeed,
     const bool mergelayer)
 {
-    TreeSupportElement current_elem(parent); // Also increases DTT by one.
+    auto current_elem = TreeSupportElement::makeFromElementAbove(parent); // Also increases DTT by one.
     Shape check_layer_data;
     if (settings.increase_radius_)
     {
-        current_elem.effective_radius_height_ += 1;
+        current_elem->effective_radius_height_ += 1;
     }
     coord_t radius = config.getCollisionRadius(current_elem);
 
@@ -652,14 +651,14 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
         increased = relevant_offset;
         if (overspeed > 0)
         {
-            const coord_t safe_movement_distance = (current_elem.use_min_xy_dist_ ? config.xy_min_distance : config.xy_distance)
+            const coord_t safe_movement_distance = (current_elem->use_min_xy_dist_ ? config.xy_min_distance : config.xy_distance)
                                                  + (std::min(config.z_distance_top_layers, config.z_distance_bottom_layers) > 0 ? config.min_feature_size : 0);
             // The difference to ensure that the result not only conforms to wall_restriction, but collision/avoidance is done later.
             // The higher last_safe_step_movement_distance comes exactly from the fact that the collision will be subtracted later.
             increased = TreeSupportUtils::safeOffsetInc(
                 increased,
                 overspeed,
-                volumes_.getWallRestriction(config.getCollisionRadius(*parent), layer_idx, parent->use_min_xy_dist_),
+                volumes_.getWallRestriction(config.getCollisionRadius(parent), layer_idx, parent->use_min_xy_dist_),
                 safe_movement_distance,
                 safe_movement_distance + radius,
                 1,
@@ -676,28 +675,28 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
         increased = *parent->area_;
     }
 
-    if ((mergelayer || current_elem.to_buildplate_) && config.support_rest_preference == RestPreference::BUILDPLATE)
+    if ((mergelayer || current_elem->to_buildplate_) && config.support_rest_preference == RestPreference::BUILDPLATE)
     {
         to_bp_data = TreeSupportUtils::safeUnion(increased.difference(volumes_.getAvoidance(radius, layer_idx - 1, settings.type_, false, settings.use_min_distance_)));
-        if (! current_elem.to_buildplate_ && to_bp_data.area() > 1) // mostly happening in the tip, but with merges one should check every time, just to be sure.
+        if (! current_elem->to_buildplate_ && to_bp_data.area() > 1) // mostly happening in the tip, but with merges one should check every time, just to be sure.
         {
-            current_elem.to_buildplate_ = true; // sometimes nodes that can reach the buildplate are marked as cant reach, tainting subtrees. This corrects it.
-            spdlog::debug("Corrected taint leading to a wrong to model value on layer {} targeting {} with radius {}", layer_idx - 1, current_elem.target_height_, radius);
+            current_elem->to_buildplate_ = true; // sometimes nodes that can reach the buildplate are marked as cant reach, tainting subtrees. This corrects it.
+            spdlog::debug("Corrected taint leading to a wrong to model value on layer {} targeting {} with radius {}", layer_idx - 1, current_elem->target_height_, radius);
         }
     }
     if (config.support_rests_on_model)
     {
-        if (mergelayer || current_elem.to_model_gracious_)
+        if (mergelayer || current_elem->to_model_gracious_)
         {
             to_model_data = TreeSupportUtils::safeUnion(increased.difference(volumes_.getAvoidance(radius, layer_idx - 1, settings.type_, true, settings.use_min_distance_)));
         }
 
-        if (! current_elem.to_model_gracious_)
+        if (! current_elem->to_model_gracious_)
         {
             if (mergelayer && to_model_data.area() >= 1)
             {
-                current_elem.to_model_gracious_ = true;
-                spdlog::debug("Corrected taint leading to a wrong non gracious value on layer {} targeting {} with radius {}", layer_idx - 1, current_elem.target_height_, radius);
+                current_elem->to_model_gracious_ = true;
+                spdlog::debug("Corrected taint leading to a wrong non gracious value on layer {} targeting {} with radius {}", layer_idx - 1, current_elem->target_height_, radius);
             }
             else
             {
@@ -707,7 +706,7 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
         }
     }
 
-    check_layer_data = current_elem.to_buildplate_ ? to_bp_data : to_model_data;
+    check_layer_data = current_elem->to_buildplate_ ? to_bp_data : to_model_data;
 
     if (settings.increase_radius_ && check_layer_data.area() > 1)
     {
@@ -719,24 +718,24 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
             }
 
             Shape to_bp_data_2;
-            if (current_elem.to_buildplate_)
+            if (current_elem->to_buildplate_)
             {
                 // Regular union as output will not be used later => this area should always be a subset of the safeUnion one.
                 to_bp_data_2 = increased.difference(volumes_.getAvoidance(next_radius, layer_idx - 1, settings.type_, false, settings.use_min_distance_)).unionPolygons();
             }
             Shape to_model_data_2;
-            if (config.support_rests_on_model && ! current_elem.to_buildplate_)
+            if (config.support_rests_on_model && ! current_elem->to_buildplate_)
             {
                 to_model_data_2 = increased
                                       .difference(volumes_.getAvoidance(
                                           next_radius,
                                           layer_idx - 1,
-                                          current_elem.to_model_gracious_ ? settings.type_ : AvoidanceType::COLLISION,
+                                          current_elem->to_model_gracious_ ? settings.type_ : AvoidanceType::COLLISION,
                                           true,
                                           settings.use_min_distance_))
                                       .unionPolygons();
             }
-            Shape check_layer_data_2 = current_elem.to_buildplate_ ? to_bp_data_2 : to_model_data_2;
+            Shape check_layer_data_2 = current_elem->to_buildplate_ ? to_bp_data_2 : to_model_data_2;
 
             return check_layer_data_2.area() > 1;
         };
@@ -752,14 +751,14 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
             {
                 current_ceil_radius = volumes_.getRadiusNextCeil(current_ceil_radius + 1, settings.use_min_distance_);
             }
-            size_t resulting_eff_dtt = current_elem.effective_radius_height_;
-            while (resulting_eff_dtt + 1 < current_elem.distance_to_top_
-                   && config.getRadius(resulting_eff_dtt + 1, current_elem.buildplate_radius_increases_) <= current_ceil_radius
-                   && config.getRadius(resulting_eff_dtt + 1, current_elem.buildplate_radius_increases_) <= config.getRadius(current_elem))
+            size_t resulting_eff_dtt = current_elem->effective_radius_height_;
+            while (resulting_eff_dtt + 1 < current_elem->distance_to_top_
+                   && config.getRadius(resulting_eff_dtt + 1, current_elem->buildplate_radius_increases_) <= current_ceil_radius
+                   && config.getRadius(resulting_eff_dtt + 1, current_elem->buildplate_radius_increases_) <= config.getRadius(current_elem))
             {
                 resulting_eff_dtt++;
             }
-            current_elem.effective_radius_height_ = resulting_eff_dtt;
+            current_elem->effective_radius_height_ = resulting_eff_dtt;
 
             // If catchup is not possible, it is likely that there is a hole below. Assuming the branches are in some kind of bowl, the branches should still stay away from the
             // wall of the bowl if possible.
@@ -768,17 +767,17 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
                 Shape new_to_bp_data;
                 Shape new_to_model_data;
 
-                if (current_elem.to_buildplate_)
+                if (current_elem->to_buildplate_)
                 {
-                    new_to_bp_data = to_bp_data.difference(volumes_.getCollision(config.getRadius(current_elem), layer_idx - 1, current_elem.use_min_xy_dist_));
+                    new_to_bp_data = to_bp_data.difference(volumes_.getCollision(config.getRadius(current_elem), layer_idx - 1, current_elem->use_min_xy_dist_));
                     if (new_to_bp_data.area() > EPSILON)
                     {
                         to_bp_data = new_to_bp_data;
                     }
                 }
-                if (config.support_rests_on_model && (! current_elem.to_buildplate_ || mergelayer))
+                if (config.support_rests_on_model && (! current_elem->to_buildplate_ || mergelayer))
                 {
-                    new_to_model_data = to_model_data.difference(volumes_.getCollision(config.getRadius(current_elem), layer_idx - 1, current_elem.use_min_xy_dist_));
+                    new_to_model_data = to_model_data.difference(volumes_.getCollision(config.getRadius(current_elem), layer_idx - 1, current_elem->use_min_xy_dist_));
                     if (new_to_model_data.area() > EPSILON)
                     {
                         to_model_data = new_to_model_data;
@@ -802,30 +801,30 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
         // would only be relevant when support_rest_preference is GRACEFUL) Also unioning areas when an avoidance is requested may also have a relevant performance impact, so there
         // can be an argument made that the current workaround is preferable.
         const bool increase_bp_foot
-            = planned_foot_increase > 0 && (current_elem.to_buildplate_ || (current_elem.to_model_gracious_ && config.support_rest_preference == RestPreference::GRACEFUL));
+            = planned_foot_increase > 0 && (current_elem->to_buildplate_ || (current_elem->to_model_gracious_ && config.support_rest_preference == RestPreference::GRACEFUL));
 
 
         if (increase_bp_foot && config.getRadius(current_elem) >= config.branch_radius && config.getRadius(current_elem) >= config.increase_radius_until_radius)
         {
-            if (validWithRadius(config.getRadius(current_elem.effective_radius_height_, current_elem.buildplate_radius_increases_ + planned_foot_increase)))
+            if (validWithRadius(config.getRadius(current_elem->effective_radius_height_, current_elem->buildplate_radius_increases_ + planned_foot_increase)))
             {
-                current_elem.buildplate_radius_increases_ += planned_foot_increase;
+                current_elem->buildplate_radius_increases_ += planned_foot_increase;
                 radius = config.getCollisionRadius(current_elem);
             }
         }
 
         if (ceil_radius_before != volumes_.ceilRadius(radius, settings.use_min_distance_))
         {
-            if (current_elem.to_buildplate_)
+            if (current_elem->to_buildplate_)
             {
                 to_bp_data = TreeSupportUtils::safeUnion(increased.difference(volumes_.getAvoidance(radius, layer_idx - 1, settings.type_, false, settings.use_min_distance_)));
             }
-            if (config.support_rests_on_model && (! current_elem.to_buildplate_ || mergelayer))
+            if (config.support_rests_on_model && (! current_elem->to_buildplate_ || mergelayer))
             {
                 to_model_data = TreeSupportUtils::safeUnion(increased.difference(
-                    volumes_.getAvoidance(radius, layer_idx - 1, current_elem.to_model_gracious_ ? settings.type_ : AvoidanceType::COLLISION, true, settings.use_min_distance_)));
+                    volumes_.getAvoidance(radius, layer_idx - 1, current_elem->to_model_gracious_ ? settings.type_ : AvoidanceType::COLLISION, true, settings.use_min_distance_)));
             }
-            check_layer_data = current_elem.to_buildplate_ ? to_bp_data : to_model_data;
+            check_layer_data = current_elem->to_buildplate_ ? to_bp_data : to_model_data;
             if (check_layer_data.area() < 1)
             {
                 spdlog::error(
@@ -836,8 +835,8 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
         }
     }
 
-    if (current_elem.influence_area_limit_active_ && ! current_elem.use_min_xy_dist_ && check_layer_data.area() > 1
-        && (current_elem.to_model_gracious_ || current_elem.distance_to_top_ <= config.min_dtt_to_model))
+    if (current_elem->influence_area_limit_active_ && ! current_elem->use_min_xy_dist_ && check_layer_data.area() > 1
+        && (current_elem->to_model_gracious_ || current_elem->distance_to_top_ <= config.min_dtt_to_model))
     {
         const coord_t max_radius_increase = std::max(
             static_cast<coord_t>((config.branch_radius - config.min_radius) / config.tip_layers),
@@ -850,44 +849,44 @@ std::optional<TreeSupportElement> TreeSupport::increaseSingleArea(
         to_model_data = TreeSupportUtils::safeUnion(to_model_data);
         while (! limit_range_validated)
         {
-            if (current_elem.to_buildplate_)
+            if (current_elem->to_buildplate_)
             {
-                Shape limited_to_bp = to_bp_data.intersection((current_elem.influence_area_limit_area_));
+                Shape limited_to_bp = to_bp_data.intersection((current_elem->influence_area_limit_area_));
                 if (limited_to_bp.area() > 1)
                 {
                     to_bp_data = limited_to_bp;
-                    to_model_data = to_model_data.intersection((current_elem.influence_area_limit_area_));
+                    to_model_data = to_model_data.intersection((current_elem->influence_area_limit_area_));
                     limit_range_validated = true;
                 }
             }
             else
             {
-                Shape limited_to_model_data = to_model_data.intersection((current_elem.influence_area_limit_area_));
+                Shape limited_to_model_data = to_model_data.intersection((current_elem->influence_area_limit_area_));
                 if (limited_to_model_data.area() > 1)
                 {
-                    to_bp_data = to_bp_data.intersection((current_elem.influence_area_limit_area_));
+                    to_bp_data = to_bp_data.intersection((current_elem->influence_area_limit_area_));
                     to_model_data = limited_to_model_data;
                     limit_range_validated = true;
                 }
             }
             if (! limit_range_validated)
             {
-                const coord_t reach_increase = std::max(current_elem.influence_area_limit_range_ / 4, (config.maximum_move_distance + max_radius_increase));
-                current_elem.influence_area_limit_range_ += reach_increase;
-                current_elem.RecreateInfluenceLimitArea();
+                const coord_t reach_increase = std::max(current_elem->influence_area_limit_range_ / 4, (config.maximum_move_distance + max_radius_increase));
+                current_elem->influence_area_limit_range_ += reach_increase;
+                current_elem->RecreateInfluenceLimitArea();
             }
         }
     }
 
-    return check_layer_data.area() > 1 ? std::optional<TreeSupportElement>(current_elem) : std::optional<TreeSupportElement>();
+    return check_layer_data.area() > 1 ? current_elem : nullptr;
 }
 
 void TreeSupport::increaseAreas(
     PropertyAreasUnordered& to_bp_areas,
     PropertyAreas& to_model_areas,
     PropertyAreas& influence_areas,
-    std::vector<TreeSupportElement*>& bypass_merge_areas,
-    const std::vector<TreeSupportElement*>& last_layer,
+    std::vector<TreeSupportElement::Ptr>& bypass_merge_areas,
+    const std::vector<TreeSupportElement::Ptr>& last_layer,
     const LayerIndex layer_idx,
     const bool mergelayer)
 {
@@ -897,10 +896,10 @@ void TreeSupport::increaseAreas(
         last_layer.size(),
         [&](const size_t idx)
         {
-            TreeSupportElement* parent = last_layer[idx];
-            TreeSupportElement elem(parent); // Also increases dtt.
+            TreeSupportElement::Ptr parent = last_layer[idx];
+            auto elem = TreeSupportElement::makeFromElementAbove(parent); // Also increases dtt.
             // Abstract representation of the model outline. If an influence area would move through it, it could teleport through a wall.
-            const Shape wall_restriction = volumes_.getWallRestriction(config.getCollisionRadius(*parent), layer_idx, parent->use_min_xy_dist_);
+            const Shape wall_restriction = volumes_.getWallRestriction(config.getCollisionRadius(parent), layer_idx, parent->use_min_xy_dist_);
 
             Shape to_bp_data;
             Shape to_model_data;
@@ -915,9 +914,9 @@ void TreeSupport::increaseAreas(
             coord_t extra_speed = EPSILON; // The extra speed is added to both movement distances. Also move 5 microns faster than allowed to avoid rounding errors, this may cause
                                            // issues at VERY VERY small layer heights.
             coord_t extra_slow_speed = 0; // Only added to the slow movement distance.
-            const coord_t ceiled_parent_radius = volumes_.ceilRadius(config.getCollisionRadius(*parent), parent->use_min_xy_dist_);
+            const coord_t ceiled_parent_radius = volumes_.ceilRadius(config.getCollisionRadius(parent), parent->use_min_xy_dist_);
             const coord_t projected_radius_increased = config.getRadius(parent->effective_radius_height_ + 1, parent->buildplate_radius_increases_);
-            const coord_t projected_radius_delta = projected_radius_increased - config.getCollisionRadius(*parent);
+            const coord_t projected_radius_delta = projected_radius_increased - config.getCollisionRadius(parent);
 
             // When z distance is more than one layer up and down the Collision used to calculate the wall restriction will always include the wall (and not just the
             // xy_min_distance) of the layer above and below like this (d = blocked area because of z distance):
@@ -927,7 +926,7 @@ void TreeSupport::increaseAreas(
              *  layer z-1:dddddxxxxxxxxxx
              *  For more detailed visualisation see calculateWallRestrictions
              */
-            const coord_t safe_movement_distance = (elem.use_min_xy_dist_ ? config.xy_min_distance : config.xy_distance)
+            const coord_t safe_movement_distance = (elem->use_min_xy_dist_ ? config.xy_min_distance : config.xy_distance)
                                                  + (std::min(config.z_distance_top_layers, config.z_distance_bottom_layers) > 0 ? config.min_feature_size : 0);
             if (ceiled_parent_radius == volumes_.ceilRadius(projected_radius_increased, parent->use_min_xy_dist_)
                 || projected_radius_increased < config.increase_radius_until_radius)
@@ -944,7 +943,7 @@ void TreeSupport::increaseAreas(
             }
 
             if (config.layer_start_bp_radius > layer_idx
-                && config.recommendedMinRadius(layer_idx - 1) < config.getRadius(elem.effective_radius_height_ + 1, elem.buildplate_radius_increases_))
+                && config.recommendedMinRadius(layer_idx - 1) < config.getRadius(elem->effective_radius_height_ + 1, elem->buildplate_radius_increases_))
             {
                 // Can guarantee elephant foot radius increase.
                 if (ceiled_parent_radius
@@ -992,41 +991,41 @@ void TreeSupport::increaseAreas(
                 }
             };
 
-            const bool parent_moved_slow = elem.last_area_increase_.increase_speed_ < config.maximum_move_distance;
-            const bool avoidance_speed_mismatch = parent_moved_slow && elem.last_area_increase_.type_ != AvoidanceType::SLOW;
-            if (elem.last_area_increase_.move_ && elem.last_area_increase_.no_error_ && elem.can_use_safe_radius_ && ! mergelayer && ! avoidance_speed_mismatch
-                && (elem.distance_to_top_ >= config.tip_layers || parent_moved_slow))
+            const bool parent_moved_slow = elem->last_area_increase_.increase_speed_ < config.maximum_move_distance;
+            const bool avoidance_speed_mismatch = parent_moved_slow && elem->last_area_increase_.type_ != AvoidanceType::SLOW;
+            if (elem->last_area_increase_.move_ && elem->last_area_increase_.no_error_ && elem->can_use_safe_radius_ && ! mergelayer && ! avoidance_speed_mismatch
+                && (elem->distance_to_top_ >= config.tip_layers || parent_moved_slow))
             {
                 // Assume that the avoidance type that was best for the parent is best for me. Makes this function about 7% faster.
-                const auto slow_or_fast = elem.last_area_increase_.increase_speed_ < config.maximum_move_distance ? slow_speed : fast_speed;
+                const auto slow_or_fast = elem->last_area_increase_.increase_speed_ < config.maximum_move_distance ? slow_speed : fast_speed;
                 insertSetting(
                     AreaIncreaseSettings(
-                        elem.last_area_increase_.type_,
+                        elem->last_area_increase_.type_,
                         slow_or_fast,
                         increase_radius,
-                        elem.last_area_increase_.no_error_,
+                        elem->last_area_increase_.no_error_,
                         ! use_min_radius,
-                        elem.last_area_increase_.move_),
+                        elem->last_area_increase_.move_),
                     true);
                 insertSetting(
                     AreaIncreaseSettings(
-                        elem.last_area_increase_.type_,
+                        elem->last_area_increase_.type_,
                         slow_or_fast,
                         ! increase_radius,
-                        elem.last_area_increase_.no_error_,
+                        elem->last_area_increase_.no_error_,
                         ! use_min_radius,
-                        elem.last_area_increase_.move_),
+                        elem->last_area_increase_.move_),
                     true);
             }
             // Branch may still go though a hole, so a check has to be done whether the hole was already passed, and the regular avoidance can be used.
-            if (! elem.can_use_safe_radius_)
+            if (! elem->can_use_safe_radius_)
             {
                 // If the radius until which it is always increased can not be guaranteed, move fast. This is to avoid holes smaller than the real branch radius.
                 // This does not guarantee the avoidance of such holes, but ensures they are avoided if possible.
                 insertSetting(AreaIncreaseSettings(AvoidanceType::SLOW, slow_speed, increase_radius, no_error, ! use_min_radius, ! move), true); // Did we go through the hole.
                 // In many cases the definition of hole is overly restrictive, so to avoid unnecessary fast movement in the tip, it is ignored there for a bit.
                 // This CAN cause a branch to go though a hole it otherwise may have avoided.
-                if (elem.distance_to_top_ < round_up_divide(config.tip_layers, 2))
+                if (elem->distance_to_top_ < round_up_divide(config.tip_layers, 2))
                 {
                     insertSetting(AreaIncreaseSettings(AvoidanceType::FAST, slow_speed, increase_radius, no_error, ! use_min_radius, ! move), true);
                 }
@@ -1042,7 +1041,7 @@ void TreeSupport::increaseAreas(
                 // While moving fast to be able to increase the radius (b) may seems preferable (over a) this can cause the a sudden skip in movement, which looks similar to a
                 // layer shift and can reduce stability. As such idx have chosen to only use the user setting for radius increases as a friendly recommendation.
                 insertSetting(AreaIncreaseSettings(AvoidanceType::SLOW, slow_speed, ! increase_radius, no_error, ! use_min_radius, move), true); // a (See above.)
-                if (elem.distance_to_top_ < config.tip_layers)
+                if (elem->distance_to_top_ < config.tip_layers)
                 {
                     insertSetting(AreaIncreaseSettings(AvoidanceType::FAST_SAFE, slow_speed, increase_radius, no_error, ! use_min_radius, move), true);
                 }
@@ -1050,7 +1049,7 @@ void TreeSupport::increaseAreas(
                 insertSetting(AreaIncreaseSettings(AvoidanceType::FAST_SAFE, fast_speed, ! increase_radius, no_error, ! use_min_radius, move), true);
             }
 
-            if (elem.use_min_xy_dist_)
+            if (elem->use_min_xy_dist_)
             {
                 std::deque<AreaIncreaseSettings> new_order;
                 // If the branch currently has to use min_xy_dist check if the configuration would also be valid with the regular xy_distance before checking with use_min_radius.
@@ -1064,20 +1063,20 @@ void TreeSupport::increaseAreas(
             }
 
             insertSetting(
-                AreaIncreaseSettings(AvoidanceType::FAST, fast_speed, ! increase_radius, ! no_error, elem.use_min_xy_dist_, move),
+                AreaIncreaseSettings(AvoidanceType::FAST, fast_speed, ! increase_radius, ! no_error, elem->use_min_xy_dist_, move),
                 true); // simplifying is very important for performance, but before an error is compensated by moving faster it makes sense to check to see if the simplifying has
                        // caused issues
 
             // The getAccumulatedPlaceable0 intersection is just a quick and dirty check to see that at least a part of the branch would correctly rest on the model.
             // Proper way would be to offset getAccumulatedPlaceable0 by -radius first, but the small benefit to maybe detect an error, that should not be happening anyway is not
             // worth the performance impact in the expected case when a branch rests on the model.
-            if (elem.to_buildplate_ || (elem.to_model_gracious_ && (parent->area_->intersection(volumes_.getPlaceableAreas(radius, layer_idx)).empty()))
-                || (! elem.to_model_gracious_ && (parent->area_->intersection(volumes_.getAccumulatedPlaceable0(layer_idx)).empty()))) // Error case.
+            if (elem->to_buildplate_ || (elem->to_model_gracious_ && (parent->area_->intersection(volumes_.getPlaceableAreas(radius, layer_idx)).empty()))
+                || (! elem->to_model_gracious_ && (parent->area_->intersection(volumes_.getAccumulatedPlaceable0(layer_idx)).empty()))) // Error case.
             {
                 // It is normal that we won't be able to find a new area at some point in time if we won't be able to reach layer 0 aka have to connect with the model.
-                insertSetting(AreaIncreaseSettings(AvoidanceType::FAST, fast_speed * 1.5, ! increase_radius, ! no_error, elem.use_min_xy_dist_, move), true);
+                insertSetting(AreaIncreaseSettings(AvoidanceType::FAST, fast_speed * 1.5, ! increase_radius, ! no_error, elem->use_min_xy_dist_, move), true);
             }
-            if (elem.distance_to_top_ < elem.dont_move_until_ && elem.can_use_safe_radius_) // Only do not move when holes would be avoided in every case.
+            if (elem->distance_to_top_ < elem->dont_move_until_ && elem->can_use_safe_radius_) // Only do not move when holes would be avoided in every case.
             {
                 insertSetting(
                     AreaIncreaseSettings(AvoidanceType::SLOW, 0, increase_radius, no_error, ! use_min_radius, ! move),
@@ -1139,7 +1138,7 @@ void TreeSupport::increaseAreas(
                         }
                     }
                 }
-                std::optional<TreeSupportElement> result;
+                TreeSupportElement::Ptr result;
 
                 // Check for errors!
                 if (! settings.no_error_)
@@ -1160,16 +1159,16 @@ void TreeSupport::increaseAreas(
                             "safe {} until move {}",
                             radius,
                             layer_idx - 1,
-                            elem.next_height_,
-                            elem.distance_to_top_,
-                            elem.buildplate_radius_increases_,
-                            elem.use_min_xy_dist_,
-                            elem.to_buildplate_,
-                            elem.to_model_gracious_,
-                            elem.can_use_safe_radius_,
-                            elem.dont_move_until_,
-                            fmt::ptr(parent),
-                            config.getCollisionRadius(*parent),
+                            elem->next_height_,
+                            elem->distance_to_top_,
+                            elem->buildplate_radius_increases_,
+                            elem->use_min_xy_dist_,
+                            elem->to_buildplate_,
+                            elem->to_model_gracious_,
+                            elem->can_use_safe_radius_,
+                            elem->dont_move_until_,
+                            fmt::ptr(parent.get()),
+                            config.getCollisionRadius(parent),
                             layer_idx,
                             parent->next_height_,
                             parent->distance_to_top_,
@@ -1197,28 +1196,28 @@ void TreeSupport::increaseAreas(
 
                 if (result)
                 {
-                    elem = result.value();
+                    elem = result;
                     radius = config.getCollisionRadius(elem);
-                    elem.last_area_increase_ = settings;
+                    elem->last_area_increase_ = settings;
                     add = true;
                     bypass_merge = ! settings.move_
                                 || (settings.use_min_distance_
-                                    && elem.distance_to_top_
+                                    && elem->distance_to_top_
                                            < config.tip_layers); // Do not merge if the branch should not move or the priority has to be to get farther away from the model.
                     if (settings.move_)
                     {
-                        elem.dont_move_until_ = 0;
+                        elem->dont_move_until_ = 0;
                     }
                     else
                     {
-                        elem.result_on_layer_ = parent->result_on_layer_;
+                        elem->result_on_layer_ = parent->result_on_layer_;
                     }
 
-                    elem.can_use_safe_radius_ = settings.type_ != AvoidanceType::FAST;
+                    elem->can_use_safe_radius_ = settings.type_ != AvoidanceType::FAST;
 
                     if (! settings.use_min_distance_)
                     {
-                        elem.use_min_xy_dist_ = false;
+                        elem->use_min_xy_dist_ = false;
                     }
                     if (! settings.no_error_ && fast_speed < settings.increase_speed_)
                     {
@@ -1235,7 +1234,7 @@ void TreeSupport::increaseAreas(
             if (add)
             {
                 Shape max_influence_area = TreeSupportUtils::safeUnion(
-                    inc_wo_collision.difference(volumes_.getCollision(radius, layer_idx - 1, elem.use_min_xy_dist_)),
+                    inc_wo_collision.difference(volumes_.getCollision(radius, layer_idx - 1, elem->use_min_xy_dist_)),
                     TreeSupportUtils::safeUnion(to_bp_data, to_model_data));
                 // ^^^ Note: union seems useless, but some rounding errors somewhere can cause to_bp_data to be slightly bigger than it should be
 
@@ -1244,13 +1243,13 @@ void TreeSupport::increaseAreas(
                     if (bypass_merge)
                     {
                         Shape* new_area = new Shape(max_influence_area);
-                        TreeSupportElement* next = new TreeSupportElement(elem, new_area);
+                        auto next = TreeSupportElement::makeCopy(elem, new_area);
                         bypass_merge_areas.emplace_back(next);
                     }
                     else
                     {
                         influence_areas.emplace(elem, max_influence_area);
-                        if (elem.to_buildplate_)
+                        if (elem->to_buildplate_)
                         {
                             to_bp_areas.emplace(elem, to_bp_data);
                         }
@@ -1271,7 +1270,7 @@ void TreeSupport::increaseAreas(
         });
 }
 
-void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement*>>& move_bounds, TimeKeeper& time_keeper)
+void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, TimeKeeper& time_keeper)
 {
     const double data_size_inverse = 1 / double(move_bounds.size());
     double progress_total = TREE_PROGRESS_PRECALC_AVO + TREE_PROGRESS_PRECALC_COLL + TREE_PROGRESS_GENERATE_NODES;
@@ -1303,12 +1302,12 @@ void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement*>>&
         PropertyAreas influence_areas; // Over this map will be iterated when merging, as such it has to be ordered to ensure deterministic results.
         PropertyAreas to_model_areas; // The area of these SupportElement is not set, to avoid to much allocation and deallocation on the heap.
         PropertyAreasUnordered to_bp_areas; // Same.
-        std::vector<TreeSupportElement*>
+        std::vector<TreeSupportElement::Ptr>
             bypass_merge_areas; // Different to the other maps of SupportElements as these here have the area already set, as they are already to be inserted into move_bounds.
 
         const auto time_a = std::chrono::high_resolution_clock::now();
 
-        std::vector<TreeSupportElement*> last_layer;
+        std::vector<TreeSupportElement::Ptr> last_layer;
         last_layer.insert(last_layer.begin(), move_bounds[layer_idx].begin(), move_bounds[layer_idx].end());
 
         // ### Increase the influence areas by the allowed movement distance
@@ -1337,21 +1336,21 @@ void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement*>>&
         new_element = ! move_bounds[layer_idx - 1].empty();
 
         // Save calculated elements to output, and allocate Polygons on heap, as they will not be changed again.
-        for (std::pair<TreeSupportElement, Shape> tup : influence_areas)
+        for (std::pair<TreeSupportElement::Ptr, Shape> tup : influence_areas)
         {
-            const TreeSupportElement elem = tup.first;
+            const TreeSupportElement::Ptr elem = tup.first;
             Shape* new_area = new Shape(TreeSupportUtils::safeUnion(tup.second));
-            TreeSupportElement* next = new TreeSupportElement(elem, new_area);
+            auto next = TreeSupportElement::makeCopy(elem, new_area);
             move_bounds[layer_idx - 1].emplace(next);
 
             if (new_area->area() < 1)
             {
-                spdlog::error("Insert Error of Influence area on layer {}. Origin of {} areas. Was to bp {}", layer_idx - 1, elem.getParents().size(), elem.to_buildplate_);
+                spdlog::error("Insert Error of Influence area on layer {}. Origin of {} areas. Was to bp {}", layer_idx - 1, elem->getParents().size(), elem->to_buildplate_);
             }
         }
 
         // Place already fully constructed elements in the output.
-        for (TreeSupportElement* elem : bypass_merge_areas)
+        for (TreeSupportElement::Ptr elem : bypass_merge_areas)
         {
             if (elem->area_->area() < 1)
             {
@@ -1368,7 +1367,7 @@ void TreeSupport::createLayerPathing(std::vector<std::set<TreeSupportElement*>>&
     time_keeper.registerTime("Creating influence areas: merge", 10ms, std::chrono::duration_cast<std::chrono::milliseconds>(dur_merge));
 }
 
-void TreeSupport::setPointsOnAreas(const TreeSupportElement* elem)
+void TreeSupport::setPointsOnAreas(const TreeSupportElement::Ptr elem)
 {
     // Based on the branch center point of the current layer, the point on the next (further up) layer is calculated.
 
@@ -1378,7 +1377,7 @@ void TreeSupport::setPointsOnAreas(const TreeSupportElement* elem)
         return;
     }
 
-    for (TreeSupportElement* next_elem : elem->getParents())
+    for (TreeSupportElement::Ptr next_elem : elem->getParents())
     {
         if (next_elem->result_on_layer_
             != Point2LL(-1, -1)) // If the value was set somewhere else it it kept. This happens when a branch tries not to move after being unable to create a roof.
@@ -1401,13 +1400,13 @@ void TreeSupport::setPointsOnAreas(const TreeSupportElement* elem)
     }
 }
 
-bool TreeSupport::setToModelContact(std::vector<std::set<TreeSupportElement*>>& move_bounds, TreeSupportElement* first_elem, const LayerIndex layer_idx)
+bool TreeSupport::setToModelContact(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, TreeSupportElement::Ptr first_elem, const LayerIndex layer_idx)
 {
     if (first_elem->to_model_gracious_)
     {
-        TreeSupportElement* check = first_elem;
+        TreeSupportElement::Ptr check = first_elem;
 
-        std::vector<TreeSupportElement*> checked;
+        std::vector<TreeSupportElement::Ptr> checked;
         LayerIndex last_successfull_layer = layer_idx;
 
         bool set = false;
@@ -1422,7 +1421,7 @@ bool TreeSupport::setToModelContact(std::vector<std::set<TreeSupportElement*>>& 
         // up layer index.
         for (LayerIndex layer_check = layer_idx; check->next_height_ >= layer_check; layer_check++)
         {
-            Shape check_valid_place_area = check->area_->intersection(volumes_.getPlaceableAreas(config.getCollisionRadius(*check), layer_check));
+            Shape check_valid_place_area = check->area_->intersection(volumes_.getPlaceableAreas(config.getCollisionRadius(check), layer_check));
 
             if (! check_valid_place_area.empty())
             {
@@ -1449,9 +1448,8 @@ bool TreeSupport::setToModelContact(std::vector<std::set<TreeSupportElement*>>& 
                 spdlog::warn("No valid placement found for to model gracious element on layer {}: REMOVING BRANCH", layer_idx);
                 for (LayerIndex layer = layer_idx; layer <= first_elem->next_height_; layer++)
                 {
-                    move_bounds[layer].erase(checked[layer - layer_idx]);
                     delete checked[layer - layer_idx]->area_;
-                    delete checked[layer - layer_idx];
+                    move_bounds[layer].erase(checked[layer - layer_idx]);
                 }
                 return true;
             }
@@ -1466,9 +1464,8 @@ bool TreeSupport::setToModelContact(std::vector<std::set<TreeSupportElement*>>& 
         for (LayerIndex layer = layer_idx + 1; layer < last_successfull_layer - 1;
              ++layer) // NOTE: Use of 'itoa' will make this crash in the loop, even though the operation should be equivalent.
         {
-            move_bounds[layer].erase(checked[layer - layer_idx]);
             delete checked[layer - layer_idx]->area_;
-            delete checked[layer - layer_idx];
+            move_bounds[layer].erase(checked[layer - layer_idx]);
         }
 
         // If resting on the buildplate keep bp location
@@ -1536,12 +1533,12 @@ bool TreeSupport::setToModelContact(std::vector<std::set<TreeSupportElement*>>& 
     }
 }
 
-void TreeSupport::createNodesFromArea(std::vector<std::set<TreeSupportElement*>>& move_bounds)
+void TreeSupport::createNodesFromArea(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds)
 {
     // Initialize points on layer 0, with a "random" point in the influence area. Point is chosen based on an inaccurate estimate where the branches will split into two, but every
     // point inside the influence area would produce a valid result.
-    std::unordered_set<TreeSupportElement*> remove;
-    for (TreeSupportElement* init : move_bounds[0])
+    std::unordered_set<TreeSupportElement::Ptr> remove;
+    for (TreeSupportElement::Ptr init : move_bounds[0])
     {
         Point2LL p = init->next_position_;
         if (! (init->area_->inside(p, true)))
@@ -1567,17 +1564,16 @@ void TreeSupport::createNodesFromArea(std::vector<std::set<TreeSupportElement*>>
         }
     }
 
-    for (TreeSupportElement* del : remove)
+    for (TreeSupportElement::Ptr del : remove)
     {
-        move_bounds[0].erase(del);
         delete del->area_;
-        delete del;
+        move_bounds[0].erase(del);
     }
     remove.clear();
 
     for (const auto layer_idx : ranges::views::iota(1UL, move_bounds.size()))
     {
-        for (TreeSupportElement* elem : move_bounds[layer_idx])
+        for (TreeSupportElement::Ptr elem : move_bounds[layer_idx])
         {
             bool removed = false;
             if (elem->result_on_layer_ == Point2LL(-1, -1)) // Check if the resulting center point is not yet set.
@@ -1595,7 +1591,7 @@ void TreeSupport::createNodesFromArea(std::vector<std::set<TreeSupportElement*>>
                     }
                     remove.emplace(elem); // We dont need to remove yet the parents as they will have a lower dtt and also no result_on_layer set.
                     removed = true;
-                    for (TreeSupportElement* parent : elem->getParents())
+                    for (TreeSupportElement::Ptr parent : elem->getParents())
                     {
                         // When the roof was not able to generate downwards enough, the top elements may have not moved, and have result_on_layer already set. As this branch needs
                         // to be removed => all parents result_on_layer have to be invalidated.
@@ -1621,20 +1617,19 @@ void TreeSupport::createNodesFromArea(std::vector<std::set<TreeSupportElement*>>
         }
 
         // Delete all not needed support elements.
-        for (TreeSupportElement* del : remove)
+        for (TreeSupportElement::Ptr del : remove)
         {
-            move_bounds[layer_idx].erase(del);
             delete del->area_;
-            delete del;
+            move_bounds[layer_idx].erase(del);
         }
         remove.clear();
     }
 }
 
 void TreeSupport::generateBranchAreas(
-    std::vector<std::pair<LayerIndex, TreeSupportElement*>>& linear_data,
-    std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons,
-    const std::map<TreeSupportElement*, TreeSupportElement*>& inverse_tree_order)
+    std::vector<std::pair<LayerIndex, TreeSupportElement::Ptr>>& linear_data,
+    std::vector<std::unordered_map<TreeSupportElement::Ptr, Shape>>& layer_tree_polygons,
+    const std::map<TreeSupportElement::Ptr, TreeSupportElement::Ptr>& inverse_tree_order)
 {
     double progress_total = TREE_PROGRESS_PRECALC_AVO + TREE_PROGRESS_PRECALC_COLL + TREE_PROGRESS_GENERATE_NODES + TREE_PROGRESS_AREA_CALC;
     constexpr int progress_report_steps = 10;
@@ -1658,10 +1653,10 @@ void TreeSupport::generateBranchAreas(
         linear_data.size(),
         [&](const size_t idx)
         {
-            TreeSupportElement* elem = linear_data[idx].second;
-            coord_t radius = config.getRadius(*elem);
+            TreeSupportElement::Ptr elem = linear_data[idx].second;
+            coord_t radius = config.getRadius(elem);
             bool parent_uses_min = false;
-            TreeSupportElement* child_elem = inverse_tree_order.count(elem) ? inverse_tree_order.at(elem) : nullptr;
+            TreeSupportElement::Ptr child_elem = inverse_tree_order.count(elem) ? inverse_tree_order.at(elem) : nullptr;
 
             // Calculate multiple ovalized circles, to connect with every parent and child. Also generate regular circle for the current layer. Merge all these into one area.
             std::vector<std::pair<Point2LL, coord_t>> movement_directions{ std::pair<Point2LL, coord_t>(Point2LL(0, 0), radius) };
@@ -1672,7 +1667,7 @@ void TreeSupport::generateBranchAreas(
                     Point2LL movement = (child_elem->result_on_layer_ - elem->result_on_layer_);
                     movement_directions.emplace_back(movement, radius);
                 }
-                for (TreeSupportElement* parent : elem->getParents())
+                for (TreeSupportElement::Ptr parent : elem->getParents())
                 {
                     Point2LL movement = (parent->result_on_layer_ - elem->result_on_layer_);
                     movement_directions.emplace_back(movement, std::max(config.getRadius(parent), config.support_line_width));
@@ -1733,7 +1728,7 @@ void TreeSupport::generateBranchAreas(
             // Ensure branch area will not overlap with model/collision. This can happen because of e.g. ovalization or increase_until_radius.
             linear_inserts[idx] = generateArea(0);
 
-            if (fast_relative_movement || config.getRadius(*elem) - config.getCollisionRadius(*elem) > config.support_line_width)
+            if (fast_relative_movement || config.getRadius(elem) - config.getCollisionRadius(elem) > config.support_line_width)
             {
                 // Simulate the path the nozzle will take on the outermost wall.
                 // If multiple parts exist, the outer line will not go all around the support part potentially causing support material to be printed mid air.
@@ -1790,7 +1785,7 @@ void TreeSupport::generateBranchAreas(
     }
 }
 
-void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons)
+void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportElement::Ptr, Shape>>& layer_tree_polygons)
 {
     double progress_total = TREE_PROGRESS_PRECALC_AVO + TREE_PROGRESS_PRECALC_COLL + TREE_PROGRESS_GENERATE_NODES + TREE_PROGRESS_AREA_CALC + TREE_PROGRESS_GENERATE_BRANCH_AREAS;
     const coord_t max_radius_change_per_layer = 1 + config.support_line_width / 2; // This is the upper limit a radius may change per layer. +1 to avoid rounding errors.
@@ -1798,26 +1793,26 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
     // Smooth upward.
     for (const auto layer_idx : ranges::views::iota(0UL, std::max<size_t>(layer_tree_polygons.size(), 1UL) - 1UL))
     {
-        std::vector<std::pair<TreeSupportElement*, Shape>> processing;
+        std::vector<std::pair<TreeSupportElement::Ptr, Shape>> processing;
         processing.insert(processing.end(), layer_tree_polygons[layer_idx].begin(), layer_tree_polygons[layer_idx].end());
-        std::vector<std::vector<std::pair<TreeSupportElement*, Shape>>> update_next(processing.size()); // With this a lock can be avoided.
+        std::vector<std::vector<std::pair<TreeSupportElement::Ptr, Shape>>> update_next(processing.size()); // With this a lock can be avoided.
         cura::parallel_for<size_t>(
             0,
             processing.size(),
             [&](const size_t processing_idx)
             {
-                std::pair<TreeSupportElement*, Shape> data_pair = processing[processing_idx];
+                std::pair<TreeSupportElement::Ptr, Shape> data_pair = processing[processing_idx];
 
                 coord_t max_outer_wall_distance = 0;
                 bool do_something = false;
-                for (TreeSupportElement* parent : data_pair.first->getParents())
+                for (TreeSupportElement::Ptr parent : data_pair.first->getParents())
                 {
-                    if (config.getRadius(*parent) != config.getCollisionRadius(*parent))
+                    if (config.getRadius(parent) != config.getCollisionRadius(parent))
                     {
                         do_something = true;
                         max_outer_wall_distance = std::max(
                             max_outer_wall_distance,
-                            vSize(data_pair.first->result_on_layer_ - parent->result_on_layer_) - (config.getRadius(*data_pair.first) - config.getRadius(*parent)));
+                            vSize(data_pair.first->result_on_layer_ - parent->result_on_layer_) - (config.getRadius(data_pair.first) - config.getRadius(parent)));
                     }
                 }
                 max_outer_wall_distance
@@ -1825,20 +1820,20 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
                 if (do_something)
                 {
                     Shape max_allowed_area = data_pair.second.offset(max_outer_wall_distance);
-                    for (TreeSupportElement* parent : data_pair.first->getParents())
+                    for (TreeSupportElement::Ptr parent : data_pair.first->getParents())
                     {
-                        if (config.getRadius(*parent) != config.getCollisionRadius(*parent))
+                        if (config.getRadius(parent) != config.getCollisionRadius(parent))
                         {
                             update_next[processing_idx].emplace_back(
-                                std::pair<TreeSupportElement*, Shape>(parent, layer_tree_polygons[layer_idx + 1][parent].intersection(max_allowed_area)));
+                                std::pair<TreeSupportElement::Ptr, Shape>(parent, layer_tree_polygons[layer_idx + 1][parent].intersection(max_allowed_area)));
                         }
                     }
                 }
             });
 
-        for (std::vector<std::pair<TreeSupportElement*, Shape>> data_vector : update_next)
+        for (std::vector<std::pair<TreeSupportElement::Ptr, Shape>> data_vector : update_next)
         {
-            for (std::pair<TreeSupportElement*, Shape> data_pair : data_vector)
+            for (std::pair<TreeSupportElement::Ptr, Shape> data_pair : data_vector)
             {
                 layer_tree_polygons[layer_idx + 1][data_pair.first] = data_pair.second;
             }
@@ -1851,26 +1846,26 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
     //     As the whole function is only 10%, and the smoothing is hard to predict a progress report in the loop may be not useful.
 
     // Smooth downwards.
-    std::unordered_set<TreeSupportElement*> updated_last_iteration;
+    std::unordered_set<TreeSupportElement::Ptr> updated_last_iteration;
     for (const auto layer_idx : ranges::views::iota(0UL, std::max<size_t>(layer_tree_polygons.size(), 1UL) - 1UL) | ranges::views::reverse)
     {
-        std::vector<std::pair<TreeSupportElement*, Shape>> processing;
+        std::vector<std::pair<TreeSupportElement::Ptr, Shape>> processing;
         processing.insert(processing.end(), layer_tree_polygons[layer_idx].begin(), layer_tree_polygons[layer_idx].end());
-        std::vector<std::pair<TreeSupportElement*, Shape>> update_next(
+        std::vector<std::pair<TreeSupportElement::Ptr, Shape>> update_next(
             processing.size(),
-            std::pair<TreeSupportElement*, Shape>(nullptr, Shape())); // With this a lock can be avoided.
+            std::pair<TreeSupportElement::Ptr, Shape>(nullptr, Shape())); // With this a lock can be avoided.
 
         cura::parallel_for<size_t>(
             0,
             processing.size(),
             [&](const size_t processing_idx)
             {
-                std::pair<TreeSupportElement*, Shape> data_pair = processing[processing_idx];
+                std::pair<TreeSupportElement::Ptr, Shape> data_pair = processing[processing_idx];
                 bool do_something = false;
                 Shape max_allowed_area;
                 for (size_t idx = 0; idx < data_pair.first->getParents().size(); idx++)
                 {
-                    TreeSupportElement* parent = data_pair.first->getParents()[idx];
+                    TreeSupportElement::Ptr parent = data_pair.first->getParents()[idx];
                     const coord_t max_outer_line_increase = max_radius_change_per_layer;
                     Shape result = layer_tree_polygons[layer_idx + 1][parent].offset(max_outer_line_increase);
                     const Point2LL direction = data_pair.first->result_on_layer_ - parent->result_on_layer_;
@@ -1883,7 +1878,7 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
                         }
                     }
                     max_allowed_area.push_back(result);
-                    do_something = do_something || updated_last_iteration.count(parent) || config.getCollisionRadius(*parent) != config.getRadius(*parent);
+                    do_something = do_something || updated_last_iteration.count(parent) || config.getCollisionRadius(parent) != config.getRadius(parent);
                 }
 
                 if (do_something)
@@ -1891,13 +1886,13 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
                     const Shape result = max_allowed_area.unionPolygons().intersection(data_pair.second);
                     if (result.area() < data_pair.second.area())
                     {
-                        update_next[processing_idx] = std::pair<TreeSupportElement*, Shape>(data_pair.first, result);
+                        update_next[processing_idx] = std::pair<TreeSupportElement::Ptr, Shape>(data_pair.first, result);
                     }
                 }
             });
 
         updated_last_iteration.clear();
-        for (std::pair<TreeSupportElement*, Shape> data_pair : update_next)
+        for (std::pair<TreeSupportElement::Ptr, Shape> data_pair : update_next)
         {
             if (data_pair.first != nullptr)
             {
@@ -1911,7 +1906,7 @@ void TreeSupport::smoothBranchAreas(std::vector<std::unordered_map<TreeSupportEl
     Progress::messageProgress(Progress::Stage::SUPPORT, progress_total * progress_multiplier + progress_offset, TREE_PROGRESS_TOTAL);
 }
 
-void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*>>& layer_tree_polygons)
+void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement::Ptr>>& layer_tree_polygons)
 {
     const size_t smooth_window = config.support_tree_smooth_layers;
     if (smooth_window < 2) // Smoothing on 1 layer will give a similar result, so can be skipped
@@ -1920,16 +1915,17 @@ void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*
     }
 
     // First go through every element and calculate their average position i.r.t their chain of children
-    boost::concurrent_flat_map<TreeSupportElement*, Point2LL> smoothed_positions;
+    boost::concurrent_flat_map<TreeSupportElement::Ptr, Point2LL> smoothed_positions;
+
     cura::parallel_for<size_t>(
         0,
         layer_tree_polygons.size(),
         [&layer_tree_polygons, &smooth_window, &smoothed_positions](const size_t layer_index)
         {
-            for (TreeSupportElement* element : layer_tree_polygons[layer_index])
+            for (TreeSupportElement::Ptr element : layer_tree_polygons[layer_index])
             {
                 const size_t actual_smooth_window = std::min(smooth_window, element->distance_to_top_);
-                const TreeSupportElement* child = element->getChild();
+                TreeSupportElement::Ptr child = element->getChild();
                 Point2LL interlayer_position_sum = element->result_on_layer_;
                 size_t added_layers;
                 for (added_layers = 1; child && child->isResultOnLayerSet() && added_layers < actual_smooth_window; ++added_layers)
@@ -1954,17 +1950,17 @@ void TreeSupport::smoothBranchSkeletons(std::vector<std::set<TreeSupportElement*
 }
 
 void TreeSupport::dropNonGraciousAreas(
-    std::vector<std::unordered_map<TreeSupportElement*, Shape>>& layer_tree_polygons,
-    const std::vector<std::pair<LayerIndex, TreeSupportElement*>>& linear_data,
+    std::vector<std::unordered_map<TreeSupportElement::Ptr, Shape>>& layer_tree_polygons,
+    const std::vector<std::pair<LayerIndex, TreeSupportElement::Ptr>>& linear_data,
     std::vector<std::vector<std::pair<LayerIndex, Shape>>>& dropped_down_areas,
-    const std::map<TreeSupportElement*, TreeSupportElement*>& inverse_tree_order)
+    const std::map<TreeSupportElement::Ptr, TreeSupportElement::Ptr>& inverse_tree_order)
 {
     cura::parallel_for<size_t>(
         0,
         linear_data.size(),
         [&](const size_t idx)
         {
-            TreeSupportElement* elem = linear_data[idx].second;
+            TreeSupportElement::Ptr elem = linear_data[idx].second;
             bool non_gracious_model_contact = ! elem->to_model_gracious_ && ! inverse_tree_order.count(elem) && linear_data[idx].first > 0
                                            && ! elem->to_buildplate_; // If an element has no child, it connects to whatever is below as no support further down for it will exist.
             if (non_gracious_model_contact)
@@ -2258,15 +2254,16 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
                 case InterfacePreference::SUPPORT_LINES_OVERWRITE_INTERFACE:
                 {
                     Shape tree_lines;
-                    tree_lines = tree_lines.unionPolygons(TreeSupportUtils::generateSupportInfillLines(
-                                                              support_layer_storage[layer_idx],
-                                                              config,
-                                                              false,
-                                                              layer_idx,
-                                                              config.support_line_distance,
-                                                              storage.support.cross_fill_provider,
-                                                              true)
-                                                              .offset(config.support_line_width / 2));
+                    tree_lines = tree_lines.unionPolygons(
+                        TreeSupportUtils::generateSupportInfillLines(
+                            support_layer_storage[layer_idx],
+                            config,
+                            false,
+                            layer_idx,
+                            config.support_line_distance,
+                            storage.support.cross_fill_provider,
+                            true)
+                            .offset(config.support_line_width / 2));
                     storage.support.supportLayers[layer_idx].support_roof = storage.support.supportLayers[layer_idx].support_roof.difference(tree_lines);
                     // Do not draw roof where the tree is. I prefer it this way as otherwise the roof may cut of a branch from its support below.
                 }
@@ -2377,20 +2374,20 @@ void TreeSupport::finalizeInterfaceAndSupportAreas(
         });
 }
 
-void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bounds, SliceDataStorage& storage, TimeKeeper& time_keeper)
+void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, SliceDataStorage& storage, TimeKeeper& time_keeper)
 {
     std::vector<Shape> support_layer_storage(move_bounds.size());
     std::vector<Shape> support_layer_storage_fractional(move_bounds.size());
     std::vector<Shape> support_roof_storage_fractional(move_bounds.size());
     std::vector<Shape> support_roof_storage(move_bounds.size());
-    std::map<TreeSupportElement*, TreeSupportElement*>
+    std::map<TreeSupportElement::Ptr, TreeSupportElement::Ptr>
         inverse_tree_order; // In the tree structure only the parents can be accessed. Inverse this to be able to access the children.
-    std::vector<std::pair<LayerIndex, TreeSupportElement*>>
+    std::vector<std::pair<LayerIndex, TreeSupportElement::Ptr>>
         linear_data; // All SupportElements are put into a layer independent storage to improve parallelization. Was added at a point in time where this function had performance
                      // issues. These were fixed by creating less initial points, but i do not see a good reason to remove a working performance optimization.
     for (const auto layer_idx : ranges::views::iota(0UL, move_bounds.size()))
     {
-        for (TreeSupportElement* elem : move_bounds[layer_idx])
+        for (TreeSupportElement::Ptr elem : move_bounds[layer_idx])
         {
             // (Check if) We either come from nowhere at the final layer or we had invalid parents 2. should never happen but just to be sure:
             if ((layer_idx > 0
@@ -2400,7 +2397,7 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
                 continue;
             }
 
-            for (TreeSupportElement* par : elem->getParents())
+            for (TreeSupportElement::Ptr par : elem->getParents())
             {
                 if (par->result_on_layer_ == Point2LL(-1, -1))
                 {
@@ -2413,7 +2410,7 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
     }
 
     // Reorder the processed data by layers again. The map also could be a vector<pair<SupportElement*,Shape>>:
-    std::vector<std::unordered_map<TreeSupportElement*, Shape>> layer_tree_polygons(move_bounds.size());
+    std::vector<std::unordered_map<TreeSupportElement::Ptr, Shape>> layer_tree_polygons(move_bounds.size());
     time_keeper.registerTime("drawArea::init");
 
     smoothBranchSkeletons(move_bounds);
@@ -2474,17 +2471,17 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
         layer_tree_polygons.size(),
         [&](const size_t layer_idx)
         {
-            for (std::pair<TreeSupportElement*, Shape> data_pair : layer_tree_polygons[layer_idx])
+            for (std::pair<TreeSupportElement::Ptr, Shape> data_pair : layer_tree_polygons[layer_idx])
             {
                 if (data_pair.first->missing_roof_layers_ > data_pair.first->distance_to_top_
                     && TreeSupportUtils::generateSupportInfillLines(data_pair.second, config, true, layer_idx, config.support_roof_line_distance, nullptr, true).empty())
                 {
-                    std::vector<TreeSupportElement*> to_disable_roofs;
+                    std::vector<TreeSupportElement::Ptr> to_disable_roofs;
                     to_disable_roofs.emplace_back(data_pair.first);
                     while (! to_disable_roofs.empty())
                     {
-                        std::vector<TreeSupportElement*> to_disable_roofs_next;
-                        for (TreeSupportElement* elem : to_disable_roofs)
+                        std::vector<TreeSupportElement::Ptr> to_disable_roofs_next;
+                        for (TreeSupportElement::Ptr elem : to_disable_roofs)
                         {
                             elem->missing_roof_layers_ = 0;
                             if (data_pair.first->missing_roof_layers_ > data_pair.first->distance_to_top_ + 1)
@@ -2503,7 +2500,7 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
         layer_tree_polygons.size(),
         [&](const size_t layer_idx)
         {
-            for (std::pair<TreeSupportElement*, Shape> data_pair : layer_tree_polygons[layer_idx])
+            for (std::pair<TreeSupportElement::Ptr, Shape> data_pair : layer_tree_polygons[layer_idx])
             {
                 if (data_pair.first->getParents().empty() && ! data_pair.first->supports_roof_ && layer_idx + 1 < support_roof_storage_fractional.size()
                     && config.z_distance_top % config.layer_height > 0)
@@ -2543,12 +2540,12 @@ void TreeSupport::drawAreas(std::vector<std::set<TreeSupportElement*>>& move_bou
     time_keeper.registerTime("drawAreas::finalizeInterfaceAndSupportAreas");
 }
 
-void TreeSupport::saveToObj(const std::vector<std::set<TreeSupportElement*>>& move_bounds, OBJ& obj) const
+void TreeSupport::saveToObj(const std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds, OBJ& obj) const
 {
     for (const auto [layer_index, elements] : move_bounds | ranges::views::enumerate)
     {
         const coord_t z = layer_index * config.layer_height;
-        for (const TreeSupportElement* element : elements)
+        for (const TreeSupportElement::Ptr element : elements)
         {
             element->saveToObj(obj, z, config.layer_height);
             obj.writeSphere(Point3D(Point3LL(element->result_on_layer_, z), 1.0), config.layer_height / 2.0, SVG::Color::RED);

--- a/src/TreeSupportElement.cpp
+++ b/src/TreeSupportElement.cpp
@@ -49,36 +49,35 @@ TreeSupportElement::TreeSupportElement(
     RecreateInfluenceLimitArea();
 }
 
-TreeSupportElement::TreeSupportElement(const TreeSupportElement& elem, Shape* newArea)
+TreeSupportElement::TreeSupportElement(const TreeSupportElement::Ptr& elem, Shape* newArea)
     : // copy constructor with possibility to set a new area
-    target_height_(elem.target_height_)
-    , target_position_(elem.target_position_)
-    , next_position_(elem.next_position_)
-    , next_height_(elem.next_height_)
-    , effective_radius_height_(elem.effective_radius_height_)
-    , to_buildplate_(elem.to_buildplate_)
-    , distance_to_top_(elem.distance_to_top_)
-    , area_(newArea != nullptr ? newArea : elem.area_)
-    , result_on_layer_(elem.result_on_layer_)
-    , increased_to_model_radius_(elem.increased_to_model_radius_)
-    , to_model_gracious_(elem.to_model_gracious_)
-    , buildplate_radius_increases_(elem.buildplate_radius_increases_)
-    , use_min_xy_dist_(elem.use_min_xy_dist_)
-    , supports_roof_(elem.supports_roof_)
-    , dont_move_until_(elem.dont_move_until_)
-    , can_use_safe_radius_(elem.can_use_safe_radius_)
-    , last_area_increase_(elem.last_area_increase_)
-    , missing_roof_layers_(elem.missing_roof_layers_)
-    , skip_ovalisation_(elem.skip_ovalisation_)
-    , all_tips_(elem.all_tips_)
-    , influence_area_limit_active_(elem.influence_area_limit_active_)
-    , influence_area_limit_range_(elem.influence_area_limit_range_)
-    , influence_area_limit_area_(elem.influence_area_limit_area_)
+    target_height_(elem->target_height_)
+    , target_position_(elem->target_position_)
+    , next_position_(elem->next_position_)
+    , next_height_(elem->next_height_)
+    , effective_radius_height_(elem->effective_radius_height_)
+    , to_buildplate_(elem->to_buildplate_)
+    , distance_to_top_(elem->distance_to_top_)
+    , area_(newArea != nullptr ? newArea : elem->area_)
+    , result_on_layer_(elem->result_on_layer_)
+    , increased_to_model_radius_(elem->increased_to_model_radius_)
+    , to_model_gracious_(elem->to_model_gracious_)
+    , buildplate_radius_increases_(elem->buildplate_radius_increases_)
+    , use_min_xy_dist_(elem->use_min_xy_dist_)
+    , supports_roof_(elem->supports_roof_)
+    , dont_move_until_(elem->dont_move_until_)
+    , can_use_safe_radius_(elem->can_use_safe_radius_)
+    , last_area_increase_(elem->last_area_increase_)
+    , missing_roof_layers_(elem->missing_roof_layers_)
+    , skip_ovalisation_(elem->skip_ovalisation_)
+    , all_tips_(elem->all_tips_)
+    , influence_area_limit_active_(elem->influence_area_limit_active_)
+    , influence_area_limit_range_(elem->influence_area_limit_range_)
+    , influence_area_limit_area_(elem->influence_area_limit_area_)
 {
-    addParents(elem.parents_);
 }
 
-TreeSupportElement::TreeSupportElement(TreeSupportElement* element_above)
+TreeSupportElement::TreeSupportElement(const TreeSupportElement::Ptr& element_above)
     : target_height_(element_above->target_height_)
     , target_position_(element_above->target_position_)
     , next_position_(element_above->next_position_)
@@ -104,12 +103,11 @@ TreeSupportElement::TreeSupportElement(TreeSupportElement* element_above)
     , influence_area_limit_range_(element_above->influence_area_limit_range_)
     , influence_area_limit_area_(element_above->influence_area_limit_area_)
 {
-    addParents({ element_above });
 }
 
 TreeSupportElement::TreeSupportElement(
-    const TreeSupportElement& first,
-    const TreeSupportElement& second,
+    const TreeSupportElement::Ptr& first,
+    const TreeSupportElement::Ptr& second,
     size_t next_height,
     Point2LL next_position,
     coord_t increased_to_model_radius,
@@ -121,37 +119,36 @@ TreeSupportElement::TreeSupportElement(
     , next_height_(next_height)
     , area_(nullptr)
     , increased_to_model_radius_(increased_to_model_radius)
-    , use_min_xy_dist_(first.use_min_xy_dist_ || second.use_min_xy_dist_)
-    , supports_roof_(first.supports_roof_ || second.supports_roof_)
-    , dont_move_until_(std::max(first.dont_move_until_, second.dont_move_until_))
-    , can_use_safe_radius_(first.can_use_safe_radius_ || second.can_use_safe_radius_)
-    , missing_roof_layers_(std::min(first.missing_roof_layers_, second.missing_roof_layers_))
+    , use_min_xy_dist_(first->use_min_xy_dist_ || second->use_min_xy_dist_)
+    , supports_roof_(first->supports_roof_ || second->supports_roof_)
+    , dont_move_until_(std::max(first->dont_move_until_, second->dont_move_until_))
+    , can_use_safe_radius_(first->can_use_safe_radius_ || second->can_use_safe_radius_)
+    , missing_roof_layers_(std::min(first->missing_roof_layers_, second->missing_roof_layers_))
     , skip_ovalisation_(false)
 {
-    if (first.target_height_ > second.target_height_)
+    if (first->target_height_ > second->target_height_)
     {
-        target_height_ = first.target_height_;
-        target_position_ = first.target_position_;
+        target_height_ = first->target_height_;
+        target_position_ = first->target_position_;
     }
     else
     {
-        target_height_ = second.target_height_;
-        target_position_ = second.target_position_;
+        target_height_ = second->target_height_;
+        target_position_ = second->target_position_;
     }
-    effective_radius_height_ = std::max(first.effective_radius_height_, second.effective_radius_height_);
-    distance_to_top_ = std::max(first.distance_to_top_, second.distance_to_top_);
+    effective_radius_height_ = std::max(first->effective_radius_height_, second->effective_radius_height_);
+    distance_to_top_ = std::max(first->distance_to_top_, second->distance_to_top_);
 
-    to_buildplate_ = first.to_buildplate_ && second.to_buildplate_;
-    to_model_gracious_ = first.to_model_gracious_ && second.to_model_gracious_; // valid as we do not merge non-gracious with gracious
-
-    addParents(first.parents_);
-    addParents(second.parents_);
+    to_buildplate_ = first->to_buildplate_ && second->to_buildplate_;
+    to_model_gracious_ = first->to_model_gracious_ && second->to_model_gracious_; // valid as we do not merge non-gracious with gracious
 
     buildplate_radius_increases_ = 0;
     if (diameter_scale_bp_radius > 0)
     {
         const coord_t foot_increase_radius = std::abs(
-            std::max(getRadius(second.effective_radius_height_, second.buildplate_radius_increases_), getRadius(first.effective_radius_height_, first.buildplate_radius_increases_))
+            std::max(
+                getRadius(second->effective_radius_height_, second->buildplate_radius_increases_),
+                getRadius(first->effective_radius_height_, first->buildplate_radius_increases_))
             - getRadius(effective_radius_height_, buildplate_radius_increases_));
         // 'buildplate_radius_increases' has to be recalculated, as when a smaller tree with a larger buildplate_radius_increases merge with a larger branch,
         //   the buildplate_radius_increases may have to be lower as otherwise the radius suddenly increases. This results often in a non integer value.
@@ -160,30 +157,30 @@ TreeSupportElement::TreeSupportElement(
 
     // set last settings to the best out of both parents. If this is wrong, it will only cause a small performance penalty instead of weird behavior.
     last_area_increase_ = AreaIncreaseSettings(
-        std::min(first.last_area_increase_.type_, second.last_area_increase_.type_),
-        std::min(first.last_area_increase_.increase_speed_, second.last_area_increase_.increase_speed_),
-        first.last_area_increase_.increase_radius_ || second.last_area_increase_.increase_radius_,
-        first.last_area_increase_.no_error_ || second.last_area_increase_.no_error_,
-        first.last_area_increase_.use_min_distance_ && second.last_area_increase_.use_min_distance_,
-        first.last_area_increase_.move_ || second.last_area_increase_.move_);
+        std::min(first->last_area_increase_.type_, second->last_area_increase_.type_),
+        std::min(first->last_area_increase_.increase_speed_, second->last_area_increase_.increase_speed_),
+        first->last_area_increase_.increase_radius_ || second->last_area_increase_.increase_radius_,
+        first->last_area_increase_.no_error_ || second->last_area_increase_.no_error_,
+        first->last_area_increase_.use_min_distance_ && second->last_area_increase_.use_min_distance_,
+        first->last_area_increase_.move_ || second->last_area_increase_.move_);
 
-    all_tips_ = first.all_tips_;
-    all_tips_.insert(all_tips_.end(), second.all_tips_.begin(), second.all_tips_.end());
-    influence_area_limit_range_ = std::max(first.influence_area_limit_range_, second.influence_area_limit_range_);
-    influence_area_limit_active_ = first.influence_area_limit_active_ || second.influence_area_limit_active_;
+    all_tips_ = first->all_tips_;
+    all_tips_.insert(all_tips_.end(), second->all_tips_.begin(), second->all_tips_.end());
+    influence_area_limit_range_ = std::max(first->influence_area_limit_range_, second->influence_area_limit_range_);
+    influence_area_limit_active_ = first->influence_area_limit_active_ || second->influence_area_limit_active_;
     RecreateInfluenceLimitArea();
-    if (first.to_buildplate_ != second.to_buildplate_)
+    if (first->to_buildplate_ != second->to_buildplate_)
     {
         setToBuildplateForAllParents(to_buildplate_);
     }
 }
 
-void TreeSupportElement::addParents(const std::vector<TreeSupportElement*>& new_parents)
+void TreeSupportElement::addParents(const std::vector<TreeSupportElement::Ptr>& new_parents)
 {
     parents_.insert(parents_.begin(), new_parents.begin(), new_parents.end());
-    for (TreeSupportElement* parent : new_parents)
+    for (const TreeSupportElement::Ptr& parent : new_parents)
     {
-        parent->child_ = this;
+        parent->child_ = shared_from_this();
     }
 }
 
@@ -216,11 +213,11 @@ void TreeSupportElement::setToBuildplateForAllParents(bool new_value)
 {
     to_buildplate_ = new_value;
     to_model_gracious_ |= new_value;
-    std::vector<TreeSupportElement*> grandparents{ parents_ };
+    std::vector<TreeSupportElement::Ptr> grandparents{ parents_ };
     while (! grandparents.empty())
     {
-        std::vector<TreeSupportElement*> next_parents;
-        for (TreeSupportElement* grandparent : grandparents)
+        std::vector<TreeSupportElement::Ptr> next_parents;
+        for (TreeSupportElement::Ptr grandparent : grandparents)
         {
             next_parents.insert(next_parents.end(), grandparent->parents_.begin(), grandparent->parents_.end());
             grandparent->to_buildplate_ = new_value;
@@ -236,6 +233,46 @@ void TreeSupportElement::saveToObj(OBJ& obj, const coord_t z, const coord_t laye
     {
         obj.write(*area_, z, layer_height, to_model_gracious_ ? SVG::Color::BLUE : SVG::Color::RED);
     }
+}
+
+TreeSupportElement::Ptr TreeSupportElement::makeFromElementAbove(const TreeSupportElement::Ptr& element_above)
+{
+    std::shared_ptr<TreeSupportElement> element(new TreeSupportElement(element_above));
+    element->addParents({ element_above });
+    return element;
+}
+
+TreeSupportElement::Ptr TreeSupportElement::makeCopy(const TreeSupportElement::Ptr& elem, Shape* newArea)
+{
+    std::shared_ptr<TreeSupportElement> element(new TreeSupportElement(elem, newArea));
+    element->addParents(elem->getParents());
+    return element;
+}
+
+TreeSupportElement::Ptr TreeSupportElement::makeMerged(
+    const TreeSupportElement::Ptr& first,
+    const TreeSupportElement::Ptr& second,
+    size_t next_height,
+    Point2LL next_position,
+    coord_t increased_to_model_radius,
+    const std::function<coord_t(size_t, double)>& getRadius,
+    double diameter_scale_bp_radius,
+    coord_t branch_radius,
+    double diameter_angle_scale_factor)
+{
+    std::shared_ptr<TreeSupportElement> element(new TreeSupportElement(
+        first,
+        second,
+        next_height,
+        next_position,
+        increased_to_model_radius,
+        getRadius,
+        diameter_scale_bp_radius,
+        branch_radius,
+        diameter_angle_scale_factor));
+    element->addParents(first->getParents());
+    element->addParents(second->getParents());
+    return element;
 }
 
 } // namespace cura

--- a/src/TreeSupportTipGenerator.cpp
+++ b/src/TreeSupportTipGenerator.cpp
@@ -624,7 +624,7 @@ void TreeSupportTipGenerator::calculateRoofAreas(const cura::SliceMeshStorage& m
 
 
 void TreeSupportTipGenerator::addPointAsInfluenceArea(
-    std::vector<std::set<TreeSupportElement*>>& move_bounds,
+    std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds,
     std::pair<Point2LL, TreeSupportTipGenerator::LineStatus> p,
     size_t dtt,
     LayerIndex insert_layer,
@@ -654,7 +654,7 @@ void TreeSupportTipGenerator::addPointAsInfluenceArea(
         {
             // Normalize the point a bit to also catch points which are so close that inserting it would achieve nothing.
             already_inserted_[insert_layer].emplace(p.first / ((config_.min_radius + 1) / 10));
-            TreeSupportElement* elem = new TreeSupportElement(
+            auto elem = std::make_shared<TreeSupportElement>(
                 dtt,
                 insert_layer,
                 p.first,
@@ -682,7 +682,7 @@ void TreeSupportTipGenerator::addPointAsInfluenceArea(
 
 
 void TreeSupportTipGenerator::addLinesAsInfluenceAreas(
-    std::vector<std::set<TreeSupportElement*>>& move_bounds,
+    std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds,
     std::vector<TreeSupportTipGenerator::LineInformation> lines,
     size_t roof_tip_layers,
     LayerIndex insert_layer_idx,
@@ -794,7 +794,7 @@ void TreeSupportTipGenerator::addLinesAsInfluenceAreas(
 
 
 void TreeSupportTipGenerator::removeUselessAddedPoints(
-    std::vector<std::set<TreeSupportElement*>>& move_bounds,
+    std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds,
     SliceDataStorage& storage,
     std::vector<Shape>& additional_support_areas)
 {
@@ -805,13 +805,13 @@ void TreeSupportTipGenerator::removeUselessAddedPoints(
         {
             if (layer_idx + 1 < storage.support.supportLayers.size())
             {
-                std::vector<TreeSupportElement*> to_be_removed;
+                std::vector<TreeSupportElement::Ptr> to_be_removed;
                 Shape roof_on_layer_above = use_fake_roof_ ? support_roof_drawn_[layer_idx + 1]
                                                            : storage.support.supportLayers[layer_idx + 1].support_roof.unionPolygons(additional_support_areas[layer_idx + 1]);
                 Shape roof_on_layer
                     = use_fake_roof_ ? support_roof_drawn_[layer_idx] : storage.support.supportLayers[layer_idx].support_roof.unionPolygons(additional_support_areas[layer_idx]);
 
-                for (TreeSupportElement* elem : move_bounds[layer_idx])
+                for (TreeSupportElement::Ptr elem : move_bounds[layer_idx])
                 {
                     if (roof_on_layer.inside(elem->result_on_layer_)) // Remove branches that start inside of support interface
                     {
@@ -834,9 +834,8 @@ void TreeSupportTipGenerator::removeUselessAddedPoints(
 
                 for (auto elem : to_be_removed)
                 {
-                    move_bounds[layer_idx].erase(elem);
                     delete elem->area_;
-                    delete elem;
+                    move_bounds[layer_idx].erase(elem);
                 }
             }
         });
@@ -846,11 +845,11 @@ void TreeSupportTipGenerator::removeUselessAddedPoints(
 void TreeSupportTipGenerator::generateTips(
     SliceDataStorage& storage,
     const SliceMeshStorage& mesh,
-    std::vector<std::set<TreeSupportElement*>>& move_bounds,
+    std::vector<std::set<TreeSupportElement::Ptr>>& move_bounds,
     std::vector<Shape>& additional_support_areas,
     std::vector<std::vector<FakeRoofArea>>& placed_fake_roof_areas)
 {
-    std::vector<std::set<TreeSupportElement*>> new_tips(move_bounds.size());
+    std::vector<std::set<TreeSupportElement::Ptr>> new_tips(move_bounds.size());
 
     const coord_t circle_length_to_half_linewidth_change
         = config_.min_radius < config_.support_line_width ? config_.min_radius / 2 : sqrt(square(config_.min_radius) - square(config_.min_radius - config_.support_line_width / 2));


### PR DESCRIPTION
Previously, the `TreeSupportElement` objects were stored directly in a map, and some pointers over them were used. However the maps can be reorganized in memory, so that makes these pointers very unsafe. Now we use smart pointers in the maps so that they can be referenced without issues. This also removes memory duplication of the elements in various maps, and boilerplate code to actually place the objects in the maps.

Note: the fix was made previously in the tree support improvement spike. It was just cherry-picked here.

CURA-13304